### PR TITLE
coll: add collattr to collective interface

### DIFF
--- a/maint/gen_coll.py
+++ b/maint/gen_coll.py
@@ -434,7 +434,8 @@ def dump_mpir_impl_persistent(name):
     dump_split(0, "int MPIR_%s_impl(%s)" % (Name, func_params))
     dump_open('{')
     G.out.append("int mpi_errno = MPI_SUCCESS;")
-    G.out.append("int collattr = 0;")
+    if not re.match(r'Neighbor_', Name):
+        G.out.append("int collattr = 0;")
     G.out.append("")
     G.out.append("MPIR_Request *req = MPIR_Request_create(MPIR_REQUEST_KIND__PREQUEST_COLL);")
     G.out.append("MPIR_ERR_CHKANDJUMP(!req, mpi_errno, MPI_ERR_OTHER, \"**nomem\");")

--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -69,25 +69,25 @@ int MPIC_Wait(MPIR_Request * request_ptr);
 int MPIC_Probe(int source, int tag, MPI_Comm comm, MPI_Status * status);
 
 int MPIC_Send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-              MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag);
+              MPIR_Comm * comm_ptr, int collattr);
 int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int tag,
-              MPIR_Comm * comm_ptr, MPI_Status * status);
+              MPIR_Comm * comm_ptr, int collattr, MPI_Status * status);
 int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag);
+               MPIR_Comm * comm_ptr, int collattr);
 int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                   int dest, int sendtag, void *recvbuf, MPI_Aint recvcount,
                   MPI_Datatype recvtype, int source, int recvtag,
-                  MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t errflag);
+                  MPIR_Comm * comm_ptr, MPI_Status * status, int collattr);
 int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
                           int dest, int sendtag,
                           int source, int recvtag,
-                          MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t errflag);
+                          MPIR_Comm * comm_ptr, MPI_Status * status, int collattr);
 int MPIC_Isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-               MPIR_Comm * comm_ptr, MPIR_Request ** request, MPIR_Errflag_t errflag);
+               MPIR_Comm * comm_ptr, MPIR_Request ** request, int collattr);
 int MPIC_Issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-                MPIR_Comm * comm_ptr, MPIR_Request ** request, MPIR_Errflag_t errflag);
+                MPIR_Comm * comm_ptr, MPIR_Request ** request, int collattr);
 int MPIC_Irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source,
-               int tag, MPIR_Comm * comm_ptr, MPIR_Request ** request);
+               int tag, MPIR_Comm * comm_ptr, int collattr, MPIR_Request ** request);
 int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status statuses[]);
 
 int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,

--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -93,16 +93,19 @@ int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status statuses[]);
 int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,
                       MPI_Op op);
 
-int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag);
+int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, int collattr);
 
 /* TSP auto */
 int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                              MPI_Datatype datatype, MPI_Op op,
-                                             MPIR_Comm * comm, MPIR_TSP_sched_t sched);
+                                             MPIR_Comm * comm, int collattr,
+                                             MPIR_TSP_sched_t sched);
 int MPIR_TSP_Ibcast_sched_intra_tsp_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype,
-                                         int root, MPIR_Comm * comm_ptr, MPIR_TSP_sched_t sched);
-int MPIR_TSP_Ibarrier_sched_intra_tsp_auto(MPIR_Comm * comm, MPIR_TSP_sched_t sched);
+                                         int root, MPIR_Comm * comm_ptr, int collattr,
+                                         MPIR_TSP_sched_t sched);
+int MPIR_TSP_Ibarrier_sched_intra_tsp_auto(MPIR_Comm * comm, int collattr, MPIR_TSP_sched_t sched);
 int MPIR_TSP_Ireduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                           MPI_Datatype datatype, MPI_Op op, int root,
-                                          MPIR_Comm * comm_ptr, MPIR_TSP_sched_t sched);
+                                          MPIR_Comm * comm_ptr, int collattr,
+                                          MPIR_TSP_sched_t sched);
 #endif /* MPIR_COLL_H_INCLUDED */

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -102,6 +102,16 @@ enum MPIR_COMM_HINT_PREDEFINED_t {
     MPIR_COMM_HINT_PREDEFINED_COUNT
 };
 
+/* lightweight comm struct defines a sub-comm for collectives */
+typedef struct MPIR_sub_comm {
+    int rank;                   /* rank in this sub-comm */
+    int size;                   /* size of this sub-comm */
+    int *ranklist;              /* A list of ranks (as in parent comm) in this sub-comm.
+                                 * NULL is interpreted as identity array */
+} MPIR_sub_comm;
+
+#define MPIR_MAX_SUBCOMM_DEPTH 1
+
 /*S
   MPIR_Comm - Description of the Communicator data structure
 
@@ -180,6 +190,9 @@ struct MPIR_Comm {
     struct MPIR_Comm *node_comm;        /* Comm of processes in this comm that are on
                                          * the same node as this process. */
     struct MPIR_Comm *node_roots_comm;  /* Comm of root processes for other nodes. */
+    int subcomm_depth;
+    MPIR_sub_comm child_subcomm[MPIR_MAX_SUBCOMM_DEPTH];
+    MPIR_sub_comm roots_subcomm[MPIR_MAX_SUBCOMM_DEPTH];
     int *intranode_table;       /* intranode_table[i] gives the rank in
                                  * node_comm of rank i in this comm or -1 if i
                                  * is not in this process' node_comm.
@@ -264,6 +277,7 @@ struct MPIR_Comm {
      MPID_DEV_COMM_DECL
 #endif
 };
+
 extern MPIR_Object_alloc_t MPIR_Comm_mem;
 
 /* this function should not be called by normal code! */

--- a/src/include/mpir_nbc.h
+++ b/src/include/mpir_nbc.h
@@ -69,13 +69,13 @@ int MPIR_Sched_start(MPIR_Sched_t s, MPIR_Comm * comm, MPIR_Request ** req);
 
 /* send and recv take a comm ptr to enable hierarchical collectives */
 int MPIR_Sched_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
-                    MPIR_Comm * comm, MPIR_Sched_t s);
+                    MPIR_Comm * comm, int collattr, MPIR_Sched_t s);
 int MPIR_Sched_recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int src, MPIR_Comm * comm,
-                    MPIR_Sched_t s);
+                    int collattr, MPIR_Sched_t s);
 
 /* just like MPI_Issend, can't complete until the matching recv is posted */
 int MPIR_Sched_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
-                     MPIR_Comm * comm, MPIR_Sched_t s);
+                     MPIR_Comm * comm, int collattr, MPIR_Sched_t s);
 
 int MPIR_Sched_reduce(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,
                       MPI_Op op, MPIR_Sched_t s);
@@ -104,12 +104,12 @@ int MPIR_Sched_barrier(MPIR_Sched_t s);
  * is no known use case.  The recv count is just an upper bound, not an exact
  * amount to be received, so an oversized recv is used instead of deferral. */
 int MPIR_Sched_send_defer(const void *buf, const MPI_Aint * count, MPI_Datatype datatype, int dest,
-                          MPIR_Comm * comm, MPIR_Sched_t s);
+                          MPIR_Comm * comm, int collattr, MPIR_Sched_t s);
 /* Just like MPIR_Sched_recv except it populates the given status object with
  * the received count and error information, much like a normal recv.  Often
  * useful in conjunction with MPIR_Sched_send_defer. */
 int MPIR_Sched_recv_status(void *buf, MPI_Aint count, MPI_Datatype datatype, int src,
-                           MPIR_Comm * comm, MPI_Status * status, MPIR_Sched_t s);
+                           MPIR_Comm * comm, MPI_Status * status, int collattr, MPIR_Sched_t s);
 
 /* buffer management, fancy reductions, etc */
 int MPIR_Sched_cb(MPIR_Sched_cb_t * cb_p, void *cb_state, MPIR_Sched_t s);

--- a/src/mpi/coll/algorithms/recexchalgo/recexchalgo.h
+++ b/src/mpi/coll/algorithms/recexchalgo/recexchalgo.h
@@ -27,7 +27,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
                                                    size_t recv_extent, const MPI_Aint * recvcounts,
                                                    const MPI_Aint * displs, MPI_Datatype recvtype,
                                                    int is_dist_halving, MPIR_Comm * comm,
-                                                   MPIR_TSP_sched_t sched);
+                                                   int collattr, MPIR_TSP_sched_t sched);
 int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *tmp_recvbuf,
                                                        const MPI_Aint * recvcounts,
                                                        MPI_Aint * displs, MPI_Datatype datatype,
@@ -36,6 +36,6 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
                                                        int step2_nphases, int **step2_nbrs,
                                                        int rank, int nranks, int sink_id,
                                                        int is_out_vtcs, int *reduce_id_,
-                                                       MPIR_TSP_sched_t sched);
+                                                       int collattr, MPIR_TSP_sched_t sched);
 
 #endif /* RECEXCHALGO_H_INCLUDED */

--- a/src/mpi/coll/allgather/allgather_allcomm_nb.c
+++ b/src/mpi/coll/allgather/allgather_allcomm_nb.c
@@ -7,15 +7,14 @@
 
 int MPIR_Allgather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                              MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno =
-        MPIR_Iallgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm_ptr,
-                        &req_ptr);
+    mpi_errno = MPIR_Iallgather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
+                                comm_ptr, collattr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
+++ b/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
@@ -15,10 +15,11 @@
 int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm_ptr, int collattr)
 {
     int rank, local_size, remote_size, mpi_errno = MPI_SUCCESS, root;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Aint sendtype_sz;
     void *tmp_buf = NULL;
     MPIR_Comm *newcomm_ptr = NULL;
@@ -48,7 +49,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
 
     if (sendcount != 0) {
         mpi_errno = MPIR_Gather(sendbuf, sendcount, sendtype, tmp_buf, sendcount * sendtype_sz,
-                                MPI_BYTE, 0, newcomm_ptr, errflag);
+                                MPI_BYTE, 0, newcomm_ptr, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
@@ -59,7 +60,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
         if (sendcount != 0) {
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Bcast(tmp_buf, sendcount * sendtype_sz * local_size,
-                                   MPI_BYTE, root, comm_ptr, errflag);
+                                   MPI_BYTE, root, comm_ptr, collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
@@ -67,7 +68,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
         if (recvcount != 0) {
             root = 0;
             mpi_errno = MPIR_Bcast(recvbuf, recvcount * remote_size,
-                                   recvtype, root, comm_ptr, errflag);
+                                   recvtype, root, comm_ptr, collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     } else {
@@ -75,7 +76,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
         if (recvcount != 0) {
             root = 0;
             mpi_errno = MPIR_Bcast(recvbuf, recvcount * remote_size,
-                                   recvtype, root, comm_ptr, errflag);
+                                   recvtype, root, comm_ptr, collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
@@ -83,7 +84,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
         if (sendcount != 0) {
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Bcast(tmp_buf, sendcount * sendtype_sz * local_size,
-                                   MPI_BYTE, root, comm_ptr, errflag);
+                                   MPI_BYTE, root, comm_ptr, collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }

--- a/src/mpi/coll/allgather/allgather_intra_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_brucks.c
@@ -19,11 +19,12 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
                                 MPI_Datatype sendtype,
                                 void *recvbuf,
                                 MPI_Aint recvcount,
-                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Aint recvtype_extent, recvtype_sz;
     int pof2, src, rem;
     void *tmp_buf = NULL;
@@ -68,7 +69,8 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
                                   MPIR_ALLGATHER_TAG,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   curr_cnt * recvtype_sz, MPI_BYTE,
-                                  src, MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  src, MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE,
+                                  collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         curr_cnt *= 2;
         pof2 *= 2;
@@ -85,7 +87,8 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
                                   dst, MPIR_ALLGATHER_TAG,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   rem * recvcount * recvtype_sz, MPI_BYTE,
-                                  src, MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  src, MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE,
+                                  collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/allgather/allgather_intra_k_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_k_brucks.c
@@ -23,10 +23,11 @@ int
 MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
                               MPI_Datatype sendtype, void *recvbuf,
                               MPI_Aint recvcount, MPI_Datatype recvtype, MPIR_Comm * comm, int k,
-                              MPIR_Errflag_t errflag)
+                              int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int i, j;
     int nphases = 0;
     int src, dst, p_of_k = 0;   /* Largest power of k that is smaller than 'size' */
@@ -142,7 +143,7 @@ MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
             /* Receive at the exact location. */
             mpi_errno = MPIC_Irecv((char *) tmp_recvbuf + j * recvcount * delta * recvtype_extent,
                                    count, recvtype, src, MPIR_ALLGATHER_TAG, comm,
-                                   &reqs[num_reqs++]);
+                                   collattr, &reqs[num_reqs++]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST,
@@ -154,7 +155,7 @@ MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
             /* Send from the start of recv till `count` amount of data. */
             mpi_errno =
                 MPIC_Isend(tmp_recvbuf, count, recvtype, dst, MPIR_ALLGATHER_TAG, comm,
-                           &reqs[num_reqs++], errflag);
+                           &reqs[num_reqs++], collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST,

--- a/src/mpi/coll/allgather/allgather_intra_ring.c
+++ b/src/mpi/coll/allgather/allgather_intra_ring.c
@@ -25,11 +25,12 @@ int MPIR_Allgather_intra_ring(const void *sendbuf,
                               MPI_Datatype sendtype,
                               void *recvbuf,
                               MPI_Aint recvcount,
-                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Aint recvtype_extent;
     int j, i;
     int left, right, jnext;
@@ -64,7 +65,8 @@ int MPIR_Allgather_intra_ring(const void *sendbuf,
                                   ((char *) recvbuf +
                                    jnext * recvcount * recvtype_extent),
                                   recvcount, recvtype, left,
-                                  MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE,
+                                  collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         j = jnext;
         jnext = (comm_size + jnext - 1) % comm_size;

--- a/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
-                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
@@ -15,7 +15,7 @@ int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Data
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Iallgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype,
-                         comm_ptr, &req_ptr);
+                         comm_ptr, collattr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
@@ -22,12 +22,12 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
                                  void *recvbuf,
                                  const MPI_Aint * recvcounts,
                                  const MPI_Aint * displs,
-                                 MPI_Datatype recvtype,
-                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr)
 {
     int comm_size, rank, j, i;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Status status;
     MPI_Aint recvtype_extent, recvtype_sz;
     int pof2, src, rem, send_cnt;
@@ -79,7 +79,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
                                   MPIR_ALLGATHERV_TAG,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   (total_count - curr_cnt) * recvtype_sz, MPI_BYTE,
-                                  src, MPIR_ALLGATHERV_TAG, comm_ptr, &status, errflag);
+                                  src, MPIR_ALLGATHERV_TAG, comm_ptr, &status, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         if (mpi_errno) {
             recv_cnt = 0;
@@ -106,7 +106,8 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
                                   dst, MPIR_ALLGATHERV_TAG,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   (total_count - curr_cnt) * recvtype_sz, MPI_BYTE,
-                                  src, MPIR_ALLGATHERV_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  src, MPIR_ALLGATHERV_TAG, comm_ptr, MPI_STATUS_IGNORE,
+                                  collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -25,11 +25,12 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                                              const MPI_Aint * recvcounts,
                                              const MPI_Aint * displs,
                                              MPI_Datatype recvtype,
-                                             MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                             MPIR_Comm * comm_ptr, int collattr)
 {
     int comm_size, rank, j, i;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Status status;
     MPI_Aint recvtype_extent, recvtype_sz;
     MPI_Aint curr_cnt, last_recv_cnt;
@@ -113,7 +114,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                                       MPIR_ALLGATHERV_TAG,
                                       ((char *) tmp_buf + recv_offset * recvtype_sz),
                                       (total_count - recv_offset) * recvtype_sz, MPI_BYTE, dst,
-                                      MPIR_ALLGATHERV_TAG, comm_ptr, &status, errflag);
+                                      MPIR_ALLGATHERV_TAG, comm_ptr, &status, collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             if (mpi_errno) {
                 last_recv_cnt = 0;
@@ -176,7 +177,8 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
 
                     mpi_errno = MPIC_Send(((char *) tmp_buf + offset * recvtype_sz),
                                           last_recv_cnt * recvtype_sz,
-                                          MPI_BYTE, dst, MPIR_ALLGATHERV_TAG, comm_ptr, errflag);
+                                          MPI_BYTE, dst, MPIR_ALLGATHERV_TAG, comm_ptr,
+                                          collattr | errflag);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     /* last_recv_cnt was set in the previous
                      * receive. that's the amount of data to be
@@ -194,7 +196,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
 
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset * recvtype_sz),
                                           (total_count - offset) * recvtype_sz, MPI_BYTE,
-                                          dst, MPIR_ALLGATHERV_TAG, comm_ptr, &status);
+                                          dst, MPIR_ALLGATHERV_TAG, comm_ptr, collattr, &status);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     if (mpi_errno) {
                         last_recv_cnt = 0;

--- a/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
+++ b/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
@@ -6,14 +6,14 @@
 #include "mpiimpl.h"
 
 int MPIR_Allreduce_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
-                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                              MPIR_Errflag_t errflag)
+                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno = MPIR_Iallreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
+    mpi_errno =
+        MPIR_Iallreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, collattr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
+++ b/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
@@ -15,10 +15,11 @@
 
 int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                               MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Aint true_extent, true_lb, extent;
     void *tmp_buf = NULL;
     MPIR_Comm *newcomm_ptr = NULL;
@@ -40,19 +41,20 @@ int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbu
     newcomm_ptr = comm_ptr->local_comm;
 
     /* Do a local reduce on this intracommunicator */
-    mpi_errno = MPIR_Reduce(sendbuf, tmp_buf, count, datatype, op, 0, newcomm_ptr, errflag);
+    mpi_errno =
+        MPIR_Reduce(sendbuf, tmp_buf, count, datatype, op, 0, newcomm_ptr, collattr | errflag);
     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     /* Do a exchange between local and remote rank 0 on this intercommunicator */
     if (comm_ptr->rank == 0) {
         mpi_errno = MPIC_Sendrecv(tmp_buf, count, datatype, 0, MPIR_REDUCE_TAG,
                                   recvbuf, count, datatype, 0, MPIR_REDUCE_TAG,
-                                  comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  comm_ptr, MPI_STATUS_IGNORE, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* Do a local broadcast on this intracommunicator */
-    mpi_errno = MPIR_Bcast(recvbuf, count, datatype, 0, newcomm_ptr, errflag);
+    mpi_errno = MPIR_Bcast(recvbuf, count, datatype, 0, newcomm_ptr, collattr | errflag);
     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
   fn_exit:

--- a/src/mpi/coll/allreduce/allreduce_intra_recexch.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recexch.c
@@ -15,9 +15,10 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
                                  MPI_Aint count,
                                  MPI_Datatype datatype,
                                  MPI_Op op, MPIR_Comm * comm, int k, int single_phase_recv,
-                                 MPIR_Errflag_t errflag)
+                                 int collattr)
 {
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int is_commutative, rank, nranks, nbr, myidx;
     int buf = 0;
     MPI_Aint true_extent, true_lb, extent;
@@ -148,14 +149,14 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
     if (!in_step2) {    /* even */
         /* non-participating rank sends the data to a participating rank */
         mpi_errno = MPIC_Send(recvbuf, count,
-                              datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm, errflag);
+                              datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {    /* odd */
         if (step1_nrecvs) {
             for (i = 0; i < step1_nrecvs; i++) {        /* participating rank gets data from non-partcipating ranks */
                 mpi_errno = MPIC_Irecv(nbr_buffer[i], count,
                                        datatype, step1_recvfrom[i],
-                                       MPIR_ALLREDUCE_TAG, comm, &recv_reqs[recv_nreq++]);
+                                       MPIR_ALLREDUCE_TAG, comm, collattr, &recv_reqs[recv_nreq++]);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
             mpi_errno = MPIC_Waitall(recv_nreq, recv_reqs, MPI_STATUSES_IGNORE);
@@ -187,7 +188,7 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
                 nbr = step2_nbrs[phase + j][i];
                 mpi_errno =
                     MPIC_Irecv(nbr_buffer[buf++], count, datatype, nbr, MPIR_ALLREDUCE_TAG,
-                               comm, &recv_reqs[recv_nreq++]);
+                               comm, collattr, &recv_reqs[recv_nreq++]);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
@@ -198,7 +199,7 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
         for (i = 0; i < k - 1; i++) {
             nbr = step2_nbrs[phase][i];
             mpi_errno = MPIC_Isend(recvbuf, count, datatype, nbr, MPIR_ALLREDUCE_TAG, comm,
-                                   &send_reqs[send_nreq++], errflag);
+                                   &send_reqs[send_nreq++], collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             if (rank > nbr) {
                 myidx = i + 1;
@@ -243,7 +244,7 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
 
                     mpi_errno =
                         MPIC_Isend(recvbuf, count, datatype, nbr, MPIR_ALLREDUCE_TAG, comm,
-                                   &send_reqs[send_nreq++], errflag);
+                                   &send_reqs[send_nreq++], collattr | errflag);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     if (rank > nbr) {
                         myidx = i + 1;
@@ -286,13 +287,13 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
      * send the data to non-partcipating rans */
     if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
         mpi_errno = MPIC_Recv(recvbuf, count, datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm,
-                              MPI_STATUS_IGNORE);
+                              collattr, MPI_STATUS_IGNORE);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {
             mpi_errno =
                 MPIC_Isend(recvbuf, count, datatype, step1_recvfrom[i], MPIR_ALLREDUCE_TAG,
-                           comm, &send_reqs[i], errflag);
+                           comm, &send_reqs[i], collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
@@ -21,12 +21,13 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
                                             void *recvbuf,
                                             MPI_Aint count,
                                             MPI_Datatype datatype,
-                                            MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                            MPI_Op op, MPIR_Comm * comm_ptr, int collattr)
 {
     MPIR_CHKLMEM_DECL(1);
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int mask, dst, is_commutative, pof2, newrank, rem, newdst;
     MPI_Aint true_extent, true_lb, extent;
     void *tmp_buf;
@@ -66,7 +67,8 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIC_Send(recvbuf, count,
-                                  datatype, rank + 1, MPIR_ALLREDUCE_TAG, comm_ptr, errflag);
+                                  datatype, rank + 1, MPIR_ALLREDUCE_TAG, comm_ptr,
+                                  collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
@@ -76,7 +78,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
         } else {        /* odd */
             mpi_errno = MPIC_Recv(tmp_buf, count,
                                   datatype, rank - 1,
-                                  MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                  MPIR_ALLREDUCE_TAG, comm_ptr, collattr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
@@ -112,7 +114,8 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
             mpi_errno = MPIC_Sendrecv(recvbuf, count, datatype,
                                       dst, MPIR_ALLREDUCE_TAG, tmp_buf,
                                       count, datatype, dst,
-                                      MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                      MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE,
+                                      collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* tmp_buf contains data received in this step.
@@ -140,11 +143,12 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
     if (rank < 2 * rem) {
         if (rank % 2)   /* odd */
             mpi_errno = MPIC_Send(recvbuf, count,
-                                  datatype, rank - 1, MPIR_ALLREDUCE_TAG, comm_ptr, errflag);
+                                  datatype, rank - 1, MPIR_ALLREDUCE_TAG, comm_ptr,
+                                  collattr | errflag);
         else    /* even */
             mpi_errno = MPIC_Recv(recvbuf, count,
                                   datatype, rank + 1,
-                                  MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                  MPIR_ALLREDUCE_TAG, comm_ptr, collattr, MPI_STATUS_IGNORE);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
   fn_exit:

--- a/src/mpi/coll/allreduce_group/allreduce_group.h
+++ b/src/mpi/coll/allreduce_group/allreduce_group.h
@@ -10,9 +10,9 @@
 
 int MPII_Allreduce_group(void *sendbuf, void *recvbuf, MPI_Aint count,
                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                         MPIR_Group * group_ptr, int tag, MPIR_Errflag_t errflag);
+                         MPIR_Group * group_ptr, int tag, int collattr);
 int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                               MPIR_Group * group_ptr, int tag, MPIR_Errflag_t errflag);
+                               MPIR_Group * group_ptr, int tag, int collattr);
 
 #endif /* ALLREDUCE_GROUP_H_INCLUDED */

--- a/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
+++ b/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                             MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                             MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
@@ -15,7 +15,7 @@ int MPIR_Alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Dataty
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Ialltoall(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm_ptr,
-                       &req_ptr);
+                       collattr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/alltoall/alltoall_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoall/alltoall_inter_pairwise_exchange.c
@@ -18,13 +18,13 @@
 
 int MPIR_Alltoall_inter_pairwise_exchange(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                          MPIR_Errflag_t errflag)
+                                          MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr)
 {
     int local_size, remote_size, max_size, i;
     MPI_Aint sendtype_extent, recvtype_extent;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Status status;
     int src, dst, rank;
     char *sendaddr, *recvaddr;
@@ -58,7 +58,7 @@ int MPIR_Alltoall_inter_pairwise_exchange(const void *sendbuf, MPI_Aint sendcoun
         mpi_errno = MPIC_Sendrecv(sendaddr, sendcount, sendtype, dst,
                                   MPIR_ALLTOALL_TAG, recvaddr,
                                   recvcount, recvtype, src,
-                                  MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
+                                  MPIR_ALLTOALL_TAG, comm_ptr, &status, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/alltoall/alltoall_intra_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_brucks.c
@@ -23,13 +23,14 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
                                MPI_Datatype sendtype,
                                void *recvbuf,
                                MPI_Aint recvcount,
-                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr)
 {
     int comm_size, i, pof2;
     MPI_Aint sendtype_extent, recvtype_extent;
     MPI_Aint recvtype_sz;
     int mpi_errno = MPI_SUCCESS, src, dst, rank;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int block, count;
     MPI_Aint pack_size;
     MPI_Datatype newtype = MPI_DATATYPE_NULL;
@@ -108,7 +109,8 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
 
         mpi_errno = MPIC_Sendrecv(tmp_buf, newtype_sz, MPI_BYTE, dst,
                                   MPIR_ALLTOALL_TAG, recvbuf, 1, newtype,
-                                  src, MPIR_ALLTOALL_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  src, MPIR_ALLTOALL_TAG, comm_ptr, MPI_STATUS_IGNORE,
+                                  collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         MPIR_Type_free_impl(&newtype);

--- a/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
@@ -108,11 +108,11 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
                                  MPI_Datatype sendtype,
                                  void *recvbuf,
                                  MPI_Aint recvcnt,
-                                 MPI_Datatype recvtype, MPIR_Comm * comm, int k,
-                                 MPIR_Errflag_t errflag)
+                                 MPI_Datatype recvtype, MPIR_Comm * comm, int k, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int i, j;
     int rank, size;
     int nphases, max;
@@ -252,12 +252,12 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
 
             mpi_errno =
                 MPIC_Irecv(tmp_rbuf[j - 1], packsize, MPI_BYTE, src, MPIR_ALLTOALL_TAG, comm,
-                           &reqs[num_reqs++]);
+                           collattr, &reqs[num_reqs++]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             mpi_errno =
                 MPIC_Isend(tmp_sbuf[j - 1], packsize, MPI_BYTE, dst, MPIR_ALLTOALL_TAG, comm,
-                           &reqs[num_reqs++], errflag);
+                           &reqs[num_reqs++], collattr | errflag);
             if (mpi_errno) {
                 MPIR_ERR_POP(mpi_errno);
             }

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
@@ -27,13 +27,13 @@ int MPIR_Alltoall_intra_pairwise(const void *sendbuf,
                                  MPI_Datatype sendtype,
                                  void *recvbuf,
                                  MPI_Aint recvcount,
-                                 MPI_Datatype recvtype,
-                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr)
 {
     int comm_size, i;
     MPI_Aint sendtype_extent, recvtype_extent;
     int mpi_errno = MPI_SUCCESS, src, dst, rank;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Status status;
 
     comm_size = comm_ptr->local_size;
@@ -76,7 +76,7 @@ int MPIR_Alltoall_intra_pairwise(const void *sendbuf,
                                   ((char *) recvbuf +
                                    src * recvcount * recvtype_extent),
                                   recvcount, recvtype, src,
-                                  MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
+                                  MPIR_ALLTOALL_TAG, comm_ptr, &status, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
@@ -25,12 +25,13 @@ int MPIR_Alltoall_intra_pairwise_sendrecv_replace(const void *sendbuf,
                                                   void *recvbuf,
                                                   MPI_Aint recvcount,
                                                   MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                  MPIR_Comm * comm_ptr, int collattr)
 {
     int comm_size, i, j;
     MPI_Aint recvtype_extent;
     int mpi_errno = MPI_SUCCESS, rank;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Status status;
 
     comm_size = comm_ptr->local_size;
@@ -56,14 +57,14 @@ int MPIR_Alltoall_intra_pairwise_sendrecv_replace(const void *sendbuf,
                 mpi_errno =
                     MPIC_Sendrecv_replace(((char *) recvbuf + j * recvcount * recvtype_extent),
                                           recvcount, recvtype, j, MPIR_ALLTOALL_TAG, j,
-                                          MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
+                                          MPIR_ALLTOALL_TAG, comm_ptr, &status, collattr | errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else if (rank == j) {
                 /* same as above with i/j args reversed */
                 mpi_errno =
                     MPIC_Sendrecv_replace(((char *) recvbuf + i * recvcount * recvtype_extent),
                                           recvcount, recvtype, i, MPIR_ALLTOALL_TAG, i,
-                                          MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
+                                          MPIR_ALLTOALL_TAG, comm_ptr, &status, collattr | errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }

--- a/src/mpi/coll/alltoall/alltoall_intra_scattered.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_scattered.c
@@ -32,13 +32,13 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
                                   MPI_Datatype sendtype,
                                   void *recvbuf,
                                   MPI_Aint recvcount,
-                                  MPI_Datatype recvtype,
-                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                  MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr)
 {
     int comm_size, i;
     MPI_Aint sendtype_extent, recvtype_extent;
     int mpi_errno = MPI_SUCCESS, dst, rank;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPIR_Request **reqarray;
     MPI_Status *starray;
     MPIR_CHKLMEM_DECL(6);
@@ -73,7 +73,7 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
             mpi_errno = MPIC_Irecv((char *) recvbuf +
                                    dst * recvcount * recvtype_extent,
                                    recvcount, recvtype, dst,
-                                   MPIR_ALLTOALL_TAG, comm_ptr, &reqarray[i]);
+                                   MPIR_ALLTOALL_TAG, comm_ptr, collattr, &reqarray[i]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
@@ -82,7 +82,8 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
             mpi_errno = MPIC_Isend((char *) sendbuf +
                                    dst * sendcount * sendtype_extent,
                                    sendcount, sendtype, dst,
-                                   MPIR_ALLTOALL_TAG, comm_ptr, &reqarray[i + ss], errflag);
+                                   MPIR_ALLTOALL_TAG, comm_ptr, &reqarray[i + ss],
+                                   collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 

--- a/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
+++ b/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
@@ -8,7 +8,7 @@
 int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
                               const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
                               const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
-                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
@@ -16,7 +16,7 @@ int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Ialltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls,
-                        recvtype, comm_ptr, &req_ptr);
+                        recvtype, comm_ptr, collattr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/alltoallv/alltoallv_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoallv/alltoallv_inter_pairwise_exchange.c
@@ -23,12 +23,13 @@ int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint *
                                            const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                            void *recvbuf, const MPI_Aint * recvcounts,
                                            const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                           MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                           MPIR_Comm * comm_ptr, int collattr)
 {
     int local_size, remote_size, max_size, i;
     MPI_Aint send_extent, recv_extent;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Status status;
     int src, dst, rank;
     char *sendaddr, *recvaddr;
@@ -66,7 +67,8 @@ int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint *
 
         mpi_errno = MPIC_Sendrecv(sendaddr, sendcount, sendtype, dst,
                                   MPIR_ALLTOALLV_TAG, recvaddr, recvcount,
-                                  recvtype, src, MPIR_ALLTOALLV_TAG, comm_ptr, &status, errflag);
+                                  recvtype, src, MPIR_ALLTOALLV_TAG, comm_ptr, &status,
+                                  collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
@@ -22,12 +22,13 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                    const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                                    void *recvbuf, const MPI_Aint * recvcounts,
                                                    const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm_ptr, int collattr)
 {
     int comm_size, i, j;
     MPI_Aint recv_extent;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Status status;
     int rank;
 
@@ -59,7 +60,7 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                   recvcounts[j], recvtype,
                                                   j, MPIR_ALLTOALLV_TAG,
                                                   j, MPIR_ALLTOALLV_TAG,
-                                                  comm_ptr, &status, errflag);
+                                                  comm_ptr, &status, collattr | errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             } else if (rank == j) {
@@ -68,7 +69,7 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                   recvcounts[i], recvtype,
                                                   i, MPIR_ALLTOALLV_TAG,
                                                   i, MPIR_ALLTOALLV_TAG,
-                                                  comm_ptr, &status, errflag);
+                                                  comm_ptr, &status, collattr | errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }

--- a/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
@@ -24,13 +24,13 @@
 int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcounts,
                                    const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
                                    const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
-                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                   MPIR_Errflag_t errflag)
+                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr)
 {
     int comm_size, i;
     MPI_Aint send_extent, recv_extent;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Status *starray;
     MPIR_Request **reqarray;
     int dst, rank, req_cnt;
@@ -73,7 +73,8 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
                 if (type_size) {
                     mpi_errno = MPIC_Irecv((char *) recvbuf + rdispls[dst] * recv_extent,
                                            recvcounts[dst], recvtype, dst,
-                                           MPIR_ALLTOALLV_TAG, comm_ptr, &reqarray[req_cnt]);
+                                           MPIR_ALLTOALLV_TAG, comm_ptr, collattr,
+                                           &reqarray[req_cnt]);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     req_cnt++;
                 }
@@ -89,7 +90,7 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
                     mpi_errno = MPIC_Isend((char *) sendbuf + sdispls[dst] * send_extent,
                                            sendcounts[dst], sendtype, dst,
                                            MPIR_ALLTOALLV_TAG, comm_ptr,
-                                           &reqarray[req_cnt], errflag);
+                                           &reqarray[req_cnt], collattr | errflag);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     req_cnt++;
                 }

--- a/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
+++ b/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
@@ -8,8 +8,7 @@
 int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const MPI_Aint sendcounts[],
                               const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                               void *recvbuf, const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
-                              const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                              MPIR_Errflag_t errflag)
+                              const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
@@ -17,7 +16,7 @@ int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const MPI_Aint sendcounts[],
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Ialltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls,
-                        recvtypes, comm_ptr, &req_ptr);
+                        recvtypes, comm_ptr, collattr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/alltoallw/alltoallw_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoallw/alltoallw_inter_pairwise_exchange.c
@@ -23,11 +23,12 @@ int MPIR_Alltoallw_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint s
                                            const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                            void *recvbuf, const MPI_Aint recvcounts[],
                                            const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                           MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                           MPIR_Comm * comm_ptr, int collattr)
 {
     int local_size, remote_size, max_size, i;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Status status;
     int src, dst, rank;
     char *sendaddr, *recvaddr;
@@ -67,7 +68,7 @@ int MPIR_Alltoallw_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint s
         mpi_errno = MPIC_Sendrecv(sendaddr, sendcount, sendtype,
                                   dst, MPIR_ALLTOALLW_TAG, recvaddr,
                                   recvcount, recvtype, src,
-                                  MPIR_ALLTOALLW_TAG, comm_ptr, &status, errflag);
+                                  MPIR_ALLTOALLW_TAG, comm_ptr, &status, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
     return mpi_errno_ret;

--- a/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
@@ -23,11 +23,12 @@ int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                    const MPI_Aint recvcounts[],
                                                    const MPI_Aint rdispls[],
                                                    const MPI_Datatype recvtypes[],
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm_ptr, int collattr)
 {
     int comm_size, i, j;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Status status;
     int rank;
 
@@ -56,7 +57,7 @@ int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                   recvcounts[j], recvtypes[j],
                                                   j, MPIR_ALLTOALLW_TAG,
                                                   j, MPIR_ALLTOALLW_TAG,
-                                                  comm_ptr, &status, errflag);
+                                                  comm_ptr, &status, collattr | errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else if (rank == j) {
                 /* same as above with i/j args reversed */
@@ -64,7 +65,7 @@ int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                   recvcounts[i], recvtypes[i],
                                                   i, MPIR_ALLTOALLW_TAG,
                                                   i, MPIR_ALLTOALLW_TAG,
-                                                  comm_ptr, &status, errflag);
+                                                  comm_ptr, &status, collattr | errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }

--- a/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
@@ -23,11 +23,12 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
                                    const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                    void *recvbuf, const MPI_Aint recvcounts[],
                                    const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                   MPIR_Comm * comm_ptr, int collattr)
 {
     int comm_size, i;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Status *starray;
     MPIR_Request **reqarray;
     int dst, rank;
@@ -71,7 +72,7 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
                     mpi_errno = MPIC_Irecv((char *) recvbuf + rdispls[dst],
                                            recvcounts[dst], recvtypes[dst], dst,
                                            MPIR_ALLTOALLW_TAG, comm_ptr,
-                                           &reqarray[outstanding_requests]);
+                                           collattr, &reqarray[outstanding_requests]);
                     MPIR_ERR_CHECK(mpi_errno);
 
                     outstanding_requests++;
@@ -87,7 +88,7 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
                     mpi_errno = MPIC_Isend((char *) sendbuf + sdispls[dst],
                                            sendcounts[dst], sendtypes[dst], dst,
                                            MPIR_ALLTOALLW_TAG, comm_ptr,
-                                           &reqarray[outstanding_requests], errflag);
+                                           &reqarray[outstanding_requests], collattr | errflag);
                     MPIR_ERR_CHECK(mpi_errno);
 
                     outstanding_requests++;

--- a/src/mpi/coll/barrier/barrier_allcomm_nb.c
+++ b/src/mpi/coll/barrier/barrier_allcomm_nb.c
@@ -5,13 +5,13 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Barrier_allcomm_nb(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+int MPIR_Barrier_allcomm_nb(MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno = MPIR_Ibarrier(comm_ptr, &req_ptr);
+    mpi_errno = MPIR_Ibarrier(comm_ptr, collattr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/barrier/barrier_inter_bcast.c
+++ b/src/mpi/coll/barrier/barrier_inter_bcast.c
@@ -17,10 +17,11 @@
  * group.
  */
 
-int MPIR_Barrier_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+int MPIR_Barrier_inter_bcast(MPIR_Comm * comm_ptr, int collattr)
 {
     int rank, mpi_errno = MPI_SUCCESS, root;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int i = 0;
     MPIR_Comm *newcomm_ptr = NULL;
 
@@ -35,28 +36,28 @@ int MPIR_Barrier_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
     newcomm_ptr = comm_ptr->local_comm;
 
     /* do a barrier on the local intracommunicator */
-    mpi_errno = MPIR_Barrier(newcomm_ptr, errflag);
+    mpi_errno = MPIR_Barrier(newcomm_ptr, collattr | errflag);
     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     if (comm_ptr->is_low_group) {
         /* bcast to right */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
-        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
+        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* receive bcast from right */
         root = 0;
-        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
+        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         /* receive bcast from left */
         root = 0;
-        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
+        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* bcast to left */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
-        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
+        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
   fn_exit:

--- a/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
+++ b/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
@@ -16,13 +16,13 @@
  * process i sends to process (i + 2^k) % p and receives from process
  * (i - 2^k + p) % p.
  */
-int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, int collattr)
 {
     int size, rank, src, dst, mask, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
 
-    size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_COLL_GET_RANK_SIZE(comm_ptr, collattr, rank, size);
 
     mask = 0x1;
     while (mask < size) {
@@ -30,7 +30,8 @@ int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t errfla
         src = (rank - mask + size) % size;
         mpi_errno = MPIC_Sendrecv(NULL, 0, MPI_BYTE, dst,
                                   MPIR_BARRIER_TAG, NULL, 0, MPI_BYTE,
-                                  src, MPIR_BARRIER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  src, MPIR_BARRIER_TAG, comm_ptr, MPI_STATUS_IGNORE,
+                                  collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         mask <<= 1;
     }
@@ -41,9 +42,10 @@ int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t errfla
 /* Algorithm: high radix dissemination
  * Similar to dissemination algorithm, but generalized with high radix k
  */
-int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t errflag)
+int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, int collattr)
 {
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int i, j, nranks, rank;
     int p_of_k;                 /* minimum power of k that is greater than or equal to number of ranks */
     int shift, to, from;
@@ -51,8 +53,7 @@ int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t e
     MPIR_Request *sreqs[MAX_RADIX], *rreqs[MAX_RADIX * 2];
     MPIR_Request **send_reqs = NULL, **recv_reqs = NULL;
 
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COLL_GET_RANK_SIZE(comm, collattr, rank, nranks);
 
     if (nranks == 1)
         goto fn_exit;
@@ -61,7 +62,7 @@ int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t e
         k = nranks;
 
     if (k == 2) {
-        return MPIR_Barrier_intra_dissemination(comm, errflag);
+        return MPIR_Barrier_intra_dissemination(comm, collattr);
     }
 
     /* If k value is greater than the maximum radix defined by MAX_RADIX macro,
@@ -95,9 +96,8 @@ int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t e
             MPIR_Assert(to >= 0 && to < nranks);
 
             /* recv from (k-1) nbrs */
-            mpi_errno =
-                MPIC_Irecv(NULL, 0, MPI_BYTE, from, MPIR_BARRIER_TAG, comm,
-                           &recv_reqs[(j - 1) + ((k - 1) * (i & 1))]);
+            mpi_errno = MPIC_Irecv(NULL, 0, MPI_BYTE, from, MPIR_BARRIER_TAG, comm,
+                                   collattr, &recv_reqs[(j - 1) + ((k - 1) * (i & 1))]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             /* wait on recvs from prev phase */
             if (i > 0 && j == 1) {
@@ -106,9 +106,8 @@ int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t e
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
 
-            mpi_errno =
-                MPIC_Isend(NULL, 0, MPI_BYTE, to, MPIR_BARRIER_TAG, comm, &send_reqs[j - 1],
-                           errflag);
+            mpi_errno = MPIC_Isend(NULL, 0, MPI_BYTE, to, MPIR_BARRIER_TAG, comm, &send_reqs[j - 1],
+                                   collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
         mpi_errno = MPIC_Waitall(k - 1, send_reqs, MPI_STATUSES_IGNORE);

--- a/src/mpi/coll/barrier/barrier_intra_recexch.c
+++ b/src/mpi/coll/barrier/barrier_intra_recexch.c
@@ -8,14 +8,13 @@
 
 /* Algorithm: call Allreduce's recursive exchange algorithm
  */
-int MPIR_Barrier_intra_recexch(MPIR_Comm * comm, int k, int single_phase_recv,
-                               MPIR_Errflag_t errflag)
+int MPIR_Barrier_intra_recexch(MPIR_Comm * comm, int k, int single_phase_recv, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Allreduce_intra_recexch(MPI_IN_PLACE, NULL, 0,
                                              MPI_BYTE, MPI_SUM, comm,
-                                             k, single_phase_recv, errflag);
+                                             k, single_phase_recv, collattr);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpi/coll/barrier/barrier_intra_smp.c
+++ b/src/mpi/coll/barrier/barrier_intra_smp.c
@@ -5,22 +5,23 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
 
     MPIR_Assert(MPIR_Comm_is_parent_comm(comm_ptr));
 
     /* do the intranode barrier on all nodes */
     if (comm_ptr->node_comm != NULL) {
-        mpi_errno = MPIR_Barrier(comm_ptr->node_comm, errflag);
+        mpi_errno = MPIR_Barrier(comm_ptr->node_comm, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     /* do the barrier across roots of all nodes */
     if (comm_ptr->node_roots_comm != NULL) {
-        mpi_errno = MPIR_Barrier(comm_ptr->node_roots_comm, errflag);
+        mpi_errno = MPIR_Barrier(comm_ptr->node_roots_comm, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
@@ -29,7 +30,7 @@ int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
      * anything) */
     if (comm_ptr->node_comm != NULL) {
         int i = 0;
-        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, 0, comm_ptr->node_comm, errflag);
+        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, 0, comm_ptr->node_comm, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/bcast/bcast.h
+++ b/src/mpi/coll/bcast/bcast.h
@@ -10,6 +10,6 @@
 
 int MPII_Scatter_for_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
                            int root, MPIR_Comm * comm_ptr, MPI_Aint nbytes, void *tmp_buf,
-                           int is_contig, MPIR_Errflag_t errflag);
+                           int is_contig, int collattr);
 
 #endif /* BCAST_H_INCLUDED */

--- a/src/mpi/coll/bcast/bcast_allcomm_nb.c
+++ b/src/mpi/coll/bcast/bcast_allcomm_nb.c
@@ -6,13 +6,13 @@
 #include "mpiimpl.h"
 
 int MPIR_Bcast_allcomm_nb(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                          MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                          MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno = MPIR_Ibcast(buffer, count, datatype, root, comm_ptr, &req_ptr);
+    mpi_errno = MPIR_Ibcast(buffer, count, datatype, root, comm_ptr, collattr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -12,13 +12,13 @@
  */
 int MPIR_Bcast_intra_binomial(void *buffer,
                               MPI_Aint count,
-                              MPI_Datatype datatype,
-                              int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                              MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr, int collattr)
 {
     int rank, comm_size, src, dst;
     int relative_rank, mask;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Aint nbytes = 0;
     MPI_Status *status_p;
 #ifdef HAVE_ERROR_CHECKING
@@ -93,10 +93,10 @@ int MPIR_Bcast_intra_binomial(void *buffer,
                 src += comm_size;
             if (!is_contig)
                 mpi_errno = MPIC_Recv(tmp_buf, nbytes, MPI_BYTE, src,
-                                      MPIR_BCAST_TAG, comm_ptr, status_p);
+                                      MPIR_BCAST_TAG, comm_ptr, collattr, status_p);
             else
                 mpi_errno = MPIC_Recv(buffer, count, datatype, src,
-                                      MPIR_BCAST_TAG, comm_ptr, status_p);
+                                      MPIR_BCAST_TAG, comm_ptr, collattr, status_p);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 #ifdef HAVE_ERROR_CHECKING
             /* check that we received as much as we expected */
@@ -127,10 +127,10 @@ int MPIR_Bcast_intra_binomial(void *buffer,
                 dst -= comm_size;
             if (!is_contig)
                 mpi_errno = MPIC_Send(tmp_buf, nbytes, MPI_BYTE, dst,
-                                      MPIR_BCAST_TAG, comm_ptr, errflag);
+                                      MPIR_BCAST_TAG, comm_ptr, collattr | errflag);
             else
                 mpi_errno = MPIC_Send(buffer, count, datatype, dst,
-                                      MPIR_BCAST_TAG, comm_ptr, errflag);
+                                      MPIR_BCAST_TAG, comm_ptr, collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
         mask >>= 1;

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -29,14 +29,14 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                                                           MPI_Aint count,
                                                           MPI_Datatype datatype,
                                                           int root,
-                                                          MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t errflag)
+                                                          MPIR_Comm * comm_ptr, int collattr)
 {
     MPI_Status status;
     int rank, comm_size, dst;
     int relative_rank, mask;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Aint curr_size, recv_size = 0;
     int j, k, i, tmp_mask, is_contig;
     MPI_Aint type_size, nbytes;
@@ -80,7 +80,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
     scatter_size = (nbytes + comm_size - 1) / comm_size;        /* ceiling division */
 
     mpi_errno = MPII_Scatter_for_bcast(buffer, count, datatype, root, comm_ptr,
-                                       nbytes, tmp_buf, is_contig, errflag);
+                                       nbytes, tmp_buf, is_contig, collattr | errflag);
     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
     /* curr_size is the amount of data that this process now has stored in
@@ -120,7 +120,8 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                                       curr_size, MPI_BYTE, dst, MPIR_BCAST_TAG,
                                       ((char *) tmp_buf + recv_offset),
                                       (nbytes - recv_offset < 0 ? 0 : nbytes - recv_offset),
-                                      MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, &status, errflag);
+                                      MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, &status,
+                                      collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             if (mpi_errno) {
                 recv_size = 0;
@@ -185,7 +186,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                      * fflush(stdout); */
                     mpi_errno = MPIC_Send(((char *) tmp_buf + offset),
                                           recv_size, MPI_BYTE, dst,
-                                          MPIR_BCAST_TAG, comm_ptr, errflag);
+                                          MPIR_BCAST_TAG, comm_ptr, collattr | errflag);
                     /* recv_size was set in the previous
                      * receive. that's the amount of data to be
                      * sent now. */
@@ -200,7 +201,8 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                      * relative_rank, dst); */
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset),
                                           nbytes - offset < 0 ? 0 : nbytes - offset,
-                                          MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, &status);
+                                          MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, collattr,
+                                          &status);
                     /* nprocs_completed is also equal to the no. of processes
                      * whose data we don't have */
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);

--- a/src/mpi/coll/bcast/bcast_utils.c
+++ b/src/mpi/coll/bcast/bcast_utils.c
@@ -21,13 +21,14 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
                            MPI_Datatype datatype ATTRIBUTE((unused)),
                            int root,
                            MPIR_Comm * comm_ptr,
-                           MPI_Aint nbytes, void *tmp_buf, int is_contig, MPIR_Errflag_t errflag)
+                           MPI_Aint nbytes, void *tmp_buf, int is_contig, int collattr)
 {
     MPI_Status status;
     int rank, comm_size, src, dst;
     int relative_rank, mask;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Aint scatter_size, recv_size = 0;
     MPI_Aint curr_size, send_size;
 
@@ -67,7 +68,8 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
             } else {
                 mpi_errno = MPIC_Recv(((char *) tmp_buf +
                                        relative_rank * scatter_size),
-                                      recv_size, MPI_BYTE, src, MPIR_BCAST_TAG, comm_ptr, &status);
+                                      recv_size, MPI_BYTE, src, MPIR_BCAST_TAG, comm_ptr, collattr,
+                                      &status);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 if (mpi_errno) {
                     curr_size = 0;
@@ -97,7 +99,8 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
                     dst -= comm_size;
                 mpi_errno = MPIC_Send(((char *) tmp_buf +
                                        scatter_size * (relative_rank + mask)),
-                                      send_size, MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, errflag);
+                                      send_size, MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr,
+                                      collattr | errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                 curr_size -= send_size;

--- a/src/mpi/coll/exscan/exscan_allcomm_nb.c
+++ b/src/mpi/coll/exscan/exscan_allcomm_nb.c
@@ -6,14 +6,13 @@
 #include "mpiimpl.h"
 
 int MPIR_Exscan_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
-                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                           MPIR_Errflag_t errflag)
+                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno = MPIR_Iexscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
+    mpi_errno = MPIR_Iexscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, collattr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
@@ -48,12 +48,13 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
                                          void *recvbuf,
                                          MPI_Aint count,
                                          MPI_Datatype datatype,
-                                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                         MPI_Op op, MPIR_Comm * comm_ptr, int collattr)
 {
     MPI_Status status;
     int rank, comm_size;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int mask, dst, is_commutative, flag;
     MPI_Aint true_extent, true_lb, extent;
     void *partial_scan, *tmp_buf;
@@ -94,7 +95,7 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
             mpi_errno = MPIC_Sendrecv(partial_scan, count, datatype,
                                       dst, MPIR_EXSCAN_TAG, tmp_buf,
                                       count, datatype, dst,
-                                      MPIR_EXSCAN_TAG, comm_ptr, &status, errflag);
+                                      MPIR_EXSCAN_TAG, comm_ptr, &status, collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             if (rank > dst) {

--- a/src/mpi/coll/gather/gather_allcomm_nb.c
+++ b/src/mpi/coll/gather/gather_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Gather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                            void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                           MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                           MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
@@ -15,7 +15,7 @@ int MPIR_Gather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Igather(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr,
-                     &req_ptr);
+                     collattr, &req_ptr);
 
     mpi_errno = MPIC_Wait(req_ptr);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/coll/gather/gather_inter_linear.c
+++ b/src/mpi/coll/gather/gather_inter_linear.c
@@ -15,10 +15,11 @@
 
 int MPIR_Gather_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                             MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                             MPIR_Comm * comm_ptr, int collattr)
 {
     int remote_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int i;
     MPI_Status status;
     MPI_Aint extent;
@@ -36,12 +37,13 @@ int MPIR_Gather_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Dataty
         for (i = 0; i < remote_size; i++) {
             mpi_errno =
                 MPIC_Recv(((char *) recvbuf + recvcount * i * extent), recvcount, recvtype, i,
-                          MPIR_GATHER_TAG, comm_ptr, &status);
+                          MPIR_GATHER_TAG, comm_ptr, collattr, &status);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     } else {
         mpi_errno =
-            MPIC_Send(sendbuf, sendcount, sendtype, root, MPIR_GATHER_TAG, comm_ptr, errflag);
+            MPIC_Send(sendbuf, sendcount, sendtype, root, MPIR_GATHER_TAG, comm_ptr,
+                      collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
+++ b/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
@@ -16,10 +16,11 @@
 int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
                                                MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                               MPIR_Comm * comm_ptr, int collattr)
 {
     int rank, local_size, remote_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Status status;
     MPIR_Comm *newcomm_ptr = NULL;
     MPIR_CHKLMEM_DECL(1);
@@ -36,7 +37,7 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sen
         /* root receives data from rank 0 on remote group */
         mpi_errno =
             MPIC_Recv(recvbuf, recvcount * remote_size, recvtype, 0, MPIR_GATHER_TAG, comm_ptr,
-                      &status);
+                      collattr, &status);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         /* remote group. Rank 0 allocates temporary buffer, does
@@ -68,12 +69,12 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sen
         /* now do the a local gather on this intracommunicator */
         mpi_errno = MPIR_Gather(sendbuf, sendcount, sendtype,
                                 tmp_buf, sendcount * sendtype_sz, MPI_BYTE, 0, newcomm_ptr,
-                                errflag);
+                                collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         if (rank == 0) {
             mpi_errno = MPIC_Send(tmp_buf, sendcount * local_size * sendtype_sz, MPI_BYTE,
-                                  root, MPIR_GATHER_TAG, comm_ptr, errflag);
+                                  root, MPIR_GATHER_TAG, comm_ptr, collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -39,11 +39,12 @@ cvars:
  */
 int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                               MPIR_Comm * comm_ptr, int collattr)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int relative_rank;
     int mask, src, dst, relative_src;
     MPI_Aint curr_cnt = 0, nbytes, sendtype_size, recvtype_size;
@@ -139,13 +140,15 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                                                (((rank +
                                                   mask) % comm_size) * (MPI_Aint) recvcount *
                                                 extent)), (MPI_Aint) recvblks * recvcount,
-                                              recvtype, src, MPIR_GATHER_TAG, comm_ptr, &status);
+                                              recvtype, src, MPIR_GATHER_TAG, comm_ptr, collattr,
+                                              &status);
                         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
                         /* small transfer size case. cast ok */
                         MPIR_Assert(recvblks * nbytes == (int) (recvblks * nbytes));
                         mpi_errno = MPIC_Recv(tmp_buf, (int) (recvblks * nbytes),
-                                              MPI_BYTE, src, MPIR_GATHER_TAG, comm_ptr, &status);
+                                              MPI_BYTE, src, MPIR_GATHER_TAG, comm_ptr, collattr,
+                                              &status);
                         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                         copy_offset = rank + mask;
                         copy_blks = recvblks;
@@ -165,7 +168,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                         MPIR_ERR_CHECK(mpi_errno);
 
                         mpi_errno = MPIC_Recv(recvbuf, 1, tmp_type, src,
-                                              MPIR_GATHER_TAG, comm_ptr, &status);
+                                              MPIR_GATHER_TAG, comm_ptr, collattr, &status);
                         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
                         MPIR_Type_free_impl(&tmp_type);
@@ -186,7 +189,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                         offset = (mask - 1) * nbytes;
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset),
                                           recvblks * nbytes, MPI_BYTE, src,
-                                          MPIR_GATHER_TAG, comm_ptr, &status);
+                                          MPIR_GATHER_TAG, comm_ptr, collattr, &status);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                     curr_cnt += (recvblks * nbytes);
                 }
@@ -198,11 +201,11 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
             if (!tmp_buf_size) {
                 /* leaf nodes send directly from sendbuf */
                 mpi_errno = MPIC_Send(sendbuf, sendcount, sendtype, dst,
-                                      MPIR_GATHER_TAG, comm_ptr, errflag);
+                                      MPIR_GATHER_TAG, comm_ptr, collattr | errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
                 mpi_errno = MPIC_Send(tmp_buf, curr_cnt, MPI_BYTE, dst,
-                                      MPIR_GATHER_TAG, comm_ptr, errflag);
+                                      MPIR_GATHER_TAG, comm_ptr, collattr | errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else {
                 MPI_Aint blocks[2];
@@ -227,7 +230,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                 MPIR_ERR_CHECK(mpi_errno);
 
                 mpi_errno = MPIC_Send(MPI_BOTTOM, 1, tmp_type, dst,
-                                      MPIR_GATHER_TAG, comm_ptr, errflag);
+                                      MPIR_GATHER_TAG, comm_ptr, collattr | errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 MPIR_Type_free_impl(&tmp_type);
                 if (types[1] != MPI_BYTE)

--- a/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
@@ -41,12 +41,12 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
                                 void *recvbuf,
                                 const MPI_Aint * recvcounts,
                                 const MPI_Aint * displs,
-                                MPI_Datatype recvtype,
-                                int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, int collattr)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Aint extent;
     int i, reqs;
     int min_procs;
@@ -84,7 +84,7 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
                 } else {
                     mpi_errno = MPIC_Irecv(((char *) recvbuf + displs[i] * extent),
                                            recvcounts[i], recvtype, i,
-                                           MPIR_GATHERV_TAG, comm_ptr, &reqarray[reqs++]);
+                                           MPIR_GATHERV_TAG, comm_ptr, collattr, &reqarray[reqs++]);
                     MPIR_ERR_CHECK(mpi_errno);
                 }
             }
@@ -109,11 +109,11 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
 
             if (comm_size >= min_procs) {
                 mpi_errno = MPIC_Ssend(sendbuf, sendcount, sendtype, root,
-                                       MPIR_GATHERV_TAG, comm_ptr, errflag);
+                                       MPIR_GATHERV_TAG, comm_ptr, collattr | errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else {
                 mpi_errno = MPIC_Send(sendbuf, sendcount, sendtype, root,
-                                      MPIR_GATHERV_TAG, comm_ptr, errflag);
+                                      MPIR_GATHERV_TAG, comm_ptr, collattr | errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }

--- a/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
@@ -7,8 +7,7 @@
 
 int MPIR_Gatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                             void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
-                            MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                            MPIR_Errflag_t errflag)
+                            MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
@@ -16,7 +15,7 @@ int MPIR_Gatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Igatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root,
-                      comm_ptr, &req_ptr);
+                      comm_ptr, collattr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/iallgather/iallgather_inter_sched_local_gather_remote_bcast.c
+++ b/src/mpi/coll/iallgather/iallgather_inter_sched_local_gather_remote_bcast.c
@@ -14,7 +14,8 @@
 int MPIR_Iallgather_inter_sched_local_gather_remote_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                           MPI_Datatype sendtype, void *recvbuf,
                                                           MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                          MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                          MPIR_Comm * comm_ptr, int collattr,
+                                                          MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, local_size, remote_size, root;
@@ -46,7 +47,7 @@ int MPIR_Iallgather_inter_sched_local_gather_remote_bcast(const void *sendbuf, M
     if (sendcount != 0) {
         mpi_errno = MPIR_Igather_intra_sched_auto(sendbuf, sendcount, sendtype,
                                                   tmp_buf, sendcount * sendtype_sz, MPI_BYTE, 0,
-                                                  newcomm_ptr, s);
+                                                  newcomm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
@@ -58,7 +59,7 @@ int MPIR_Iallgather_inter_sched_local_gather_remote_bcast(const void *sendbuf, M
         if (sendcount != 0) {
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Ibcast_inter_sched_auto(tmp_buf, sendcount * local_size * sendtype_sz,
-                                                     MPI_BYTE, root, comm_ptr, s);
+                                                     MPI_BYTE, root, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
 
@@ -68,7 +69,7 @@ int MPIR_Iallgather_inter_sched_local_gather_remote_bcast(const void *sendbuf, M
         if (recvcount != 0) {
             root = 0;
             mpi_errno = MPIR_Ibcast_inter_sched_auto(recvbuf, recvcount * remote_size,
-                                                     recvtype, root, comm_ptr, s);
+                                                     recvtype, root, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
         MPIR_SCHED_BARRIER(s);
@@ -77,7 +78,7 @@ int MPIR_Iallgather_inter_sched_local_gather_remote_bcast(const void *sendbuf, M
         if (recvcount != 0) {
             root = 0;
             mpi_errno = MPIR_Ibcast_inter_sched_auto(recvbuf, recvcount * remote_size,
-                                                     recvtype, root, comm_ptr, s);
+                                                     recvtype, root, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
 
@@ -87,7 +88,7 @@ int MPIR_Iallgather_inter_sched_local_gather_remote_bcast(const void *sendbuf, M
         if (sendcount != 0) {
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Ibcast_inter_sched_auto(tmp_buf, sendcount * local_size * sendtype_sz,
-                                                     MPI_BYTE, root, comm_ptr, s);
+                                                     MPI_BYTE, root, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/iallgather/iallgather_intra_sched_brucks.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_sched_brucks.c
@@ -16,7 +16,8 @@
  */
 int MPIR_Iallgather_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
                                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr,
+                                       MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int pof2, rem, src, dst;
@@ -56,11 +57,12 @@ int MPIR_Iallgather_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
         src = (rank + pof2) % comm_size;
         dst = (rank - pof2 + comm_size) % comm_size;
 
-        mpi_errno = MPIR_Sched_send(tmp_buf, curr_cnt * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_send(tmp_buf, curr_cnt * recvtype_sz, MPI_BYTE, dst, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         /* logically sendrecv, so no barrier here */
         mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + curr_cnt * recvtype_sz),
-                                    curr_cnt * recvtype_sz, MPI_BYTE, src, comm_ptr, s);
+                                    curr_cnt * recvtype_sz, MPI_BYTE, src, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
@@ -76,11 +78,13 @@ int MPIR_Iallgather_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
         dst = (rank - pof2 + comm_size) % comm_size;
 
         mpi_errno =
-            MPIR_Sched_send(tmp_buf, rem * recvcount * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
+            MPIR_Sched_send(tmp_buf, rem * recvcount * recvtype_sz, MPI_BYTE, dst, comm_ptr,
+                            collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         /* logically sendrecv, so no barrier here */
         mpi_errno = MPIR_Sched_recv((char *) tmp_buf + curr_cnt * recvtype_sz,
-                                    rem * recvcount * recvtype_sz, MPI_BYTE, src, comm_ptr, s);
+                                    rem * recvcount * recvtype_sz, MPI_BYTE, src, comm_ptr,
+                                    collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }

--- a/src/mpi/coll/iallgather/iallgather_intra_sched_ring.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_sched_ring.c
@@ -22,7 +22,8 @@
  */
 int MPIR_Iallgather_intra_sched_ring(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype
                                      sendtype, void *recvbuf, MPI_Aint recvcount,
-                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr,
+                                     MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size;
@@ -52,11 +53,11 @@ int MPIR_Iallgather_intra_sched_ring(const void *sendbuf, MPI_Aint sendcount, MP
     jnext = left;
     for (i = 1; i < comm_size; i++) {
         mpi_errno = MPIR_Sched_send(((char *) recvbuf + j * recvcount * recvtype_extent),
-                                    recvcount, recvtype, right, comm_ptr, s);
+                                    recvcount, recvtype, right, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         /* concurrent, no barrier here */
         mpi_errno = MPIR_Sched_recv(((char *) recvbuf + jnext * recvcount * recvtype_extent),
-                                    recvcount, recvtype, left, comm_ptr, s);
+                                    recvcount, recvtype, left, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks.c
@@ -10,7 +10,8 @@ int
 MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                        MPI_Datatype sendtype, void *recvbuf,
                                        MPI_Aint recvcount, MPI_Datatype recvtype,
-                                       MPIR_Comm * comm, int k, MPIR_TSP_sched_t sched)
+                                       MPIR_Comm * comm, int k, int collattr,
+                                       MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -117,18 +118,19 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
             /* Receive at the exact location. */
             mpi_errno =
                 MPIR_TSP_sched_irecv((char *) tmp_recvbuf + j * recvcount * delta * recvtype_extent,
-                                     count, recvtype, src, tag, comm, sched, 0, NULL, &vtx_id);
+                                     count, recvtype, src, tag, comm, collattr, sched, 0, NULL,
+                                     &vtx_id);
 
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             recv_id[i_recv++] = vtx_id;
             /* Send from the start of recv till `count` amount of data. */
             if (i == 0)
                 mpi_errno =
-                    MPIR_TSP_sched_isend(tmp_recvbuf, count, recvtype, dst, tag, comm, sched, 0,
-                                         NULL, &vtx_id);
+                    MPIR_TSP_sched_isend(tmp_recvbuf, count, recvtype, dst, tag, comm, collattr,
+                                         sched, 0, NULL, &vtx_id);
             else
                 mpi_errno = MPIR_TSP_sched_isend(tmp_recvbuf, count, recvtype, dst, tag,
-                                                 comm, sched, n_invtcs, recv_id, &vtx_id);
+                                                 comm, collattr, sched, n_invtcs, recv_id, &vtx_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
         n_invtcs += (k - 1);

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring.c
@@ -9,7 +9,7 @@
 int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                                          MPI_Datatype sendtype, void *recvbuf,
                                          MPI_Aint recvcount, MPI_Datatype recvtype,
-                                         MPIR_Comm * comm, MPIR_TSP_sched_t sched)
+                                         MPIR_Comm * comm, int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -91,14 +91,16 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
             nvtcs = 1;
             vtcs[0] = dtcopy_id[0];
             mpi_errno = MPIR_TSP_sched_isend((char *) sbuf, recvcount, recvtype,
-                                             dst, tag, comm, sched, nvtcs, vtcs, &send_id[0]);
+                                             dst, tag, comm, collattr, sched, nvtcs, vtcs,
+                                             &send_id[0]);
             nvtcs = 0;
         } else {
             nvtcs = 2;
             vtcs[0] = recv_id[(i - 1) % 3];
             vtcs[1] = send_id[(i - 1) % 3];
             mpi_errno = MPIR_TSP_sched_isend((char *) sbuf, recvcount, recvtype,
-                                             dst, tag, comm, sched, nvtcs, vtcs, &send_id[i % 3]);
+                                             dst, tag, comm, collattr, sched, nvtcs, vtcs,
+                                             &send_id[i % 3]);
             if (i == 1) {
                 nvtcs = 2;
                 vtcs[0] = send_id[0];
@@ -113,7 +115,8 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         mpi_errno = MPIR_TSP_sched_irecv((char *) rbuf, recvcount, recvtype,
-                                         src, tag, comm, sched, nvtcs, vtcs, &recv_id[i % 3]);
+                                         src, tag, comm, collattr, sched, nvtcs, vtcs,
+                                         &recv_id[i % 3]);
 
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 

--- a/src/mpi/coll/iallgatherv/iallgatherv_inter_sched_remote_gather_local_bcast.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_inter_sched_remote_gather_local_bcast.c
@@ -21,7 +21,8 @@ int MPIR_Iallgatherv_inter_sched_remote_gather_local_bcast(const void *sendbuf, 
                                                            const MPI_Aint recvcounts[],
                                                            const MPI_Aint displs[],
                                                            MPI_Datatype recvtype,
-                                                           MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                           MPIR_Comm * comm_ptr, int collattr,
+                                                           MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int remote_size, root, rank;
@@ -37,23 +38,27 @@ int MPIR_Iallgatherv_inter_sched_remote_gather_local_bcast(const void *sendbuf, 
         /* gatherv from right group */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Igatherv_inter_sched_auto(sendbuf, sendcount, sendtype, recvbuf,
-                                                   recvcounts, displs, recvtype, root, comm_ptr, s);
+                                                   recvcounts, displs, recvtype, root, comm_ptr,
+                                                   collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         /* gatherv to right group */
         root = 0;
         mpi_errno = MPIR_Igatherv_inter_sched_auto(sendbuf, sendcount, sendtype, recvbuf,
-                                                   recvcounts, displs, recvtype, root, comm_ptr, s);
+                                                   recvcounts, displs, recvtype, root, comm_ptr,
+                                                   collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* gatherv to left group  */
         root = 0;
         mpi_errno = MPIR_Igatherv_inter_sched_auto(sendbuf, sendcount, sendtype, recvbuf,
-                                                   recvcounts, displs, recvtype, root, comm_ptr, s);
+                                                   recvcounts, displs, recvtype, root, comm_ptr,
+                                                   collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         /* gatherv from left group */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Igatherv_inter_sched_auto(sendbuf, sendcount, sendtype, recvbuf,
-                                                   recvcounts, displs, recvtype, root, comm_ptr, s);
+                                                   recvcounts, displs, recvtype, root, comm_ptr,
+                                                   collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -76,7 +81,7 @@ int MPIR_Iallgatherv_inter_sched_remote_gather_local_bcast(const void *sendbuf, 
     mpi_errno = MPIR_Type_commit_impl(&newtype);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIR_Ibcast_intra_sched_auto(recvbuf, 1, newtype, 0, newcomm_ptr, s);
+    mpi_errno = MPIR_Ibcast_intra_sched_auto(recvbuf, 1, newtype, 0, newcomm_ptr, collattr, s);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Type_free_impl(&newtype);

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_brucks.c
@@ -8,7 +8,8 @@
 int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
                                         MPI_Datatype sendtype, void *recvbuf,
                                         const MPI_Aint recvcounts[], const MPI_Aint displs[],
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr,
+                                        MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, rank, j, i;
@@ -69,11 +70,14 @@ int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
             incoming_count += recvcounts[(src + i) % comm_size];
         }
 
-        mpi_errno = MPIR_Sched_send(tmp_buf, curr_count * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_send(tmp_buf, curr_count * recvtype_sz, MPI_BYTE, dst, comm_ptr, collattr,
+                            s);
         MPIR_ERR_CHECK(mpi_errno);
         /* sendrecv, no barrier */
         mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + curr_count * recvtype_sz),
-                                    incoming_count * recvtype_sz, MPI_BYTE, src, comm_ptr, s);
+                                    incoming_count * recvtype_sz, MPI_BYTE, src, comm_ptr, collattr,
+                                    s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
@@ -92,12 +96,13 @@ int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
         for (i = 0; i < rem; i++)
             cnt += recvcounts[(rank + i) % comm_size];
 
-        mpi_errno = MPIR_Sched_send(tmp_buf, cnt * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_send(tmp_buf, cnt * recvtype_sz, MPI_BYTE, dst, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         /* sendrecv, no barrier */
         mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + curr_count * recvtype_sz),
                                     (total_count - curr_count) * recvtype_sz, MPI_BYTE,
-                                    src, comm_ptr, s);
+                                    src, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_recursive_doubling.c
@@ -9,7 +9,8 @@ int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, MPI_Ain
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const MPI_Aint recvcounts[],
                                                     const MPI_Aint displs[], MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                    MPIR_Comm * comm_ptr, int collattr,
+                                                    MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, rank, i, j, k;
@@ -108,11 +109,13 @@ int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, MPI_Ain
                 incoming_count += recvcounts[j];
 
             mpi_errno = MPIR_Sched_send(((char *) tmp_buf + send_offset * recvtype_sz),
-                                        curr_count * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
+                                        curr_count * recvtype_sz, MPI_BYTE, dst, comm_ptr, collattr,
+                                        s);
             MPIR_ERR_CHECK(mpi_errno);
             /* sendrecv, no barrier here */
             mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + recv_offset * recvtype_sz),
-                                        incoming_count * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
+                                        incoming_count * recvtype_sz, MPI_BYTE, dst, comm_ptr,
+                                        collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
@@ -177,7 +180,7 @@ int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, MPI_Ain
                      * sent now. */
                     mpi_errno = MPIR_Sched_send(((char *) tmp_buf + offset),
                                                 incoming_count * recvtype_sz, MPI_BYTE,
-                                                dst, comm_ptr, s);
+                                                dst, comm_ptr, collattr, s);
                     MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                 }
@@ -199,7 +202,7 @@ int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, MPI_Ain
 
                     mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + offset * recvtype_sz),
                                                 incoming_count * recvtype_sz, MPI_BYTE,
-                                                dst, comm_ptr, s);
+                                                dst, comm_ptr, collattr, s);
                     MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                     curr_count += incoming_count;

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_ring.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_ring.c
@@ -8,7 +8,8 @@
 int MPIR_Iallgatherv_intra_sched_ring(const void *sendbuf, MPI_Aint sendcount,
                                       MPI_Datatype sendtype, void *recvbuf,
                                       const MPI_Aint recvcounts[], const MPI_Aint displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr,
+                                      MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, total_count;
@@ -77,12 +78,12 @@ int MPIR_Iallgatherv_intra_sched_ring(const void *sendbuf, MPI_Aint sendcount,
 
         /* Communicate */
         if (recvnow) {  /* If there's no data to send, just do a recv call */
-            mpi_errno = MPIR_Sched_recv(rbuf, recvnow, recvtype, left, comm_ptr, s);
+            mpi_errno = MPIR_Sched_recv(rbuf, recvnow, recvtype, left, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             torecv -= recvnow;
         }
         if (sendnow) {  /* If there's no data to receive, just do a send call */
-            mpi_errno = MPIR_Sched_send(sbuf, sendnow, recvtype, right, comm_ptr, s);
+            mpi_errno = MPIR_Sched_send(sbuf, sendnow, recvtype, right, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             tosend -= sendnow;
         }

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks.c
@@ -30,7 +30,7 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                         MPI_Datatype sendtype, void *recvbuf,
                                         const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                         MPI_Datatype recvtype, MPIR_Comm * comm,
-                                        int k, MPIR_TSP_sched_t sched)
+                                        int k, int collattr, MPIR_TSP_sched_t sched)
 {
     int i, j, l;
     int nphases = 0;
@@ -219,8 +219,8 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
             /* Recv at the exact location */
             mpi_errno =
                 MPIR_TSP_sched_irecv((char *) tmp_recvbuf + recv_index[idx] * recvtype_extent,
-                                     r_counts[i][j - 1], recvtype, src, tag, comm, sched, 0, NULL,
-                                     &vtx_id);
+                                     r_counts[i][j - 1], recvtype, src, tag, comm, collattr, sched,
+                                     0, NULL, &vtx_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             recv_id[idx] = vtx_id;
@@ -229,7 +229,7 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
             /* Send from the start of recv till the count amount of data */
             mpi_errno =
                 MPIR_TSP_sched_isend(tmp_recvbuf, s_counts[i][j - 1], recvtype, dst, tag, comm,
-                                     sched, n_invtcs, recv_id, &vtx_id);
+                                     collattr, sched, n_invtcs, recv_id, &vtx_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
         n_invtcs += (k - 1);

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring.c
@@ -11,7 +11,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
                                           MPI_Datatype sendtype, void *recvbuf,
                                           const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                           MPI_Datatype recvtype, MPIR_Comm * comm,
-                                          MPIR_TSP_sched_t sched)
+                                          int collattr, MPIR_TSP_sched_t sched)
 {
     size_t extent;
     MPI_Aint lb, true_extent;
@@ -95,8 +95,8 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
             vtcs[0] = dtcopy_id[0];
 
             mpi_errno =
-                MPIR_TSP_sched_isend(sbuf, recvcounts[send_rank], recvtype, dst, tag, comm, sched,
-                                     nvtcs, vtcs, &send_id[i % 3]);
+                MPIR_TSP_sched_isend(sbuf, recvcounts[send_rank], recvtype, dst, tag, comm,
+                                     collattr, sched, nvtcs, vtcs, &send_id[i % 3]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             nvtcs = 0;
         } else {
@@ -105,8 +105,8 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
             vtcs[1] = send_id[(i - 1) % 3];
 
             mpi_errno =
-                MPIR_TSP_sched_isend(sbuf, recvcounts[send_rank], recvtype, dst, tag, comm, sched,
-                                     nvtcs, vtcs, &send_id[i % 3]);
+                MPIR_TSP_sched_isend(sbuf, recvcounts[send_rank], recvtype, dst, tag, comm,
+                                     collattr, sched, nvtcs, vtcs, &send_id[i % 3]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             if (i == 1) {
@@ -122,8 +122,8 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
         }
 
         mpi_errno =
-            MPIR_TSP_sched_irecv(rbuf, recvcounts[recv_rank], recvtype, src, tag, comm, sched,
-                                 nvtcs, vtcs, &recv_id[i % 3]);
+            MPIR_TSP_sched_irecv(rbuf, recvcounts[recv_rank], recvtype, src, tag, comm, collattr,
+                                 sched, nvtcs, vtcs, &recv_id[i % 3]);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         /* Copy to correct position in recvbuf */
         mpi_errno =

--- a/src/mpi/coll/iallreduce/iallreduce_inter_sched_remote_reduce_local_bcast.c
+++ b/src/mpi/coll/iallreduce/iallreduce_inter_sched_remote_reduce_local_bcast.c
@@ -19,7 +19,7 @@
 int MPIR_Iallreduce_inter_sched_remote_reduce_local_bcast(const void *sendbuf, void *recvbuf,
                                                           MPI_Aint count, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm_ptr,
-                                                          MPIR_Sched_t s)
+                                                          int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, root;
@@ -35,7 +35,8 @@ int MPIR_Iallreduce_inter_sched_remote_reduce_local_bcast(const void *sendbuf, v
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno =
-            MPIR_Ireduce_inter_sched_auto(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, s);
+            MPIR_Ireduce_inter_sched_auto(sendbuf, recvbuf, count, datatype, op, root, comm_ptr,
+                                          collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
 
         /* no barrier, these reductions can be concurrent */
@@ -43,13 +44,15 @@ int MPIR_Iallreduce_inter_sched_remote_reduce_local_bcast(const void *sendbuf, v
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno =
-            MPIR_Ireduce_inter_sched_auto(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, s);
+            MPIR_Ireduce_inter_sched_auto(sendbuf, recvbuf, count, datatype, op, root, comm_ptr,
+                                          collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* reduce to rank 0 of left group */
         root = 0;
         mpi_errno =
-            MPIR_Ireduce_inter_sched_auto(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, s);
+            MPIR_Ireduce_inter_sched_auto(sendbuf, recvbuf, count, datatype, op, root, comm_ptr,
+                                          collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
 
         /* no barrier, these reductions can be concurrent */
@@ -57,7 +60,8 @@ int MPIR_Iallreduce_inter_sched_remote_reduce_local_bcast(const void *sendbuf, v
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno =
-            MPIR_Ireduce_inter_sched_auto(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, s);
+            MPIR_Ireduce_inter_sched_auto(sendbuf, recvbuf, count, datatype, op, root, comm_ptr,
+                                          collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -72,7 +76,7 @@ int MPIR_Iallreduce_inter_sched_remote_reduce_local_bcast(const void *sendbuf, v
     }
     lcomm_ptr = comm_ptr->local_comm;
 
-    mpi_errno = MPIR_Ibcast_intra_sched_auto(recvbuf, count, datatype, 0, lcomm_ptr, s);
+    mpi_errno = MPIR_Ibcast_intra_sched_auto(recvbuf, count, datatype, 0, lcomm_ptr, collattr, s);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpi/coll/iallreduce/iallreduce_intra_sched_naive.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_sched_naive.c
@@ -8,7 +8,7 @@
 /* implements the naive intracomm allreduce, that is, reduce followed by bcast */
 int MPIR_Iallreduce_intra_sched_naive(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                      MPIR_Sched_t s)
+                                      int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank;
@@ -17,17 +17,19 @@ int MPIR_Iallreduce_intra_sched_naive(const void *sendbuf, void *recvbuf, MPI_Ai
 
     if ((sendbuf == MPI_IN_PLACE) && (rank != 0)) {
         mpi_errno =
-            MPIR_Ireduce_intra_sched_auto(recvbuf, NULL, count, datatype, op, 0, comm_ptr, s);
+            MPIR_Ireduce_intra_sched_auto(recvbuf, NULL, count, datatype, op, 0, comm_ptr, collattr,
+                                          s);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         mpi_errno =
-            MPIR_Ireduce_intra_sched_auto(sendbuf, recvbuf, count, datatype, op, 0, comm_ptr, s);
+            MPIR_Ireduce_intra_sched_auto(sendbuf, recvbuf, count, datatype, op, 0, comm_ptr,
+                                          collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_SCHED_BARRIER(s);
 
-    mpi_errno = MPIR_Ibcast_intra_sched_auto(recvbuf, count, datatype, 0, comm_ptr, s);
+    mpi_errno = MPIR_Ibcast_intra_sched_auto(recvbuf, count, datatype, 0, comm_ptr, collattr, s);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpi/coll/iallreduce/iallreduce_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_sched_recursive_doubling.c
@@ -7,7 +7,8 @@
 
 int MPIR_Iallreduce_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf,
                                                    MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                   MPIR_Comm * comm_ptr, int collattr,
+                                                   MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int pof2, rem, comm_size, is_commutative, rank;
@@ -18,7 +19,7 @@ int MPIR_Iallreduce_intra_sched_recursive_doubling(const void *sendbuf, void *re
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
 
-    is_commutative = MPIR_Op_is_commutative(op);
+    is_commutative = collattr, MPIR_Op_is_commutative(op);
 
     /* need to allocate temporary buffer to store incoming data */
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
@@ -50,7 +51,7 @@ int MPIR_Iallreduce_intra_sched_recursive_doubling(const void *sendbuf, void *re
 
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
-            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank + 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank + 1, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
@@ -59,7 +60,7 @@ int MPIR_Iallreduce_intra_sched_recursive_doubling(const void *sendbuf, void *re
              * doubling */
             newrank = -1;
         } else {        /* odd */
-            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, rank - 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, rank - 1, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
@@ -85,10 +86,10 @@ int MPIR_Iallreduce_intra_sched_recursive_doubling(const void *sendbuf, void *re
 
             /* Send the most current data, which is in recvbuf. Recv
              * into tmp_buf */
-            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             /* sendrecv, no barrier here */
-            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
@@ -120,10 +121,10 @@ int MPIR_Iallreduce_intra_sched_recursive_doubling(const void *sendbuf, void *re
      * (rank-1), the ranks who didn't participate above. */
     if (rank < 2 * rem) {
         if (rank % 2) { /* odd */
-            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank - 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank - 1, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         } else {        /* even */
-            mpi_errno = MPIR_Sched_recv(recvbuf, count, datatype, rank + 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_recv(recvbuf, count, datatype, rank + 1, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }

--- a/src/mpi/coll/iallreduce/iallreduce_intra_sched_smp.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_sched_smp.c
@@ -8,7 +8,7 @@
 
 int MPIR_Iallreduce_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                     MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                    MPIR_Sched_t s)
+                                    int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_commutative;
@@ -26,7 +26,8 @@ int MPIR_Iallreduce_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint
     if (!is_commutative) {
         /* use flat fallback */
         mpi_errno =
-            MPIR_Iallreduce_intra_sched_auto(sendbuf, recvbuf, count, datatype, op, comm_ptr, s);
+            MPIR_Iallreduce_intra_sched_auto(sendbuf, recvbuf, count, datatype, op, comm_ptr,
+                                             collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -39,11 +40,14 @@ int MPIR_Iallreduce_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint
         if ((sendbuf == MPI_IN_PLACE) && (comm_ptr->node_comm->rank != 0)) {
             /* IN_PLACE and not root of reduce. Data supplied to this
              * allreduce is in recvbuf. Pass that as the sendbuf to reduce. */
-            mpi_errno = MPIR_Ireduce_intra_sched_auto(recvbuf, NULL, count, datatype, op, 0, nc, s);
+            mpi_errno =
+                MPIR_Ireduce_intra_sched_auto(recvbuf, NULL, count, datatype, op, 0, nc, collattr,
+                                              s);
             MPIR_ERR_CHECK(mpi_errno);
         } else {
             mpi_errno =
-                MPIR_Ireduce_intra_sched_auto(sendbuf, recvbuf, count, datatype, op, 0, nc, s);
+                MPIR_Ireduce_intra_sched_auto(sendbuf, recvbuf, count, datatype, op, 0, nc,
+                                              collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
         MPIR_SCHED_BARRIER(s);
@@ -59,14 +63,15 @@ int MPIR_Iallreduce_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint
     /* now do an IN_PLACE allreduce among the local roots of all nodes */
     if (nrc != NULL) {
         mpi_errno =
-            MPIR_Iallreduce_intra_sched_auto(MPI_IN_PLACE, recvbuf, count, datatype, op, nrc, s);
+            MPIR_Iallreduce_intra_sched_auto(MPI_IN_PLACE, recvbuf, count, datatype, op, nrc,
+                                             collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
 
     /* now broadcast the result among local processes */
     if (comm_ptr->node_comm != NULL) {
-        mpi_errno = MPIR_Ibcast_intra_sched_auto(recvbuf, count, datatype, 0, nc, s);
+        mpi_errno = MPIR_Ibcast_intra_sched_auto(recvbuf, count, datatype, 0, nc, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_auto.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_auto.c
@@ -10,7 +10,7 @@
 /* Routine to schedule a pipelined tree based allreduce */
 int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                              MPI_Datatype datatype, MPI_Op op,
-                                             MPIR_Comm * comm, MPIR_TSP_sched_t sched)
+                                             MPIR_Comm * comm, int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_commutative = MPIR_Op_is_commutative(op);
@@ -37,7 +37,8 @@ int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf,
                 MPIR_TSP_Iallreduce_sched_intra_recexch(sendbuf, recvbuf, count,
                                                         datatype, op, comm,
                                                         MPIR_IALLREDUCE_RECEXCH_TYPE_SINGLE_BUFFER,
-                                                        MPIR_CVAR_IALLREDUCE_RECEXCH_KVAL, sched);
+                                                        MPIR_CVAR_IALLREDUCE_RECEXCH_KVAL, collattr,
+                                                        sched);
             break;
 
         case MPIR_CVAR_IALLREDUCE_INTRA_ALGORITHM_tsp_recexch_multiple_buffer:
@@ -45,7 +46,8 @@ int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf,
                 MPIR_TSP_Iallreduce_sched_intra_recexch(sendbuf, recvbuf, count,
                                                         datatype, op, comm,
                                                         MPIR_IALLREDUCE_RECEXCH_TYPE_MULTIPLE_BUFFER,
-                                                        MPIR_CVAR_IALLREDUCE_RECEXCH_KVAL, sched);
+                                                        MPIR_CVAR_IALLREDUCE_RECEXCH_KVAL, collattr,
+                                                        sched);
             break;
 
         case MPIR_CVAR_IALLREDUCE_INTRA_ALGORITHM_tsp_tree:
@@ -53,14 +55,14 @@ int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf,
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, is_commutative ||
                                            MPIR_Iallreduce_tree_type ==
                                            MPIR_TREE_TYPE_KNOMIAL_1, mpi_errno,
-                                           "Iallreduce gentran_tree cannot be applied.\n");
+                                           "Iallreduce gentran_tree cannot be collattr, applied.\n");
             mpi_errno =
                 MPIR_TSP_Iallreduce_sched_intra_tree(sendbuf, recvbuf, count, datatype, op,
                                                      comm, MPIR_Iallreduce_tree_type,
                                                      MPIR_CVAR_IALLREDUCE_TREE_KVAL,
                                                      MPIR_CVAR_IALLREDUCE_TREE_PIPELINE_CHUNK_SIZE,
                                                      MPIR_CVAR_IALLREDUCE_TREE_BUFFER_PER_CHILD,
-                                                     sched);
+                                                     collattr, sched);
             break;
 
         case MPIR_CVAR_IALLREDUCE_INTRA_ALGORITHM_tsp_ring:
@@ -68,7 +70,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf,
                                            "Iallreduce gentran_ring cannot be applied.\n");
             mpi_errno =
                 MPIR_TSP_Iallreduce_sched_intra_ring(sendbuf, recvbuf, count, datatype,
-                                                     op, comm, sched);
+                                                     op, comm, collattr, sched);
             break;
         case MPIR_CVAR_IALLREDUCE_INTRA_ALGORITHM_tsp_recexch_reduce_scatter_recexch_allgatherv:
             /* This algorithm will work for commutative
@@ -78,7 +80,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf,
              * will be run */
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, is_commutative &&
                                            count >= nranks, mpi_errno,
-                                           "Iallreduce gentran_recexch_reduce_scatter_recexch_allgatherv cannot be applied.\n");
+                                           "Iallreduce gentran_recexch_reduce_scatter_recexch_allgatherv cannot be collattr, applied.\n");
             mpi_errno =
                 MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(sendbuf,
                                                                                           recvbuf,
@@ -87,6 +89,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf,
                                                                                           op,
                                                                                           comm,
                                                                                           MPIR_CVAR_IALLREDUCE_RECEXCH_KVAL,
+                                                                                          collattr,
                                                                                           sched);
             break;
         default:
@@ -101,7 +104,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf,
                                                                 MPIR_IALLREDUCE_RECEXCH_TYPE_SINGLE_BUFFER,
                                                                 cnt->u.
                                                                 iallreduce.intra_tsp_recexch_single_buffer.
-                                                                k, sched);
+                                                                k, collattr, sched);
                     break;
 
                 case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Iallreduce_intra_tsp_recexch_multiple_buffer:
@@ -111,7 +114,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf,
                                                                 MPIR_IALLREDUCE_RECEXCH_TYPE_MULTIPLE_BUFFER,
                                                                 cnt->u.
                                                                 iallreduce.intra_tsp_recexch_single_buffer.
-                                                                k, sched);
+                                                                k, collattr, sched);
                     break;
 
                 case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Iallreduce_intra_tsp_tree:
@@ -125,13 +128,13 @@ int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf,
                                                              intra_tsp_tree.chunk_size,
                                                              cnt->u.iallreduce.
                                                              intra_tsp_tree.buffer_per_child,
-                                                             sched);
+                                                             collattr, sched);
                     break;
 
                 case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Iallreduce_intra_tsp_ring:
                     mpi_errno =
                         MPIR_TSP_Iallreduce_sched_intra_ring(sendbuf, recvbuf, count, datatype, op,
-                                                             comm, sched);
+                                                             comm, collattr, sched);
                     break;
 
                 case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Iallreduce_intra_tsp_recexch_reduce_scatter_recexch_allgatherv:
@@ -139,7 +142,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf,
                         MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv
                         (sendbuf, recvbuf, count, datatype, op, comm,
                          cnt->u.iallreduce.intra_tsp_recexch_reduce_scatter_recexch_allgatherv.k,
-                         sched);
+                         collattr, sched);
                     break;
 
                 default:
@@ -157,7 +160,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf,
         MPIR_TSP_Iallreduce_sched_intra_recexch(sendbuf, recvbuf, count,
                                                 datatype, op, comm,
                                                 MPIR_IALLREDUCE_RECEXCH_TYPE_MULTIPLE_BUFFER,
-                                                MPIR_CVAR_IALLREDUCE_RECEXCH_KVAL, sched);
+                                                MPIR_CVAR_IALLREDUCE_RECEXCH_KVAL, collattr, sched);
   fn_exit:
     return mpi_errno;
   fn_fail:

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
@@ -12,7 +12,7 @@
 int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                             MPI_Datatype datatype, MPI_Op op,
                                             MPIR_Comm * comm, int per_nbr_buffer, int k,
-                                            MPIR_TSP_sched_t sched)
+                                            int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -77,7 +77,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                                                   tag, extent, dtcopy_id, recv_id, reduce_id, vtcs,
                                                   is_inplace, step1_sendto, in_step2, step1_nrecvs,
                                                   step1_recvfrom, per_nbr_buffer, &step1_recvbuf,
-                                                  comm, sched);
+                                                  comm, collattr, sched);
 
     mpi_errno = MPIR_TSP_sched_sink(sched, &step1_id);  /* sink for all the tasks up to end of Step 1 */
     if (mpi_errno)
@@ -153,8 +153,8 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
 
             nbr = step2_nbrs[phase][i];
             mpi_errno =
-                MPIR_TSP_sched_isend(tmp_buf, count, datatype, nbr, tag, comm, sched, nvtcs, vtcs,
-                                     &send_id[i]);
+                MPIR_TSP_sched_isend(tmp_buf, count, datatype, nbr, tag, comm, collattr, sched,
+                                     nvtcs, vtcs, &send_id[i]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             if (rank > nbr) {
                 myidx = i + 1;
@@ -169,8 +169,8 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                 vtcs[nvtcs++] = (counter == 0) ? reduce_id[k - 2] : reduce_id[counter - 1];
             }
             mpi_errno =
-                MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, sched, nvtcs,
-                                     vtcs, &recv_id[buf]);
+                MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, collattr,
+                                     sched, nvtcs, vtcs, &recv_id[buf]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             if (count != 0) {
@@ -197,8 +197,8 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                 vtcs[nvtcs++] = (counter == 0) ? reduce_id[k - 2] : reduce_id[counter - 1];
             }
             mpi_errno =
-                MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, sched, nvtcs,
-                                     vtcs, &recv_id[buf]);
+                MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, collattr,
+                                     sched, nvtcs, vtcs, &recv_id[buf]);
 
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
@@ -234,8 +234,8 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
      * send the data to non-partcipating ranks */
     if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
         mpi_errno =
-            MPIR_TSP_sched_irecv(recvbuf, count, datatype, step1_sendto, tag, comm, sched, 0, NULL,
-                                 &vtx_id);
+            MPIR_TSP_sched_irecv(recvbuf, count, datatype, step1_sendto, tag, comm, collattr, sched,
+                                 0, NULL, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {
@@ -254,8 +254,8 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                 vtcs[0] = reduce_id[k - 2];
             }
             mpi_errno =
-                MPIR_TSP_sched_isend(recvbuf, count, datatype, step1_recvfrom[i], tag, comm, sched,
-                                     nvtcs, vtcs, &vtx_id);
+                MPIR_TSP_sched_isend(recvbuf, count, datatype, step1_recvfrom[i], tag, comm,
+                                     collattr, sched, nvtcs, vtcs, &vtx_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.c
@@ -46,13 +46,13 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
                                                   int step1_sendto, bool in_step2, int step1_nrecvs,
                                                   int *step1_recvfrom, int per_nbr_buffer,
                                                   void ***step1_recvbuf_, MPIR_Comm * comm,
-                                                  MPIR_TSP_sched_t sched)
+                                                  int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, nvtcs, vtx_id;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     void **step1_recvbuf;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
     /* Step 1 */
@@ -64,8 +64,8 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
         else
             buf_to_send = sendbuf;
         mpi_errno =
-            MPIR_TSP_sched_isend(buf_to_send, count, datatype, step1_sendto, tag, comm, sched, 0,
-                                 NULL, &vtx_id);
+            MPIR_TSP_sched_isend(buf_to_send, count, datatype, step1_sendto, tag, comm, collattr,
+                                 sched, 0, NULL, &vtx_id);
         if (mpi_errno) {
             /* for communication errors, just record the error but continue */
             errflag = MPIR_ERR_OTHER;
@@ -96,8 +96,8 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
                                  reduce_id[i - 1]));
             }
             mpi_errno = MPIR_TSP_sched_irecv(step1_recvbuf[i], count, datatype,
-                                             step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
-                                             &recv_id[i]);
+                                             step1_recvfrom[i], tag, comm, collattr, sched, nvtcs,
+                                             vtcs, &recv_id[i]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             if (count != 0) {   /* Reduce only if data is present */
                 /* setup reduce dependencies */

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.h
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.h
@@ -16,5 +16,5 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
                                                   int step1_sendto, bool in_step2, int step1_nrecvs,
                                                   int *step1_recvfrom, int per_nbr_buffer,
                                                   void ***step1_recvbuf_, MPIR_Comm * comm,
-                                                  MPIR_TSP_sched_t sched);
+                                                  int collattr, MPIR_TSP_sched_t sched);
 #endif /* IALLREDUCE_TSP_RECURSIVE_EXCHANGE_COMMON_H_INCLUDED */

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree.c
@@ -11,7 +11,7 @@
 int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                          MPI_Datatype datatype, MPI_Op op,
                                          MPIR_Comm * comm, int tree_type, int k, int chunk_size,
-                                         int buffer_per_child, MPIR_TSP_sched_t sched)
+                                         int buffer_per_child, int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -140,7 +140,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
             }
 
             mpi_errno = MPIR_TSP_sched_irecv(recv_address, msgsize, datatype, child, tag, comm,
-                                             sched, nvtcs, vtcs, &recv_id[i]);
+                                             collattr, sched, nvtcs, vtcs, &recv_id[i]);
 
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             /* Setup dependencies for reduction. Reduction depends on the corresponding recv to complete */
@@ -187,7 +187,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
         if (rank != root) {
             mpi_errno =
                 MPIR_TSP_sched_isend(reduce_address, msgsize, datatype, my_tree.parent, tag, comm,
-                                     sched, nvtcs, vtcs, &vtx_id);
+                                     collattr, sched, nvtcs, vtcs, &vtx_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
@@ -201,7 +201,8 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
         if (my_tree.parent != -1) {
             mpi_errno =
                 MPIR_TSP_sched_irecv(reduce_address, msgsize, datatype,
-                                     my_tree.parent, tag, comm, sched, 1, &sink_id, &bcast_recv_id);
+                                     my_tree.parent, tag, comm, collattr, sched, 1, &sink_id,
+                                     &bcast_recv_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
@@ -211,7 +212,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
             vtcs[0] = bcast_recv_id;
             mpi_errno = MPIR_TSP_sched_imcast(reduce_address, msgsize, datatype,
                                               ut_int_array(my_tree.children), num_children, tag,
-                                              comm, sched, nvtcs, vtcs, &vtx_id);
+                                              comm, collattr, sched, nvtcs, vtcs, &vtx_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 

--- a/src/mpi/coll/ialltoall/ialltoall_inter_sched_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoall/ialltoall_inter_sched_pairwise_exchange.c
@@ -19,7 +19,7 @@
 int MPIR_Ialltoall_inter_sched_pairwise_exchange(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                 MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int local_size, remote_size, max_size, i;
@@ -53,9 +53,9 @@ int MPIR_Ialltoall_inter_sched_pairwise_exchange(const void *sendbuf, MPI_Aint s
             sendaddr = (char *) sendbuf + dst * sendcount * sendtype_extent;
         }
 
-        mpi_errno = MPIR_Sched_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_send(sendaddr, sendcount, sendtype, dst, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
-        mpi_errno = MPIR_Sched_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_recv(recvaddr, recvcount, recvtype, src, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_brucks.c
@@ -20,7 +20,8 @@
  */
 int MPIR_Ialltoall_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
                                       MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr,
+                                      MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -107,9 +108,9 @@ int MPIR_Ialltoall_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
         MPIR_SCHED_BARRIER(s);
 
         /* now send and recv in parallel */
-        mpi_errno = MPIR_Sched_send(tmp_buf, newtype_size, MPI_BYTE, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_send(tmp_buf, newtype_size, MPI_BYTE, dst, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
-        mpi_errno = MPIR_Sched_recv(recvbuf, 1, newtype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_recv(recvbuf, 1, newtype, src, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_inplace.c
@@ -19,7 +19,8 @@
  * scenario. */
 int MPIR_Ialltoall_intra_sched_inplace(const void *sendbuf, MPI_Aint sendcount,
                                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr,
+                                       MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     void *tmp_buf = NULL;
@@ -60,10 +61,10 @@ int MPIR_Ialltoall_intra_sched_inplace(const void *sendbuf, MPI_Aint sendcount,
                 MPIR_SCHED_BARRIER(s);
 
                 /* now simultaneously send from tmp_buf and recv to recvbuf */
-                mpi_errno = MPIR_Sched_send(tmp_buf, nbytes, MPI_BYTE, peer, comm_ptr, s);
+                mpi_errno = MPIR_Sched_send(tmp_buf, nbytes, MPI_BYTE, peer, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_recv(((char *) recvbuf + peer * recvcount * recvtype_extent),
-                                            recvcount, recvtype, peer, comm_ptr, s);
+                                            recvcount, recvtype, peer, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_pairwise.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_pairwise.c
@@ -24,7 +24,8 @@
  */
 int MPIR_Ialltoall_intra_sched_pairwise(const void *sendbuf, MPI_Aint sendcount,
                                         MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr,
+                                        MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -62,10 +63,10 @@ int MPIR_Ialltoall_intra_sched_pairwise(const void *sendbuf, MPI_Aint sendcount,
         }
 
         mpi_errno = MPIR_Sched_send(((char *) sendbuf + dst * sendcount * sendtype_extent),
-                                    sendcount, sendtype, dst, comm_ptr, s);
+                                    sendcount, sendtype, dst, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_recv(((char *) recvbuf + src * recvcount * recvtype_extent),
-                                    recvcount, recvtype, src, comm_ptr, s);
+                                    recvcount, recvtype, src, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_permuted_sendrecv.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_permuted_sendrecv.c
@@ -16,7 +16,7 @@
 int MPIR_Ialltoall_intra_sched_permuted_sendrecv(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                 MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -44,14 +44,14 @@ int MPIR_Ialltoall_intra_sched_permuted_sendrecv(const void *sendbuf, MPI_Aint s
         for (i = 0; i < ss; i++) {
             dst = (rank + i + ii) % comm_size;
             mpi_errno = MPIR_Sched_recv(((char *) recvbuf + dst * recvcount * recvtype_extent),
-                                        recvcount, recvtype, dst, comm_ptr, s);
+                                        recvcount, recvtype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
 
         for (i = 0; i < ss; i++) {
             dst = (rank - i - ii + comm_size) % comm_size;
             mpi_errno = MPIR_Sched_send(((char *) sendbuf + dst * sendcount * sendtype_extent),
-                                        sendcount, sendtype, dst, comm_ptr, s);
+                                        sendcount, sendtype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
 

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks.c
@@ -115,7 +115,8 @@ int
 MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                       MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                       MPI_Datatype recvtype, MPIR_Comm * comm,
-                                      int k, int buffer_per_phase, MPIR_TSP_sched_t sched)
+                                      int k, int buffer_per_phase, int collattr,
+                                      MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -284,7 +285,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
 
             mpi_errno =
                 MPIR_TSP_sched_isend(tmp_sbuf[i][j - 1], packsize, MPI_BYTE, dst, tag,
-                                     comm, sched, 1, &packids[j - 1], &sendids[j - 1]);
+                                     comm, collattr, sched, 1, &packids[j - 1], &sendids[j - 1]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             if (i != 0 && buffer_per_phase == 0) {      /* this dependency holds only when we don't have dedicated recv buffer per phase */
@@ -293,7 +294,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
             }
             mpi_errno =
                 MPIR_TSP_sched_irecv(tmp_rbuf[i][j - 1], packsize, MPI_BYTE,
-                                     src, tag, comm, sched, recv_ninvtcs, recv_invtcs,
+                                     src, tag, comm, collattr, sched, recv_ninvtcs, recv_invtcs,
                                      &recvids[j - 1]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring.c
@@ -36,7 +36,7 @@ copy (buf1)<--recv (buf1)            send (buf2)   /
 int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                                         MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                         MPI_Datatype recvtype, MPIR_Comm * comm,
-                                        MPIR_TSP_sched_t sched)
+                                        int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -132,8 +132,8 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
         }
 
         mpi_errno =
-            MPIR_TSP_sched_isend((char *) sbuf, size * recvcount, recvtype, dst, tag, comm, sched,
-                                 nvtcs, vtcs, &send_id[i % 3]);
+            MPIR_TSP_sched_isend((char *) sbuf, size * recvcount, recvtype, dst, tag, comm,
+                                 collattr, sched, nvtcs, vtcs, &send_id[i % 3]);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         /* schedule recv */
         if (i == 0)
@@ -150,8 +150,8 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
         }
 
         mpi_errno =
-            MPIR_TSP_sched_irecv((char *) rbuf, size * recvcount, recvtype, src, tag, comm, sched,
-                                 nvtcs, vtcs, &recv_id[i % 3]);
+            MPIR_TSP_sched_irecv((char *) rbuf, size * recvcount, recvtype, src, tag, comm,
+                                 collattr, sched, nvtcs, vtcs, &recv_id[i % 3]);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* destination offset of the copy */

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_scattered.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_scattered.c
@@ -38,7 +38,7 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
                                              MPI_Datatype sendtype, void *recvbuf,
                                              MPI_Aint recvcount, MPI_Datatype recvtype,
                                              MPIR_Comm * comm, int batch_size, int bblock,
-                                             MPIR_TSP_sched_t sched)
+                                             int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -111,13 +111,15 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
         src = (rank + i) % size;
         mpi_errno =
             MPIR_TSP_sched_irecv((char *) recvbuf + src * recvcount * recvtype_extent,
-                                 recvcount, recvtype, src, tag, comm, sched, 0, NULL, &recv_id[i]);
+                                 recvcount, recvtype, src, tag, comm, collattr, sched, 0, NULL,
+                                 &recv_id[i]);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         dst = (rank - i + size) % size;
         mpi_errno =
             MPIR_TSP_sched_isend((char *) data_buf + dst * sendcount * sendtype_extent,
-                                 sendcount, sendtype, dst, tag, comm, sched, 0, NULL, &send_id[i]);
+                                 sendcount, sendtype, dst, tag, comm, collattr, sched, 0, NULL,
+                                 &send_id[i]);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
@@ -138,15 +140,15 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
             src = (rank + i + j) % size;
             mpi_errno =
                 MPIR_TSP_sched_irecv((char *) recvbuf + src * recvcount * recvtype_extent,
-                                     recvcount, recvtype, src, tag, comm, sched, 1, &invtcs,
-                                     &recv_id[(i + j) % bblock]);
+                                     recvcount, recvtype, src, tag, comm, collattr, sched, 1,
+                                     &invtcs, &recv_id[(i + j) % bblock]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             dst = (rank - i - j + size) % size;
             mpi_errno =
                 MPIR_TSP_sched_isend((char *) data_buf + dst * sendcount * sendtype_extent,
-                                     sendcount, sendtype, dst, tag, comm, sched, 1, &invtcs,
-                                     &send_id[(i + j) % bblock]);
+                                     sendcount, sendtype, dst, tag, comm, collattr, sched, 1,
+                                     &invtcs, &send_id[(i + j) % bblock]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }

--- a/src/mpi/coll/ialltoallv/ialltoallv_inter_sched_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_inter_sched_pairwise_exchange.c
@@ -9,7 +9,8 @@ int MPIR_Ialltoallv_inter_sched_pairwise_exchange(const void *sendbuf, const MPI
                                                   const MPI_Aint sdispls[], MPI_Datatype sendtype,
                                                   void *recvbuf, const MPI_Aint recvcounts[],
                                                   const MPI_Aint rdispls[], MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                  MPIR_Comm * comm_ptr, int collattr,
+                                                  MPIR_Sched_t s)
 {
     /* Intercommunicator alltoallv. We use a pairwise exchange algorithm
      * similar to the one used in intracommunicator alltoallv. Since the
@@ -66,9 +67,9 @@ int MPIR_Ialltoallv_inter_sched_pairwise_exchange(const void *sendbuf, const MPI
         if (recvcount * recvtype_size == 0)
             src = MPI_PROC_NULL;
 
-        mpi_errno = MPIR_Sched_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_send(sendaddr, sendcount, sendtype, dst, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
-        mpi_errno = MPIR_Sched_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_recv(recvaddr, recvcount, recvtype, src, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_barrier(s);
         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_blocked.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_blocked.c
@@ -9,7 +9,7 @@ int MPIR_Ialltoallv_intra_sched_blocked(const void *sendbuf, const MPI_Aint send
                                         const MPI_Aint sdispls[], MPI_Datatype sendtype,
                                         void *recvbuf, const MPI_Aint recvcounts[],
                                         const MPI_Aint rdispls[], MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size;
@@ -46,7 +46,7 @@ int MPIR_Ialltoallv_intra_sched_blocked(const void *sendbuf, const MPI_Aint send
             dst = (rank + i + ii) % comm_size;
             if (recvcounts[dst] && recvtype_size) {
                 mpi_errno = MPIR_Sched_recv((char *) recvbuf + rdispls[dst] * recv_extent,
-                                            recvcounts[dst], recvtype, dst, comm_ptr, s);
+                                            recvcounts[dst], recvtype, dst, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
             }
         }
@@ -55,7 +55,7 @@ int MPIR_Ialltoallv_intra_sched_blocked(const void *sendbuf, const MPI_Aint send
             dst = (rank - i - ii + comm_size) % comm_size;
             if (sendcounts[dst] && sendtype_size) {
                 mpi_errno = MPIR_Sched_send((char *) sendbuf + sdispls[dst] * send_extent,
-                                            sendcounts[dst], sendtype, dst, comm_ptr, s);
+                                            sendcounts[dst], sendtype, dst, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
             }
         }

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_inplace.c
@@ -9,7 +9,7 @@ int MPIR_Ialltoallv_intra_sched_inplace(const void *sendbuf, const MPI_Aint send
                                         const MPI_Aint sdispls[], MPI_Datatype sendtype,
                                         void *recvbuf, const MPI_Aint recvcounts[],
                                         const MPI_Aint rdispls[], MPI_Datatype recvtype,
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     void *tmp_buf = NULL;
     int mpi_errno = MPI_SUCCESS;
@@ -58,10 +58,10 @@ int MPIR_Ialltoallv_intra_sched_inplace(const void *sendbuf, const MPI_Aint send
                     dst = i;
 
                 mpi_errno = MPIR_Sched_send(((char *) recvbuf + rdispls[dst] * recvtype_extent),
-                                            recvcounts[dst], recvtype, dst, comm_ptr, s);
+                                            recvcounts[dst], recvtype, dst, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_recv(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
-                                            dst, comm_ptr, s);
+                                            dst, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked.c
@@ -11,7 +11,8 @@ int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                                             const MPI_Aint sdispls[], MPI_Datatype sendtype,
                                             void *recvbuf, const MPI_Aint recvcounts[],
                                             const MPI_Aint rdispls[], MPI_Datatype recvtype,
-                                            MPIR_Comm * comm, int bblock, MPIR_TSP_sched_t sched)
+                                            MPIR_Comm * comm, int bblock, int collattr,
+                                            MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -56,8 +57,8 @@ int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
             dst = (rank + j + i) % nranks;
             if (recvcounts[dst] && recvtype_size) {
                 mpi_errno = MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[dst] * recv_extent,
-                                                 recvcounts[dst], recvtype, dst, tag, comm, sched,
-                                                 0, NULL, &vtx_id);
+                                                 recvcounts[dst], recvtype, dst, tag, comm,
+                                                 collattr, sched, 0, NULL, &vtx_id);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }
@@ -66,8 +67,8 @@ int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
             dst = (rank - j - i + nranks) % nranks;
             if (sendcounts[dst] && sendtype_size) {
                 mpi_errno = MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst] * send_extent,
-                                                 sendcounts[dst], sendtype, dst, tag, comm, sched,
-                                                 0, NULL, &vtx_id);
+                                                 sendcounts[dst], sendtype, dst, tag, comm,
+                                                 collattr, sched, 0, NULL, &vtx_id);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace.c
@@ -11,7 +11,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
                                             const MPI_Aint sdispls[], MPI_Datatype sendtype,
                                             void *recvbuf, const MPI_Aint recvcounts[],
                                             const MPI_Aint rdispls[], MPI_Datatype recvtype,
-                                            MPIR_Comm * comm, MPIR_TSP_sched_t sched)
+                                            MPIR_Comm * comm, int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -53,12 +53,12 @@ int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
 
             mpi_errno = MPIR_TSP_sched_isend((char *) recvbuf + rdispls[dst] * recv_extent,
                                              recvcounts[dst], recvtype, dst, tag, comm,
-                                             sched, nvtcs, vtcs, &send_id);
+                                             collattr, sched, nvtcs, vtcs, &send_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             mpi_errno =
                 MPIR_TSP_sched_irecv(tmp_buf, recvcounts[dst], recvtype, dst, tag, comm,
-                                     sched, nvtcs, vtcs, &recv_id);
+                                     collattr, sched, nvtcs, vtcs, &recv_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             nvtcs = 2;

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered.c
@@ -12,7 +12,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Ain
                                               void *recvbuf, const MPI_Aint recvcounts[],
                                               const MPI_Aint rdispls[], MPI_Datatype recvtype,
                                               MPIR_Comm * comm, int batch_size, int bblock,
-                                              MPIR_TSP_sched_t sched)
+                                              int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -64,15 +64,15 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Ain
         src = (rank + i) % size;
         mpi_errno =
             MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[src] * recvtype_extent,
-                                 recvcounts[src], recvtype, src, tag, comm, sched, 0, NULL,
-                                 &recv_id[i]);
+                                 recvcounts[src], recvtype, src, tag, comm, collattr, sched, 0,
+                                 NULL, &recv_id[i]);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         dst = (rank - i + size) % size;
         mpi_errno =
             MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst] * sendtype_extent,
-                                 sendcounts[dst], sendtype, dst, tag, comm, sched, 0, NULL,
-                                 &send_id[i]);
+                                 sendcounts[dst], sendtype, dst, tag, comm, collattr, sched, 0,
+                                 NULL, &send_id[i]);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
@@ -94,15 +94,15 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Ain
             src = (rank + i + j) % size;
             mpi_errno =
                 MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[src] * recvtype_extent,
-                                     recvcounts[src], recvtype, src, tag, comm, sched, 1, &invtcs,
-                                     &recv_id[(i + j) % bblock]);
+                                     recvcounts[src], recvtype, src, tag, comm, collattr, sched, 1,
+                                     &invtcs, &recv_id[(i + j) % bblock]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             dst = (rank - i - j + size) % size;
             mpi_errno =
                 MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst] * sendtype_extent,
-                                     sendcounts[dst], sendtype, dst, tag, comm, sched, 1, &invtcs,
-                                     &send_id[(i + j) % bblock]);
+                                     sendcounts[dst], sendtype, dst, tag, comm, collattr, sched, 1,
+                                     &invtcs, &send_id[(i + j) % bblock]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }

--- a/src/mpi/coll/ialltoallw/ialltoallw_inter_sched_pairwise_exchange.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_inter_sched_pairwise_exchange.c
@@ -11,7 +11,8 @@ int MPIR_Ialltoallw_inter_sched_pairwise_exchange(const void *sendbuf, const MPI
                                                   const MPI_Aint recvcounts[],
                                                   const MPI_Aint rdispls[],
                                                   const MPI_Datatype recvtypes[],
-                                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                  MPIR_Comm * comm_ptr, int collattr,
+                                                  MPIR_Sched_t s)
 {
 /* Intercommunicator alltoallw. We use a pairwise exchange algorithm
    similar to the one used in intracommunicator alltoallw. Since the local and
@@ -59,10 +60,10 @@ int MPIR_Ialltoallw_inter_sched_pairwise_exchange(const void *sendbuf, const MPI
             sendtype = sendtypes[dst];
         }
 
-        mpi_errno = MPIR_Sched_send(sendaddr, sendcount, sendtype, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_send(sendaddr, sendcount, sendtype, dst, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         /* sendrecv, no barrier here */
-        mpi_errno = MPIR_Sched_recv(recvaddr, recvcount, recvtype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_recv(recvaddr, recvcount, recvtype, src, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_blocked.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_blocked.c
@@ -23,7 +23,7 @@ int MPIR_Ialltoallw_intra_sched_blocked(const void *sendbuf, const MPI_Aint send
                                         const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                         void *recvbuf, const MPI_Aint recvcounts[],
                                         const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, i;
@@ -53,7 +53,8 @@ int MPIR_Ialltoallw_intra_sched_blocked(const void *sendbuf, const MPI_Aint send
                 MPIR_Datatype_get_size_macro(recvtypes[dst], type_size);
                 if (type_size) {
                     mpi_errno = MPIR_Sched_recv((char *) recvbuf + rdispls[dst],
-                                                recvcounts[dst], recvtypes[dst], dst, comm_ptr, s);
+                                                recvcounts[dst], recvtypes[dst], dst, comm_ptr,
+                                                collattr, s);
                     MPIR_ERR_CHECK(mpi_errno);
                 }
             }
@@ -66,7 +67,8 @@ int MPIR_Ialltoallw_intra_sched_blocked(const void *sendbuf, const MPI_Aint send
                 MPIR_Datatype_get_size_macro(sendtypes[dst], type_size);
                 if (type_size) {
                     mpi_errno = MPIR_Sched_send((char *) sendbuf + sdispls[dst],
-                                                sendcounts[dst], sendtypes[dst], dst, comm_ptr, s);
+                                                sendcounts[dst], sendtypes[dst], dst, comm_ptr,
+                                                collattr, s);
                     MPIR_ERR_CHECK(mpi_errno);
                 }
             }

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_inplace.c
@@ -21,7 +21,7 @@ int MPIR_Ialltoallw_intra_sched_inplace(const void *sendbuf, const MPI_Aint send
                                         const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                         void *recvbuf, const MPI_Aint recvcounts[],
                                         const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, i, j;
@@ -67,10 +67,11 @@ int MPIR_Ialltoallw_intra_sched_inplace(const void *sendbuf, const MPI_Aint send
 
                 MPIR_Datatype_get_size_macro(recvtypes[i], recvtype_sz);
                 mpi_errno = MPIR_Sched_send(((char *) recvbuf + rdispls[dst]),
-                                            recvcounts[dst], recvtypes[dst], dst, comm_ptr, s);
+                                            recvcounts[dst], recvtypes[dst], dst, comm_ptr,
+                                            collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_recv(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
-                                            dst, comm_ptr, s);
+                                            dst, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked.c
@@ -12,7 +12,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                                             const MPI_Datatype sendtypes[], void *recvbuf,
                                             const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                                             const MPI_Datatype recvtypes[], MPIR_Comm * comm,
-                                            int bblock, MPIR_TSP_sched_t sched)
+                                            int bblock, int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -49,7 +49,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                 if (recvtype_size) {
                     mpi_errno = MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[dst],
                                                      recvcounts[dst], recvtypes[dst], dst, tag,
-                                                     comm, sched, 0, NULL, &vtx_id);
+                                                     comm, collattr, sched, 0, NULL, &vtx_id);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
             }
@@ -62,7 +62,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                 if (sendtype_size) {
                     mpi_errno = MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst],
                                                      sendcounts[dst], sendtypes[dst], dst, tag,
-                                                     comm, sched, 0, NULL, &vtx_id);
+                                                     comm, collattr, sched, 0, NULL, &vtx_id);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 }
             }

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace.c
@@ -12,7 +12,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
                                             const MPI_Datatype sendtypes[], void *recvbuf,
                                             const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                                             const MPI_Datatype recvtypes[], MPIR_Comm * comm,
-                                            MPIR_TSP_sched_t sched)
+                                            int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -59,12 +59,12 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
             adj_tmp_buf = (void *) ((char *) tmp_buf - true_lb);
 
             mpi_errno = MPIR_TSP_sched_isend((char *) recvbuf + rdispls[dst],
-                                             recvcounts[dst], recvtypes[dst], dst, tag, comm, sched,
-                                             nvtcs, vtcs, &send_id);
+                                             recvcounts[dst], recvtypes[dst], dst, tag, comm,
+                                             collattr, sched, nvtcs, vtcs, &send_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             mpi_errno =
                 MPIR_TSP_sched_irecv(adj_tmp_buf, recvcounts[dst], recvtypes[dst], dst, tag, comm,
-                                     sched, nvtcs, vtcs, &recv_id);
+                                     collattr, sched, nvtcs, vtcs, &recv_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             nvtcs = 2;

--- a/src/mpi/coll/ibarrier/ibarrier_inter_sched_bcast.c
+++ b/src/mpi/coll/ibarrier/ibarrier_inter_sched_bcast.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Ibarrier_inter_sched_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_inter_sched_bcast(MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, root;
@@ -23,7 +23,7 @@ int MPIR_Ibarrier_inter_sched_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 
     /* do a barrier on the local intracommunicator */
     if (comm_ptr->local_size != 1) {
-        mpi_errno = MPIR_Ibarrier_intra_sched_auto(comm_ptr->local_comm, s);
+        mpi_errno = MPIR_Ibarrier_intra_sched_auto(comm_ptr->local_comm, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
@@ -40,26 +40,26 @@ int MPIR_Ibarrier_inter_sched_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
      * left group */
     if (comm_ptr->is_low_group) {
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
-        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPI_BYTE, root, comm_ptr, s);
+        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPI_BYTE, root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_SCHED_BARRIER(s);
 
         /* receive bcast from right */
         root = 0;
-        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPI_BYTE, root, comm_ptr, s);
+        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPI_BYTE, root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* receive bcast from left */
         root = 0;
-        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPI_BYTE, root, comm_ptr, s);
+        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPI_BYTE, root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_SCHED_BARRIER(s);
 
         /* bcast to left */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
-        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPI_BYTE, root, comm_ptr, s);
+        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPI_BYTE, root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/coll/ibarrier/ibarrier_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_sched_recursive_doubling.c
@@ -18,7 +18,7 @@
  * process i sends to process (i + 2^k) % p and receives from process
  * (i - 2^k + p) % p.
  */
-int MPIR_Ibarrier_intra_sched_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_intra_sched_recursive_doubling(MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int size, rank, src, dst, mask;
@@ -33,10 +33,10 @@ int MPIR_Ibarrier_intra_sched_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sche
         dst = (rank + mask) % size;
         src = (rank - mask + size) % size;
 
-        mpi_errno = MPIR_Sched_send(NULL, 0, MPI_BYTE, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_send(NULL, 0, MPI_BYTE, dst, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
 
-        mpi_errno = MPIR_Sched_recv(NULL, 0, MPI_BYTE, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_recv(NULL, 0, MPI_BYTE, src, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Sched_barrier(s);

--- a/src/mpi/coll/ibarrier/ibarrier_intra_tsp_dissem.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_tsp_dissem.c
@@ -6,7 +6,8 @@
 #include "mpiimpl.h"
 
 /* Routine to schedule a disdem based barrier with radix k */
-int MPIR_TSP_Ibarrier_sched_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_TSP_sched_t sched)
+int MPIR_TSP_Ibarrier_sched_intra_k_dissemination(MPIR_Comm * comm, int k, int collattr,
+                                                  MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -51,15 +52,15 @@ int MPIR_TSP_Ibarrier_sched_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST, "dissem barrier - scheduling recv from %d\n", from));
             mpi_errno =
-                MPIR_TSP_sched_irecv(NULL, 0, MPI_BYTE, from, tag, comm, sched, 0, NULL,
+                MPIR_TSP_sched_irecv(NULL, 0, MPI_BYTE, from, tag, comm, collattr, sched, 0, NULL,
                                      &recv_ids[i * (k - 1) + j - 1]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST, "dissem barrier - scheduling send to %d\n", to));
             mpi_errno =
-                MPIR_TSP_sched_isend(NULL, 0, MPI_BYTE, to, tag, comm, sched, i * (k - 1), recv_ids,
-                                     &vtx_id);
+                MPIR_TSP_sched_isend(NULL, 0, MPI_BYTE, to, tag, comm, collattr, sched, i * (k - 1),
+                                     recv_ids, &vtx_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,

--- a/src/mpi/coll/ibarrier/ibarrier_intra_tsp_recexch.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_tsp_recexch.c
@@ -6,7 +6,8 @@
 #include "mpiimpl.h"
 
 /* Routine to schedule a disdem based barrier with radix k */
-int MPIR_TSP_Ibarrier_sched_intra_recexch(MPIR_Comm * comm, int k, MPIR_TSP_sched_t sched)
+int MPIR_TSP_Ibarrier_sched_intra_recexch(MPIR_Comm * comm, int k, int collattr,
+                                          MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     void *recvbuf = NULL;
@@ -16,7 +17,7 @@ int MPIR_TSP_Ibarrier_sched_intra_recexch(MPIR_Comm * comm, int k, MPIR_TSP_sche
         MPIR_TSP_Iallreduce_sched_intra_recexch(MPI_IN_PLACE, recvbuf, 0, MPI_BYTE, MPI_SUM,
                                                 comm,
                                                 MPIR_IALLREDUCE_RECEXCH_TYPE_MULTIPLE_BUFFER,
-                                                k, sched);
+                                                k, collattr, sched);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpi/coll/ibarrier/ibarrier_tsp_auto.c
+++ b/src/mpi/coll/ibarrier/ibarrier_tsp_auto.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 
 /* sched version of CVAR and json based collective selection. Meant only for gentran scheduler */
-int MPIR_TSP_Ibarrier_sched_intra_tsp_auto(MPIR_Comm * comm, MPIR_TSP_sched_t sched)
+int MPIR_TSP_Ibarrier_sched_intra_tsp_auto(MPIR_Comm * comm, int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -25,13 +25,14 @@ int MPIR_TSP_Ibarrier_sched_intra_tsp_auto(MPIR_Comm * comm, MPIR_TSP_sched_t sc
                 MPIR_TSP_Iallreduce_sched_intra_recexch(MPI_IN_PLACE, recvbuf, 0, MPI_BYTE, MPI_SUM,
                                                         comm,
                                                         MPIR_IALLREDUCE_RECEXCH_TYPE_MULTIPLE_BUFFER,
-                                                        MPIR_CVAR_IBARRIER_RECEXCH_KVAL, sched);
+                                                        MPIR_CVAR_IBARRIER_RECEXCH_KVAL,
+                                                        collattr, sched);
             break;
 
         case MPIR_CVAR_IBARRIER_INTRA_ALGORITHM_tsp_k_dissemination:
             mpi_errno =
                 MPIR_TSP_Ibarrier_sched_intra_k_dissemination(comm, MPIR_CVAR_IBARRIER_DISSEM_KVAL,
-                                                              sched);
+                                                              collattr, sched);
             break;
 
         default:
@@ -45,7 +46,7 @@ int MPIR_TSP_Ibarrier_sched_intra_tsp_auto(MPIR_Comm * comm, MPIR_TSP_sched_t sc
                                                                 MPI_SUM, comm,
                                                                 MPIR_IALLREDUCE_RECEXCH_TYPE_MULTIPLE_BUFFER,
                                                                 cnt->u.ibarrier.intra_tsp_recexch.k,
-                                                                sched);
+                                                                collattr, sched);
                     break;
 
                 case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibarrier_intra_tsp_k_dissemination:
@@ -53,7 +54,7 @@ int MPIR_TSP_Ibarrier_sched_intra_tsp_auto(MPIR_Comm * comm, MPIR_TSP_sched_t sc
                         MPIR_TSP_Ibarrier_sched_intra_k_dissemination(comm,
                                                                       cnt->u.
                                                                       ibarrier.intra_tsp_k_dissemination.
-                                                                      k, sched);
+                                                                      k, collattr, sched);
                     break;
 
                 default:
@@ -68,7 +69,8 @@ int MPIR_TSP_Ibarrier_sched_intra_tsp_auto(MPIR_Comm * comm, MPIR_TSP_sched_t sc
 
   fallback:
     mpi_errno = MPIR_TSP_Iallreduce_sched_intra_recexch(MPI_IN_PLACE, NULL, 0,
-                                                        MPI_BYTE, MPI_SUM, comm, 0, 2, sched);
+                                                        MPI_BYTE, MPI_SUM, comm, 0, 2, collattr,
+                                                        sched);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/ibcast/ibcast.h
+++ b/src/mpi/coll/ibcast/ibcast.h
@@ -21,6 +21,6 @@ int MPII_Ibcast_sched_test_curr_length(MPIR_Comm * comm, int tag, void *state);
 int MPII_Ibcast_sched_init_length(MPIR_Comm * comm, int tag, void *state);
 int MPII_Ibcast_sched_add_length(MPIR_Comm * comm, int tag, void *state);
 int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr, MPI_Aint nbytes,
-                                  MPIR_Sched_t s);
+                                  int collattr, MPIR_Sched_t s);
 
 #endif /* IBCAST_H_INCLUDED */

--- a/src/mpi/coll/ibcast/ibcast_inter_sched_flat.c
+++ b/src/mpi/coll/ibcast/ibcast_inter_sched_flat.c
@@ -7,7 +7,7 @@
 #include "ibcast.h"
 
 int MPIR_Ibcast_inter_sched_flat(void *buffer, MPI_Aint count, MPI_Datatype datatype,
-                                 int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                 int root, MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -21,12 +21,12 @@ int MPIR_Ibcast_inter_sched_flat(void *buffer, MPI_Aint count, MPI_Datatype data
         mpi_errno = MPI_SUCCESS;
     } else if (root == MPI_ROOT) {
         /* root sends to rank 0 on remote group and returns */
-        mpi_errno = MPIR_Sched_send(buffer, count, datatype, 0, comm_ptr, s);
+        mpi_errno = MPIR_Sched_send(buffer, count, datatype, 0, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* remote group. rank 0 on remote group receives from root */
         if (comm_ptr->rank == 0) {
-            mpi_errno = MPIR_Sched_recv(buffer, count, datatype, root, comm_ptr, s);
+            mpi_errno = MPIR_Sched_recv(buffer, count, datatype, root, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
@@ -39,7 +39,8 @@ int MPIR_Ibcast_inter_sched_flat(void *buffer, MPI_Aint count, MPI_Datatype data
         /* now do the usual broadcast on this intracommunicator
          * with rank 0 as root. */
         mpi_errno =
-            MPIR_Ibcast_intra_sched_auto(buffer, count, datatype, root, comm_ptr->local_comm, s);
+            MPIR_Ibcast_intra_sched_auto(buffer, count, datatype, root, comm_ptr->local_comm,
+                                         collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_binomial.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_binomial.c
@@ -13,7 +13,7 @@
  * to build up a larger hierarchical broadcast from multiple invocations of this
  * function. */
 int MPIR_Ibcast_intra_sched_binomial(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int mask;
@@ -92,10 +92,10 @@ int MPIR_Ibcast_intra_sched_binomial(void *buffer, MPI_Aint count, MPI_Datatype 
                 src += comm_size;
             if (!is_contig)
                 mpi_errno = MPIR_Sched_recv_status(tmp_buf, nbytes, MPI_BYTE, src,
-                                                   comm_ptr, &ibcast_state->status, s);
+                                                   comm_ptr, &ibcast_state->status, collattr, s);
             else
                 mpi_errno = MPIR_Sched_recv_status(buffer, count, datatype, src,
-                                                   comm_ptr, &ibcast_state->status, s);
+                                                   comm_ptr, &ibcast_state->status, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
 
             MPIR_SCHED_BARRIER(s);
@@ -125,9 +125,9 @@ int MPIR_Ibcast_intra_sched_binomial(void *buffer, MPI_Aint count, MPI_Datatype 
             if (dst >= comm_size)
                 dst -= comm_size;
             if (!is_contig)
-                mpi_errno = MPIR_Sched_send(tmp_buf, nbytes, MPI_BYTE, dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_send(tmp_buf, nbytes, MPI_BYTE, dst, comm_ptr, collattr, s);
             else
-                mpi_errno = MPIR_Sched_send(buffer, count, datatype, dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_send(buffer, count, datatype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
 
             /* NOTE: This is departure from MPIR_Bcast_intra_binomial.  A true analog

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_ring_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_ring_allgather.c
@@ -26,7 +26,8 @@
  */
 int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
                                                    MPI_Datatype datatype, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                   MPIR_Comm * comm_ptr, int collattr,
+                                                   MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, rank;
@@ -78,7 +79,7 @@ int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
         }
     }
 
-    mpi_errno = MPII_Iscatter_for_bcast_sched(tmp_buf, root, comm_ptr, nbytes, s);
+    mpi_errno = MPII_Iscatter_for_bcast_sched(tmp_buf, root, comm_ptr, nbytes, collattr, s);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPI_Aint scatter_size, curr_size;
@@ -119,12 +120,12 @@ int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
         right_disp = rel_j * scatter_size;
 
         mpi_errno = MPIR_Sched_send(((char *) tmp_buf + right_disp),
-                                    right_count, MPI_BYTE, right, comm_ptr, s);
+                                    right_count, MPI_BYTE, right, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         /* sendrecv, no barrier here */
         mpi_errno = MPIR_Sched_recv_status(((char *) tmp_buf + left_disp),
                                            left_count, MPI_BYTE, left, comm_ptr,
-                                           &ibcast_state->status, s);
+                                           &ibcast_state->status, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
         mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_add_length, ibcast_state, s);

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatterv_ring_allgatherv.c
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatterv_ring_allgatherv.c
@@ -10,7 +10,7 @@
 int MPIR_TSP_Ibcast_sched_intra_scatterv_ring_allgatherv(void *buffer, MPI_Aint count,
                                                          MPI_Datatype datatype, int root,
                                                          MPIR_Comm * comm, int scatterv_k,
-                                                         MPIR_TSP_sched_t sched)
+                                                         int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -19,7 +19,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_ring_allgatherv(void *buffer, MPI_Aint 
     mpi_errno = MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(buffer, count, datatype, root,
                                                                 comm,
                                                                 MPIR_CVAR_IALLGATHERV_INTRA_ALGORITHM_tsp_ring,
-                                                                scatterv_k, 0, sched);
+                                                                scatterv_k, 0, collattr, sched);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpi/coll/ibcast/ibcast_tsp_tree.c
+++ b/src/mpi/coll/ibcast/ibcast_tsp_tree.c
@@ -11,7 +11,7 @@
 /* Routine to schedule a pipelined tree based broadcast */
 int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
                                      MPIR_Comm * comm, int tree_type, int k, int chunk_size,
-                                     MPIR_TSP_sched_t sched)
+                                     int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -71,7 +71,7 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype 
 #ifdef HAVE_ERROR_CHECKING
             mpi_errno =
                 MPIR_TSP_sched_irecv_status((char *) buffer + offset * extent, msgsize,
-                                            datatype, my_tree.parent, tag, comm,
+                                            datatype, my_tree.parent, tag, comm, collattr,
                                             &ibcast_state->status, sched, 0, NULL, &recv_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             MPIR_TSP_sched_cb(&MPII_Ibcast_sched_test_length, ibcast_state, sched, 1, &recv_id,
@@ -79,7 +79,7 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype 
 #else
             mpi_errno =
                 MPIR_TSP_sched_irecv((char *) buffer + offset * extent, msgsize, datatype,
-                                     my_tree.parent, tag, comm, sched, 0, NULL, &recv_id);
+                                     my_tree.parent, tag, comm, collattr, sched, 0, NULL, &recv_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 #endif
         }
@@ -88,8 +88,8 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype 
             /* Multicast data to the children */
             mpi_errno = MPIR_TSP_sched_imcast((char *) buffer + offset * extent, msgsize, datatype,
                                               ut_int_array(my_tree.children), num_children, tag,
-                                              comm, sched, (my_tree.parent != -1) ? 1 : 0, &recv_id,
-                                              &vtx_id);
+                                              comm, collattr, sched, (my_tree.parent != -1) ? 1 : 0,
+                                              &recv_id, &vtx_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
         offset += msgsize;

--- a/src/mpi/coll/ibcast/ibcast_utils.c
+++ b/src/mpi/coll/ibcast/ibcast_utils.c
@@ -69,7 +69,7 @@ int MPII_Ibcast_sched_add_length(MPIR_Comm * comm, int tag, void *state)
  * typical scatter arguments.  At the moment this function always
  * scatters a buffer of nbytes starting at tmp_buf address. */
 int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr, MPI_Aint nbytes,
-                                  MPIR_Sched_t s)
+                                  int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, src, dst;
@@ -110,7 +110,7 @@ int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr,
 
             if (recv_size > 0) {
                 mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + relative_rank * scatter_size),
-                                            recv_size, MPI_BYTE, src, comm_ptr, s);
+                                            recv_size, MPI_BYTE, src, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
@@ -135,7 +135,7 @@ int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr,
                     dst -= comm_size;
                 mpi_errno =
                     MPIR_Sched_send(((char *) tmp_buf + scatter_size * (relative_rank + mask)),
-                                    send_size, MPI_BYTE, dst, comm_ptr, s);
+                                    send_size, MPI_BYTE, dst, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
 
                 curr_size -= send_size;

--- a/src/mpi/coll/iexscan/iexscan_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iexscan/iexscan_intra_sched_recursive_doubling.c
@@ -50,7 +50,7 @@
 */
 int MPIR_Iexscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size;
@@ -61,7 +61,7 @@ int MPIR_Iexscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvb
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
 
-    is_commutative = MPIR_Op_is_commutative(op);
+    is_commutative = collattr, MPIR_Op_is_commutative(op);
 
     /* need to allocate temporary buffer to store partial scan */
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
@@ -89,10 +89,10 @@ int MPIR_Iexscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvb
         dst = rank ^ mask;
         if (dst < comm_size) {
             /* Send partial_scan to dst. Recv into tmp_buf */
-            mpi_errno = MPIR_Sched_send(partial_scan, count, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_send(partial_scan, count, datatype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             /* sendrecv, no barrier here */
-            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 

--- a/src/mpi/coll/igather/igather_inter_sched_long.c
+++ b/src/mpi/coll/igather/igather_inter_sched_long.c
@@ -14,7 +14,7 @@
  */
 int MPIR_Igather_inter_sched_long(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                  int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                  int root, MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint remote_size;
@@ -29,11 +29,11 @@ int MPIR_Igather_inter_sched_long(const void *sendbuf, MPI_Aint sendcount, MPI_D
 
         for (i = 0; i < remote_size; i++) {
             mpi_errno = MPIR_Sched_recv(((char *) recvbuf + recvcount * i * extent),
-                                        recvcount, recvtype, i, comm_ptr, s);
+                                        recvcount, recvtype, i, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
     } else {
-        mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, root, comm_ptr, s);
+        mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/coll/igatherv/igatherv_allcomm_sched_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_allcomm_sched_linear.c
@@ -15,7 +15,7 @@ int MPIR_Igatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
                                        MPI_Datatype sendtype, void *recvbuf,
                                        const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                        MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                       MPIR_Sched_t s)
+                                       int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -46,7 +46,7 @@ int MPIR_Igatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
                     }
                 } else {
                     mpi_errno = MPIR_Sched_recv(((char *) recvbuf + displs[i] * extent),
-                                                recvcounts[i], recvtype, i, comm_ptr, s);
+                                                recvcounts[i], recvtype, i, comm_ptr, collattr, s);
                     MPIR_ERR_CHECK(mpi_errno);
                 }
             }
@@ -66,9 +66,11 @@ int MPIR_Igatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
                 MPIR_CVAR_GET_DEFAULT_INT(GATHERV_INTER_SSEND_MIN_PROCS, &min_procs);
 
             if (comm_size >= min_procs)
-                mpi_errno = MPIR_Sched_ssend(sendbuf, sendcount, sendtype, root, comm_ptr, s);
+                mpi_errno =
+                    MPIR_Sched_ssend(sendbuf, sendcount, sendtype, root, comm_ptr, collattr, s);
             else
-                mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, root, comm_ptr, s);
+                mpi_errno =
+                    MPIR_Sched_send(sendbuf, sendcount, sendtype, root, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }

--- a/src/mpi/coll/igatherv/igatherv_tsp_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_tsp_linear.c
@@ -21,7 +21,7 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcou
                                            MPI_Datatype sendtype, void *recvbuf,
                                            const MPI_Aint recvcounts[], const MPI_Aint displs[],
                                            MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                           MPIR_TSP_sched_t sched)
+                                           int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -60,7 +60,7 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcou
                 } else {
                     mpi_errno = MPIR_TSP_sched_irecv(((char *) recvbuf + displs[i] * extent),
                                                      recvcounts[i], recvtype, i, tag, comm_ptr,
-                                                     sched, 0, NULL, &vtx_id);
+                                                     collattr, sched, 0, NULL, &vtx_id);
                 }
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
@@ -81,12 +81,12 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcou
 
             if (comm_size >= min_procs)
                 mpi_errno =
-                    MPIR_TSP_sched_issend(sendbuf, sendcount, sendtype, root, tag, comm_ptr, sched,
-                                          0, NULL, &vtx_id);
+                    MPIR_TSP_sched_issend(sendbuf, sendcount, sendtype, root, tag, comm_ptr,
+                                          collattr, sched, 0, NULL, &vtx_id);
             else
                 mpi_errno =
-                    MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, root, tag, comm_ptr, sched,
-                                         0, NULL, &vtx_id);
+                    MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, root, tag, comm_ptr,
+                                         collattr, sched, 0, NULL, &vtx_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_sched_linear.c
@@ -22,6 +22,7 @@ int MPIR_Ineighbor_allgather_allcomm_sched_linear(const void *sendbuf, MPI_Aint 
     int k, l;
     int *srcs, *dsts;
     MPI_Aint recvtype_extent;
+    int collattr = 0;
     MPIR_CHKLMEM_DECL(2);
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
@@ -36,13 +37,13 @@ int MPIR_Ineighbor_allgather_allcomm_sched_linear(const void *sendbuf, MPI_Aint 
     MPIR_ERR_CHECK(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
-        mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, dsts[k], comm_ptr, s);
+        mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, dsts[k], comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
-        mpi_errno = MPIR_Sched_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
+        mpi_errno = MPIR_Sched_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear.c
@@ -20,6 +20,7 @@ int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, MPI_A
     int *srcs, *dsts;
     int tag, vtx_id;
     MPI_Aint recvtype_extent;
+    int collattr = 0;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
@@ -44,16 +45,16 @@ int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, MPI_A
 
     for (k = 0; k < outdegree; ++k) {
         mpi_errno =
-            MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, dsts[k], tag, comm_ptr, sched, 0,
-                                 NULL, &vtx_id);
+            MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, dsts[k], tag, comm_ptr,
+                                 collattr | errflag, sched, 0, NULL, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
         mpi_errno =
-            MPIR_TSP_sched_irecv(rb, recvcount, recvtype, srcs[l], tag, comm_ptr, sched, 0, NULL,
-                                 &vtx_id);
+            MPIR_TSP_sched_irecv(rb, recvcount, recvtype, srcs[l], tag, comm_ptr, collattr, sched,
+                                 0, NULL, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_sched_linear.c
@@ -23,6 +23,7 @@ int MPIR_Ineighbor_allgatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint
     int k, l;
     int *srcs, *dsts;
     MPI_Aint recvtype_extent;
+    int collattr = 0;
     MPIR_CHKLMEM_DECL(2);
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
@@ -37,13 +38,13 @@ int MPIR_Ineighbor_allgatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint
     MPIR_ERR_CHECK(mpi_errno);
 
     for (k = 0; k < outdegree; ++k) {
-        mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, dsts[k], comm_ptr, s);
+        mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, dsts[k], comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + displs[l] * recvtype_extent;
-        mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
+        mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear.c
@@ -22,6 +22,7 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_
     int *srcs, *dsts;
     int tag, vtx_id;
     MPI_Aint recvtype_extent;
+    int collattr = 0;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(2);
 
@@ -45,16 +46,16 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_
 
     for (k = 0; k < outdegree; ++k) {
         mpi_errno =
-            MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, dsts[k], tag, comm_ptr, sched, 0,
-                                 NULL, &vtx_id);
+            MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, dsts[k], tag, comm_ptr, collattr,
+                                 sched, 0, NULL, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     for (l = 0; l < indegree; ++l) {
         char *rb = ((char *) recvbuf) + displs[l] * recvtype_extent;
         mpi_errno =
-            MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtype, srcs[l], tag, comm_ptr, sched, 0,
-                                 NULL, &vtx_id);
+            MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtype, srcs[l], tag, comm_ptr, collattr,
+                                 sched, 0, NULL, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_sched_linear.c
@@ -22,6 +22,7 @@ int MPIR_Ineighbor_alltoall_allcomm_sched_linear(const void *sendbuf, MPI_Aint s
     int k, l;
     int *srcs, *dsts;
     MPI_Aint sendtype_extent, recvtype_extent;
+    int collattr = 0;
     MPIR_CHKLMEM_DECL(2);
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
@@ -38,7 +39,7 @@ int MPIR_Ineighbor_alltoall_allcomm_sched_linear(const void *sendbuf, MPI_Aint s
 
     for (k = 0; k < outdegree; ++k) {
         char *sb = ((char *) sendbuf) + k * sendcount * sendtype_extent;
-        mpi_errno = MPIR_Sched_send(sb, sendcount, sendtype, dsts[k], comm_ptr, s);
+        mpi_errno = MPIR_Sched_send(sb, sendcount, sendtype, dsts[k], comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -57,7 +58,7 @@ int MPIR_Ineighbor_alltoall_allcomm_sched_linear(const void *sendbuf, MPI_Aint s
      */
     for (l = indegree - 1; l >= 0; l--) {
         char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
-        mpi_errno = MPIR_Sched_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, s);
+        mpi_errno = MPIR_Sched_recv(rb, recvcount, recvtype, srcs[l], comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear.c
@@ -20,6 +20,7 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, MPI_Ai
     int *srcs, *dsts;
     MPI_Aint sendtype_extent, recvtype_extent;
     int tag, vtx_id;
+    int collattr = 0;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
@@ -47,8 +48,8 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, MPI_Ai
     for (k = 0; k < outdegree; ++k) {
         char *sb = ((char *) sendbuf) + k * sendcount * sendtype_extent;
         mpi_errno =
-            MPIR_TSP_sched_isend(sb, sendcount, sendtype, dsts[k], tag, comm_ptr, sched, 0, NULL,
-                                 &vtx_id);
+            MPIR_TSP_sched_isend(sb, sendcount, sendtype, dsts[k], tag, comm_ptr, collattr, sched,
+                                 0, NULL, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
@@ -58,8 +59,8 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, MPI_Ai
     for (l = indegree - 1; l >= 0; l--) {
         char *rb = ((char *) recvbuf) + l * recvcount * recvtype_extent;
         mpi_errno =
-            MPIR_TSP_sched_irecv(rb, recvcount, recvtype, srcs[l], tag, comm_ptr, sched, 0, NULL,
-                                 &vtx_id);
+            MPIR_TSP_sched_irecv(rb, recvcount, recvtype, srcs[l], tag, comm_ptr, collattr, sched,
+                                 0, NULL, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_sched_linear.c
@@ -23,6 +23,7 @@ int MPIR_Ineighbor_alltoallv_allcomm_sched_linear(const void *sendbuf, const MPI
     int k, l;
     int *srcs, *dsts;
     MPI_Aint sendtype_extent, recvtype_extent;
+    int collattr = 0;
     MPIR_CHKLMEM_DECL(2);
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
@@ -39,7 +40,7 @@ int MPIR_Ineighbor_alltoallv_allcomm_sched_linear(const void *sendbuf, const MPI
 
     for (k = 0; k < outdegree; ++k) {
         char *sb = ((char *) sendbuf) + sdispls[k] * sendtype_extent;
-        mpi_errno = MPIR_Sched_send(sb, sendcounts[k], sendtype, dsts[k], comm_ptr, s);
+        mpi_errno = MPIR_Sched_send(sb, sendcounts[k], sendtype, dsts[k], comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -48,7 +49,7 @@ int MPIR_Ineighbor_alltoallv_allcomm_sched_linear(const void *sendbuf, const MPI
      * ref. ineighbor_alltoall_allcomm_sched_linear.c */
     for (l = indegree - 1; l >= 0; l--) {
         char *rb = ((char *) recvbuf) + rdispls[l] * recvtype_extent;
-        mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, s);
+        mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtype, srcs[l], comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear.c
@@ -23,6 +23,7 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf,
     int k, l;
     int *srcs, *dsts;
     int tag, vtx_id;
+    int collattr = 0;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPI_Aint sendtype_extent, recvtype_extent;
 
@@ -50,8 +51,8 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf,
     for (k = 0; k < outdegree; ++k) {
         char *sb = ((char *) sendbuf) + sdispls[k] * sendtype_extent;
         mpi_errno =
-            MPIR_TSP_sched_isend(sb, sendcounts[k], sendtype, dsts[k], tag, comm_ptr, sched, 0,
-                                 NULL, &vtx_id);
+            MPIR_TSP_sched_isend(sb, sendcounts[k], sendtype, dsts[k], tag, comm_ptr, collattr,
+                                 sched, 0, NULL, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
@@ -61,8 +62,8 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf,
     for (l = indegree - 1; l >= 0; l--) {
         char *rb = ((char *) recvbuf) + rdispls[l] * recvtype_extent;
         mpi_errno =
-            MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtype, srcs[l], tag, comm_ptr, sched, 0,
-                                 NULL, &vtx_id);
+            MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtype, srcs[l], tag, comm_ptr, collattr,
+                                 sched, 0, NULL, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_sched_linear.c
@@ -24,6 +24,7 @@ int MPIR_Ineighbor_alltoallw_allcomm_sched_linear(const void *sendbuf, const MPI
     int indegree, outdegree, weighted;
     int k, l;
     int *srcs, *dsts;
+    int collattr = 0;
     MPIR_CHKLMEM_DECL(2);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
@@ -39,7 +40,8 @@ int MPIR_Ineighbor_alltoallw_allcomm_sched_linear(const void *sendbuf, const MPI
         char *sb;
 
         sb = ((char *) sendbuf) + sdispls[k];
-        mpi_errno = MPIR_Sched_send(sb, sendcounts[k], sendtypes[k], dsts[k], comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_send(sb, sendcounts[k], sendtypes[k], dsts[k], comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -50,7 +52,8 @@ int MPIR_Ineighbor_alltoallw_allcomm_sched_linear(const void *sendbuf, const MPI
         char *rb;
 
         rb = ((char *) recvbuf) + rdispls[l];
-        mpi_errno = MPIR_Sched_recv(rb, recvcounts[l], recvtypes[l], srcs[l], comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_recv(rb, recvcounts[l], recvtypes[l], srcs[l], comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear.c
@@ -23,6 +23,7 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf,
     int k, l;
     int *srcs, *dsts;
     int tag, vtx_id;
+    int collattr = 0;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
@@ -48,8 +49,8 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf,
 
         sb = ((char *) sendbuf) + sdispls[k];
         mpi_errno =
-            MPIR_TSP_sched_isend(sb, sendcounts[k], sendtypes[k], dsts[k], tag, comm_ptr, sched, 0,
-                                 NULL, &vtx_id);
+            MPIR_TSP_sched_isend(sb, sendcounts[k], sendtypes[k], dsts[k], tag, comm_ptr, collattr,
+                                 sched, 0, NULL, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
@@ -61,8 +62,8 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf,
 
         rb = ((char *) recvbuf) + rdispls[l];
         mpi_errno =
-            MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtypes[l], srcs[l], tag, comm_ptr, sched, 0,
-                                 NULL, &vtx_id);
+            MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtypes[l], srcs[l], tag, comm_ptr, collattr,
+                                 sched, 0, NULL, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/ireduce/ireduce_inter_sched_local_reduce_remote_send.c
+++ b/src/mpi/coll/ireduce/ireduce_inter_sched_local_reduce_remote_send.c
@@ -14,7 +14,7 @@
 int MPIR_Ireduce_inter_sched_local_reduce_remote_send(const void *sendbuf, void *recvbuf,
                                                       MPI_Aint count, MPI_Datatype datatype,
                                                       MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                                                      MPIR_Sched_t s)
+                                                      int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank;
@@ -30,7 +30,7 @@ int MPIR_Ireduce_inter_sched_local_reduce_remote_send(const void *sendbuf, void 
 
     if (root == MPI_ROOT) {
         /* root receives data from rank 0 on remote group */
-        mpi_errno = MPIR_Sched_recv(recvbuf, count, datatype, 0, comm_ptr, s);
+        mpi_errno = MPIR_Sched_recv(recvbuf, count, datatype, 0, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_barrier(s);
         MPIR_ERR_CHECK(mpi_errno);
@@ -57,13 +57,13 @@ int MPIR_Ireduce_inter_sched_local_reduce_remote_send(const void *sendbuf, void 
 
         mpi_errno =
             MPIR_Ireduce_intra_sched_auto(sendbuf, tmp_buf, count, datatype, op, 0,
-                                          comm_ptr->local_comm, s);
+                                          comm_ptr->local_comm, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_barrier(s);
         MPIR_ERR_CHECK(mpi_errno);
 
         if (rank == 0) {
-            mpi_errno = MPIR_Sched_send(tmp_buf, count, datatype, root, comm_ptr, s);
+            mpi_errno = MPIR_Sched_send(tmp_buf, count, datatype, root, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             mpi_errno = MPIR_Sched_barrier(s);
             MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/coll/ireduce/ireduce_intra_sched_reduce_scatter_gather.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_sched_reduce_scatter_gather.c
@@ -34,7 +34,8 @@
 */
 int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *recvbuf,
                                                    MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                   int root, MPIR_Comm * comm_ptr, int collattr,
+                                                   MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, j, comm_size, rank, pof2, is_commutative ATTRIBUTE((unused));
@@ -104,7 +105,7 @@ int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *re
 
     if (rank < 2 * rem) {
         if (rank % 2 != 0) {    /* odd */
-            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank - 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, rank - 1, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
@@ -113,7 +114,7 @@ int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *re
              * doubling */
             newrank = -1;
         } else {        /* even */
-            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, rank + 1, comm_ptr, s);
+            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, rank + 1, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
@@ -182,11 +183,11 @@ int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *re
 
             /* Send data from recvbuf. Recv into tmp_buf */
             mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[send_idx] * extent),
-                                        send_cnt, datatype, dst, comm_ptr, s);
+                                        send_cnt, datatype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             /* sendrecv, no barrier here */
             mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + disps[recv_idx] * extent),
-                                        recv_cnt, datatype, dst, comm_ptr, s);
+                                        recv_cnt, datatype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
@@ -231,7 +232,7 @@ int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *re
                 for (i = 1; i < pof2; i++)
                     disps[i] = disps[i - 1] + cnts[i - 1];
 
-                mpi_errno = MPIR_Sched_recv(recvbuf, cnts[0], datatype, 0, comm_ptr, s);
+                mpi_errno = MPIR_Sched_recv(recvbuf, cnts[0], datatype, 0, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
@@ -239,7 +240,8 @@ int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *re
                 send_idx = 0;
                 last_idx = 2;
             } else if (newrank == 0) {  /* send */
-                mpi_errno = MPIR_Sched_send(recvbuf, cnts[0], datatype, root, comm_ptr, s);
+                mpi_errno =
+                    MPIR_Sched_send(recvbuf, cnts[0], datatype, root, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
                 newrank = -1;
@@ -304,14 +306,14 @@ int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *re
                 /* send and exit */
                 /* Send data from recvbuf. Recv into tmp_buf */
                 mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[send_idx] * extent),
-                                            send_cnt, datatype, dst, comm_ptr, s);
+                                            send_cnt, datatype, dst, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
                 break;
             } else {
                 /* recv and continue */
                 mpi_errno = MPIR_Sched_recv(((char *) recvbuf + disps[recv_idx] * extent),
-                                            recv_cnt, datatype, dst, comm_ptr, s);
+                                            recv_cnt, datatype, dst, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }

--- a/src/mpi/coll/ireduce/ireduce_tsp_auto.c
+++ b/src/mpi/coll/ireduce/ireduce_tsp_auto.c
@@ -12,7 +12,7 @@
 static int MPIR_Ireduce_sched_intra_tsp_flat_auto(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                   int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_TSP_sched_t sched)
+                                                  int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int tree_type = MPIR_TREE_TYPE_KNOMIAL_1;
@@ -27,7 +27,7 @@ static int MPIR_Ireduce_sched_intra_tsp_flat_auto(const void *sendbuf, void *rec
     mpi_errno = MPIR_TSP_Ireduce_sched_intra_tree(sendbuf, recvbuf, count,
                                                   datatype, op, root, comm_ptr,
                                                   tree_type, radix, block_size,
-                                                  buffer_per_child, sched);
+                                                  buffer_per_child, collattr, sched);
     if (mpi_errno)
         MPIR_ERR_POP(mpi_errno);
 
@@ -40,7 +40,8 @@ static int MPIR_Ireduce_sched_intra_tsp_flat_auto(const void *sendbuf, void *rec
 /* sched version of CVAR and json based collective selection. Meant only for gentran scheduler */
 int MPIR_TSP_Ireduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                           MPI_Datatype datatype, MPI_Op op, int root,
-                                          MPIR_Comm * comm_ptr, MPIR_TSP_sched_t sched)
+                                          MPIR_Comm * comm_ptr, int collattr,
+                                          MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -64,13 +65,15 @@ int MPIR_TSP_Ireduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf, MP
             /*Only knomial_1 tree supports non-commutative operations */
             MPII_COLLECTIVE_FALLBACK_CHECK(comm_ptr->rank, MPIR_Op_is_commutative(op) ||
                                            MPIR_Ireduce_tree_type == MPIR_TREE_TYPE_KNOMIAL_1,
-                                           mpi_errno, "Ireduce gentran_tree cannot be applied.\n");
+                                           mpi_errno,
+                                           "Ireduce gentran_tree cannot be collattr, applied.\n");
             mpi_errno =
                 MPIR_TSP_Ireduce_sched_intra_tree(sendbuf, recvbuf, count, datatype, op, root,
                                                   comm_ptr, MPIR_Ireduce_tree_type,
                                                   MPIR_CVAR_IREDUCE_TREE_KVAL,
                                                   MPIR_CVAR_IREDUCE_TREE_PIPELINE_CHUNK_SIZE,
-                                                  MPIR_CVAR_IREDUCE_TREE_BUFFER_PER_CHILD, sched);
+                                                  MPIR_CVAR_IREDUCE_TREE_BUFFER_PER_CHILD, collattr,
+                                                  sched);
             break;
 
         case MPIR_CVAR_IREDUCE_INTRA_ALGORITHM_tsp_ring:
@@ -78,7 +81,8 @@ int MPIR_TSP_Ireduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf, MP
                 MPIR_TSP_Ireduce_sched_intra_tree(sendbuf, recvbuf, count, datatype, op, root,
                                                   comm_ptr, MPIR_TREE_TYPE_KARY, 1,
                                                   MPIR_CVAR_IREDUCE_RING_CHUNK_SIZE,
-                                                  MPIR_CVAR_IREDUCE_TREE_BUFFER_PER_CHILD, sched);
+                                                  MPIR_CVAR_IREDUCE_TREE_BUFFER_PER_CHILD, collattr,
+                                                  sched);
             break;
 
         default:
@@ -94,7 +98,8 @@ int MPIR_TSP_Ireduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf, MP
                                                           cnt->u.ireduce.intra_tsp_tree.k,
                                                           cnt->u.ireduce.intra_tsp_tree.chunk_size,
                                                           cnt->u.ireduce.
-                                                          intra_tsp_tree.buffer_per_child, sched);
+                                                          intra_tsp_tree.buffer_per_child, collattr,
+                                                          sched);
                     break;
 
                 case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ireduce_intra_tsp_ring:
@@ -103,14 +108,16 @@ int MPIR_TSP_Ireduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf, MP
                                                           root, comm_ptr, MPIR_TREE_TYPE_KARY, 1,
                                                           cnt->u.ireduce.intra_tsp_ring.chunk_size,
                                                           cnt->u.ireduce.
-                                                          intra_tsp_ring.buffer_per_child, sched);
+                                                          intra_tsp_ring.buffer_per_child, collattr,
+                                                          sched);
                     break;
 
                 default:
                     /* Replace this call with MPIR_Assert(0) when json files have gentran algos */
                     mpi_errno =
                         MPIR_Ireduce_sched_intra_tsp_flat_auto(sendbuf, recvbuf, count,
-                                                               datatype, op, root, comm_ptr, sched);
+                                                               datatype, op, root, comm_ptr,
+                                                               collattr, sched);
                     break;
             }
     }
@@ -122,7 +129,7 @@ int MPIR_TSP_Ireduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf, MP
         MPIR_TSP_Ireduce_sched_intra_tree(sendbuf, recvbuf, count, datatype, op, root,
                                           comm_ptr, MPIR_TREE_TYPE_KARY, 1,
                                           MPIR_CVAR_IREDUCE_RING_CHUNK_SIZE,
-                                          MPIR_CVAR_IREDUCE_TREE_BUFFER_PER_CHILD, sched);
+                                          MPIR_CVAR_IREDUCE_TREE_BUFFER_PER_CHILD, collattr, sched);
 
 
   fn_exit:

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree.c
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree.c
@@ -11,7 +11,7 @@
 int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                       MPI_Datatype datatype, MPI_Op op, int root,
                                       MPIR_Comm * comm, int tree_type, int k, int chunk_size,
-                                      int buffer_per_child, MPIR_TSP_sched_t sched)
+                                      int buffer_per_child, int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -177,7 +177,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
             }
 
             mpi_errno = MPIR_TSP_sched_irecv(recv_address, msgsize, datatype, child, tag, comm,
-                                             sched, nvtcs, vtcs, &recv_id[i]);
+                                             collattr, sched, nvtcs, vtcs, &recv_id[i]);
 
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             /* Setup dependencies for reduction. Reduction depends on the corresponding recv to complete */
@@ -223,7 +223,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
         if (!is_tree_root) {
             mpi_errno =
                 MPIR_TSP_sched_isend(reduce_address, msgsize, datatype, my_tree.parent, tag, comm,
-                                     sched, nvtcs, vtcs, &vtx_id);
+                                     collattr, sched, nvtcs, vtcs, &vtx_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 
@@ -231,12 +231,12 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
         if (tree_root != root) {
             if (is_tree_root) { /* tree_root sends data to root */
                 mpi_errno =
-                    MPIR_TSP_sched_isend(reduce_address, msgsize, datatype, root, tag, comm, sched,
-                                         nvtcs, vtcs, &vtx_id);
+                    MPIR_TSP_sched_isend(reduce_address, msgsize, datatype, root, tag, comm,
+                                         collattr, sched, nvtcs, vtcs, &vtx_id);
             } else if (is_root) {       /* root receives data from tree_root */
                 mpi_errno =
                     MPIR_TSP_sched_irecv((char *) recvbuf + offset * extent, msgsize, datatype,
-                                         tree_root, tag, comm, sched, 0, NULL, &vtx_id);
+                                         tree_root, tag, comm, collattr, sched, 0, NULL, &vtx_id);
             }
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_inter_sched_remote_reduce_local_scatterv.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_inter_sched_remote_reduce_local_scatterv.c
@@ -17,7 +17,7 @@ int MPIR_Ireduce_scatter_inter_sched_remote_reduce_local_scatterv(const void *se
                                                                   const MPI_Aint recvcounts[],
                                                                   MPI_Datatype datatype, MPI_Op op,
                                                                   MPIR_Comm * comm_ptr,
-                                                                  MPIR_Sched_t s)
+                                                                  int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, root, local_size, total_count, i;
@@ -62,7 +62,7 @@ int MPIR_Ireduce_scatter_inter_sched_remote_reduce_local_scatterv(const void *se
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Ireduce_inter_sched_auto(sendbuf, tmp_buf, total_count,
-                                                  datatype, op, root, comm_ptr, s);
+                                                  datatype, op, root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
 
         /* sched barrier intentionally omitted here to allow both reductions to
@@ -71,13 +71,13 @@ int MPIR_Ireduce_scatter_inter_sched_remote_reduce_local_scatterv(const void *se
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno = MPIR_Ireduce_inter_sched_auto(sendbuf, tmp_buf, total_count,
-                                                  datatype, op, root, comm_ptr, s);
+                                                  datatype, op, root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno = MPIR_Ireduce_inter_sched_auto(sendbuf, tmp_buf, total_count,
-                                                  datatype, op, root, comm_ptr, s);
+                                                  datatype, op, root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
 
         /* sched barrier intentionally omitted here to allow both reductions to
@@ -86,7 +86,7 @@ int MPIR_Ireduce_scatter_inter_sched_remote_reduce_local_scatterv(const void *se
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Ireduce_inter_sched_auto(sendbuf, tmp_buf, total_count,
-                                                  datatype, op, root, comm_ptr, s);
+                                                  datatype, op, root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
     MPIR_SCHED_BARRIER(s);
@@ -101,7 +101,7 @@ int MPIR_Ireduce_scatter_inter_sched_remote_reduce_local_scatterv(const void *se
 
     mpi_errno = MPIR_Iscatterv_intra_sched_auto(tmp_buf, recvcounts, disps, datatype,
                                                 recvbuf, recvcounts[rank], datatype, 0, newcomm_ptr,
-                                                s);
+                                                collattr, s);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_noncommutative.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_noncommutative.c
@@ -23,7 +23,8 @@
 int MPIR_Ireduce_scatter_intra_sched_noncommutative(const void *sendbuf, void *recvbuf,
                                                     const MPI_Aint recvcounts[],
                                                     MPI_Datatype datatype, MPI_Op op,
-                                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                    MPIR_Comm * comm_ptr, int collattr,
+                                                    MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size = comm_ptr->local_size;
@@ -98,10 +99,10 @@ int MPIR_Ireduce_scatter_intra_sched_noncommutative(const void *sendbuf, void *r
         }
 
         mpi_errno = MPIR_Sched_send((outgoing_data + send_offset * true_extent),
-                                    size, datatype, peer, comm_ptr, s);
+                                    size, datatype, peer, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_recv((incoming_data + recv_offset * true_extent),
-                                    size, datatype, peer, comm_ptr, s);
+                                    size, datatype, peer, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_pairwise.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_pairwise.c
@@ -14,7 +14,8 @@
  */
 int MPIR_Ireduce_scatter_intra_sched_pairwise(const void *sendbuf, void *recvbuf,
                                               const MPI_Aint recvcounts[], MPI_Datatype datatype,
-                                              MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                              MPI_Op op, MPIR_Comm * comm_ptr, int collattr,
+                                              MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;
@@ -72,14 +73,15 @@ int MPIR_Ireduce_scatter_intra_sched_pairwise(const void *sendbuf, void *recvbuf
          * needs from src into tmp_recvbuf */
         if (sendbuf != MPI_IN_PLACE) {
             mpi_errno = MPIR_Sched_send(((char *) sendbuf + disps[dst] * extent),
-                                        recvcounts[dst], datatype, dst, comm_ptr, s);
+                                        recvcounts[dst], datatype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         } else {
             mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[dst] * extent),
-                                        recvcounts[dst], datatype, dst, comm_ptr, s);
+                                        recvcounts[dst], datatype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
-        mpi_errno = MPIR_Sched_recv(tmp_recvbuf, recvcounts[rank], datatype, src, comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_recv(tmp_recvbuf, recvcounts[rank], datatype, src, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_doubling.c
@@ -19,7 +19,8 @@
 int MPIR_Ireduce_scatter_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf,
                                                         const MPI_Aint recvcounts[],
                                                         MPI_Datatype datatype, MPI_Op op,
-                                                        MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                        MPIR_Comm * comm_ptr, int collattr,
+                                                        MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;
@@ -140,9 +141,9 @@ int MPIR_Ireduce_scatter_intra_sched_recursive_doubling(const void *sendbuf, voi
              * received in tmp_recvbuf and then accumulated into
              * tmp_results. accumulation is done later below.   */
 
-            mpi_errno = MPIR_Sched_send(tmp_results, 1, sendtype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_send(tmp_results, 1, sendtype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
-            mpi_errno = MPIR_Sched_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
             received = 1;
@@ -183,7 +184,8 @@ int MPIR_Ireduce_scatter_intra_sched_recursive_doubling(const void *sendbuf, voi
                 if ((dst > rank) && (rank < tree_root + nprocs_completed)
                     && (dst >= tree_root + nprocs_completed)) {
                     /* send the current result */
-                    mpi_errno = MPIR_Sched_send(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
+                    mpi_errno =
+                        MPIR_Sched_send(tmp_recvbuf, 1, recvtype, dst, comm_ptr, collattr, s);
                     MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                 }
@@ -192,7 +194,8 @@ int MPIR_Ireduce_scatter_intra_sched_recursive_doubling(const void *sendbuf, voi
                 else if ((dst < rank) &&
                          (dst < tree_root + nprocs_completed) &&
                          (rank >= tree_root + nprocs_completed)) {
-                    mpi_errno = MPIR_Sched_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
+                    mpi_errno =
+                        MPIR_Sched_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, collattr, s);
                     MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                     received = 1;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_halving.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_halving.c
@@ -36,7 +36,8 @@
 int MPIR_Ireduce_scatter_intra_sched_recursive_halving(const void *sendbuf, void *recvbuf,
                                                        const MPI_Aint recvcounts[],
                                                        MPI_Datatype datatype, MPI_Op op,
-                                                       MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                       MPIR_Comm * comm_ptr, int collattr,
+                                                       MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;
@@ -107,7 +108,9 @@ int MPIR_Ireduce_scatter_intra_sched_recursive_halving(const void *sendbuf, void
 
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
-            mpi_errno = MPIR_Sched_send(tmp_results, total_count, datatype, rank + 1, comm_ptr, s);
+            mpi_errno =
+                MPIR_Sched_send(tmp_results, total_count, datatype, rank + 1, comm_ptr, collattr,
+                                s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
@@ -116,7 +119,9 @@ int MPIR_Ireduce_scatter_intra_sched_recursive_halving(const void *sendbuf, void
              * doubling */
             newrank = -1;
         } else {        /* odd */
-            mpi_errno = MPIR_Sched_recv(tmp_recvbuf, total_count, datatype, rank - 1, comm_ptr, s);
+            mpi_errno =
+                MPIR_Sched_recv(tmp_recvbuf, total_count, datatype, rank - 1, comm_ptr, collattr,
+                                s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
@@ -190,10 +195,10 @@ int MPIR_Ireduce_scatter_intra_sched_recursive_halving(const void *sendbuf, void
                 int recv_dst = (recv_cnt ? dst : MPI_PROC_NULL);
 
                 mpi_errno = MPIR_Sched_send(((char *) tmp_results + newdisps[send_idx] * extent),
-                                            send_cnt, datatype, send_dst, comm_ptr, s);
+                                            send_cnt, datatype, send_dst, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_recv(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
-                                            recv_cnt, datatype, recv_dst, comm_ptr, s);
+                                            recv_cnt, datatype, recv_dst, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
@@ -231,14 +236,16 @@ int MPIR_Ireduce_scatter_intra_sched_recursive_halving(const void *sendbuf, void
         if (rank % 2) { /* odd */
             if (recvcounts[rank - 1]) {
                 mpi_errno = MPIR_Sched_send(((char *) tmp_results + disps[rank - 1] * extent),
-                                            recvcounts[rank - 1], datatype, rank - 1, comm_ptr, s);
+                                            recvcounts[rank - 1], datatype, rank - 1, comm_ptr,
+                                            collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
         } else {        /* even */
             if (recvcounts[rank]) {
                 mpi_errno =
-                    MPIR_Sched_recv(recvbuf, recvcounts[rank], datatype, rank + 1, comm_ptr, s);
+                    MPIR_Sched_recv(recvbuf, recvcounts[rank], datatype, rank + 1, comm_ptr,
+                                    collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_inter_sched_remote_reduce_local_scatterv.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_inter_sched_remote_reduce_local_scatterv.c
@@ -18,6 +18,7 @@ int MPIR_Ireduce_scatter_block_inter_sched_remote_reduce_local_scatterv(const vo
                                                                         MPI_Datatype datatype,
                                                                         MPI_Op op,
                                                                         MPIR_Comm * comm_ptr,
+                                                                        int collattr,
                                                                         MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -51,7 +52,7 @@ int MPIR_Ireduce_scatter_block_inter_sched_remote_reduce_local_scatterv(const vo
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Ireduce_inter_sched_auto(sendbuf, tmp_buf, total_count,
-                                                  datatype, op, root, comm_ptr, s);
+                                                  datatype, op, root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
 
         /* sched barrier intentionally omitted here to allow both reductions to
@@ -60,13 +61,13 @@ int MPIR_Ireduce_scatter_block_inter_sched_remote_reduce_local_scatterv(const vo
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno = MPIR_Ireduce_inter_sched_auto(sendbuf, tmp_buf, total_count,
-                                                  datatype, op, root, comm_ptr, s);
+                                                  datatype, op, root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno = MPIR_Ireduce_inter_sched_auto(sendbuf, tmp_buf, total_count,
-                                                  datatype, op, root, comm_ptr, s);
+                                                  datatype, op, root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
 
         /* sched barrier intentionally omitted here to allow both reductions to
@@ -75,7 +76,7 @@ int MPIR_Ireduce_scatter_block_inter_sched_remote_reduce_local_scatterv(const vo
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Ireduce_inter_sched_auto(sendbuf, tmp_buf, total_count,
-                                                  datatype, op, root, comm_ptr, s);
+                                                  datatype, op, root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
     MPIR_SCHED_BARRIER(s);
@@ -89,7 +90,8 @@ int MPIR_Ireduce_scatter_block_inter_sched_remote_reduce_local_scatterv(const vo
     newcomm_ptr = comm_ptr->local_comm;
 
     mpi_errno = MPIR_Iscatter_intra_sched_auto(tmp_buf, recvcount, datatype,
-                                               recvbuf, recvcount, datatype, 0, newcomm_ptr, s);
+                                               recvbuf, recvcount, datatype, 0, newcomm_ptr,
+                                               collattr, s);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_noncommutative.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_noncommutative.c
@@ -12,7 +12,7 @@
 int MPIR_Ireduce_scatter_block_intra_sched_noncommutative(const void *sendbuf, void *recvbuf,
                                                           MPI_Aint recvcount, MPI_Datatype datatype,
                                                           MPI_Op op, MPIR_Comm * comm_ptr,
-                                                          MPIR_Sched_t s)
+                                                          int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size = comm_ptr->local_size;
@@ -84,10 +84,10 @@ int MPIR_Ireduce_scatter_block_intra_sched_noncommutative(const void *sendbuf, v
         }
 
         mpi_errno = MPIR_Sched_send((outgoing_data + send_offset * true_extent),
-                                    size, datatype, peer, comm_ptr, s);
+                                    size, datatype, peer, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_recv((incoming_data + recv_offset * true_extent),
-                                    size, datatype, peer, comm_ptr, s);
+                                    size, datatype, peer, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_pairwise.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_pairwise.c
@@ -9,7 +9,8 @@
  * commutative op and is intended for use with large messages. */
 int MPIR_Ireduce_scatter_block_intra_sched_pairwise(const void *sendbuf, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype datatype,
-                                                    MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                    MPI_Op op, MPIR_Comm * comm_ptr, int collattr,
+                                                    MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;
@@ -62,14 +63,14 @@ int MPIR_Ireduce_scatter_block_intra_sched_pairwise(const void *sendbuf, void *r
          * needs from src into tmp_recvbuf */
         if (sendbuf != MPI_IN_PLACE) {
             mpi_errno = MPIR_Sched_send(((char *) sendbuf + disps[dst] * extent),
-                                        recvcount, datatype, dst, comm_ptr, s);
+                                        recvcount, datatype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         } else {
             mpi_errno = MPIR_Sched_send(((char *) recvbuf + disps[dst] * extent),
-                                        recvcount, datatype, dst, comm_ptr, s);
+                                        recvcount, datatype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
-        mpi_errno = MPIR_Sched_recv(tmp_recvbuf, recvcount, datatype, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_recv(tmp_recvbuf, recvcount, datatype, src, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_doubling.c
@@ -10,7 +10,8 @@
 int MPIR_Ireduce_scatter_block_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf,
                                                               MPI_Aint recvcount,
                                                               MPI_Datatype datatype, MPI_Op op,
-                                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                              MPIR_Comm * comm_ptr, int collattr,
+                                                              MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;
@@ -123,9 +124,9 @@ int MPIR_Ireduce_scatter_block_intra_sched_recursive_doubling(const void *sendbu
             /* tmp_results contains data to be sent in each step. Data is
              * received in tmp_recvbuf and then accumulated into
              * tmp_results. accumulation is done later below.   */
-            mpi_errno = MPIR_Sched_send(tmp_results, 1, sendtype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_send(tmp_results, 1, sendtype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
-            mpi_errno = MPIR_Sched_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
             received = 1;
@@ -166,7 +167,8 @@ int MPIR_Ireduce_scatter_block_intra_sched_recursive_doubling(const void *sendbu
                 if ((dst > rank) && (rank < tree_root + nprocs_completed)
                     && (dst >= tree_root + nprocs_completed)) {
                     /* send the current result */
-                    mpi_errno = MPIR_Sched_send(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
+                    mpi_errno =
+                        MPIR_Sched_send(tmp_recvbuf, 1, recvtype, dst, comm_ptr, collattr, s);
                     MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                 }
@@ -175,7 +177,8 @@ int MPIR_Ireduce_scatter_block_intra_sched_recursive_doubling(const void *sendbu
                 else if ((dst < rank) &&
                          (dst < tree_root + nprocs_completed) &&
                          (rank >= tree_root + nprocs_completed)) {
-                    mpi_errno = MPIR_Sched_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, s);
+                    mpi_errno =
+                        MPIR_Sched_recv(tmp_recvbuf, 1, recvtype, dst, comm_ptr, collattr, s);
                     MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                     received = 1;

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_halving.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_halving.c
@@ -10,7 +10,8 @@
 int MPIR_Ireduce_scatter_block_intra_sched_recursive_halving(const void *sendbuf, void *recvbuf,
                                                              MPI_Aint recvcount,
                                                              MPI_Datatype datatype, MPI_Op op,
-                                                             MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                             MPIR_Comm * comm_ptr, int collattr,
+                                                             MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size, i;
@@ -76,7 +77,9 @@ int MPIR_Ireduce_scatter_block_intra_sched_recursive_halving(const void *sendbuf
 
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
-            mpi_errno = MPIR_Sched_send(tmp_results, total_count, datatype, rank + 1, comm_ptr, s);
+            mpi_errno =
+                MPIR_Sched_send(tmp_results, total_count, datatype, rank + 1, comm_ptr, collattr,
+                                s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
@@ -85,7 +88,9 @@ int MPIR_Ireduce_scatter_block_intra_sched_recursive_halving(const void *sendbuf
              * doubling */
             newrank = -1;
         } else {        /* odd */
-            mpi_errno = MPIR_Sched_recv(tmp_recvbuf, total_count, datatype, rank - 1, comm_ptr, s);
+            mpi_errno =
+                MPIR_Sched_recv(tmp_recvbuf, total_count, datatype, rank - 1, comm_ptr, collattr,
+                                s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
@@ -158,10 +163,10 @@ int MPIR_Ireduce_scatter_block_intra_sched_recursive_halving(const void *sendbuf
                 int recv_dst = (recv_cnt ? dst : MPI_PROC_NULL);
 
                 mpi_errno = MPIR_Sched_send(((char *) tmp_results + newdisps[send_idx] * extent),
-                                            send_cnt, datatype, send_dst, comm_ptr, s);
+                                            send_cnt, datatype, send_dst, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_recv(((char *) tmp_recvbuf + newdisps[recv_idx] * extent),
-                                            recv_cnt, datatype, recv_dst, comm_ptr, s);
+                                            recv_cnt, datatype, recv_dst, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
@@ -196,11 +201,12 @@ int MPIR_Ireduce_scatter_block_intra_sched_recursive_halving(const void *sendbuf
     if (rank < 2 * rem) {
         if (rank % 2) { /* odd */
             mpi_errno = MPIR_Sched_send(((char *) tmp_results + disps[rank - 1] * extent),
-                                        recvcount, datatype, rank - 1, comm_ptr, s);
+                                        recvcount, datatype, rank - 1, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         } else {        /* even */
-            mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, datatype, rank + 1, comm_ptr, s);
+            mpi_errno =
+                MPIR_Sched_recv(recvbuf, recvcount, datatype, rank + 1, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }

--- a/src/mpi/coll/iscan/iscan_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iscan/iscan_intra_sched_recursive_doubling.c
@@ -7,7 +7,7 @@
 
 int MPIR_Iscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                               MPI_Datatype datatype, MPI_Op op,
-                                              MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                              MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint true_extent, true_lb, extent;
@@ -19,7 +19,7 @@ int MPIR_Iscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
 
-    is_commutative = MPIR_Op_is_commutative(op);
+    is_commutative = collattr, MPIR_Op_is_commutative(op);
 
     /* need to allocate temporary buffer to store partial scan */
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
@@ -56,10 +56,10 @@ int MPIR_Iscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf
         dst = rank ^ mask;
         if (dst < comm_size) {
             /* Send partial_scan to dst. Recv into tmp_buf */
-            mpi_errno = MPIR_Sched_send(partial_scan, count, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_send(partial_scan, count, datatype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             /* sendrecv, no barrier here */
-            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, dst, comm_ptr, s);
+            mpi_errno = MPIR_Sched_recv(tmp_buf, count, datatype, dst, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 

--- a/src/mpi/coll/iscan/iscan_intra_sched_smp.c
+++ b/src/mpi/coll/iscan/iscan_intra_sched_smp.c
@@ -8,7 +8,7 @@
 
 int MPIR_Iscan_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                               MPIR_Sched_t s)
+                               int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank = comm_ptr->rank;
@@ -28,7 +28,7 @@ int MPIR_Iscan_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint coun
         /* We can't use the SMP-aware algorithm, use the non-SMP-aware
          * one */
         return MPIR_Iscan_intra_sched_recursive_doubling(sendbuf, recvbuf, count, datatype, op,
-                                                         comm_ptr, s);
+                                                         comm_ptr, collattr, s);
     }
 
     node_comm = comm_ptr->node_comm;
@@ -58,7 +58,8 @@ int MPIR_Iscan_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint coun
      * one process, just copy the raw data. */
     if (node_comm != NULL) {
         mpi_errno =
-            MPIR_Iscan_intra_sched_auto(sendbuf, recvbuf, count, datatype, op, node_comm, s);
+            MPIR_Iscan_intra_sched_auto(sendbuf, recvbuf, count, datatype, op, node_comm, collattr,
+                                        s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     } else if (sendbuf != MPI_IN_PLACE) {
@@ -73,12 +74,12 @@ int MPIR_Iscan_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint coun
      * reduced data of rank 1,2,3. */
     if (roots_comm != NULL && node_comm != NULL) {
         mpi_errno = MPIR_Sched_recv(localfulldata, count, datatype,
-                                    (node_comm->local_size - 1), node_comm, s);
+                                    (node_comm->local_size - 1), node_comm, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     } else if (roots_comm == NULL && node_comm != NULL &&
                node_comm->rank == node_comm->local_size - 1) {
-        mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, 0, node_comm, s);
+        mpi_errno = MPIR_Sched_send(recvbuf, count, datatype, 0, node_comm, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     } else if (roots_comm != NULL) {
@@ -96,18 +97,21 @@ int MPIR_Iscan_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint coun
 
         mpi_errno =
             MPIR_Iscan_intra_sched_auto(localfulldata, prefulldata, count, datatype, op, roots_comm,
-                                        s);
+                                        collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         if (roots_rank != roots_comm->local_size - 1) {
             mpi_errno =
-                MPIR_Sched_send(prefulldata, count, datatype, (roots_rank + 1), roots_comm, s);
+                MPIR_Sched_send(prefulldata, count, datatype, (roots_rank + 1), roots_comm,
+                                collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
         if (roots_rank != 0) {
-            mpi_errno = MPIR_Sched_recv(tempbuf, count, datatype, (roots_rank - 1), roots_comm, s);
+            mpi_errno =
+                MPIR_Sched_recv(tempbuf, count, datatype, (roots_rank - 1), roots_comm, collattr,
+                                s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
@@ -124,7 +128,8 @@ int MPIR_Iscan_intra_sched_smp(const void *sendbuf, void *recvbuf, MPI_Aint coun
          * "prefulldata" from another leader into "tempbuf" */
 
         if (node_comm != NULL) {
-            mpi_errno = MPIR_Ibcast_intra_sched_auto(tempbuf, count, datatype, 0, node_comm, s);
+            mpi_errno =
+                MPIR_Ibcast_intra_sched_auto(tempbuf, count, datatype, 0, node_comm, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling.c
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling.c
@@ -9,7 +9,8 @@
 /* Routine to schedule a recursive exchange based scan */
 int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm, MPIR_TSP_sched_t sched)
+                                                  MPIR_Comm * comm, int collattr,
+                                                  MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -75,8 +76,8 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
             nvtcs = 1;
             vtcs[0] = (loop_count == 0) ? dtcopy_id : reduce_id;
             mpi_errno =
-                MPIR_TSP_sched_isend(partial_scan, count, datatype, dst, tag, comm, sched, nvtcs,
-                                     vtcs, &send_id);
+                MPIR_TSP_sched_isend(partial_scan, count, datatype, dst, tag, comm, collattr, sched,
+                                     nvtcs, vtcs, &send_id);
 
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
@@ -85,8 +86,8 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
                 vtcs[1] = recv_reduce;
             }
             mpi_errno =
-                MPIR_TSP_sched_irecv(tmp_buf, count, datatype, dst, tag, comm, sched, nvtcs, vtcs,
-                                     &recv_id);
+                MPIR_TSP_sched_irecv(tmp_buf, count, datatype, dst, tag, comm, collattr, sched,
+                                     nvtcs, vtcs, &recv_id);
 
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 

--- a/src/mpi/coll/iscatter/iscatter_inter_sched_linear.c
+++ b/src/mpi/coll/iscatter/iscatter_inter_sched_linear.c
@@ -15,7 +15,7 @@
 
 int MPIR_Iscatter_inter_sched_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                     int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     int root, MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int remote_size;
@@ -34,12 +34,12 @@ int MPIR_Iscatter_inter_sched_linear(const void *sendbuf, MPI_Aint sendcount, MP
         for (i = 0; i < remote_size; i++) {
             mpi_errno =
                 MPIR_Sched_send(((char *) sendbuf + sendcount * i * extent), sendcount, sendtype, i,
-                                comm_ptr, s);
+                                comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
         MPIR_SCHED_BARRIER(s);
     } else {
-        mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, recvtype, root, comm_ptr, s);
+        mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, recvtype, root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }

--- a/src/mpi/coll/iscatter/iscatter_inter_sched_remote_send_local_scatter.c
+++ b/src/mpi/coll/iscatter/iscatter_inter_sched_remote_send_local_scatter.c
@@ -18,7 +18,7 @@ int MPIR_Iscatter_inter_sched_remote_send_local_scatter(const void *sendbuf, MPI
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         MPI_Aint recvcount, MPI_Datatype recvtype,
                                                         int root, MPIR_Comm * comm_ptr,
-                                                        MPIR_Sched_t s)
+                                                        int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, local_size, remote_size;
@@ -34,7 +34,8 @@ int MPIR_Iscatter_inter_sched_remote_send_local_scatter(const void *sendbuf, MPI
 
     if (root == MPI_ROOT) {
         /* root sends all data to rank 0 on remote group and returns */
-        mpi_errno = MPIR_Sched_send(sendbuf, sendcount * remote_size, sendtype, 0, comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_send(sendbuf, sendcount * remote_size, sendtype, 0, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
         goto fn_exit;
@@ -53,7 +54,7 @@ int MPIR_Iscatter_inter_sched_remote_send_local_scatter(const void *sendbuf, MPI
 
             mpi_errno =
                 MPIR_Sched_recv(tmp_buf, recvcount * local_size * recvtype_sz, MPI_BYTE,
-                                root, comm_ptr, s);
+                                root, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         } else {
@@ -70,7 +71,8 @@ int MPIR_Iscatter_inter_sched_remote_send_local_scatter(const void *sendbuf, MPI
         /* now do the usual scatter on this intracommunicator */
         mpi_errno =
             MPIR_Iscatter_intra_sched_auto(tmp_buf, recvcount * recvtype_sz, MPI_BYTE,
-                                           recvbuf, recvcount, recvtype, 0, newcomm_ptr, s);
+                                           recvbuf, recvcount, recvtype, 0, newcomm_ptr, collattr,
+                                           s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }

--- a/src/mpi/coll/iscatter/iscatter_intra_sched_binomial.c
+++ b/src/mpi/coll/iscatter/iscatter_intra_sched_binomial.c
@@ -66,7 +66,7 @@ static int calc_curr_count(MPIR_Comm * comm, int tag, void *state)
 int MPIR_Iscatter_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
                                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                        MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                       MPIR_Sched_t s)
+                                       int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint extent = 0;
@@ -158,7 +158,8 @@ int MPIR_Iscatter_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
              * they don't have to forward data to anyone. Others
              * receive data into a temporary buffer. */
             if (relative_rank % 2) {
-                mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, recvtype, src, comm_ptr, s);
+                mpi_errno =
+                    MPIR_Sched_recv(recvbuf, recvcount, recvtype, src, comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             } else {
@@ -167,7 +168,7 @@ int MPIR_Iscatter_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
                  * some cases. query amount of data actually received */
                 mpi_errno =
                     MPIR_Sched_recv_status(tmp_buf, tmp_buf_size, MPI_BYTE, src, comm_ptr,
-                                           &ss->status, s);
+                                           &ss->status, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
                 mpi_errno = MPIR_Sched_cb(&get_count, ss, s);
@@ -205,7 +206,8 @@ int MPIR_Iscatter_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
                 /* mask is also the size of this process's subtree */
                 mpi_errno =
                     MPIR_Sched_send_defer(((char *) sendbuf + extent * sendcount * mask),
-                                          &ss->send_subtree_count, sendtype, dst, comm_ptr, s);
+                                          &ss->send_subtree_count, sendtype, dst, comm_ptr,
+                                          collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             } else {
@@ -218,7 +220,7 @@ int MPIR_Iscatter_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
                 /* mask is also the size of this process's subtree */
                 mpi_errno = MPIR_Sched_send_defer(((char *) tmp_buf + ss->nbytes * mask),
                                                   &ss->send_subtree_count, MPI_BYTE, dst,
-                                                  comm_ptr, s);
+                                                  comm_ptr, collattr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree.c
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree.c
@@ -10,7 +10,7 @@
 int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
                                        MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                        MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                       int k, MPIR_TSP_sched_t sched)
+                                       int k, int collattr, MPIR_TSP_sched_t sched)
 {
     MPIR_FUNC_ENTER;
 
@@ -149,7 +149,7 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     /* receive data from the parent */
     if (my_tree.parent != -1) {
         mpi_errno = MPIR_TSP_sched_irecv(tmp_buf, recv_size, recvtype, my_tree.parent,
-                                         tag, comm, sched, 0, NULL, &recv_id);
+                                         tag, comm, collattr, sched, 0, NULL, &recv_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "rank:%d posts recv", rank));
     }
@@ -159,7 +159,7 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
         int child = *(int *) utarray_eltptr(my_tree.children, i);
         mpi_errno = MPIR_TSP_sched_isend((char *) tmp_buf + child_data_offset[i] * sendtype_extent,
                                          child_subtree_size[i] * sendcount, sendtype,
-                                         child, tag, comm, sched, num_send_dependencies,
+                                         child, tag, comm, collattr, sched, num_send_dependencies,
                                          (lrank == 0) ? dtcopy_id : &recv_id, &vtx_id);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }

--- a/src/mpi/coll/iscatterv/iscatterv_allcomm_sched_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_allcomm_sched_linear.c
@@ -18,7 +18,8 @@
 int MPIR_Iscatterv_allcomm_sched_linear(const void *sendbuf, const MPI_Aint sendcounts[],
                                         const MPI_Aint displs[], MPI_Datatype sendtype,
                                         void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                        int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                        int root, MPIR_Comm * comm_ptr, int collattr,
+                                        MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int rank, comm_size;
@@ -48,7 +49,7 @@ int MPIR_Iscatterv_allcomm_sched_linear(const void *sendbuf, const MPI_Aint send
                     }
                 } else {
                     mpi_errno = MPIR_Sched_send(((char *) sendbuf + displs[i] * extent),
-                                                sendcounts[i], sendtype, i, comm_ptr, s);
+                                                sendcounts[i], sendtype, i, comm_ptr, collattr, s);
                     MPIR_ERR_CHECK(mpi_errno);
                 }
             }
@@ -58,7 +59,7 @@ int MPIR_Iscatterv_allcomm_sched_linear(const void *sendbuf, const MPI_Aint send
     else if (root != MPI_PROC_NULL) {
         /* non-root nodes, and in the intercomm. case, non-root nodes on remote side */
         if (recvcount) {
-            mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, recvtype, root, comm_ptr, s);
+            mpi_errno = MPIR_Sched_recv(recvbuf, recvcount, recvtype, root, comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }

--- a/src/mpi/coll/iscatterv/iscatterv_tsp_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_tsp_linear.c
@@ -11,7 +11,7 @@ int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const MPI_Aint 
                                             const MPI_Aint displs[], MPI_Datatype sendtype,
                                             void *recvbuf, MPI_Aint recvcount,
                                             MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                                            MPIR_TSP_sched_t sched)
+                                            int collattr, MPIR_TSP_sched_t sched)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
@@ -58,7 +58,7 @@ int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const MPI_Aint 
                 } else {
                     mpi_errno = MPIR_TSP_sched_isend(((char *) sendbuf + displs[i] * extent),
                                                      sendcounts[i], sendtype, i, tag, comm_ptr,
-                                                     sched, 0, NULL, &vtx_id);
+                                                     collattr, sched, 0, NULL, &vtx_id);
                 }
             }
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
@@ -69,8 +69,8 @@ int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const MPI_Aint 
         /* non-root nodes, and in the intercomm. case, non-root nodes on remote side */
         if (recvcount) {
             mpi_errno =
-                MPIR_TSP_sched_irecv(recvbuf, recvcount, recvtype, root, tag, comm_ptr, sched, 0,
-                                     NULL, &vtx_id);
+                MPIR_TSP_sched_irecv(recvbuf, recvcount, recvtype, root, tag, comm_ptr, collattr,
+                                     sched, 0, NULL, &vtx_id);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }

--- a/src/mpi/coll/mpir_coll_sched_auto.c
+++ b/src/mpi/coll/mpir_coll_sched_auto.c
@@ -12,28 +12,28 @@
  * defining them here.
  */
 
-int MPIR_Ibarrier_intra_sched_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_intra_sched_auto(MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Ibarrier_intra_sched_recursive_doubling(comm_ptr, s);
+    mpi_errno = MPIR_Ibarrier_intra_sched_recursive_doubling(comm_ptr, collattr, s);
 
     return mpi_errno;
 }
 
 /* It will choose between several different algorithms based on the given
  * parameters. */
-int MPIR_Ibarrier_inter_sched_auto(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+int MPIR_Ibarrier_inter_sched_auto(MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno;
 
-    mpi_errno = MPIR_Ibarrier_inter_sched_bcast(comm_ptr, s);
+    mpi_errno = MPIR_Ibarrier_inter_sched_bcast(comm_ptr, collattr, s);
 
     return mpi_errno;
 }
 
 int MPIR_Ibcast_intra_sched_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                 MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size;
@@ -42,7 +42,8 @@ int MPIR_Ibcast_intra_sched_auto(void *buffer, MPI_Aint count, MPI_Datatype data
     MPIR_Assert(comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM);
 
     if (comm_ptr->hierarchy_kind == MPIR_COMM_HIERARCHY_KIND__PARENT) {
-        mpi_errno = MPIR_Ibcast_intra_sched_smp(buffer, count, datatype, root, comm_ptr, s);
+        mpi_errno =
+            MPIR_Ibcast_intra_sched_smp(buffer, count, datatype, root, comm_ptr, collattr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
@@ -55,7 +56,8 @@ int MPIR_Ibcast_intra_sched_auto(void *buffer, MPI_Aint count, MPI_Datatype data
 
     /* simplistic implementation for now */
     if ((nbytes < MPIR_CVAR_BCAST_SHORT_MSG_SIZE) || (comm_size < MPIR_CVAR_BCAST_MIN_PROCS)) {
-        mpi_errno = MPIR_Ibcast_intra_sched_binomial(buffer, count, datatype, root, comm_ptr, s);
+        mpi_errno =
+            MPIR_Ibcast_intra_sched_binomial(buffer, count, datatype, root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else {    /* (nbytes >= MPIR_CVAR_BCAST_SHORT_MSG_SIZE) && (comm_size >= MPIR_CVAR_BCAST_MIN_PROCS) */
 
@@ -63,12 +65,12 @@ int MPIR_Ibcast_intra_sched_auto(void *buffer, MPI_Aint count, MPI_Datatype data
             mpi_errno =
                 MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(buffer, count,
                                                                              datatype, root,
-                                                                             comm_ptr, s);
+                                                                             comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         } else {
             mpi_errno =
                 MPIR_Ibcast_intra_sched_scatter_ring_allgather(buffer, count, datatype, root,
-                                                               comm_ptr, s);
+                                                               comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }
@@ -83,24 +85,24 @@ int MPIR_Ibcast_intra_sched_auto(void *buffer, MPI_Aint count, MPI_Datatype data
  * know anything about hierarchy.  It will choose between several
  * different algorithms based on the given parameters. */
 int MPIR_Ibcast_inter_sched_auto(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                 MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Ibcast_inter_sched_flat(buffer, count, datatype, root, comm_ptr, s);
+    mpi_errno = MPIR_Ibcast_inter_sched_flat(buffer, count, datatype, root, comm_ptr, collattr, s);
 
     return mpi_errno;
 }
 
 int MPIR_Igather_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                  int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                  int root, MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
         MPIR_Igather_intra_sched_binomial(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                          recvtype, root, comm_ptr, s);
+                                          recvtype, root, comm_ptr, collattr, s);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -111,7 +113,7 @@ int MPIR_Igather_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_D
 
 int MPIR_Igather_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                  int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                  int root, MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint local_size, remote_size;
@@ -137,11 +139,11 @@ int MPIR_Igather_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_D
     if (nbytes < MPIR_CVAR_GATHER_INTER_SHORT_MSG_SIZE) {
         mpi_errno =
             MPIR_Igather_inter_sched_short(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                           recvtype, root, comm_ptr, s);
+                                           recvtype, root, comm_ptr, collattr, s);
     } else {
         mpi_errno =
             MPIR_Igather_inter_sched_long(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                          recvtype, root, comm_ptr, s);
+                                          recvtype, root, comm_ptr, collattr, s);
     }
 
   fn_exit:
@@ -151,13 +153,13 @@ int MPIR_Igather_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_D
 int MPIR_Igatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const MPI_Aint recvcounts[],
                                    const MPI_Aint displs[], MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
         MPIR_Igatherv_allcomm_sched_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
-                                           displs, recvtype, root, comm_ptr, s);
+                                           displs, recvtype, root, comm_ptr, collattr, s);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -170,13 +172,13 @@ int MPIR_Igatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_
 int MPIR_Igatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const MPI_Aint recvcounts[],
                                    const MPI_Aint displs[], MPI_Datatype recvtype, int root,
-                                   MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
         MPIR_Igatherv_allcomm_sched_linear(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
-                                           displs, recvtype, root, comm_ptr, s);
+                                           displs, recvtype, root, comm_ptr, collattr, s);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -188,13 +190,13 @@ int MPIR_Igatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_
 
 int MPIR_Iscatter_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   int root, MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
         MPIR_Iscatter_intra_sched_binomial(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                           recvtype, root, comm_ptr, s);
+                                           recvtype, root, comm_ptr, collattr, s);
     MPIR_ERR_CHECK(mpi_errno);
 
 
@@ -206,7 +208,7 @@ int MPIR_Iscatter_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_
 
 int MPIR_Iscatter_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                   int root, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                   int root, MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int local_size, remote_size;
     MPI_Aint sendtype_size, recvtype_size, nbytes;
@@ -227,11 +229,11 @@ int MPIR_Iscatter_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_
         mpi_errno =
             MPIR_Iscatter_inter_sched_remote_send_local_scatter(sendbuf, sendcount, sendtype,
                                                                 recvbuf, recvcount, recvtype, root,
-                                                                comm_ptr, s);
+                                                                comm_ptr, collattr, s);
     } else {
         mpi_errno = MPIR_Iscatter_inter_sched_linear(sendbuf, sendcount, sendtype,
                                                      recvbuf, recvcount, recvtype, root, comm_ptr,
-                                                     s);
+                                                     collattr, s);
     }
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -245,13 +247,13 @@ int MPIR_Iscatter_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_
 int MPIR_Iscatterv_intra_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
                                     const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf,
                                     MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                    MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
         MPIR_Iscatterv_allcomm_sched_linear(sendbuf, sendcounts, displs, sendtype, recvbuf,
-                                            recvcount, recvtype, root, comm_ptr, s);
+                                            recvcount, recvtype, root, comm_ptr, collattr, s);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -264,13 +266,13 @@ int MPIR_Iscatterv_intra_sched_auto(const void *sendbuf, const MPI_Aint sendcoun
 int MPIR_Iscatterv_inter_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
                                     const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf,
                                     MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                    MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
         MPIR_Iscatterv_allcomm_sched_linear(sendbuf, sendcounts, displs, sendtype, recvbuf,
-                                            recvcount, recvtype, root, comm_ptr, s);
+                                            recvcount, recvtype, root, comm_ptr, collattr, s);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -282,7 +284,7 @@ int MPIR_Iscatterv_inter_sched_auto(const void *sendbuf, const MPI_Aint sendcoun
 
 int MPIR_Iallgather_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                      void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size;
@@ -296,15 +298,16 @@ int MPIR_Iallgather_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MP
     if ((tot_bytes < MPIR_CVAR_ALLGATHER_LONG_MSG_SIZE) && !(comm_size & (comm_size - 1))) {
         mpi_errno =
             MPIR_Iallgather_intra_sched_recursive_doubling(sendbuf, sendcount, sendtype, recvbuf,
-                                                           recvcount, recvtype, comm_ptr, s);
+                                                           recvcount, recvtype, comm_ptr, collattr,
+                                                           s);
     } else if (tot_bytes < MPIR_CVAR_ALLGATHER_SHORT_MSG_SIZE) {
         mpi_errno =
             MPIR_Iallgather_intra_sched_brucks(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                               recvtype, comm_ptr, s);
+                                               recvtype, comm_ptr, collattr, s);
     } else {
         mpi_errno =
             MPIR_Iallgather_intra_sched_ring(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                             recvtype, comm_ptr, s);
+                                             recvtype, comm_ptr, collattr, s);
     }
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -316,13 +319,15 @@ int MPIR_Iallgather_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MP
 
 int MPIR_Iallgather_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                      MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr,
+                                     MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Iallgather_inter_sched_local_gather_remote_bcast(sendbuf, sendcount,
                                                                       sendtype, recvbuf, recvcount,
-                                                                      recvtype, comm_ptr, s);
+                                                                      recvtype, comm_ptr, collattr,
+                                                                      s);
 
     return mpi_errno;
 }
@@ -330,7 +335,8 @@ int MPIR_Iallgather_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
 int MPIR_Iallgatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                       MPI_Datatype sendtype, void *recvbuf,
                                       const MPI_Aint recvcounts[], const MPI_Aint displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr,
+                                      MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, comm_size;
@@ -353,21 +359,21 @@ int MPIR_Iallgatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
         mpi_errno =
             MPIR_Iallgatherv_intra_sched_recursive_doubling(sendbuf, sendcount, sendtype, recvbuf,
                                                             recvcounts, displs, recvtype, comm_ptr,
-                                                            s);
+                                                            collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else if (total_count * recvtype_size < MPIR_CVAR_ALLGATHER_SHORT_MSG_SIZE) {
         /* Short message and non-power-of-two no. of processes. Use
          * Bruck algorithm (see description above). */
         mpi_errno =
             MPIR_Iallgatherv_intra_sched_brucks(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
-                                                displs, recvtype, comm_ptr, s);
+                                                displs, recvtype, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* long message or medium-size message and non-power-of-two
          * no. of processes. Use ring algorithm. */
         mpi_errno =
             MPIR_Iallgatherv_intra_sched_ring(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
-                                              displs, recvtype, comm_ptr, s);
+                                              displs, recvtype, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -380,21 +386,22 @@ int MPIR_Iallgatherv_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount,
 int MPIR_Iallgatherv_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount,
                                       MPI_Datatype sendtype, void *recvbuf,
                                       const MPI_Aint recvcounts[], const MPI_Aint displs[],
-                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr,
+                                      MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Iallgatherv_inter_sched_remote_gather_local_bcast(sendbuf, sendcount,
                                                                        sendtype, recvbuf,
                                                                        recvcounts, displs, recvtype,
-                                                                       comm_ptr, s);
+                                                                       comm_ptr, collattr, s);
 
     return mpi_errno;
 }
 
 int MPIR_Ialltoall_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                     void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                    MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                    MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size;
@@ -408,19 +415,20 @@ int MPIR_Ialltoall_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI
     if (sendbuf == MPI_IN_PLACE) {
         mpi_errno =
             MPIR_Ialltoall_intra_sched_inplace(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                               recvtype, comm_ptr, s);
+                                               recvtype, comm_ptr, collattr, s);
     } else if ((nbytes <= MPIR_CVAR_ALLTOALL_SHORT_MSG_SIZE) && (comm_size >= 8)) {
         mpi_errno =
             MPIR_Ialltoall_intra_sched_brucks(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                              recvtype, comm_ptr, s);
+                                              recvtype, comm_ptr, collattr, s);
     } else if (nbytes <= MPIR_CVAR_ALLTOALL_MEDIUM_MSG_SIZE) {
         mpi_errno =
             MPIR_Ialltoall_intra_sched_permuted_sendrecv(sendbuf, sendcount, sendtype, recvbuf,
-                                                         recvcount, recvtype, comm_ptr, s);
+                                                         recvcount, recvtype, comm_ptr, collattr,
+                                                         s);
     } else {
         mpi_errno =
             MPIR_Ialltoall_intra_sched_pairwise(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                                recvtype, comm_ptr, s);
+                                                recvtype, comm_ptr, collattr, s);
     }
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -433,13 +441,14 @@ int MPIR_Ialltoall_intra_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI
 
 int MPIR_Ialltoall_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype
                                     sendtype, void *recvbuf, MPI_Aint recvcount,
-                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                    MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr,
+                                    MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Ialltoall_inter_sched_pairwise_exchange(sendbuf, sendcount,
                                                              sendtype, recvbuf, recvcount, recvtype,
-                                                             comm_ptr, s);
+                                                             comm_ptr, collattr, s);
 
     return mpi_errno;
 }
@@ -447,7 +456,8 @@ int MPIR_Ialltoall_inter_sched_auto(const void *sendbuf, MPI_Aint sendcount, MPI
 int MPIR_Ialltoallv_intra_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
                                      const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                      const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
-                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr,
+                                     MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -456,11 +466,11 @@ int MPIR_Ialltoallv_intra_sched_auto(const void *sendbuf, const MPI_Aint sendcou
     if (sendbuf == MPI_IN_PLACE) {
         mpi_errno = MPIR_Ialltoallv_intra_sched_inplace(sendbuf, sendcounts, sdispls,
                                                         sendtype, recvbuf, recvcounts,
-                                                        rdispls, recvtype, comm_ptr, s);
+                                                        rdispls, recvtype, comm_ptr, collattr, s);
     } else {
         mpi_errno = MPIR_Ialltoallv_intra_sched_blocked(sendbuf, sendcounts, sdispls,
                                                         sendtype, recvbuf, recvcounts,
-                                                        rdispls, recvtype, comm_ptr, s);
+                                                        rdispls, recvtype, comm_ptr, collattr, s);
     }
 
     return mpi_errno;
@@ -469,13 +479,15 @@ int MPIR_Ialltoallv_intra_sched_auto(const void *sendbuf, const MPI_Aint sendcou
 int MPIR_Ialltoallv_inter_sched_auto(const void *sendbuf, const MPI_Aint sendcounts[],
                                      const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf,
                                      const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
-                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int collattr,
+                                     MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Ialltoallv_inter_sched_pairwise_exchange(sendbuf, sendcounts, sdispls,
                                                               sendtype, recvbuf, recvcounts,
-                                                              rdispls, recvtype, comm_ptr, s);
+                                                              rdispls, recvtype, comm_ptr, collattr,
+                                                              s);
 
     return mpi_errno;
 }
@@ -484,18 +496,18 @@ int MPIR_Ialltoallw_intra_sched_auto(const void *sendbuf, const MPI_Aint sendcou
                                      const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                      void *recvbuf, const MPI_Aint recvcounts[],
                                      const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     if (sendbuf == MPI_IN_PLACE) {
         mpi_errno = MPIR_Ialltoallw_intra_sched_inplace(sendbuf, sendcounts, sdispls,
                                                         sendtypes, recvbuf, recvcounts,
-                                                        rdispls, recvtypes, comm_ptr, s);
+                                                        rdispls, recvtypes, comm_ptr, collattr, s);
     } else {
         mpi_errno = MPIR_Ialltoallw_intra_sched_blocked(sendbuf, sendcounts, sdispls,
                                                         sendtypes, recvbuf, recvcounts,
-                                                        rdispls, recvtypes, comm_ptr, s);
+                                                        rdispls, recvtypes, comm_ptr, collattr, s);
     }
 
     return mpi_errno;
@@ -505,20 +517,21 @@ int MPIR_Ialltoallw_inter_sched_auto(const void *sendbuf, const MPI_Aint sendcou
                                      const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                      void *recvbuf, const MPI_Aint recvcounts[],
                                      const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                     MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Ialltoallw_inter_sched_pairwise_exchange(sendbuf, sendcounts, sdispls,
                                                               sendtypes, recvbuf, recvcounts,
-                                                              rdispls, recvtypes, comm_ptr, s);
+                                                              rdispls, recvtypes, comm_ptr,
+                                                              collattr, s);
 
     return mpi_errno;
 }
 
 int MPIR_Ireduce_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                   MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                                  MPIR_Sched_t s)
+                                  int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int pof2;
@@ -528,7 +541,7 @@ int MPIR_Ireduce_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint c
 
     if (comm_ptr->hierarchy_kind == MPIR_COMM_HIERARCHY_KIND__PARENT && MPIR_Op_is_commutative(op)) {
         mpi_errno = MPIR_Ireduce_intra_sched_smp(sendbuf, recvbuf, count,
-                                                 datatype, op, root, comm_ptr, s);
+                                                 datatype, op, root, comm_ptr, collattr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
@@ -545,13 +558,13 @@ int MPIR_Ireduce_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint c
         /* do a reduce-scatter followed by gather to root. */
         mpi_errno =
             MPIR_Ireduce_intra_sched_reduce_scatter_gather(sendbuf, recvbuf, count, datatype, op,
-                                                           root, comm_ptr, s);
+                                                           root, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* use a binomial tree algorithm */
         mpi_errno =
             MPIR_Ireduce_intra_sched_binomial(sendbuf, recvbuf, count, datatype, op, root, comm_ptr,
-                                              s);
+                                              collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -563,19 +576,20 @@ int MPIR_Ireduce_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint c
 
 int MPIR_Ireduce_inter_sched_auto(const void *sendbuf, void *recvbuf,
                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op, int root,
-                                  MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                  MPIR_Comm * comm_ptr, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Ireduce_inter_sched_local_reduce_remote_send(sendbuf, recvbuf, count,
-                                                                  datatype, op, root, comm_ptr, s);
+                                                                  datatype, op, root, comm_ptr,
+                                                                  collattr, s);
 
     return mpi_errno;
 }
 
 int MPIR_Iallreduce_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s)
+                                     int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int pof2;
@@ -584,7 +598,8 @@ int MPIR_Iallreduce_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Ain
 
     if (comm_ptr->hierarchy_kind == MPIR_COMM_HIERARCHY_KIND__PARENT && MPIR_Op_is_commutative(op)) {
         mpi_errno =
-            MPIR_Iallreduce_intra_sched_smp(sendbuf, recvbuf, count, datatype, op, comm_ptr, s);
+            MPIR_Iallreduce_intra_sched_smp(sendbuf, recvbuf, count, datatype, op, comm_ptr,
+                                            collattr, s);
         if (mpi_errno)
             MPIR_ERR_POP(mpi_errno);
 
@@ -611,13 +626,13 @@ int MPIR_Iallreduce_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Ain
         /* use recursive doubling */
         mpi_errno =
             MPIR_Iallreduce_intra_sched_recursive_doubling(sendbuf, recvbuf, count, datatype, op,
-                                                           comm_ptr, s);
+                                                           comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* do a reduce-scatter followed by allgather */
         mpi_errno =
             MPIR_Iallreduce_intra_sched_reduce_scatter_allgather(sendbuf, recvbuf, count, datatype,
-                                                                 op, comm_ptr, s);
+                                                                 op, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -629,19 +644,21 @@ int MPIR_Iallreduce_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Ain
 
 int MPIR_Iallreduce_inter_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                      MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                     MPIR_Sched_t s)
+                                     int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Iallreduce_inter_sched_remote_reduce_local_bcast(sendbuf, recvbuf, count,
-                                                                      datatype, op, comm_ptr, s);
+                                                                      datatype, op, comm_ptr,
+                                                                      collattr, s);
 
     return mpi_errno;
 }
 
 int MPIR_Ireduce_scatter_intra_sched_auto(const void *sendbuf, void *recvbuf,
                                           const MPI_Aint recvcounts[], MPI_Datatype datatype,
-                                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                          MPI_Op op, MPIR_Comm * comm_ptr, int collattr,
+                                          MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
@@ -666,12 +683,12 @@ int MPIR_Ireduce_scatter_intra_sched_auto(const void *sendbuf, void *recvbuf,
     if (is_commutative && (nbytes < MPIR_CVAR_REDUCE_SCATTER_COMMUTATIVE_LONG_MSG_SIZE)) {
         mpi_errno =
             MPIR_Ireduce_scatter_intra_sched_recursive_halving(sendbuf, recvbuf, recvcounts,
-                                                               datatype, op, comm_ptr, s);
+                                                               datatype, op, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else if (is_commutative && (nbytes >= MPIR_CVAR_REDUCE_SCATTER_COMMUTATIVE_LONG_MSG_SIZE)) {
         mpi_errno =
             MPIR_Ireduce_scatter_intra_sched_pairwise(sendbuf, recvbuf, recvcounts, datatype, op,
-                                                      comm_ptr, s);
+                                                      comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else {    /* (!is_commutative) */
 
@@ -687,13 +704,15 @@ int MPIR_Ireduce_scatter_intra_sched_auto(const void *sendbuf, void *recvbuf,
             /* noncommutative, pof2 size, and block regular */
             mpi_errno =
                 MPIR_Ireduce_scatter_intra_sched_noncommutative(sendbuf, recvbuf, recvcounts,
-                                                                datatype, op, comm_ptr, s);
+                                                                datatype, op, comm_ptr, collattr,
+                                                                s);
             MPIR_ERR_CHECK(mpi_errno);
         } else {
             /* noncommutative and (non-pof2 or block irregular), use recursive doubling. */
             mpi_errno =
                 MPIR_Ireduce_scatter_intra_sched_recursive_doubling(sendbuf, recvbuf, recvcounts,
-                                                                    datatype, op, comm_ptr, s);
+                                                                    datatype, op, comm_ptr,
+                                                                    collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }
@@ -706,20 +725,23 @@ int MPIR_Ireduce_scatter_intra_sched_auto(const void *sendbuf, void *recvbuf,
 
 int MPIR_Ireduce_scatter_inter_sched_auto(const void *sendbuf, void *recvbuf,
                                           const MPI_Aint recvcounts[], MPI_Datatype datatype,
-                                          MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                          MPI_Op op, MPIR_Comm * comm_ptr, int collattr,
+                                          MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
         MPIR_Ireduce_scatter_inter_sched_remote_reduce_local_scatterv(sendbuf, recvbuf, recvcounts,
-                                                                      datatype, op, comm_ptr, s);
+                                                                      datatype, op, comm_ptr,
+                                                                      collattr, s);
 
     return mpi_errno;
 }
 
 int MPIR_Ireduce_scatter_block_intra_sched_auto(const void *sendbuf, void *recvbuf,
                                                 MPI_Aint recvcount, MPI_Datatype datatype,
-                                                MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                MPI_Op op, MPIR_Comm * comm_ptr, int collattr,
+                                                MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_commutative;
@@ -740,12 +762,13 @@ int MPIR_Ireduce_scatter_block_intra_sched_auto(const void *sendbuf, void *recvb
     if (is_commutative && (nbytes < MPIR_CVAR_REDUCE_SCATTER_COMMUTATIVE_LONG_MSG_SIZE)) {
         mpi_errno =
             MPIR_Ireduce_scatter_block_intra_sched_recursive_halving(sendbuf, recvbuf, recvcount,
-                                                                     datatype, op, comm_ptr, s);
+                                                                     datatype, op, comm_ptr,
+                                                                     collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else if (is_commutative && (nbytes >= MPIR_CVAR_REDUCE_SCATTER_COMMUTATIVE_LONG_MSG_SIZE)) {
         mpi_errno =
             MPIR_Ireduce_scatter_block_intra_sched_pairwise(sendbuf, recvbuf, recvcount, datatype,
-                                                            op, comm_ptr, s);
+                                                            op, comm_ptr, collattr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else {    /* (!is_commutative) */
 
@@ -753,14 +776,15 @@ int MPIR_Ireduce_scatter_block_intra_sched_auto(const void *sendbuf, void *recvb
             /* noncommutative, pof2 size */
             mpi_errno =
                 MPIR_Ireduce_scatter_block_intra_sched_noncommutative(sendbuf, recvbuf, recvcount,
-                                                                      datatype, op, comm_ptr, s);
+                                                                      datatype, op, comm_ptr,
+                                                                      collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         } else {
             /* noncommutative and non-pof2, use recursive doubling. */
             mpi_errno =
                 MPIR_Ireduce_scatter_block_intra_sched_recursive_doubling(sendbuf, recvbuf,
                                                                           recvcount, datatype, op,
-                                                                          comm_ptr, s);
+                                                                          comm_ptr, collattr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }
@@ -774,30 +798,33 @@ int MPIR_Ireduce_scatter_block_intra_sched_auto(const void *sendbuf, void *recvb
 
 int MPIR_Ireduce_scatter_block_inter_sched_auto(const void *sendbuf, void *recvbuf,
                                                 MPI_Aint recvcount, MPI_Datatype datatype,
-                                                MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Sched_t s)
+                                                MPI_Op op, MPIR_Comm * comm_ptr, int collattr,
+                                                MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
         MPIR_Ireduce_scatter_block_inter_sched_remote_reduce_local_scatterv(sendbuf, recvbuf,
                                                                             recvcount, datatype, op,
-                                                                            comm_ptr, s);
+                                                                            comm_ptr, collattr, s);
 
     return mpi_errno;
 }
 
 int MPIR_Iscan_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                MPIR_Sched_t s)
+                                int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     if (comm_ptr->hierarchy_kind == MPIR_COMM_HIERARCHY_KIND__PARENT) {
-        mpi_errno = MPIR_Iscan_intra_sched_smp(sendbuf, recvbuf, count, datatype, op, comm_ptr, s);
+        mpi_errno =
+            MPIR_Iscan_intra_sched_smp(sendbuf, recvbuf, count, datatype, op, comm_ptr, collattr,
+                                       s);
     } else {
         mpi_errno =
             MPIR_Iscan_intra_sched_recursive_doubling(sendbuf, recvbuf, count, datatype, op,
-                                                      comm_ptr, s);
+                                                      comm_ptr, collattr, s);
     }
 
     return mpi_errno;
@@ -805,13 +832,13 @@ int MPIR_Iscan_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint cou
 
 int MPIR_Iexscan_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                  MPIR_Sched_t s)
+                                  int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno =
         MPIR_Iexscan_intra_sched_recursive_doubling(sendbuf, recvbuf, count, datatype, op, comm_ptr,
-                                                    s);
+                                                    collattr, s);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpi/coll/reduce/reduce_allcomm_nb.c
+++ b/src/mpi/coll/reduce/reduce_allcomm_nb.c
@@ -7,13 +7,14 @@
 
 int MPIR_Reduce_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
                            MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                           MPIR_Errflag_t errflag)
+                           int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno = MPIR_Ireduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, &req_ptr);
+    mpi_errno =
+        MPIR_Ireduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, collattr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
@@ -7,14 +7,15 @@
 
 int MPIR_Reduce_scatter_allcomm_nb(const void *sendbuf, void *recvbuf, const MPI_Aint recvcounts[],
                                    MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                   MPIR_Errflag_t errflag)
+                                   int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
-        MPIR_Ireduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, &req_ptr);
+        MPIR_Ireduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, collattr,
+                             &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
@@ -15,11 +15,11 @@
 int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, void *recvbuf,
                                                           const MPI_Aint recvcounts[],
                                                           MPI_Datatype datatype, MPI_Op op,
-                                                          MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t errflag)
+                                                          MPIR_Comm * comm_ptr, int collattr)
 {
     int rank, mpi_errno, root, local_size, total_count, i;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Aint true_extent, true_lb = 0, extent;
     void *tmp_buf = NULL;
     MPI_Aint *disps = NULL;
@@ -62,25 +62,25 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
+                                             root, comm_ptr, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
+                                             root, comm_ptr, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         /* reduce to rank 0 of left group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
+                                             root, comm_ptr, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
+                                             root, comm_ptr, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
@@ -93,7 +93,7 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
     newcomm_ptr = comm_ptr->local_comm;
 
     mpi_errno = MPIR_Scatterv(tmp_buf, recvcounts, disps, datatype, recvbuf,
-                              recvcounts[rank], datatype, 0, newcomm_ptr, errflag);
+                              recvcounts[rank], datatype, 0, newcomm_ptr, collattr | errflag);
     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
   fn_exit:

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
@@ -22,11 +22,11 @@
  */
 int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
                                              const MPI_Aint recvcounts[], MPI_Datatype datatype,
-                                             MPI_Op op, MPIR_Comm * comm_ptr,
-                                             MPIR_Errflag_t errflag)
+                                             MPI_Op op, MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int comm_size = comm_ptr->local_size;
     int rank = comm_ptr->rank;
     int log2_comm_size;
@@ -102,7 +102,7 @@ int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
                                   size, datatype, peer, MPIR_REDUCE_SCATTER_TAG,
                                   incoming_data + recv_offset * true_extent,
                                   size, datatype, peer, MPIR_REDUCE_SCATTER_TAG,
-                                  comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  comm_ptr, MPI_STATUS_IGNORE, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         /* always perform the reduction at recv_offset, the data at send_offset
          * is now our peer's responsibility */

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
@@ -15,7 +15,7 @@
  */
 int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
                                        const MPI_Aint recvcounts[], MPI_Datatype datatype,
-                                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                       MPI_Op op, MPIR_Comm * comm_ptr, int collattr)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;
@@ -23,6 +23,7 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
     void *tmp_recvbuf;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int total_count, src, dst;
     MPIR_CHKLMEM_DECL(5);
 
@@ -81,14 +82,14 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
                                       MPIR_REDUCE_SCATTER_TAG, tmp_recvbuf,
                                       recvcounts[rank], datatype, src,
                                       MPIR_REDUCE_SCATTER_TAG, comm_ptr,
-                                      MPI_STATUS_IGNORE, errflag);
+                                      MPI_STATUS_IGNORE, collattr | errflag);
         else
             mpi_errno = MPIC_Sendrecv(((char *) recvbuf + disps[dst] * extent),
                                       recvcounts[dst], datatype, dst,
                                       MPIR_REDUCE_SCATTER_TAG, tmp_recvbuf,
                                       recvcounts[rank], datatype, src,
                                       MPIR_REDUCE_SCATTER_TAG, comm_ptr,
-                                      MPI_STATUS_IGNORE, errflag);
+                                      MPI_STATUS_IGNORE, collattr | errflag);
 
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -36,8 +36,7 @@
  */
 int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvbuf,
                                                 const MPI_Aint recvcounts[], MPI_Datatype datatype,
-                                                MPI_Op op, MPIR_Comm * comm_ptr,
-                                                MPIR_Errflag_t errflag)
+                                                MPI_Op op, MPIR_Comm * comm_ptr, int collattr)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;
@@ -45,6 +44,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
     void *tmp_recvbuf, *tmp_results;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int total_count, dst;
     int mask;
     int rem, newdst, send_idx, recv_idx, last_idx, send_cnt, recv_cnt;
@@ -115,7 +115,8 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIC_Send(tmp_results, total_count,
-                                  datatype, rank + 1, MPIR_REDUCE_SCATTER_TAG, comm_ptr, errflag);
+                                  datatype, rank + 1, MPIR_REDUCE_SCATTER_TAG, comm_ptr,
+                                  collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
@@ -125,7 +126,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
         } else {        /* odd */
             mpi_errno = MPIC_Recv(tmp_recvbuf, total_count,
                                   datatype, rank - 1,
-                                  MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                  MPIR_REDUCE_SCATTER_TAG, comm_ptr, collattr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* do the reduction on received data. since the
@@ -202,17 +203,18 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
                                           newdisps[recv_idx] * extent,
                                           recv_cnt, datatype, dst,
                                           MPIR_REDUCE_SCATTER_TAG, comm_ptr,
-                                          MPI_STATUS_IGNORE, errflag);
+                                          MPI_STATUS_IGNORE, collattr | errflag);
             else if ((send_cnt == 0) && (recv_cnt != 0))
                 mpi_errno = MPIC_Recv((char *) tmp_recvbuf +
                                       newdisps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
-                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr, collattr,
+                                      MPI_STATUS_IGNORE);
             else if ((recv_cnt == 0) && (send_cnt != 0))
                 mpi_errno = MPIC_Send((char *) tmp_results +
                                       newdisps[send_idx] * extent,
                                       send_cnt, datatype,
-                                      dst, MPIR_REDUCE_SCATTER_TAG, comm_ptr, errflag);
+                                      dst, MPIR_REDUCE_SCATTER_TAG, comm_ptr, collattr | errflag);
 
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
@@ -252,14 +254,15 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
                 mpi_errno = MPIC_Send((char *) tmp_results +
                                       disps[rank - 1] * extent, recvcounts[rank - 1],
                                       datatype, rank - 1,
-                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr, errflag);
+                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr, collattr | errflag);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         } else {        /* even */
             if (recvcounts[rank]) {
                 mpi_errno = MPIC_Recv(recvbuf, recvcounts[rank],
                                       datatype, rank + 1,
-                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr, collattr,
+                                      MPI_STATUS_IGNORE);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             }
         }

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
@@ -7,14 +7,15 @@
 
 int MPIR_Reduce_scatter_block_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint recvcount,
                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                         MPIR_Errflag_t errflag)
+                                         int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
     mpi_errno =
-        MPIR_Ireduce_scatter_block(sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, &req_ptr);
+        MPIR_Ireduce_scatter_block(sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, collattr,
+                                   &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_inter_remote_reduce_local_scatter.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_inter_remote_reduce_local_scatter.c
@@ -17,11 +17,11 @@ int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *send
                                                                 MPI_Aint recvcount,
                                                                 MPI_Datatype datatype,
                                                                 MPI_Op op,
-                                                                MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t errflag)
+                                                                MPIR_Comm * comm_ptr, int collattr)
 {
     int rank, mpi_errno, root, local_size;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Aint true_extent, true_lb = 0, extent;
     void *tmp_buf = NULL;
     MPIR_Comm *newcomm_ptr = NULL;
@@ -52,25 +52,25 @@ int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *send
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
+                                             root, comm_ptr, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
+                                             root, comm_ptr, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else {
         /* reduce to rank 0 of left group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
+                                             root, comm_ptr, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
+                                             root, comm_ptr, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
@@ -81,7 +81,7 @@ int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *send
     newcomm_ptr = comm_ptr->local_comm;
 
     mpi_errno = MPIR_Scatter(tmp_buf, recvcount, datatype, recvbuf,
-                             recvcount, datatype, 0, newcomm_ptr, errflag);
+                             recvcount, datatype, 0, newcomm_ptr, collattr | errflag);
     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
   fn_exit:

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
@@ -24,11 +24,11 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
                                                    void *recvbuf,
                                                    MPI_Aint recvcount,
                                                    MPI_Datatype datatype,
-                                                   MPI_Op op,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPI_Op op, MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int comm_size = comm_ptr->local_size;
     int rank = comm_ptr->rank;
     int log2_comm_size;
@@ -100,7 +100,7 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
                                   size, datatype, peer, MPIR_REDUCE_SCATTER_BLOCK_TAG,
                                   incoming_data + recv_offset * true_extent,
                                   size, datatype, peer, MPIR_REDUCE_SCATTER_BLOCK_TAG,
-                                  comm_ptr, MPI_STATUS_IGNORE, errflag);
+                                  comm_ptr, MPI_STATUS_IGNORE, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         /* always perform the reduction at recv_offset, the data at send_offset
          * is now our peer's responsibility */

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
@@ -24,14 +24,14 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
                                              void *recvbuf,
                                              MPI_Aint recvcount,
                                              MPI_Datatype datatype,
-                                             MPI_Op op,
-                                             MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                             MPI_Op op, MPIR_Comm * comm_ptr, int collattr)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;
     void *tmp_recvbuf;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int src, dst;
     MPIR_CHKLMEM_DECL(5);
 
@@ -85,14 +85,14 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
                                       MPIR_REDUCE_SCATTER_BLOCK_TAG, tmp_recvbuf,
                                       recvcount, datatype, src,
                                       MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
-                                      MPI_STATUS_IGNORE, errflag);
+                                      MPI_STATUS_IGNORE, collattr | errflag);
         else
             mpi_errno = MPIC_Sendrecv(((char *) recvbuf + disps[dst] * extent),
                                       recvcount, datatype, dst,
                                       MPIR_REDUCE_SCATTER_BLOCK_TAG, tmp_recvbuf,
                                       recvcount, datatype, src,
                                       MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
-                                      MPI_STATUS_IGNORE, errflag);
+                                      MPI_STATUS_IGNORE, collattr | errflag);
 
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 

--- a/src/mpi/coll/scan/scan_allcomm_nb.c
+++ b/src/mpi/coll/scan/scan_allcomm_nb.c
@@ -6,13 +6,13 @@
 #include "mpiimpl.h"
 
 int MPIR_Scan_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
-                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                         MPI_Op op, MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
 
     /* just call the nonblocking version and wait on it */
-    mpi_errno = MPIR_Iscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, &req_ptr);
+    mpi_errno = MPIR_Iscan(sendbuf, recvbuf, count, datatype, op, comm_ptr, collattr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/scan/scan_intra_recursive_doubling.c
+++ b/src/mpi/coll/scan/scan_intra_recursive_doubling.c
@@ -44,12 +44,13 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
                                        void *recvbuf,
                                        MPI_Aint count,
                                        MPI_Datatype datatype,
-                                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                       MPI_Op op, MPIR_Comm * comm_ptr, int collattr)
 {
     MPI_Status status;
     int rank, comm_size;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int mask, dst, is_commutative;
     MPI_Aint true_extent, true_lb, extent;
     void *partial_scan, *tmp_buf;
@@ -98,7 +99,7 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
             mpi_errno = MPIC_Sendrecv(partial_scan, count, datatype,
                                       dst, MPIR_SCAN_TAG, tmp_buf,
                                       count, datatype, dst,
-                                      MPIR_SCAN_TAG, comm_ptr, &status, errflag);
+                                      MPIR_SCAN_TAG, comm_ptr, &status, collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             if (rank > dst) {

--- a/src/mpi/coll/scan/scan_intra_smp.c
+++ b/src/mpi/coll/scan/scan_intra_smp.c
@@ -7,11 +7,11 @@
 
 
 int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
-                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                        MPIR_Errflag_t errflag)
+                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPIR_CHKLMEM_DECL(3);
     int rank = comm_ptr->rank;
     MPI_Status status;
@@ -44,7 +44,9 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
     /* perform intranode scan to get temporary result in recvbuf. if there is only
      * one process, just copy the raw data. */
     if (comm_ptr->node_comm != NULL) {
-        mpi_errno = MPIR_Scan(sendbuf, recvbuf, count, datatype, op, comm_ptr->node_comm, errflag);
+        mpi_errno =
+            MPIR_Scan(sendbuf, recvbuf, count, datatype, op, comm_ptr->node_comm,
+                      collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
@@ -58,13 +60,13 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
     if (comm_ptr->node_roots_comm != NULL && comm_ptr->node_comm != NULL) {
         mpi_errno = MPIC_Recv(localfulldata, count, datatype,
                               comm_ptr->node_comm->local_size - 1, MPIR_SCAN_TAG,
-                              comm_ptr->node_comm, &status);
+                              comm_ptr->node_comm, collattr, &status);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else if (comm_ptr->node_roots_comm == NULL &&
                comm_ptr->node_comm != NULL &&
                MPIR_Get_intranode_rank(comm_ptr, rank) == comm_ptr->node_comm->local_size - 1) {
         mpi_errno = MPIC_Send(recvbuf, count, datatype,
-                              0, MPIR_SCAN_TAG, comm_ptr->node_comm, errflag);
+                              0, MPIR_SCAN_TAG, comm_ptr->node_comm, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     } else if (comm_ptr->node_roots_comm != NULL) {
         localfulldata = recvbuf;
@@ -76,19 +78,19 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
      * main process of node 3. */
     if (comm_ptr->node_roots_comm != NULL) {
         mpi_errno = MPIR_Scan(localfulldata, prefulldata, count, datatype,
-                              op, comm_ptr->node_roots_comm, errflag);
+                              op, comm_ptr->node_roots_comm, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
         if (MPIR_Get_internode_rank(comm_ptr, rank) != comm_ptr->node_roots_comm->local_size - 1) {
             mpi_errno = MPIC_Send(prefulldata, count, datatype,
                                   MPIR_Get_internode_rank(comm_ptr, rank) + 1,
-                                  MPIR_SCAN_TAG, comm_ptr->node_roots_comm, errflag);
+                                  MPIR_SCAN_TAG, comm_ptr->node_roots_comm, collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
         if (MPIR_Get_internode_rank(comm_ptr, rank) != 0) {
             mpi_errno = MPIC_Recv(tempbuf, count, datatype,
                                   MPIR_Get_internode_rank(comm_ptr, rank) - 1,
-                                  MPIR_SCAN_TAG, comm_ptr->node_roots_comm, &status);
+                                  MPIR_SCAN_TAG, comm_ptr->node_roots_comm, collattr, &status);
             noneed = 0;
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
@@ -101,13 +103,14 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
      * reduce it with recvbuf to get final result if necessary. */
 
     if (comm_ptr->node_comm != NULL) {
-        mpi_errno = MPIR_Bcast(&noneed, 1, MPI_INT, 0, comm_ptr->node_comm, errflag);
+        mpi_errno = MPIR_Bcast(&noneed, 1, MPI_INT, 0, comm_ptr->node_comm, collattr | errflag);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 
     if (noneed == 0) {
         if (comm_ptr->node_comm != NULL) {
-            mpi_errno = MPIR_Bcast(tempbuf, count, datatype, 0, comm_ptr->node_comm, errflag);
+            mpi_errno =
+                MPIR_Bcast(tempbuf, count, datatype, 0, comm_ptr->node_comm, collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
 

--- a/src/mpi/coll/scatter/scatter_allcomm_nb.c
+++ b/src/mpi/coll/scatter/scatter_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Scatter_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                             void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                            MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                            MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
@@ -15,7 +15,7 @@ int MPIR_Scatter_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Iscatter(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr,
-                      &req_ptr);
+                      collattr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/scatter/scatter_inter_linear.c
+++ b/src/mpi/coll/scatter/scatter_inter_linear.c
@@ -14,10 +14,11 @@
 
 int MPIR_Scatter_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                              MPIR_Comm * comm_ptr, int collattr)
 {
     int remote_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     int i;
     MPI_Status status;
     MPI_Aint extent;
@@ -34,12 +35,13 @@ int MPIR_Scatter_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
         for (i = 0; i < remote_size; i++) {
             mpi_errno =
                 MPIC_Send(((char *) sendbuf + sendcount * i * extent), sendcount, sendtype, i,
-                          MPIR_SCATTER_TAG, comm_ptr, errflag);
+                          MPIR_SCATTER_TAG, comm_ptr, collattr | errflag);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     } else {
         mpi_errno =
-            MPIC_Recv(recvbuf, recvcount, recvtype, root, MPIR_SCATTER_TAG, comm_ptr, &status);
+            MPIC_Recv(recvbuf, recvcount, recvtype, root, MPIR_SCATTER_TAG, comm_ptr, collattr,
+                      &status);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -28,7 +28,7 @@
 /* not declared static because a machine-specific function may call this one in some cases */
 int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                                MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                MPIR_Comm * comm_ptr, int collattr)
 {
     MPI_Status status;
     MPI_Aint extent = 0;
@@ -40,6 +40,7 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
     void *tmp_buf = NULL;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPIR_CHKLMEM_DECL(4);
 
     comm_size = comm_ptr->local_size;
@@ -118,11 +119,11 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
              * receive data into a temporary buffer. */
             if (relative_rank % 2) {
                 mpi_errno = MPIC_Recv(recvbuf, recvcount, recvtype,
-                                      src, MPIR_SCATTER_TAG, comm_ptr, &status);
+                                      src, MPIR_SCATTER_TAG, comm_ptr, collattr, &status);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else {
                 mpi_errno = MPIC_Recv(tmp_buf, tmp_buf_size, MPI_BYTE, src,
-                                      MPIR_SCATTER_TAG, comm_ptr, &status);
+                                      MPIR_SCATTER_TAG, comm_ptr, collattr, &status);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 if (mpi_errno) {
                     curr_cnt = 0;
@@ -154,14 +155,16 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
                 mpi_errno = MPIC_Send(((char *) sendbuf +
                                        extent * sendcount * mask),
                                       send_subtree_cnt,
-                                      sendtype, dst, MPIR_SCATTER_TAG, comm_ptr, errflag);
+                                      sendtype, dst, MPIR_SCATTER_TAG, comm_ptr,
+                                      collattr | errflag);
             } else {
                 /* non-zero root and others */
                 send_subtree_cnt = curr_cnt - nbytes * mask;
                 /* mask is also the size of this process's subtree */
                 mpi_errno = MPIC_Send(((char *) tmp_buf + nbytes * mask),
                                       send_subtree_cnt,
-                                      MPI_BYTE, dst, MPIR_SCATTER_TAG, comm_ptr, errflag);
+                                      MPI_BYTE, dst, MPIR_SCATTER_TAG, comm_ptr,
+                                      collattr | errflag);
             }
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             curr_cnt -= send_subtree_cnt;

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -20,10 +20,11 @@
 int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcounts,
                                  const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
                                  MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                 MPIR_Comm * comm_ptr, int collattr)
 {
     int rank, comm_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
+    int errflag = 0;
     MPI_Aint extent;
     int i, reqs;
     MPIR_Request **reqarray;
@@ -60,7 +61,8 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcount
                 } else {
                     mpi_errno = MPIC_Isend(((char *) sendbuf + displs[i] * extent),
                                            sendcounts[i], sendtype, i,
-                                           MPIR_SCATTERV_TAG, comm_ptr, &reqarray[reqs++], errflag);
+                                           MPIR_SCATTERV_TAG, comm_ptr, &reqarray[reqs++],
+                                           collattr | errflag);
                     MPIR_ERR_CHECK(mpi_errno);
                 }
             }
@@ -73,7 +75,7 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcount
     else if (root != MPI_PROC_NULL) {   /* non-root nodes, and in the intercomm. case, non-root nodes on remote side */
         if (recvcount) {
             mpi_errno = MPIC_Recv(recvbuf, recvcount, recvtype, root,
-                                  MPIR_SCATTERV_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                  MPIR_SCATTERV_TAG, comm_ptr, collattr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         }
     }

--- a/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
@@ -8,7 +8,7 @@
 int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
                              const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
                              MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                             MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                             MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;
@@ -16,7 +16,7 @@ int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
     /* just call the nonblocking version and wait on it */
     mpi_errno =
         MPIR_Iscatterv(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root,
-                       comm_ptr, &req_ptr);
+                       comm_ptr, collattr, &req_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIC_Wait(req_ptr);

--- a/src/mpi/coll/transports/gentran/gentran_types.h
+++ b/src/mpi/coll/transports/gentran/gentran_types.h
@@ -50,6 +50,7 @@ typedef struct MPII_Genutil_vtx_t {
             int dest;
             int tag;
             MPIR_Comm *comm;
+            int collattr;
             MPIR_Request *req;
         } isend;
         struct {
@@ -59,6 +60,7 @@ typedef struct MPII_Genutil_vtx_t {
             int src;
             int tag;
             MPIR_Comm *comm;
+            int collattr;
             MPIR_Request *req;
         } irecv;
         struct {
@@ -68,6 +70,7 @@ typedef struct MPII_Genutil_vtx_t {
             int src;
             int tag;
             MPIR_Comm *comm;
+            int collattr;
             MPIR_Request *req;
             MPI_Status *status;
         } irecv_status;
@@ -79,6 +82,7 @@ typedef struct MPII_Genutil_vtx_t {
             int num_dests;
             int tag;
             MPIR_Comm *comm;
+            int collattr;
             MPIR_Request **req;
             int last_complete;
         } imcast;
@@ -89,6 +93,7 @@ typedef struct MPII_Genutil_vtx_t {
             int dest;
             int tag;
             MPIR_Comm *comm;
+            int collattr;
             MPIR_Request *req;
         } issend;
         struct {

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -75,7 +75,7 @@ static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t 
                                vtxp->u.irecv.count,
                                vtxp->u.irecv.dt,
                                vtxp->u.irecv.src, vtxp->u.irecv.tag, vtxp->u.irecv.comm,
-                               &vtxp->u.irecv.req);
+                               vtxp->u.irecv.collattr, &vtxp->u.irecv.req);
 
                     if (MPIR_Request_is_complete(vtxp->u.irecv.req)) {
                         MPIR_Request_free(vtxp->u.irecv.req);
@@ -104,7 +104,8 @@ static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t 
                                vtxp->u.irecv_status.count,
                                vtxp->u.irecv_status.dt,
                                vtxp->u.irecv_status.src, vtxp->u.irecv_status.tag,
-                               vtxp->u.irecv_status.comm, &vtxp->u.irecv_status.req);
+                               vtxp->u.irecv_status.comm,
+                               vtxp->u.irecv_status.collattr, &vtxp->u.irecv_status.req);
 
                     if (MPIR_Request_is_complete(vtxp->u.irecv_status.req)) {
                         if (vtxp->u.irecv_status.status != MPI_STATUS_IGNORE) {
@@ -144,7 +145,7 @@ static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t 
                                    vtxp->u.imcast.dt,
                                    dests[i],
                                    vtxp->u.imcast.tag, vtxp->u.imcast.comm, &vtxp->u.imcast.req[i],
-                                   r->u.nbc.errflag);
+                                   vtxp->u.imcast.collattr | r->u.nbc.errflag);
 
                     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                                     (MPL_DBG_FDEST,
@@ -160,7 +161,7 @@ static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t 
                                 vtxp->u.issend.dt,
                                 vtxp->u.issend.dest,
                                 vtxp->u.issend.tag, vtxp->u.issend.comm, &vtxp->u.issend.req,
-                                r->u.nbc.errflag);
+                                vtxp->u.issend.collattr | r->u.nbc.errflag);
 
                     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                                     (MPL_DBG_FDEST,

--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -191,8 +191,8 @@ int MPIR_TSP_sched_isend(const void *buf,
                          MPI_Datatype dt,
                          int dest,
                          int tag,
-                         MPIR_Comm * comm_ptr, MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs,
-                         int *vtx_id)
+                         MPIR_Comm * comm_ptr, int collattr, MPIR_TSP_sched_t s, int n_in_vtcs,
+                         int *in_vtcs, int *vtx_id)
 {
     MPII_Genutil_sched_t *sched = s;
     vtx_t *vtxp;
@@ -209,6 +209,7 @@ int MPIR_TSP_sched_isend(const void *buf,
     vtxp->u.isend.dest = dest;
     vtxp->u.isend.tag = tag;
     vtxp->u.isend.comm = comm_ptr;
+    vtxp->u.isend.collattr = collattr;
 
     /* the user may free the comm & type after initiating but before the
      * underlying send is actually posted, so we must add a reference here and
@@ -228,8 +229,8 @@ int MPIR_TSP_sched_irecv(void *buf,
                          MPI_Datatype dt,
                          int source,
                          int tag,
-                         MPIR_Comm * comm_ptr, MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs,
-                         int *vtx_id)
+                         MPIR_Comm * comm_ptr, int collattr, MPIR_TSP_sched_t s, int n_in_vtcs,
+                         int *in_vtcs, int *vtx_id)
 {
     MPII_Genutil_sched_t *sched = s;
     vtx_t *vtxp;
@@ -247,6 +248,7 @@ int MPIR_TSP_sched_irecv(void *buf,
     vtxp->u.irecv.src = source;
     vtxp->u.irecv.tag = tag;
     vtxp->u.irecv.comm = comm_ptr;
+    vtxp->u.irecv.collattr = collattr;
 
     MPIR_Comm_add_ref(comm_ptr);
     MPIR_Datatype_add_ref_if_not_builtin(dt);
@@ -262,7 +264,7 @@ int MPIR_TSP_sched_irecv_status(void *buf,
                                 MPI_Datatype dt,
                                 int source,
                                 int tag,
-                                MPIR_Comm * comm_ptr, MPI_Status * status,
+                                MPIR_Comm * comm_ptr, int collattr, MPI_Status * status,
                                 MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs, int *vtx_id)
 {
     vtx_t *vtxp;
@@ -282,6 +284,7 @@ int MPIR_TSP_sched_irecv_status(void *buf,
     vtxp->u.irecv_status.tag = tag;
     vtxp->u.irecv_status.comm = comm_ptr;
     vtxp->u.irecv_status.status = status;
+    vtxp->u.irecv_status.collattr = collattr;
 
     MPIR_Comm_add_ref(comm_ptr);
     MPIR_Datatype_add_ref_if_not_builtin(dt);
@@ -300,8 +303,8 @@ int MPIR_TSP_sched_imcast(const void *buf,
                           int *dests,
                           int num_dests,
                           int tag,
-                          MPIR_Comm * comm_ptr, MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs,
-                          int *vtx_id)
+                          MPIR_Comm * comm_ptr, int collattr, MPIR_TSP_sched_t s, int n_in_vtcs,
+                          int *in_vtcs, int *vtx_id)
 {
     MPII_Genutil_sched_t *sched = s;
     vtx_t *vtxp;
@@ -321,6 +324,7 @@ int MPIR_TSP_sched_imcast(const void *buf,
     memcpy(ut_int_array(&vtxp->u.imcast.dests), dests, num_dests * sizeof(int));
     vtxp->u.imcast.tag = tag;
     vtxp->u.imcast.comm = comm_ptr;
+    vtxp->u.imcast.collattr = collattr;
     vtxp->u.imcast.req =
         (struct MPIR_Request **) MPL_malloc(sizeof(struct MPIR_Request *) * num_dests,
                                             MPL_MEM_COLL);
@@ -339,8 +343,8 @@ int MPIR_TSP_sched_issend(const void *buf,
                           MPI_Datatype dt,
                           int dest,
                           int tag,
-                          MPIR_Comm * comm_ptr, MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs,
-                          int *vtx_id)
+                          MPIR_Comm * comm_ptr, int collattr, MPIR_TSP_sched_t s, int n_in_vtcs,
+                          int *in_vtcs, int *vtx_id)
 {
     MPII_Genutil_sched_t *sched = s;
     vtx_t *vtxp;
@@ -357,6 +361,7 @@ int MPIR_TSP_sched_issend(const void *buf,
     vtxp->u.issend.dest = dest;
     vtxp->u.issend.tag = tag;
     vtxp->u.issend.comm = comm_ptr;
+    vtxp->u.issend.collattr = collattr;
 
     MPIR_Comm_add_ref(comm_ptr);
     MPIR_Datatype_add_ref_if_not_builtin(dt);

--- a/src/mpi/coll/transports/tsp_impl.h
+++ b/src/mpi/coll/transports/tsp_impl.h
@@ -49,8 +49,8 @@ int MPIR_TSP_sched_isend(const void *buf,
                          MPI_Datatype dt,
                          int dest,
                          int tag,
-                         MPIR_Comm * comm_ptr, MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs,
-                         int *vtx_id);
+                         MPIR_Comm * comm_ptr, int collattr,
+                         MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs, int *vtx_id);
 
 /* Transport function to schedule a issend vertex */
 int MPIR_TSP_sched_issend(const void *buf,
@@ -58,7 +58,7 @@ int MPIR_TSP_sched_issend(const void *buf,
                           MPI_Datatype dt,
                           int dest,
                           int tag,
-                          MPIR_Comm * comm_ptr,
+                          MPIR_Comm * comm_ptr, int collattr,
                           MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs, int *vtx_id);
 
 /* Transport function to schedule an irecv vertex */
@@ -67,8 +67,8 @@ int MPIR_TSP_sched_irecv(void *buf,
                          MPI_Datatype dt,
                          int source,
                          int tag,
-                         MPIR_Comm * comm_ptr, MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs,
-                         int *vtx_id);
+                         MPIR_Comm * comm_ptr, int collattr,
+                         MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs, int *vtx_id);
 
 /* Transport function to schedule a irecv with status vertex */
 int MPIR_TSP_sched_irecv_status(void *buf,
@@ -76,7 +76,7 @@ int MPIR_TSP_sched_irecv_status(void *buf,
                                 MPI_Datatype dt,
                                 int source,
                                 int tag,
-                                MPIR_Comm * comm_ptr, MPI_Status * status,
+                                MPIR_Comm * comm_ptr, int collattr, MPI_Status * status,
                                 MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs, int *vtx_id);
 
 /* Transport function to schedule an imcast vertex */
@@ -86,7 +86,7 @@ int MPIR_TSP_sched_imcast(const void *buf,
                           int *dests,
                           int num_dests,
                           int tag,
-                          MPIR_Comm * comm_ptr,
+                          MPIR_Comm * comm_ptr, int collattr,
                           MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs, int *vtx_id);
 
 

--- a/src/mpi/comm/contextid.c
+++ b/src/mpi/comm/contextid.c
@@ -651,18 +651,18 @@ static int sched_cb_gcn_bcast(MPIR_Comm * comm, int tag, void *state)
         if (st->comm_ptr_inter->rank == 0) {
             mpi_errno =
                 MPIR_Sched_recv(st->ctx1, 1, MPIR_CONTEXT_ID_T_DATATYPE, 0, st->comm_ptr_inter,
-                                st->s);
+                                MPIR_COLL_ATTR_NONE, st->s);
             MPIR_ERR_CHECK(mpi_errno);
             mpi_errno =
                 MPIR_Sched_send(st->ctx0, 1, MPIR_CONTEXT_ID_T_DATATYPE, 0, st->comm_ptr_inter,
-                                st->s);
+                                MPIR_COLL_ATTR_NONE, st->s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(st->s);
         }
 
         mpi_errno = MPIR_Ibcast_intra_sched_auto(st->ctx1, 1,
                                                  MPIR_CONTEXT_ID_T_DATATYPE, 0, st->comm_ptr,
-                                                 st->s);
+                                                 MPIR_COLL_ATTR_NONE, st->s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(st->s);
     }
@@ -844,7 +844,7 @@ static int sched_cb_gcn_copy_mask(MPIR_Comm * comm, int tag, void *state)
 
     mpi_errno = MPIR_Iallreduce_intra_sched_auto(MPI_IN_PLACE, st->local_mask,
                                                  MPIR_MAX_CONTEXT_MASK + 1, MPI_UINT32_T, MPI_BAND,
-                                                 st->comm_ptr, st->s);
+                                                 st->comm_ptr, MPIR_COLL_ATTR_NONE, st->s);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_SCHED_BARRIER(st->s);
 

--- a/src/mpi/topo/dist_graph_create.c
+++ b/src/mpi/topo/dist_graph_create.c
@@ -150,14 +150,14 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
             /* send edges where i is a destination to process i */
             mpi_errno =
                 MPIC_Isend(&rin[i][0], rin_sizes[i], MPI_INT, i, MPIR_TOPO_A_TAG, comm_ptr,
-                           &reqs[idx++], MPIR_ERR_NONE);
+                           &reqs[idx++], MPIR_COLL_ATTR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
         }
         if (rout_sizes[i]) {
             /* send edges where i is a source to process i */
             mpi_errno =
                 MPIC_Isend(&rout[i][0], rout_sizes[i], MPI_INT, i, MPIR_TOPO_B_TAG, comm_ptr,
-                           &reqs[idx++], MPIR_ERR_NONE);
+                           &reqs[idx++], MPIR_COLL_ATTR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }
@@ -203,7 +203,7 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
         MPIR_ERR_CHKANDJUMP(!buf, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
         mpi_errno = MPIC_Recv(buf, count, MPI_INT, MPI_ANY_SOURCE, MPIR_TOPO_A_TAG,
-                              comm_ptr, MPI_STATUS_IGNORE);
+                              comm_ptr, MPIR_COLL_ATTR_NONE, MPI_STATUS_IGNORE);
         MPIR_ERR_CHECK(mpi_errno);
 
         for (int j = 0; j < count / 2; ++j) {
@@ -236,7 +236,7 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
         MPIR_ERR_CHKANDJUMP(!buf, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
         mpi_errno = MPIC_Recv(buf, count, MPI_INT, MPI_ANY_SOURCE, MPIR_TOPO_B_TAG,
-                              comm_ptr, MPI_STATUS_IGNORE);
+                              comm_ptr, MPIR_COLL_ATTR_NONE, MPI_STATUS_IGNORE);
         MPIR_ERR_CHECK(mpi_errno);
 
         for (int j = 0; j < count / 2; ++j) {

--- a/src/mpid/ch3/include/mpid_coll.h
+++ b/src/mpid/ch3/include/mpid_coll.h
@@ -11,39 +11,39 @@
 #include "../../common/hcoll/hcoll.h"
 #endif
 
-static inline int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t errflag)
+static inline int MPID_Barrier(MPIR_Comm * comm, int collattr)
 {
 #ifdef HAVE_HCOLL
     if (MPI_SUCCESS == hcoll_Barrier(comm, errflag))
         return MPI_SUCCESS;
 #endif
-    return MPIR_Barrier_impl(comm, errflag);
+    return MPIR_Barrier_impl(comm, collattr);
 }
 
 static inline int MPID_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                             MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                             MPIR_Comm * comm, int collattr)
 {
 #ifdef HAVE_HCOLL
     if (MPI_SUCCESS == hcoll_Bcast(buffer, count, datatype, root, comm, errflag))
         return MPI_SUCCESS;
 #endif
-    return MPIR_Bcast_impl(buffer, count, datatype, root, comm, errflag);
+    return MPIR_Bcast_impl(buffer, count, datatype, root, comm, collattr);
 }
 
 static inline int MPID_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                 MPIR_Errflag_t errflag)
+                                 int collattr)
 {
 #ifdef HAVE_HCOLL
     if (MPI_SUCCESS == hcoll_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag))
         return MPI_SUCCESS;
 #endif
-    return MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    return MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr);
 }
 
 static inline int MPID_Allgather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                 MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                 MPIR_Comm * comm, int collattr)
 {
 #ifdef HAVE_HCOLL
     if (MPI_SUCCESS == hcoll_Allgather(sendbuf, sendcount, sendtype, recvbuf,
@@ -51,30 +51,30 @@ static inline int MPID_Allgather(const void *sendbuf, MPI_Aint sendcount, MPI_Da
         return MPI_SUCCESS;
 #endif
     return MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                    recvcount, recvtype, comm, errflag);
+                                    recvcount, recvtype, comm, collattr);
 }
 
 static inline int MPID_Allgatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
-                                  MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                  MPI_Datatype recvtype, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                                      recvcounts, displs, recvtype, comm,
-                                     errflag);
+                                     collattr);
 
     return mpi_errno;
 }
 
 static inline int MPID_Scatter(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                               int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                               int root, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                  recvcount, recvtype, root, comm, errflag);
+                                  recvcount, recvtype, root, comm, collattr);
 
     return mpi_errno;
 }
@@ -82,25 +82,25 @@ static inline int MPID_Scatter(const void *sendbuf, MPI_Aint sendcount, MPI_Data
 static inline int MPID_Scatterv(const void *sendbuf, const MPI_Aint * sendcounts, const MPI_Aint * displs,
                                 MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                MPIR_Errflag_t errflag)
+                                int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Scatterv_impl(sendbuf, sendcounts, displs, sendtype,
                                    recvbuf, recvcount, recvtype, root, comm,
-                                   errflag);
+                                   collattr);
 
     return mpi_errno;
 }
 
 static inline int MPID_Gather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                              int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                              int root, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                 recvcount, recvtype, root, comm, errflag);
+                                 recvcount, recvtype, root, comm, collattr);
 
     return mpi_errno;
 }
@@ -108,25 +108,25 @@ static inline int MPID_Gather(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
 static inline int MPID_Gatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                               MPIR_Errflag_t errflag)
+                               int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                                   recvcounts, displs, recvtype, root, comm,
-                                  errflag);
+                                  collattr);
 
     return mpi_errno;
 }
 
 static inline int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                   recvcount, recvtype, comm, errflag);
+                                   recvcount, recvtype, comm, collattr);
 
     return mpi_errno;
 }
@@ -134,13 +134,13 @@ static inline int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
 static inline int MPID_Alltoallv(const void *sendbuf, const MPI_Aint * sendcounts, const MPI_Aint * sdispls,
                                  MPI_Datatype sendtype, void *recvbuf, const MPI_Aint * recvcounts,
                                  const MPI_Aint * rdispls, MPI_Datatype recvtype, MPIR_Comm * comm,
-                                 MPIR_Errflag_t errflag)
+                                 int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
                                     recvbuf, recvcounts, rdispls, recvtype,
-                                    comm, errflag);
+                                    comm, collattr);
 
     return mpi_errno;
 }
@@ -149,37 +149,37 @@ static inline int MPID_Alltoallw(const void *sendbuf, const MPI_Aint sendcounts[
                                  const MPI_Datatype sendtypes[], void *recvbuf,
                                  const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                                  const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                 MPIR_Errflag_t errflag)
+                                 int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Alltoallw_impl(sendbuf, sendcounts, sdispls, sendtypes,
                                     recvbuf, recvcounts, rdispls, recvtypes,
-                                    comm_ptr, errflag);
+                                    comm_ptr, collattr);
 
     return mpi_errno;
 }
 
 static inline int MPID_Reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                               MPI_Datatype datatype, MPI_Op op, int root,
-                              MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                              MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root,
-                                 comm, errflag);
+                                 comm, collattr);
 
     return mpi_errno;
 }
 
 static inline int MPID_Reduce_scatter(const void *sendbuf, void *recvbuf, const MPI_Aint recvcounts[],
                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                      MPIR_Errflag_t errflag)
+                                      int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts,
-                                         datatype, op, comm_ptr, errflag);
+                                         datatype, op, comm_ptr, collattr);
 
     return mpi_errno;
 }
@@ -187,37 +187,37 @@ static inline int MPID_Reduce_scatter(const void *sendbuf, void *recvbuf, const 
 static inline int MPID_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
                                             MPI_Aint recvcount, MPI_Datatype datatype,
                                             MPI_Op op, MPIR_Comm * comm_ptr,
-                                            MPIR_Errflag_t errflag)
+                                            int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount,
                                                datatype, op, comm_ptr,
-                                               errflag);
+                                               collattr);
 
     return mpi_errno;
 }
 
 static inline int MPID_Scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                            MPIR_Errflag_t errflag)
+                            int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm,
-                               errflag);
+                               collattr);
 
     return mpi_errno;
 }
 
 static inline int MPID_Exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                              MPIR_Errflag_t errflag)
+                              int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm,
-                                 errflag);
+                                 collattr);
 
     return mpi_errno;
 }
@@ -366,70 +366,70 @@ static inline int MPID_Ineighbor_alltoallw(const void *sendbuf, const MPI_Aint s
     return mpi_errno;
 }
 
-static inline int MPID_Ibarrier(MPIR_Comm * comm, MPIR_Request **request)
+static inline int MPID_Ibarrier(MPIR_Comm * comm, int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Ibarrier_impl(comm, request);
+    mpi_errno = MPIR_Ibarrier_impl(comm, collattr, request);
 
     return mpi_errno;
 }
 
 static inline int MPID_Ibcast(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                              MPIR_Comm * comm, MPIR_Request **request)
+                              MPIR_Comm * comm, int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Ibcast_impl(buffer, count, datatype, root, comm, request);
+    mpi_errno = MPIR_Ibcast_impl(buffer, count, datatype, root, comm, collattr, request);
 
     return mpi_errno;
 }
 
 static inline int MPID_Iallgather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                  MPIR_Comm * comm, MPIR_Request **request)
+                                  MPIR_Comm * comm, int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Iallgather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                     recvcount, recvtype, comm, request);
+                                     recvcount, recvtype, comm, collattr, request);
 
     return mpi_errno;
 }
 
 static inline int MPID_Iallgatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                    void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
-                                   MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Request **request)
+                                   MPI_Datatype recvtype, MPIR_Comm * comm, int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Iallgatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                                       recvcounts, displs, recvtype, comm,
-                                      request);
+                                      collattr, request);
 
     return mpi_errno;
 }
 
 static inline int MPID_Iallreduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                   MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                  MPIR_Request **request)
+                                  int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Iallreduce_impl(sendbuf, recvbuf, count, datatype, op,
-                                     comm, request);
+                                     comm, collattr, request);
 
     return mpi_errno;
 }
 
 static inline int MPID_Ialltoall(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                 MPIR_Comm * comm, MPIR_Request **request)
+                                 MPIR_Comm * comm, int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Ialltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                    recvcount, recvtype, comm, request);
+                                    recvcount, recvtype, comm, collattr, request);
 
     return mpi_errno;
 }
@@ -438,13 +438,13 @@ static inline int MPID_Ialltoallv(const void *sendbuf, const MPI_Aint sendcounts
                                   const MPI_Aint sdispls[], MPI_Datatype sendtype,
                                   void *recvbuf, const MPI_Aint recvcounts[],
                                   const MPI_Aint rdispls[], MPI_Datatype recvtype,
-                                  MPIR_Comm * comm, MPIR_Request **request)
+                                  MPIR_Comm * comm, int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Ialltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
                                      recvbuf, recvcounts, rdispls, recvtype,
-                                     comm, request);
+                                     comm, collattr, request);
 
     return mpi_errno;
 }
@@ -453,37 +453,37 @@ static inline int MPID_Ialltoallw(const void *sendbuf, const MPI_Aint sendcounts
                                   const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                   void *recvbuf, const MPI_Aint recvcounts[],
                                   const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                  MPIR_Comm * comm, MPIR_Request **request)
+                                  MPIR_Comm * comm, int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Ialltoallw_impl(sendbuf, sendcounts, sdispls, sendtypes,
                                      recvbuf, recvcounts, rdispls, recvtypes,
-                                     comm, request);
+                                     comm, collattr, request);
 
     return mpi_errno;
 }
 
 static inline int MPID_Iexscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                               MPIR_Request **request)
+                               int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Iexscan_impl(sendbuf, recvbuf, count, datatype, op, comm,
-                                  request);
+                                  collattr, request);
 
     return mpi_errno;
 }
 
 static inline int MPID_Igather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                               int root, MPIR_Comm * comm, MPIR_Request **request)
+                               int root, MPIR_Comm * comm, int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Igather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                  recvcount, recvtype, root, comm, request);
+                                  recvcount, recvtype, root, comm, collattr, request);
 
     return mpi_errno;
 }
@@ -491,71 +491,71 @@ static inline int MPID_Igather(const void *sendbuf, MPI_Aint sendcount, MPI_Data
 static inline int MPID_Igatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                MPIR_Request **request)
+                                int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Igatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                                    recvcounts, displs, recvtype, root, comm,
-                                   request);
+                                   collattr, request);
 
     return mpi_errno;
 }
 
 static inline int MPID_Ireduce_scatter_block(const void *sendbuf, void *recvbuf, MPI_Aint recvcount,
                                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                             MPIR_Request **request)
+                                             int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Ireduce_scatter_block_impl(sendbuf, recvbuf, recvcount,
-                                                datatype, op, comm, request);
+                                                datatype, op, comm, collattr, request);
 
     return mpi_errno;
 }
 
 static inline int MPID_Ireduce_scatter(const void *sendbuf, void *recvbuf, const MPI_Aint recvcounts[],
                                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                       MPIR_Request **request)
+                                       int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Ireduce_scatter_impl(sendbuf, recvbuf, recvcounts,
-                                          datatype, op, comm, request);
+                                          datatype, op, comm, collattr, request);
 
     return mpi_errno;
 }
 
 static inline int MPID_Ireduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
-                               MPI_Op op, int root, MPIR_Comm * comm, MPIR_Request **request)
+                               MPI_Op op, int root, MPIR_Comm * comm, int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Ireduce_impl(sendbuf, recvbuf, count, datatype, op, root,
-                                  comm, request);
+                                  comm, collattr, request);
 
     return mpi_errno;
 }
 
 static inline int MPID_Iscan(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
-                             MPI_Op op, MPIR_Comm * comm, MPIR_Request **request)
+                             MPI_Op op, MPIR_Comm * comm, int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Iscan_impl(sendbuf, recvbuf, count, datatype, op, comm,
-                                request);
+                                collattr, request);
 
     return mpi_errno;
 }
 
 static inline int MPID_Iscatter(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                int root, MPIR_Comm * comm, MPIR_Request **request)
+                                int root, MPIR_Comm * comm, int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Iscatter_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                   recvcount, recvtype, root, comm, request);
+                                   recvcount, recvtype, root, comm, collattr, request);
 
     return mpi_errno;
 }
@@ -563,13 +563,13 @@ static inline int MPID_Iscatter(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
 static inline int MPID_Iscatterv(const void *sendbuf, const MPI_Aint * sendcounts,
                                  const MPI_Aint * displs, MPI_Datatype sendtype,
                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                 int root, MPIR_Comm * comm, MPIR_Request **request)
+                                 int root, MPIR_Comm * comm, int collattr, MPIR_Request **request)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Iscatterv_impl(sendbuf, sendcounts, displs, sendtype,
                                     recvbuf, recvcount, recvtype, root, comm,
-                                    request);
+                                    collattr, request);
 
     return mpi_errno;
 }

--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -647,7 +647,7 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
         mpi_errno = MPIC_Sendrecv(send_ints, 3, MPI_INT, 0,
                                      sendtag++, recv_ints, 3, MPI_INT,
                                      0, recvtag++, tmp_comm,
-                                     MPI_STATUS_IGNORE, MPIR_ERR_NONE);
+                                     MPI_STATUS_IGNORE, MPIR_COLL_ATTR_NONE);
         if (mpi_errno != MPI_SUCCESS) {
             /* this is a no_port error because we may fail to connect
                on the send if the port name is invalid */
@@ -690,7 +690,7 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
 				  MPI_INT, 0, sendtag++,
 				  remote_translation, remote_comm_size * 2, 
 				  MPI_INT, 0, recvtag++, tmp_comm,
-				  MPI_STATUS_IGNORE, MPIR_ERR_NONE);
+				  MPI_STATUS_IGNORE, MPIR_COLL_ATTR_NONE);
 	MPIR_ERR_CHECK(mpi_errno);
 
 #ifdef MPICH_DBG_OUTPUT
@@ -741,7 +741,7 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
         mpi_errno = MPIC_Sendrecv(&i, 0, MPI_INT, 0,
                                      sendtag++, &j, 0, MPI_INT,
                                      0, recvtag++, tmp_comm,
-                                     MPI_STATUS_IGNORE, MPIR_ERR_NONE);
+                                     MPI_STATUS_IGNORE, MPIR_COLL_ATTR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
 
         /* All communication with remote root done. Release the communicator. */
@@ -928,7 +928,7 @@ static int ReceivePGAndDistribute( MPIR_Comm *tmp_comm, MPIR_Comm *comm_ptr,
 	if (rank == root) {
 	    /* First, receive the pg description from the partner */
 	    mpi_errno = MPIC_Recv(&j, 1, MPI_INT, 0, recvtag++,
-				  tmp_comm, MPI_STATUS_IGNORE);
+				  tmp_comm, MPIR_COLL_ATTR_NONE, MPI_STATUS_IGNORE);
 	    *recvtag_p = recvtag;
 	    MPIR_ERR_CHECK(mpi_errno);
 	    pg_str = (char*)MPL_malloc(j, MPL_MEM_DYNAMIC);
@@ -936,7 +936,7 @@ static int ReceivePGAndDistribute( MPIR_Comm *tmp_comm, MPIR_Comm *comm_ptr,
 		MPIR_ERR_POP(mpi_errno);
 	    }
 	    mpi_errno = MPIC_Recv(pg_str, j, MPI_CHAR, 0, recvtag++,
-				  tmp_comm, MPI_STATUS_IGNORE);
+				  tmp_comm, MPIR_COLL_ATTR_NONE, MPI_STATUS_IGNORE);
 	    *recvtag_p = recvtag;
 	    MPIR_ERR_CHECK(mpi_errno);
 	}
@@ -1083,13 +1083,13 @@ static int SendPGtoPeerAndFree( MPIR_Comm *tmp_comm, int *sendtag_p,
 	pg_iter = pg_list;
 	i = pg_iter->lenStr;
 	/*printf("connect:sending 1 int: %d\n", i);fflush(stdout);*/
-	mpi_errno = MPIC_Send(&i, 1, MPI_INT, 0, sendtag++, tmp_comm, MPIR_ERR_NONE);
+	mpi_errno = MPIC_Send(&i, 1, MPI_INT, 0, sendtag++, tmp_comm, MPIR_COLL_ATTR_NONE);
 	*sendtag_p = sendtag;
 	MPIR_ERR_CHECK(mpi_errno);
 	
 	/* printf("connect:sending string length %d\n", i);fflush(stdout); */
 	mpi_errno = MPIC_Send(pg_iter->str, i, MPI_CHAR, 0, sendtag++,
-			      tmp_comm, MPIR_ERR_NONE);
+			      tmp_comm, MPIR_COLL_ATTR_NONE);
 	*sendtag_p = sendtag;
 	MPIR_ERR_CHECK(mpi_errno);
 	
@@ -1183,7 +1183,7 @@ int MPIDI_Comm_accept(const char *port_name, MPIR_Info *info, int root,
         mpi_errno = MPIC_Sendrecv(send_ints, 3, MPI_INT, 0,
                                      sendtag++, recv_ints, 3, MPI_INT,
                                      0, recvtag++, tmp_comm,
-                                     MPI_STATUS_IGNORE, MPIR_ERR_NONE);
+                                     MPI_STATUS_IGNORE, MPIR_COLL_ATTR_NONE);
 	MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -1222,7 +1222,7 @@ int MPIDI_Comm_accept(const char *port_name, MPIR_Info *info, int root,
 				  MPI_INT, 0, sendtag++,
 				  remote_translation, remote_comm_size * 2, 
 				  MPI_INT, 0, recvtag++, tmp_comm,
-				  MPI_STATUS_IGNORE, MPIR_ERR_NONE);
+				  MPI_STATUS_IGNORE, MPIR_COLL_ATTR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
 
 #ifdef MPICH_DBG_OUTPUT
@@ -1272,7 +1272,7 @@ int MPIDI_Comm_accept(const char *port_name, MPIR_Info *info, int root,
         mpi_errno = MPIC_Sendrecv(&i, 0, MPI_INT, 0,
                                      sendtag++, &j, 0, MPI_INT,
                                      0, recvtag++, tmp_comm,
-                                     MPI_STATUS_IGNORE, MPIR_ERR_NONE);
+                                     MPI_STATUS_IGNORE, MPIR_COLL_ATTR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
 
         /* All communication with remote root done. Release the communicator. */

--- a/src/mpid/ch3/src/ch3u_rma_sync.c
+++ b/src/mpid/ch3/src/ch3u_rma_sync.c
@@ -493,7 +493,7 @@ int MPID_Win_fence(int assert, MPIR_Win * win_ptr)
                 MPIR_ERR_CHECK(mpi_errno);
             }
 
-            mpi_errno = MPIR_Ibarrier(win_ptr->comm_ptr, &fence_sync_req_ptr);
+            mpi_errno = MPIR_Ibarrier(win_ptr->comm_ptr, MPIR_COLL_ATTR_NONE, &fence_sync_req_ptr);
             MPIR_ERR_CHECK(mpi_errno);
 
             if (fence_sync_req_ptr == NULL) {
@@ -604,7 +604,7 @@ int MPID_Win_fence(int assert, MPIR_Win * win_ptr)
             MPIR_Request* fence_sync_req_ptr;
 
             /* Prepare for the next possible epoch */
-            mpi_errno = MPIR_Ibarrier(win_ptr->comm_ptr, &fence_sync_req_ptr);
+            mpi_errno = MPIR_Ibarrier(win_ptr->comm_ptr, MPIR_COLL_ATTR_NONE, &fence_sync_req_ptr);
             MPIR_ERR_CHECK(mpi_errno);
 
             if (fence_sync_req_ptr == NULL) {

--- a/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
+++ b/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
@@ -107,7 +107,7 @@ int MPID_Comm_get_all_failed_procs(MPIR_Comm *comm_ptr, MPIR_Group **failed_grou
         for (i = 1; i < comm_ptr->local_size; i++) {
             /* Get everyone's list of failed processes to aggregate */
             ret_errno = MPIC_Recv(remote_bitarray, bitarray_size, MPI_INT,
-                i, tag, comm_ptr, MPI_STATUS_IGNORE);
+                i, tag, comm_ptr, MPIR_COLL_ATTR_NONE, MPI_STATUS_IGNORE);
             if (ret_errno) continue;
 
             /* Combine the received bitarray with my own */
@@ -121,7 +121,7 @@ int MPID_Comm_get_all_failed_procs(MPIR_Comm *comm_ptr, MPIR_Group **failed_grou
         for (i = 1; i < comm_ptr->local_size; i++) {
             /* Send the list to each rank to be processed locally */
             ret_errno = MPIC_Send(bitarray, bitarray_size, MPI_INT, i,
-                tag, comm_ptr, MPIR_ERR_NONE);
+                tag, comm_ptr, MPIR_COLL_ATTR_NONE);
             if (ret_errno) continue;
         }
 
@@ -130,11 +130,11 @@ int MPID_Comm_get_all_failed_procs(MPIR_Comm *comm_ptr, MPIR_Group **failed_grou
     } else {
         /* Send my bitarray to rank 0 */
         mpi_errno = MPIC_Send(bitarray, bitarray_size, MPI_INT, 0,
-            tag, comm_ptr, MPIR_ERR_NONE);
+            tag, comm_ptr, MPIR_COLL_ATTR_NONE);
 
         /* Get the resulting bitarray back from rank 0 */
         mpi_errno = MPIC_Recv(remote_bitarray, bitarray_size, MPI_INT, 0,
-            tag, comm_ptr, MPI_STATUS_IGNORE);
+            tag, comm_ptr, MPIR_COLL_ATTR_NONE, MPI_STATUS_IGNORE);
 
         /* Convert the bitarray into a group */
         *failed_group = bitarray_to_group(comm_ptr, remote_bitarray);

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -272,56 +272,56 @@ Native API:
   rank_is_local : int
       NM*: target, comm
   mpi_barrier : int
-      NM*: comm, errflag
-     SHM*: comm, errflag
+      NM*: comm, collattr
+     SHM*: comm, collattr
   mpi_bcast : int
-      NM*: buffer, count, datatype, root, comm, errflag
-     SHM*: buffer, count, datatype, root, comm, errflag
+      NM*: buffer, count, datatype, root, comm, collattr
+     SHM*: buffer, count, datatype, root, comm, collattr
   mpi_allreduce : int
-      NM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
-     SHM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
+      NM*: sendbuf, recvbuf, count, datatype, op, comm, collattr
+     SHM*: sendbuf, recvbuf, count, datatype, op, comm, collattr
   mpi_allgather : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, errflag
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, errflag
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, collattr
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, collattr
   mpi_allgatherv : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, errflag
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, errflag
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, collattr
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, collattr
   mpi_scatter : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, errflag
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, errflag
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, collattr
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, collattr
   mpi_scatterv : int
-      NM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr, errflag
-     SHM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr, errflag
+      NM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr, collattr
+     SHM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr, collattr
   mpi_gather : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, errflag
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, errflag
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, collattr
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, collattr
   mpi_gatherv : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, errflag
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, errflag
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, collattr
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, collattr
   mpi_alltoall : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, errflag
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, errflag
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, collattr
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, collattr
   mpi_alltoallv : int
-      NM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, errflag
-     SHM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, errflag
+      NM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, collattr
+     SHM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, collattr
   mpi_alltoallw : int
-      NM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, errflag
-     SHM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, errflag
+      NM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, collattr
+     SHM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, collattr
   mpi_reduce : int
-      NM*: sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag
-     SHM*: sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag
+      NM*: sendbuf, recvbuf, count, datatype, op, root, comm_ptr, collattr
+     SHM*: sendbuf, recvbuf, count, datatype, op, root, comm_ptr, collattr
   mpi_reduce_scatter : int
-      NM*: sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, errflag
-     SHM*: sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, errflag
+      NM*: sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, collattr
+     SHM*: sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, collattr
   mpi_reduce_scatter_block : int
-      NM*: sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, errflag
-     SHM*: sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, errflag
+      NM*: sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, collattr
+     SHM*: sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, collattr
   mpi_scan : int
-      NM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
-     SHM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
+      NM*: sendbuf, recvbuf, count, datatype, op, comm, collattr
+     SHM*: sendbuf, recvbuf, count, datatype, op, comm, collattr
   mpi_exscan : int
-      NM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
-     SHM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
+      NM*: sendbuf, recvbuf, count, datatype, op, comm, collattr
+     SHM*: sendbuf, recvbuf, count, datatype, op, comm, collattr
   mpi_neighbor_allgather : int
       NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm
      SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm
@@ -353,56 +353,56 @@ Native API:
       NM*: sendbuf, sendcounts, sdispls-2, sendtypes, recvbuf, recvcounts, rdispls-2, recvtypes, comm, req_p
      SHM*: sendbuf, sendcounts, sdispls-2, sendtypes, recvbuf, recvcounts, rdispls-2, recvtypes, comm, req_p
   mpi_ibarrier : int
-      NM*: comm, req_p
-     SHM*: comm, req_p
+      NM*: comm, collattr, req_p
+     SHM*: comm, collattr, req_p
   mpi_ibcast : int
-      NM*: buffer, count, datatype, root, comm, req_p
-     SHM*: buffer, count, datatype, root, comm, req_p
+      NM*: buffer, count, datatype, root, comm, collattr, req_p
+     SHM*: buffer, count, datatype, root, comm, collattr, req_p
   mpi_iallgather : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, collattr, req_p
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, collattr, req_p
   mpi_iallgatherv : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, req_p
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, req_p
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, collattr, req_p
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, collattr, req_p
   mpi_iallreduce : int
-      NM*: sendbuf, recvbuf, count, datatype, op, comm, req_p
-     SHM*: sendbuf, recvbuf, count, datatype, op, comm, req_p
+      NM*: sendbuf, recvbuf, count, datatype, op, comm, collattr, req_p
+     SHM*: sendbuf, recvbuf, count, datatype, op, comm, collattr, req_p
   mpi_ialltoall : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, req_p
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, collattr, req_p
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, collattr, req_p
   mpi_ialltoallv : int
-      NM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, req_p
-     SHM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, req_p
+      NM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, collattr, req_p
+     SHM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, collattr, req_p
   mpi_ialltoallw : int
-      NM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, req_p
-     SHM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, req_p
+      NM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, collattr, req_p
+     SHM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, collattr, req_p
   mpi_iexscan : int
-      NM*: sendbuf, recvbuf, count, datatype, op, comm, req_p
-     SHM*: sendbuf, recvbuf, count, datatype, op, comm, req_p
+      NM*: sendbuf, recvbuf, count, datatype, op, comm, collattr, req_p
+     SHM*: sendbuf, recvbuf, count, datatype, op, comm, collattr, req_p
   mpi_igather : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req_p
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req_p
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, collattr, req_p
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, collattr, req_p
   mpi_igatherv : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, req_p
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, req_p
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, collattr, req_p
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, collattr, req_p
   mpi_ireduce_scatter_block : int
-      NM*: sendbuf, recvbuf, recvcount, datatype, op, comm, req_p
-     SHM*: sendbuf, recvbuf, recvcount, datatype, op, comm, req_p
+      NM*: sendbuf, recvbuf, recvcount, datatype, op, comm, collattr, req_p
+     SHM*: sendbuf, recvbuf, recvcount, datatype, op, comm, collattr, req_p
   mpi_ireduce_scatter : int
-      NM*: sendbuf, recvbuf, recvcounts, datatype, op, comm, req_p
-     SHM*: sendbuf, recvbuf, recvcounts, datatype, op, comm, req_p
+      NM*: sendbuf, recvbuf, recvcounts, datatype, op, comm, collattr, req_p
+     SHM*: sendbuf, recvbuf, recvcounts, datatype, op, comm, collattr, req_p
   mpi_ireduce : int
-      NM*: sendbuf, recvbuf, count, datatype, op, root, comm_ptr, req_p
-     SHM*: sendbuf, recvbuf, count, datatype, op, root, comm_ptr, req_p
+      NM*: sendbuf, recvbuf, count, datatype, op, root, comm, collattr, req_p
+     SHM*: sendbuf, recvbuf, count, datatype, op, root, comm, collattr, req_p
   mpi_iscan : int
-      NM*: sendbuf, recvbuf, count, datatype, op, comm, req_p
-     SHM*: sendbuf, recvbuf, count, datatype, op, comm, req_p
+      NM*: sendbuf, recvbuf, count, datatype, op, comm, collattr, req_p
+     SHM*: sendbuf, recvbuf, count, datatype, op, comm, collattr, req_p
   mpi_iscatter : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req_p
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, req_p
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, collattr, req_p
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, collattr, req_p
   mpi_iscatterv : int
-      NM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr, req_p
-     SHM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr, req_p
+      NM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm, collattr, req_p
+     SHM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm, collattr, req_p
   mpi_type_commit_hook : int
       NM : datatype_p
      SHM : type
@@ -438,6 +438,7 @@ PARAM:
     buf: const void *
     buf-2: void *
     buffer: void *
+    collattr: int
     comm: MPIR_Comm *
     comm_ptr: MPIR_Comm *
     compare_addr: const void *
@@ -451,7 +452,6 @@ PARAM:
     disp_unit_p: int *
     displs: const MPI_Aint *
     dst_vci: int
-    errflag: MPIR_Errflag_t
     flag: int *
     group: MPIR_Group *
     handler_id: int

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -177,52 +177,51 @@ int MPID_Comm_set_hints(MPIR_Comm *, MPIR_Info *);
 int MPID_Comm_commit_post_hook(MPIR_Comm *);
 int MPID_Stream_create_hook(MPIR_Stream * stream);
 int MPID_Stream_free_hook(MPIR_Stream * stream);
-MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm *, int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *, MPI_Aint, MPI_Datatype, int, MPIR_Comm *,
-                                        MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                        int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
-                                            MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                            MPIR_Comm *, int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                             MPI_Datatype, MPIR_Comm *,
-                                            MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                            int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *, MPI_Aint, MPI_Datatype, void *,
                                              const MPI_Aint *, const MPI_Aint *, MPI_Datatype,
-                                             MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                             MPIR_Comm *, int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                           MPI_Datatype, int, MPIR_Comm *,
-                                          MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                          int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *, const MPI_Aint *, const MPI_Aint *,
                                            MPI_Datatype, void *, MPI_Aint, MPI_Datatype, int,
-                                           MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                           MPIR_Comm *, int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                          MPI_Datatype, int, MPIR_Comm *,
-                                         MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                         int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *, MPI_Aint, MPI_Datatype, void *,
                                           const MPI_Aint *, const MPI_Aint *, MPI_Datatype, int,
-                                          MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                          MPIR_Comm *, int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
-                                           MPI_Datatype, MPIR_Comm *,
-                                           MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                           MPI_Datatype, MPIR_Comm *, int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Alltoallv(const void *, const MPI_Aint *, const MPI_Aint *,
                                             MPI_Datatype, void *, const MPI_Aint *,
                                             const MPI_Aint *, MPI_Datatype, MPIR_Comm *,
-                                            MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                            int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Alltoallw(const void *, const MPI_Aint[], const MPI_Aint[],
                                             const MPI_Datatype[], void *, const MPI_Aint[],
                                             const MPI_Aint[], const MPI_Datatype[], MPIR_Comm *,
-                                            MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                            int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op, int,
-                                         MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                         MPIR_Comm *, int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *, void *, const MPI_Aint[],
                                                  MPI_Datatype, MPI_Op, MPIR_Comm *,
-                                                 MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                                 int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *, void *, MPI_Aint, MPI_Datatype,
                                                        MPI_Op, MPIR_Comm *,
-                                                       MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                                       int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
-                                       MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                       MPIR_Comm *, int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Exscan(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
-                                         MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                         MPIR_Comm *, int) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgather(const void *, MPI_Aint, MPI_Datatype, void *,
                                                      MPI_Aint, MPI_Datatype,
                                                      MPIR_Comm *) MPL_STATIC_INLINE_SUFFIX;
@@ -263,61 +262,67 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallw(const void *, const MPI_Ai
                                                       void *, const MPI_Aint[], const MPI_Aint[],
                                                       const MPI_Datatype[], MPIR_Comm *,
                                                       MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier(MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-MPL_STATIC_INLINE_PREFIX int MPID_Ibcast(void *, MPI_Aint, MPI_Datatype, int, MPIR_Comm *,
+MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier(MPIR_Comm *, int,
+                                           MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Ibcast(void *, MPI_Aint, MPI_Datatype, int, MPIR_Comm *, int,
                                          MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Iallgather(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
-                                             MPI_Datatype, MPIR_Comm *,
+                                             MPI_Datatype, MPIR_Comm *, int,
                                              MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv(const void *, MPI_Aint, MPI_Datatype, void *,
                                               const MPI_Aint *, const MPI_Aint *, MPI_Datatype,
-                                              MPIR_Comm *,
+                                              MPIR_Comm *, int,
                                               MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
-                                             MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+                                             MPIR_Comm *, int,
+                                             MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ialltoall(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
-                                            MPI_Datatype, MPIR_Comm *,
+                                            MPI_Datatype, MPIR_Comm *, int,
                                             MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallv(const void *, const MPI_Aint[], const MPI_Aint[],
                                              MPI_Datatype, void *, const MPI_Aint[],
-                                             const MPI_Aint[], MPI_Datatype, MPIR_Comm *,
+                                             const MPI_Aint[], MPI_Datatype, MPIR_Comm *, int,
                                              MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw(const void *, const MPI_Aint[], const MPI_Aint[],
                                              const MPI_Datatype[], void *, const MPI_Aint[],
                                              const MPI_Aint[], const MPI_Datatype[], MPIR_Comm *,
-                                             MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+                                             int, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Iexscan(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
-                                          MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+                                          MPIR_Comm *, int,
+                                          MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Igather(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
-                                          MPI_Datatype, int, MPIR_Comm *,
+                                          MPI_Datatype, int, MPIR_Comm *, int,
                                           MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Igatherv(const void *, MPI_Aint, MPI_Datatype, void *,
                                            const MPI_Aint *, const MPI_Aint *, MPI_Datatype, int,
-                                           MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+                                           MPIR_Comm *, int,
+                                           MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block(const void *, void *, MPI_Aint,
-                                                        MPI_Datatype, MPI_Op, MPIR_Comm *,
+                                                        MPI_Datatype, MPI_Op, MPIR_Comm *, int,
                                                         MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter(const void *, void *, const MPI_Aint[],
-                                                  MPI_Datatype, MPI_Op, MPIR_Comm *,
+                                                  MPI_Datatype, MPI_Op, MPIR_Comm *, int,
                                                   MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op, int,
-                                          MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+                                          MPIR_Comm *, int,
+                                          MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Iscan(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
-                                        MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+                                        MPIR_Comm *, int, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Iscatter(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
-                                           MPI_Datatype, int, MPIR_Comm *,
+                                           MPI_Datatype, int, MPIR_Comm *, int,
                                            MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv(const void *, const MPI_Aint *, const MPI_Aint *,
                                             MPI_Datatype, void *, MPI_Aint, MPI_Datatype, int,
-                                            MPIR_Comm *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
-int MPID_Send_enqueue(const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                      int dest, int tag, MPIR_Comm * comm_ptr);
-int MPID_Recv_enqueue(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                      int source, int tag, MPIR_Comm * comm_ptr, MPI_Status * status);
-int MPID_Isend_enqueue(const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                       int dest, int tag, MPIR_Comm * comm_ptr, MPIR_Request ** req);
-int MPID_Irecv_enqueue(void *buf, MPI_Aint count, MPI_Datatype datatype,
-                       int source, int tag, MPIR_Comm * comm_ptr, MPIR_Request ** req);
+                                            MPIR_Comm *, int,
+                                            MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+int MPID_Send_enqueue(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
+                      MPIR_Comm * comm_ptr);
+int MPID_Recv_enqueue(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int tag,
+                      MPIR_Comm * comm_ptr, MPI_Status * status);
+int MPID_Isend_enqueue(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
+                       MPIR_Comm * comm_ptr, MPIR_Request ** req);
+int MPID_Irecv_enqueue(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int tag,
+                       MPIR_Comm * comm_ptr, MPIR_Request ** req);
 int MPID_Wait_enqueue(MPIR_Request * req_ptr, MPI_Status * status);
 int MPID_Waitall_enqueue(int count, MPI_Request * array_of_requests,
                          MPI_Status * array_of_statuses);

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_coll.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_coll.h
@@ -6,22 +6,20 @@
 #ifndef NETMOD_AM_FALLBACK_COLL_H_INCLUDED
 #define NETMOD_AM_FALLBACK_COLL_H_INCLUDED
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Barrier_impl(comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
-                                                int root, MPIR_Comm * comm_ptr,
-                                                MPIR_Errflag_t errflag)
+                                                int root, MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                     MPI_Aint count, MPI_Datatype datatype,
-                                                    MPI_Op op, MPIR_Comm * comm_ptr,
-                                                    MPIR_Errflag_t errflag)
+                                                    MPI_Op op, MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
@@ -29,7 +27,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf,
                                recvcount, recvtype, comm_ptr, errflag);
@@ -39,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                     MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcounts, displs, recvtype, comm_ptr, errflag);
@@ -48,8 +46,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                 int root, MPIR_Comm * comm_ptr,
-                                                 MPIR_Errflag_t errflag)
+                                                 int root, MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf,
                             recvcount, recvtype, root, comm_ptr, errflag);
@@ -59,8 +56,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   const MPI_Aint * recvcounts,
                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcounts, displs, recvtype, root, comm_ptr, errflag);
@@ -69,8 +65,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcount, recvtype, root, comm_ptr, errflag);
@@ -80,7 +75,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
                                                    const MPI_Aint * displs, MPI_Datatype sendtype,
                                                    void *recvbuf, MPI_Aint recvcount,
                                                    MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Scatterv_impl(sendbuf, sendcounts, displs, sendtype,
                               recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
@@ -89,7 +84,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
                               recvcount, recvtype, comm_ptr, errflag);
@@ -100,7 +95,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
                                                     const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                                     void *recvbuf, const MPI_Aint * recvcounts,
                                                     const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
                                recvbuf, recvcounts, rdispls, recvtype, comm_ptr, errflag);
@@ -113,7 +108,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
                                                     const MPI_Aint recvcounts[],
                                                     const MPI_Aint rdispls[],
                                                     const MPI_Datatype recvtypes[],
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Alltoallw_impl(sendbuf, sendcounts, sdispls, sendtypes,
                                recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, errflag);
@@ -121,7 +116,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                 MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
 }
@@ -129,8 +124,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
                                                          const MPI_Aint recvcounts[],
                                                          MPI_Datatype datatype, MPI_Op op,
-                                                         MPIR_Comm * comm_ptr,
-                                                         MPIR_Errflag_t errflag)
+                                                         MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, errflag);
 }
@@ -138,8 +132,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, vo
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                                MPI_Aint recvcount,
                                                                MPI_Datatype datatype, MPI_Op op,
-                                                               MPIR_Comm * comm_ptr,
-                                                               MPIR_Errflag_t errflag)
+                                                               MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount,
                                           datatype, op, comm_ptr, errflag);
@@ -147,14 +140,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                               MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                 MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_coll.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_coll.h
@@ -9,13 +9,13 @@
 #include "ofi_impl.h"
 #include "ch4_csel_container.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Barrier_impl(comm, errflag);
+    mpi_errno = MPIR_Barrier_impl(comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -28,13 +28,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
-                                                int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                int root, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm, errflag);
+    mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -48,14 +48,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MP
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                     MPI_Aint count, MPI_Datatype datatype,
-                                                    MPI_Op op, MPIR_Comm * comm,
-                                                    MPIR_Errflag_t errflag)
+                                                    MPI_Op op, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -70,14 +69,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Allgather_impl(sendbuf, sendcount, sendtype,
-                                    recvbuf, recvcount, recvtype, comm, errflag);
+                                    recvbuf, recvcount, recvtype, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -93,14 +92,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                     MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype,
-                                     recvbuf, recvcounts, displs, recvtype, comm, errflag);
+                                     recvbuf, recvcounts, displs, recvtype, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -115,14 +114,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                 int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                 int root, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                 recvcount, recvtype, root, comm, errflag);
+                                 recvcount, recvtype, root, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -138,15 +137,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   const MPI_Aint * recvcounts,
                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                  recvcounts, displs, recvtype, root, comm, errflag);
+                                  recvcounts, displs, recvtype, root, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -162,15 +160,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                  recvcount, recvtype, root, comm, errflag);
+                                  recvcount, recvtype, root, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -186,14 +183,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
                                                    const MPI_Aint * displs, MPI_Datatype sendtype,
                                                    void *recvbuf, MPI_Aint recvcount,
                                                    MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Scatterv_impl(sendbuf, sendcounts, displs, sendtype, recvbuf,
-                                   recvcount, recvtype, root, comm, errflag);
+                                   recvcount, recvtype, root, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -208,14 +205,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Alltoall_impl(sendbuf, sendcount, sendtype,
-                                   recvbuf, recvcount, recvtype, comm, errflag);
+                                   recvbuf, recvcount, recvtype, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -232,7 +229,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
                                                     const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                                     void *recvbuf, const MPI_Aint * recvcounts,
                                                     const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -240,7 +237,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
 
     mpi_errno = MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls,
                                     sendtype, recvbuf, recvcounts,
-                                    rdispls, recvtype, comm, errflag);
+                                    rdispls, recvtype, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -259,7 +256,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
                                                     const MPI_Aint recvcounts[],
                                                     const MPI_Aint rdispls[],
                                                     const MPI_Datatype recvtypes[],
-                                                    MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -267,7 +264,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
 
     mpi_errno = MPIR_Alltoallw_impl(sendbuf, sendcounts, sdispls,
                                     sendtypes, recvbuf, recvcounts,
-                                    rdispls, recvtypes, comm, errflag);
+                                    rdispls, recvtypes, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -281,13 +278,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                 MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                 MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm, errflag);
+    mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -302,13 +299,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
                                                          const MPI_Aint recvcounts[],
                                                          MPI_Datatype datatype, MPI_Op op,
-                                                         MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                         MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm, errflag);
+    mpi_errno =
+        MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -323,14 +321,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, vo
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                                MPI_Aint recvcount,
                                                                MPI_Datatype datatype, MPI_Op op,
-                                                               MPIR_Comm * comm,
-                                                               MPIR_Errflag_t errflag)
+                                                               MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount, datatype, op, comm, errflag);
+    MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount, datatype, op, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -344,13 +341,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                               MPIR_Errflag_t errflag)
+                                               int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    mpi_errno = MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -364,13 +361,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbu
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                 MPIR_Errflag_t errflag)
+                                                 int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    mpi_errno = MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -564,12 +561,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw(const void *sendbu
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm, int collattr,
+                                                   MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Ibarrier_impl(comm, req);
+    mpi_errno = MPIR_Ibarrier_impl(comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -577,12 +575,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Reques
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, MPI_Aint count,
                                                  MPI_Datatype datatype, int root, MPIR_Comm * comm,
-                                                 MPIR_Request ** req)
+                                                 int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Ibcast_impl(buffer, count, datatype, root, comm, req);
+    mpi_errno = MPIR_Ibcast_impl(buffer, count, datatype, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -591,13 +589,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, MPI_Aint count,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Request ** req)
+                                                     MPIR_Comm * comm, int collattr,
+                                                     MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Iallgather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                     recvcount, recvtype, comm, req);
+                                     recvcount, recvtype, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -608,13 +607,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, MPI_A
                                                       const MPI_Aint * recvcounts,
                                                       const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                      MPIR_Request ** req)
+                                                      int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Iallgatherv_impl(sendbuf, sendcount, sendtype,
-                                      recvbuf, recvcounts, displs, recvtype, comm, req);
+                                      recvbuf, recvcounts, displs, recvtype, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -623,12 +622,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, MPI_A
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *recvbuf,
                                                      MPI_Aint count, MPI_Datatype datatype,
                                                      MPI_Op op, MPIR_Comm * comm,
-                                                     MPIR_Request ** request)
+                                                     int collattr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Iallreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, request);
+    mpi_errno =
+        MPIR_Iallreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr, request);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -637,13 +637,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Request ** req)
+                                                    MPIR_Comm * comm, int collattr,
+                                                    MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Ialltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                    recvcount, recvtype, comm, req);
+                                    recvcount, recvtype, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -656,13 +657,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv(const void *sendbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * rdispls,
                                                      MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                     MPIR_Request ** req)
+                                                     int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Ialltoallv_impl(sendbuf, sendcounts, sdispls,
-                                     sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, req);
+                                     sendtype, recvbuf, recvcounts, rdispls, recvtype, comm,
+                                     collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -675,13 +677,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * rdispls,
                                                      const MPI_Datatype recvtypes[],
-                                                     MPIR_Comm * comm, MPIR_Request ** req)
+                                                     MPIR_Comm * comm, int collattr,
+                                                     MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Ialltoallw_impl(sendbuf, sendcounts, sdispls,
-                                     sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, req);
+                                     sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm,
+                                     collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -689,12 +693,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm, MPIR_Request ** req)
+                                                  MPIR_Comm * comm, int collattr,
+                                                  MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Iexscan_impl(sendbuf, recvbuf, count, datatype, op, comm, req);
+    mpi_errno = MPIR_Iexscan_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -703,13 +708,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *rec
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm, MPIR_Request ** req)
+                                                  int root, MPIR_Comm * comm, int collattr,
+                                                  MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Igather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                  recvcount, recvtype, root, comm, req);
+                                  recvcount, recvtype, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -719,13 +725,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, MPI_Aint
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const MPI_Aint * recvcounts,
                                                    const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                   int root, MPIR_Comm * comm, MPIR_Request ** req)
+                                                   int root, MPIR_Comm * comm, int collattr,
+                                                   MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Igatherv_impl(sendbuf, sendcount, sendtype,
-                                   recvbuf, recvcounts, displs, recvtype, root, comm, req);
+                                   recvbuf, recvcounts, displs, recvtype, root, comm, collattr,
+                                   req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -735,13 +743,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block(const void *send
                                                                 MPI_Aint recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
                                                                 MPIR_Comm * comm,
-                                                                MPIR_Request ** req)
+                                                                int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Ireduce_scatter_block_impl(sendbuf, recvbuf, recvcount,
-                                                datatype, op, comm, req);
+                                                datatype, op, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -750,12 +758,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block(const void *send
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
                                                           const MPI_Aint recvcounts[],
                                                           MPI_Datatype datatype, MPI_Op op,
-                                                          MPIR_Comm * comm, MPIR_Request ** req)
+                                                          MPIR_Comm * comm, int collattr,
+                                                          MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Ireduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm, req);
+    mpi_errno =
+        MPIR_Ireduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -763,12 +773,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, v
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  int root, MPIR_Comm * comm, MPIR_Request ** req)
+                                                  int root, MPIR_Comm * comm, int collattr,
+                                                  MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Ireduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm, req);
+    mpi_errno = MPIR_Ireduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -776,12 +787,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *rec
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                 MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                MPIR_Request ** req)
+                                                int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Iscan_impl(sendbuf, recvbuf, count, datatype, op, comm, req);
+    mpi_errno = MPIR_Iscan_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -791,13 +802,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, MPI_Aint
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    int root, MPIR_Comm * comm,
-                                                   MPIR_Request ** request)
+                                                   int collattr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Iscatter_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                   recvcount, recvtype, root, comm, request);
+                                   recvcount, recvtype, root, comm, collattr, request);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -808,13 +819,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf,
                                                     const MPI_Aint * displs, MPI_Datatype sendtype,
                                                     void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm, MPIR_Request ** request)
+                                                    MPIR_Comm * comm, int collattr,
+                                                    MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Iscatterv_impl(sendbuf, sendcounts, displs, sendtype,
-                                    recvbuf, recvcount, recvtype, root, comm, request);
+                                    recvbuf, recvcount, recvtype, root, comm, collattr, request);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ucx/ucx_coll.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_coll.h
@@ -11,17 +11,17 @@
 #include "../../../common/hcoll/hcoll.h"
 #endif
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
 #ifdef HAVE_HCOLL
-    mpi_errno = hcoll_Barrier(comm_ptr, errflag);
+    mpi_errno = hcoll_Barrier(comm_ptr, collattr);
     if (mpi_errno != MPI_SUCCESS)
 #endif
     {
-        mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
+        mpi_errno = MPIR_Barrier_impl(comm_ptr, collattr);
     }
 
     MPIR_FUNC_EXIT;
@@ -29,18 +29,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Err
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
-                                                int root, MPIR_Comm * comm_ptr,
-                                                MPIR_Errflag_t errflag)
+                                                int root, MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
 #ifdef HAVE_HCOLL
-    mpi_errno = hcoll_Bcast(buffer, count, datatype, root, comm_ptr, errflag);
+    mpi_errno = hcoll_Bcast(buffer, count, datatype, root, comm_ptr, collattr);
     if (mpi_errno != MPI_SUCCESS)
 #endif
     {
-        mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
+        mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, collattr);
     }
 
     MPIR_FUNC_EXIT;
@@ -49,18 +48,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MP
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                     MPI_Aint count, MPI_Datatype datatype,
-                                                    MPI_Op op, MPIR_Comm * comm_ptr,
-                                                    MPIR_Errflag_t errflag)
+                                                    MPI_Op op, MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
 #ifdef HAVE_HCOLL
-    mpi_errno = hcoll_Allreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
+    mpi_errno = hcoll_Allreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, collattr);
     if (mpi_errno != MPI_SUCCESS)
 #endif
     {
-        mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
+        mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, collattr);
     }
 
     MPIR_FUNC_EXIT;
@@ -70,19 +68,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
 #ifdef HAVE_HCOLL
     mpi_errno = hcoll_Allgather(sendbuf, sendcount, sendtype, recvbuf,
-                                recvcount, recvtype, comm_ptr, errflag);
+                                recvcount, recvtype, comm_ptr, collattr);
     if (mpi_errno != MPI_SUCCESS)
 #endif
     {
         mpi_errno = MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                        recvcount, recvtype, comm_ptr, errflag);
+                                        recvcount, recvtype, comm_ptr, collattr);
     }
 
     MPIR_FUNC_EXIT;
@@ -93,13 +91,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                     MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                     recvcounts, displs, recvtype, comm_ptr, errflag);
+                                     recvcounts, displs, recvtype, comm_ptr, collattr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -108,14 +106,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                 int root, MPIR_Comm * comm_ptr,
-                                                 MPIR_Errflag_t errflag)
+                                                 int root, MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                 recvcount, recvtype, root, comm_ptr, errflag);
+                                 recvcount, recvtype, root, comm_ptr, collattr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -125,14 +122,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   const MPI_Aint * recvcounts,
                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                  recvcounts, displs, recvtype, root, comm_ptr, errflag);
+                                  recvcounts, displs, recvtype, root, comm_ptr, collattr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -141,14 +137,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                  recvcount, recvtype, root, comm_ptr, errflag);
+                                  recvcount, recvtype, root, comm_ptr, collattr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -158,13 +153,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
                                                    const MPI_Aint * displs, MPI_Datatype sendtype,
                                                    void *recvbuf, MPI_Aint recvcount,
                                                    MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Scatterv_impl(sendbuf, sendcounts, displs, sendtype,
-                                   recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
+                                   recvbuf, recvcount, recvtype, root, comm_ptr, collattr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -173,19 +168,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
 #ifdef HAVE_HCOLL
     mpi_errno = hcoll_Alltoall(sendbuf, sendcount, sendtype, recvbuf,
-                               recvcount, recvtype, comm_ptr, errflag);
+                               recvcount, recvtype, comm_ptr, collattr);
     if (mpi_errno != MPI_SUCCESS)
 #endif
     {
         mpi_errno = MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                       recvcount, recvtype, comm_ptr, errflag);
+                                       recvcount, recvtype, comm_ptr, collattr);
     }
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -196,19 +191,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
                                                     const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                                     void *recvbuf, const MPI_Aint * recvcounts,
                                                     const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
 #ifdef HAVE_HCOLL
     mpi_errno = hcoll_Alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
-                                recvcounts, rdispls, recvtype, comm_ptr, errflag);
+                                recvcounts, rdispls, recvtype, comm_ptr, collattr);
     if (mpi_errno != MPI_SUCCESS)
 #endif
     {
         mpi_errno = MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
-                                        recvbuf, recvcounts, rdispls, recvtype, comm_ptr, errflag);
+                                        recvbuf, recvcounts, rdispls, recvtype, comm_ptr, collattr);
     }
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -221,13 +216,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
                                                     const MPI_Aint recvcounts[],
                                                     const MPI_Aint rdispls[],
                                                     const MPI_Datatype recvtypes[],
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Alltoallw_impl(sendbuf, sendcounts, sdispls, sendtypes,
-                                    recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, errflag);
+                                    recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, collattr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -235,18 +230,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                 MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
 #ifdef HAVE_HCOLL
-    mpi_errno = hcoll_Reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
+    mpi_errno = hcoll_Reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, collattr);
     if (mpi_errno != MPI_SUCCESS)
 #endif
     {
         mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr,
-                                     errflag);
+                                     collattr);
     }
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -255,14 +250,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
                                                          const MPI_Aint recvcounts[],
                                                          MPI_Datatype datatype, MPI_Op op,
-                                                         MPIR_Comm * comm_ptr,
-                                                         MPIR_Errflag_t errflag)
+                                                         MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts,
-                                         datatype, op, comm_ptr, errflag);
+                                         datatype, op, comm_ptr, collattr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -271,14 +265,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, vo
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                                MPI_Aint recvcount,
                                                                MPI_Datatype datatype, MPI_Op op,
-                                                               MPIR_Comm * comm_ptr,
-                                                               MPIR_Errflag_t errflag)
+                                                               MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount,
-                                               datatype, op, comm_ptr, errflag);
+                                               datatype, op, comm_ptr, collattr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -286,12 +279,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                               MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
+    mpi_errno = MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, collattr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -299,12 +292,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbu
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                 MPIR_Comm * comm_ptr, int collattr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
+    mpi_errno = MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, collattr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -501,12 +494,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ineighbor_alltoallw(const void *sendbu
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm_ptr, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm_ptr,
+                                                   int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Ibarrier_impl(comm_ptr, req);
+    mpi_errno = MPIR_Ibarrier_impl(comm_ptr, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -514,12 +508,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibarrier(MPIR_Comm * comm_ptr, MPIR_Re
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, MPI_Aint count,
                                                  MPI_Datatype datatype, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Request ** req)
+                                                 MPIR_Comm * comm_ptr,
+                                                 int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Ibcast_impl(buffer, count, datatype, root, comm_ptr, req);
+    mpi_errno = MPIR_Ibcast_impl(buffer, count, datatype, root, comm_ptr, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -528,13 +523,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ibcast(void *buffer, MPI_Aint count,
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgather(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm_ptr, MPIR_Request ** req)
+                                                     MPIR_Comm * comm_ptr, int collattr,
+                                                     MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Iallgather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                     recvcount, recvtype, comm_ptr, req);
+                                     recvcount, recvtype, comm_ptr, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -545,13 +541,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, MPI_A
                                                       const MPI_Aint * recvcounts,
                                                       const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                      MPIR_Request ** req)
+                                                      int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Iallgatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                      recvcounts, displs, recvtype, comm_ptr, req);
+                                      recvcounts, displs, recvtype, comm_ptr, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -560,12 +556,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallgatherv(const void *sendbuf, MPI_A
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *recvbuf,
                                                      MPI_Aint count, MPI_Datatype datatype,
                                                      MPI_Op op, MPIR_Comm * comm,
-                                                     MPIR_Request ** request)
+                                                     int collattr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Iallreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, request);
+    mpi_errno =
+        MPIR_Iallreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr, request);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -574,13 +571,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iallreduce(const void *sendbuf, void *
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoall(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Request ** req)
+                                                    MPIR_Comm * comm_ptr, int collattr,
+                                                    MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Ialltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                    recvcount, recvtype, comm_ptr, req);
+                                    recvcount, recvtype, comm_ptr, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -593,13 +591,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallv(const void *sendbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * rdispls,
                                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                     MPIR_Request ** req)
+                                                     int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Ialltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
-                                     recvbuf, recvcounts, rdispls, recvtype, comm_ptr, req);
+                                     recvbuf, recvcounts, rdispls, recvtype, comm_ptr, collattr,
+                                     req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -612,13 +611,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * rdispls,
                                                      const MPI_Datatype recvtypes[],
-                                                     MPIR_Comm * comm_ptr, MPIR_Request ** req)
+                                                     MPIR_Comm * comm_ptr, int collattr,
+                                                     MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Ialltoallw_impl(sendbuf, sendcounts, sdispls, sendtypes,
-                                     recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, req);
+                                     recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, collattr,
+                                     req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -626,12 +627,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ialltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iexscan(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm_ptr, MPIR_Request ** req)
+                                                  MPIR_Comm * comm_ptr, int collattr,
+                                                  MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Iexscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, req);
+    mpi_errno = MPIR_Iexscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -641,13 +643,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igather(const void *sendbuf, MPI_Aint 
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
                                                   int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Request ** req)
+                                                  int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Igather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                  recvcount, recvtype, root, comm_ptr, req);
+                                  recvcount, recvtype, root, comm_ptr, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -658,13 +660,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_igatherv(const void *sendbuf, MPI_Aint
                                                    const MPI_Aint * recvcounts,
                                                    const MPI_Aint * displs, MPI_Datatype recvtype,
                                                    int root, MPIR_Comm * comm_ptr,
-                                                   MPIR_Request ** req)
+                                                   int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Igatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                   recvcounts, displs, recvtype, root, comm_ptr, req);
+                                   recvcounts, displs, recvtype, root, comm_ptr, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -674,13 +676,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block(const void *send
                                                                 MPI_Aint recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
                                                                 MPIR_Comm * comm_ptr,
-                                                                MPIR_Request ** req)
+                                                                int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Ireduce_scatter_block_impl(sendbuf, recvbuf, recvcount,
-                                                datatype, op, comm_ptr, req);
+                                                datatype, op, comm_ptr, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -689,13 +691,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter_block(const void *send
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
                                                           const MPI_Aint recvcounts[],
                                                           MPI_Datatype datatype, MPI_Op op,
-                                                          MPIR_Comm * comm_ptr, MPIR_Request ** req)
+                                                          MPIR_Comm * comm_ptr, int collattr,
+                                                          MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Ireduce_scatter_impl(sendbuf, recvbuf, recvcounts,
-                                          datatype, op, comm_ptr, req);
+                                          datatype, op, comm_ptr, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -704,12 +707,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce_scatter(const void *sendbuf, v
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                   int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Request ** req)
+                                                  int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Ireduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, req);
+    mpi_errno =
+        MPIR_Ireduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -717,12 +721,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_ireduce(const void *sendbuf, void *rec
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Request ** req)
+                                                MPIR_Comm * comm_ptr, int collattr,
+                                                MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Iscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, req);
+    mpi_errno = MPIR_Iscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -732,13 +737,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatter(const void *sendbuf, MPI_Aint
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
                                                    int root, MPIR_Comm * comm,
-                                                   MPIR_Request ** request)
+                                                   int collattr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Iscatter_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                   recvcount, recvtype, root, comm, request);
+                                   recvcount, recvtype, root, comm, collattr, request);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -749,13 +754,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iscatterv(const void *sendbuf,
                                                     const MPI_Aint * displs, MPI_Datatype sendtype,
                                                     void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm, MPIR_Request ** request)
+                                                    MPIR_Comm * comm, int collattr,
+                                                    MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Iscatterv_impl(sendbuf, sendcounts, displs, sendtype,
-                                    recvbuf, recvcount, recvtype, root, comm, request);
+                                    recvbuf, recvcount, recvtype, root, comm, collattr, request);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/shm/posix/posix_coll.h
+++ b/src/mpid/ch4/shm/posix/posix_coll.h
@@ -110,7 +110,7 @@ cvars:
 */
 
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier(MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -125,7 +125,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier(MPIR_Comm * comm, MPIR_Errf
         case MPIR_CVAR_BARRIER_POSIX_INTRA_ALGORITHM_release_gather:
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, !MPIR_IS_THREADED, mpi_errno,
                                            "Barrier release_gather cannot be applied.\n");
-            mpi_errno = MPIDI_POSIX_mpi_barrier_release_gather(comm, errflag);
+            mpi_errno = MPIDI_POSIX_mpi_barrier_release_gather(comm, collattr);
             break;
 
         case MPIR_CVAR_BARRIER_POSIX_INTRA_ALGORITHM_mpir:
@@ -139,7 +139,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier(MPIR_Comm * comm, MPIR_Errf
             switch (cnt->id) {
                 case MPIDI_POSIX_CSEL_CONTAINER_TYPE__ALGORITHM__MPIDI_POSIX_mpi_barrier_release_gather:
                     mpi_errno =
-                        MPIDI_POSIX_mpi_barrier_release_gather(comm, errflag);
+                        MPIDI_POSIX_mpi_barrier_release_gather(comm, collattr);
                     break;
                 case MPIDI_POSIX_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Barrier_impl:
                     goto fallback;
@@ -156,7 +156,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier(MPIR_Comm * comm, MPIR_Errf
     goto fn_exit;
 
   fallback:
-    mpi_errno = MPIR_Barrier_impl(comm, errflag);
+    mpi_errno = MPIR_Barrier_impl(comm, collattr);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -168,7 +168,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier(MPIR_Comm * comm, MPIR_Errf
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast(void *buffer, MPI_Aint count,
                                                    MPI_Datatype datatype, int root,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -188,7 +188,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast(void *buffer, MPI_Aint count,
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, !MPIR_IS_THREADED, mpi_errno,
                                            "Bcast release_gather cannot be applied.\n");
             mpi_errno =
-                MPIDI_POSIX_mpi_bcast_release_gather(buffer, count, datatype, root, comm, errflag);
+                MPIDI_POSIX_mpi_bcast_release_gather(buffer, count, datatype, root, comm, collattr);
             break;
 
         case MPIR_CVAR_BCAST_POSIX_INTRA_ALGORITHM_mpir:
@@ -203,7 +203,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast(void *buffer, MPI_Aint count,
                 case MPIDI_POSIX_CSEL_CONTAINER_TYPE__ALGORITHM__MPIDI_POSIX_mpi_bcast_release_gather:
                     mpi_errno =
                         MPIDI_POSIX_mpi_bcast_release_gather(buffer, count, datatype, root, comm,
-                                                             errflag);
+                                                             collattr);
                     break;
                 case MPIDI_POSIX_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Bcast_impl:
                     goto fallback;
@@ -220,7 +220,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast(void *buffer, MPI_Aint count,
     goto fn_exit;
 
   fallback:
-    mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm, errflag);
+    mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm, collattr);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -232,8 +232,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast(void *buffer, MPI_Aint count,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                        MPI_Aint count, MPI_Datatype datatype,
-                                                       MPI_Op op, MPIR_Comm * comm,
-                                                       MPIR_Errflag_t errflag)
+                                                       MPI_Op op, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -256,7 +255,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce(const void *sendbuf, void
                                            "Allreduce release_gather cannot be applied.\n");
             mpi_errno =
                 MPIDI_POSIX_mpi_allreduce_release_gather(sendbuf, recvbuf, count, datatype, op,
-                                                         comm, errflag);
+                                                         comm, collattr);
             break;
 
         case MPIR_CVAR_ALLREDUCE_POSIX_INTRA_ALGORITHM_mpir:
@@ -271,7 +270,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce(const void *sendbuf, void
                 case MPIDI_POSIX_CSEL_CONTAINER_TYPE__ALGORITHM__MPIDI_POSIX_mpi_allreduce_release_gather:
                     mpi_errno =
                         MPIDI_POSIX_mpi_allreduce_release_gather(sendbuf, recvbuf, count, datatype,
-                                                                 op, comm, errflag);
+                                                                 op, comm, collattr);
                     break;
 
                 case MPIDI_POSIX_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Allreduce_impl:
@@ -290,7 +289,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce(const void *sendbuf, void
     goto fn_exit;
 
   fallback:
-    mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -303,14 +302,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce(const void *sendbuf, void
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
                                                        MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                       MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                       MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Allgather_impl(sendbuf, sendcount, sendtype,
-                                    recvbuf, recvcount, recvtype, comm, errflag);
+                                    recvbuf, recvcount, recvtype, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -327,14 +326,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgatherv(const void *sendbuf, MPI
                                                         const MPI_Aint * recvcounts,
                                                         const MPI_Aint * displs,
                                                         MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                        MPIR_Errflag_t errflag)
+                                                        int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype,
-                                     recvbuf, recvcounts, displs, recvtype, comm, errflag);
+                                     recvbuf, recvcounts, displs, recvtype, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -349,15 +348,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgatherv(const void *sendbuf, MPI
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    int root, MPIR_Comm * comm,
-                                                    MPIR_Errflag_t errflag)
+                                                    int root, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                 recvtype, root, comm, errflag);
+                                 recvtype, root, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -373,15 +371,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_gatherv(const void *sendbuf, MPI_Ai
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                     int root, MPIR_Comm * comm,
-                                                     MPIR_Errflag_t errflag)
+                                                     int root, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
-                                  displs, recvtype, root, comm, errflag);
+                                  displs, recvtype, root, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -397,15 +394,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_gatherv(const void *sendbuf, MPI_Ai
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                     int root, MPIR_Comm * comm,
-                                                     MPIR_Errflag_t errflag)
+                                                     int root, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                  recvtype, root, comm, errflag);
+                                  recvtype, root, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -422,15 +418,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scatterv(const void *sendbuf,
                                                       const MPI_Aint * displs,
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                      int root, MPIR_Comm * comm,
-                                                      MPIR_Errflag_t errflag)
+                                                      int root, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Scatterv_impl(sendbuf, sendcounts, displs, sendtype,
-                                   recvbuf, recvcount, recvtype, root, comm, errflag);
+                                   recvbuf, recvcount, recvtype, root, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -445,14 +440,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scatterv(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                      MPIR_Comm * comm, int collattr)
 {
     int mpi_errno;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Alltoall_impl(sendbuf, sendcount, sendtype,
-                                   recvbuf, recvcount, recvtype, comm, errflag);
+                                   recvbuf, recvcount, recvtype, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -471,7 +466,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoallv(const void *sendbuf,
                                                        const MPI_Aint * recvcounts,
                                                        const MPI_Aint * rdispls,
                                                        MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                       MPIR_Errflag_t errflag)
+                                                       int collattr)
 {
     int mpi_errno;
 
@@ -479,7 +474,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoallv(const void *sendbuf,
 
     mpi_errno = MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls,
                                     sendtype, recvbuf, recvcounts,
-                                    rdispls, recvtype, comm, errflag);
+                                    rdispls, recvtype, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -498,7 +493,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoallw(const void *sendbuf,
                                                        void *recvbuf, const MPI_Aint recvcounts[],
                                                        const MPI_Aint rdispls[],
                                                        const MPI_Datatype recvtypes[],
-                                                       MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                       MPIR_Comm * comm, int collattr)
 {
     int mpi_errno;
 
@@ -506,7 +501,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoallw(const void *sendbuf,
 
     mpi_errno = MPIR_Alltoallw_impl(sendbuf, sendcounts, sdispls,
                                     sendtypes, recvbuf, recvcounts,
-                                    rdispls, recvtypes, comm, errflag);
+                                    rdispls, recvtypes, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -521,7 +516,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoallw(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce(const void *sendbuf, void *recvbuf,
                                                     MPI_Aint count, MPI_Datatype datatype,
                                                     MPI_Op op, int root, MPIR_Comm * comm,
-                                                    MPIR_Errflag_t errflag)
+                                                    int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -545,7 +540,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce(const void *sendbuf, void *r
                                            "Reduce release_gather cannot be applied.\n");
             mpi_errno =
                 MPIDI_POSIX_mpi_reduce_release_gather(sendbuf, recvbuf, count, datatype, op, root,
-                                                      comm, errflag);
+                                                      comm, collattr);
             break;
 
         case MPIR_CVAR_REDUCE_POSIX_INTRA_ALGORITHM_mpir:
@@ -560,7 +555,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce(const void *sendbuf, void *r
                 case MPIDI_POSIX_CSEL_CONTAINER_TYPE__ALGORITHM__MPIDI_POSIX_mpi_reduce_release_gather:
                     mpi_errno =
                         MPIDI_POSIX_mpi_reduce_release_gather(sendbuf, recvbuf, count, datatype, op,
-                                                              root, comm, errflag);
+                                                              root, comm, collattr);
                     break;
 
                 case MPIDI_POSIX_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Reduce_impl:
@@ -579,7 +574,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce(const void *sendbuf, void *r
     goto fn_exit;
 
   fallback:
-    mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm, errflag);
+    mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm, collattr);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -592,14 +587,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce(const void *sendbuf, void *r
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
                                                             const MPI_Aint recvcounts[],
                                                             MPI_Datatype datatype, MPI_Op op,
-                                                            MPIR_Comm * comm,
-                                                            MPIR_Errflag_t errflag)
+                                                            MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm, errflag);
+    mpi_errno =
+        MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -614,14 +609,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_scatter(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_scatter_block(const void *sendbuf,
                                                                   void *recvbuf, MPI_Aint recvcount,
                                                                   MPI_Datatype datatype, MPI_Op op,
-                                                                  MPIR_Comm * comm,
-                                                                  MPIR_Errflag_t errflag)
+                                                                  MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount, datatype, op, comm, errflag);
+    MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount, datatype, op, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -635,13 +629,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_scatter_block(const void *se
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scan(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                  MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    mpi_errno = MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -655,14 +649,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_scan(const void *sendbuf, void *rec
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_exscan(const void *sendbuf, void *recvbuf,
                                                     MPI_Aint count, MPI_Datatype datatype,
-                                                    MPI_Op op, MPIR_Comm * comm,
-                                                    MPIR_Errflag_t errflag)
+                                                    MPI_Op op, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    mpi_errno = MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -866,12 +859,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ineighbor_alltoallw(const void *sen
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ibarrier(MPIR_Comm * comm, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ibarrier(MPIR_Comm * comm, int collattr,
+                                                      MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Ibarrier_impl(comm, req);
+    mpi_errno = MPIR_Ibarrier_impl(comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -879,12 +873,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ibarrier(MPIR_Comm * comm, MPIR_Req
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ibcast(void *buffer, MPI_Aint count,
                                                     MPI_Datatype datatype, int root,
-                                                    MPIR_Comm * comm, MPIR_Request ** req)
+                                                    MPIR_Comm * comm, int collattr,
+                                                    MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Ibcast_impl(buffer, count, datatype, root, comm, req);
+    mpi_errno = MPIR_Ibcast_impl(buffer, count, datatype, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -893,13 +888,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ibcast(void *buffer, MPI_Aint count
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iallgather(const void *sendbuf, MPI_Aint sendcount,
                                                         MPI_Datatype sendtype, void *recvbuf,
                                                         MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                        MPIR_Comm * comm, MPIR_Request ** req)
+                                                        MPIR_Comm * comm, int collattr,
+                                                        MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Iallgather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                     recvcount, recvtype, comm, req);
+                                     recvcount, recvtype, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -910,13 +906,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iallgatherv(const void *sendbuf, MP
                                                          const MPI_Aint * recvcounts,
                                                          const MPI_Aint * displs,
                                                          MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                         MPIR_Request ** req)
+                                                         int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Iallgatherv_impl(sendbuf, sendcount, sendtype,
-                                      recvbuf, recvcounts, displs, recvtype, comm, req);
+                                      recvbuf, recvcounts, displs, recvtype, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -925,13 +921,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iallgatherv(const void *sendbuf, MP
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ialltoall(const void *sendbuf, MPI_Aint sendcount,
                                                        MPI_Datatype sendtype, void *recvbuf,
                                                        MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                       MPIR_Comm * comm, MPIR_Request ** req)
+                                                       MPIR_Comm * comm, int collattr,
+                                                       MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Ialltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                    recvcount, recvtype, comm, req);
+                                    recvcount, recvtype, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -944,13 +941,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ialltoallv(const void *sendbuf,
                                                         const MPI_Aint * recvcounts,
                                                         const MPI_Aint * rdispls,
                                                         MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                        MPIR_Request ** req)
+                                                        int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Ialltoallv_impl(sendbuf, sendcounts, sdispls,
-                                     sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, req);
+                                     sendtype, recvbuf, recvcounts, rdispls, recvtype, comm,
+                                     collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -963,13 +961,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ialltoallw(const void *sendbuf,
                                                         void *recvbuf, const MPI_Aint * recvcounts,
                                                         const MPI_Aint * rdispls,
                                                         const MPI_Datatype recvtypes[],
-                                                        MPIR_Comm * comm, MPIR_Request ** req)
+                                                        MPIR_Comm * comm, int collattr,
+                                                        MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Ialltoallw_impl(sendbuf, sendcounts, sdispls,
-                                     sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, req);
+                                     sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm,
+                                     collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -978,12 +978,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ialltoallw(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iexscan(const void *sendbuf, void *recvbuf,
                                                      MPI_Aint count, MPI_Datatype datatype,
                                                      MPI_Op op, MPIR_Comm * comm,
-                                                     MPIR_Request ** req)
+                                                     int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Iexscan_impl(sendbuf, recvbuf, count, datatype, op, comm, req);
+    mpi_errno = MPIR_Iexscan_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -993,13 +993,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_igather(const void *sendbuf, MPI_Ai
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
                                                      int root, MPIR_Comm * comm,
-                                                     MPIR_Request ** req)
+                                                     int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Igather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                  recvcount, recvtype, root, comm, req);
+                                  recvcount, recvtype, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -1010,13 +1010,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_igatherv(const void *sendbuf, MPI_A
                                                       const MPI_Aint * recvcounts,
                                                       const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, int root,
-                                                      MPIR_Comm * comm, MPIR_Request ** req)
+                                                      MPIR_Comm * comm, int collattr,
+                                                      MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Igatherv_impl(sendbuf, sendcount, sendtype,
-                                   recvbuf, recvcounts, displs, recvtype, root, comm, req);
+                                   recvbuf, recvcounts, displs, recvtype, root, comm, collattr,
+                                   req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -1027,13 +1029,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ireduce_scatter_block(const void *s
                                                                    MPI_Aint recvcount,
                                                                    MPI_Datatype datatype, MPI_Op op,
                                                                    MPIR_Comm * comm,
+                                                                   int collattr,
                                                                    MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno =
-        MPIR_Ireduce_scatter_block_impl(sendbuf, recvbuf, recvcount, datatype, op, comm, req);
+        MPIR_Ireduce_scatter_block_impl(sendbuf, recvbuf, recvcount, datatype, op, comm, collattr,
+                                        req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -1042,12 +1046,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ireduce_scatter_block(const void *s
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
                                                              const MPI_Aint recvcounts[],
                                                              MPI_Datatype datatype, MPI_Op op,
-                                                             MPIR_Comm * comm, MPIR_Request ** req)
+                                                             MPIR_Comm * comm, int collattr,
+                                                             MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Ireduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm, req);
+    mpi_errno =
+        MPIR_Ireduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -1056,12 +1062,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ireduce_scatter(const void *sendbuf
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ireduce(const void *sendbuf, void *recvbuf,
                                                      MPI_Aint count, MPI_Datatype datatype,
                                                      MPI_Op op, int root, MPIR_Comm * comm,
-                                                     MPIR_Request ** req)
+                                                     int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Ireduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm, req);
+    mpi_errno = MPIR_Ireduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -1070,12 +1076,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_ireduce(const void *sendbuf, void *
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iallreduce(const void *sendbuf, void *recvbuf,
                                                         MPI_Aint count, MPI_Datatype datatype,
                                                         MPI_Op op, MPIR_Comm * comm,
-                                                        MPIR_Request ** req)
+                                                        int collattr, MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Iallreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, req);
+    mpi_errno = MPIR_Iallreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -1083,12 +1089,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iallreduce(const void *sendbuf, voi
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iscan(const void *sendbuf, void *recvbuf,
                                                    MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm, MPIR_Request ** req)
+                                                   MPIR_Comm * comm, int collattr,
+                                                   MPIR_Request ** req)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Iscan_impl(sendbuf, recvbuf, count, datatype, op, comm, req);
+    mpi_errno = MPIR_Iscan_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -1098,13 +1105,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iscatter(const void *sendbuf, MPI_A
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       MPI_Aint recvcount, MPI_Datatype recvtype,
                                                       int root, MPIR_Comm * comm,
-                                                      MPIR_Request ** request)
+                                                      int collattr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Iscatter_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                   recvcount, recvtype, root, comm, request);
+                                   recvcount, recvtype, root, comm, collattr, request);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -1116,13 +1123,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iscatterv(const void *sendbuf,
                                                        MPI_Datatype sendtype, void *recvbuf,
                                                        MPI_Aint recvcount, MPI_Datatype recvtype,
                                                        int root, MPIR_Comm * comm,
-                                                       MPIR_Request ** request)
+                                                       int collattr, MPIR_Request ** request)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Iscatterv_impl(sendbuf, sendcounts, displs, sendtype,
-                                    recvbuf, recvcount, recvtype, root, comm, request);
+                                    recvbuf, recvcount, recvtype, root, comm, collattr, request);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/shm/posix/release_gather/nb_reduce_release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_reduce_release_gather.h
@@ -240,6 +240,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_reduce_start_sendrecv_completion(
     int root = per_call_data->root;
     int segment = per_call_data->seq_no % MPIR_CVAR_REDUCE_INTRANODE_NUM_CELLS;
     MPIR_Comm *comm_ptr = per_call_data->comm_ptr;
+    int collattr = per_call_data->collattr;
     MPIDI_POSIX_release_gather_comm_t *nb_release_gather_info_ptr;
     nb_release_gather_info_ptr = &MPIDI_POSIX_COMM(comm_ptr, nb_release_gather);
     int rank = MPIR_Comm_rank(comm_ptr);
@@ -248,11 +249,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_reduce_start_sendrecv_completion(
     if (root != 0) {
         if (rank == root) {
             MPIC_Irecv(per_call_data->recv_buf, per_call_data->count, per_call_data->datatype,
-                       0, per_call_data->tag, comm_ptr, &(per_call_data->rreq));
+                       0, per_call_data->tag, comm_ptr, collattr, &(per_call_data->rreq));
         } else if (rank == 0) {
             MPIC_Isend(MPIDI_POSIX_RELEASE_GATHER_NB_REDUCE_DATA_ADDR(rank, segment),
                        per_call_data->count, per_call_data->datatype, per_call_data->root,
-                       per_call_data->tag, comm_ptr, &(per_call_data->sreq), MPIR_ERR_NONE);
+                       per_call_data->tag, comm_ptr, &(per_call_data->sreq), collattr);
         }
     }
 
@@ -348,6 +349,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_nb_release_gather_ireduce_impl(void *se
                                                                         MPI_Datatype datatype,
                                                                         MPI_Op op, const int root,
                                                                         MPIR_Comm * comm_ptr,
+                                                                        int collattr,
                                                                         MPIR_TSP_sched_t sched)
 {
     MPIR_FUNC_ENTER;
@@ -437,6 +439,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_nb_release_gather_ireduce_impl(void *se
         data->root = root;
         data->op = op;
         data->comm_ptr = comm_ptr;
+        data->collattr = collattr;
         data->tag = tag;
         data->sreq = NULL;
         data->rreq = NULL;

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather_types.h
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather_types.h
@@ -54,6 +54,7 @@ typedef struct MPIDI_POSIX_per_call_ibcast_info_t {
     int root, tag;
     MPI_Datatype datatype;
     MPIR_Comm *comm_ptr;
+    int collattr;
     MPIR_Request *sreq, *rreq;
 } MPIDI_POSIX_per_call_ibcast_info_t;
 
@@ -66,6 +67,7 @@ typedef struct MPIDI_POSIX_per_call_ireduce_info_t {
     MPI_Op op;
     MPI_Datatype datatype;
     MPIR_Comm *comm_ptr;
+    int collattr;
     MPIR_Request *sreq, *rreq;
 } MPIDI_POSIX_per_call_ireduce_info_t;
 

--- a/src/mpid/ch4/shm/src/shm_am_fallback_coll.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_coll.h
@@ -6,22 +6,21 @@
 #ifndef SHM_AM_FALLBACK_COLL_H_INCLUDED
 #define SHM_AM_FALLBACK_COLL_H_INCLUDED
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Barrier_impl(comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, MPI_Aint count,
                                                  MPI_Datatype datatype, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                 MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                      MPI_Aint count, MPI_Datatype datatype,
-                                                     MPI_Op op, MPIR_Comm * comm_ptr,
-                                                     MPIR_Errflag_t errflag)
+                                                     MPI_Op op, MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
@@ -29,7 +28,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                     MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf,
                                recvcount, recvtype, comm_ptr, errflag);
@@ -40,7 +39,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, MPI_A
                                                       const MPI_Aint * recvcounts,
                                                       const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                      MPIR_Errflag_t errflag)
+                                                      int collattr)
 {
     return MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcounts, displs, recvtype, comm_ptr, errflag);
@@ -49,8 +48,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, MPI_A
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf,
                             recvcount, recvtype, root, comm_ptr, errflag);
@@ -60,8 +58,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, MPI_Aint
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const MPI_Aint * recvcounts,
                                                    const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                   int root, MPIR_Comm * comm_ptr,
-                                                   MPIR_Errflag_t errflag)
+                                                   int root, MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcounts, displs, recvtype, root, comm_ptr, errflag);
@@ -70,8 +67,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, MPI_Aint
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   int root, MPIR_Comm * comm_ptr,
-                                                   MPIR_Errflag_t errflag)
+                                                   int root, MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcount, recvtype, root, comm_ptr, errflag);
@@ -82,7 +78,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf,
                                                     const MPI_Aint * displs, MPI_Datatype sendtype,
                                                     void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Scatterv_impl(sendbuf, sendcounts, displs, sendtype,
                               recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
@@ -91,7 +87,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
                               recvcount, recvtype, comm_ptr, errflag);
@@ -104,7 +100,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * rdispls,
                                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                     MPIR_Errflag_t errflag)
+                                                     int collattr)
 {
     return MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
                                recvbuf, recvcounts, rdispls, recvtype, comm_ptr, errflag);
@@ -117,7 +113,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf,
                                                      const MPI_Aint recvcounts[],
                                                      const MPI_Aint rdispls[],
                                                      const MPI_Datatype recvtypes[],
-                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                     MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Alltoallw_impl(sendbuf, sendcounts, sdispls, sendtypes,
                                recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, errflag);
@@ -125,8 +121,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
 }
@@ -134,8 +129,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *rec
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
                                                           const MPI_Aint recvcounts[],
                                                           MPI_Datatype datatype, MPI_Op op,
-                                                          MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t errflag)
+                                                          MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, errflag);
 }
@@ -143,8 +137,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, v
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                                 MPI_Aint recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t errflag)
+                                                                MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount,
                                           datatype, op, comm_ptr, errflag);
@@ -152,14 +145,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *send
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                  MPIR_Comm * comm_ptr, int collattr)
 {
     return MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }

--- a/src/mpid/ch4/shm/src/shm_coll.h
+++ b/src/mpid/ch4/shm/src/shm_coll.h
@@ -9,13 +9,13 @@
 #include <shm.h>
 #include "../posix/shm_inline.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm, int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_barrier(comm, errflag);
+    ret = MPIDI_POSIX_mpi_barrier(comm, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -23,13 +23,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm, MPIR_Errfla
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, MPI_Aint count,
                                                  MPI_Datatype datatype, int root, MPIR_Comm * comm,
-                                                 MPIR_Errflag_t errflag)
+                                                 int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_bcast(buffer, count, datatype, root, comm, errflag);
+    ret = MPIDI_POSIX_mpi_bcast(buffer, count, datatype, root, comm, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -37,14 +37,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, MPI_Aint count,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                      MPI_Aint count, MPI_Datatype datatype,
-                                                     MPI_Op op, MPIR_Comm * comm,
-                                                     MPIR_Errflag_t errflag)
+                                                     MPI_Op op, MPIR_Comm * comm, int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    ret = MPIDI_POSIX_mpi_allreduce(sendbuf, recvbuf, count, datatype, op, comm, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -53,14 +52,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                     MPIR_Comm * comm, int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                    recvtype, comm, errflag);
+                                    recvtype, comm, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -71,14 +70,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, MPI_A
                                                       const MPI_Aint * recvcounts,
                                                       const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                      MPIR_Errflag_t errflag)
+                                                      int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_allgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
-                                     displs, recvtype, comm, errflag);
+                                     displs, recvtype, comm, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -87,15 +86,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, MPI_A
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   int root, MPIR_Comm * comm,
-                                                   MPIR_Errflag_t errflag)
+                                                   int root, MPIR_Comm * comm, int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_scatter(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                  recvtype, root, comm, errflag);
+                                  recvtype, root, comm, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -106,14 +104,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf,
                                                     const MPI_Aint * displs, MPI_Datatype sendtype,
                                                     void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_scatterv(sendbuf, sendcounts, displs, sendtype, recvbuf,
-                                   recvcount, recvtype, root, comm_ptr, errflag);
+                                   recvcount, recvtype, root, comm_ptr, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -122,15 +120,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm, int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_gather(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                 recvtype, root, comm, errflag);
+                                 recvtype, root, comm, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -140,15 +137,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, MPI_Aint
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const MPI_Aint * recvcounts,
                                                    const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                   int root, MPIR_Comm * comm,
-                                                   MPIR_Errflag_t errflag)
+                                                   int root, MPIR_Comm * comm, int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_gatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
-                                  displs, recvtype, root, comm, errflag);
+                                  displs, recvtype, root, comm, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -157,14 +153,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, MPI_Aint
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm, int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_alltoall(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                   recvtype, comm, errflag);
+                                   recvtype, comm, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -177,14 +173,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * rdispls,
                                                      MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                     MPIR_Errflag_t errflag)
+                                                     int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
-                                    recvcounts, rdispls, recvtype, comm, errflag);
+                                    recvcounts, rdispls, recvtype, comm, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -197,14 +193,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * rdispls,
                                                      const MPI_Datatype recvtypes[],
-                                                     MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                     MPIR_Comm * comm, int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
-                                    recvcounts, rdispls, recvtypes, comm, errflag);
+                                    recvcounts, rdispls, recvtypes, comm, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -212,14 +208,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm_ptr, int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
+    ret = MPIDI_POSIX_mpi_reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -228,15 +223,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *rec
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
                                                           const MPI_Aint * recvcounts,
                                                           MPI_Datatype datatype, MPI_Op op,
-                                                          MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t errflag)
+                                                          MPIR_Comm * comm_ptr, int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_reduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op,
-                                         comm_ptr, errflag);
+                                         comm_ptr, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -245,15 +239,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, v
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *sendbuf,
                                                                 void *recvbuf, MPI_Aint recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t errflag)
+                                                                MPIR_Comm * comm_ptr, int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_reduce_scatter_block(sendbuf, recvbuf, recvcount, datatype,
-                                               op, comm_ptr, errflag);
+                                               op, comm_ptr, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -261,13 +254,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *send
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvbuf,
                                                 MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                MPIR_Comm * comm, int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_scan(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    ret = MPIDI_POSIX_mpi_scan(sendbuf, recvbuf, count, datatype, op, comm, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -275,13 +268,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvb
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                  MPIR_Comm * comm, int collattr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_exscan(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    ret = MPIDI_POSIX_mpi_exscan(sendbuf, recvbuf, count, datatype, op, comm, collattr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -486,13 +479,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ineighbor_alltoallw(const void *sendb
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibarrier(MPIR_Comm * comm, int collattr,
+                                                    MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_ibarrier(comm, req);
+    ret = MPIDI_POSIX_mpi_ibarrier(comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -500,13 +494,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibarrier(MPIR_Comm * comm, MPIR_Reque
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibcast(void *buffer, MPI_Aint count,
                                                   MPI_Datatype datatype, int root, MPIR_Comm * comm,
-                                                  MPIR_Request ** req)
+                                                  int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_ibcast(buffer, count, datatype, root, comm, req);
+    ret = MPIDI_POSIX_mpi_ibcast(buffer, count, datatype, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -515,14 +509,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ibcast(void *buffer, MPI_Aint count,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgather(const void *sendbuf, MPI_Aint sendcount,
                                                       MPI_Datatype sendtype, void *recvbuf,
                                                       MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                      MPIR_Comm * comm, MPIR_Request ** req)
+                                                      MPIR_Comm * comm, int collattr,
+                                                      MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_iallgather(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                     recvtype, comm, req);
+                                     recvtype, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -533,14 +528,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, MPI_
                                                        const MPI_Aint * recvcounts,
                                                        const MPI_Aint * displs,
                                                        MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                       MPIR_Request ** req)
+                                                       int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_iallgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
-                                      displs, recvtype, comm, req);
+                                      displs, recvtype, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -549,13 +544,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallgatherv(const void *sendbuf, MPI_
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallreduce(const void *sendbuf, void *recvbuf,
                                                       MPI_Aint count, MPI_Datatype datatype,
                                                       MPI_Op op, MPIR_Comm * comm,
-                                                      MPIR_Request ** req)
+                                                      int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_iallreduce(sendbuf, recvbuf, count, datatype, op, comm, req);
+    ret = MPIDI_POSIX_mpi_iallreduce(sendbuf, recvbuf, count, datatype, op, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -564,14 +559,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iallreduce(const void *sendbuf, void 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoall(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Request ** req)
+                                                     MPIR_Comm * comm, int collattr,
+                                                     MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_ialltoall(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                    recvtype, comm, req);
+                                    recvtype, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -584,14 +580,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallv(const void *sendbuf,
                                                       const MPI_Aint * recvcounts,
                                                       const MPI_Aint * rdispls,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                      MPIR_Request ** req)
+                                                      int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_ialltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
-                                     recvcounts, rdispls, recvtype, comm, req);
+                                     recvcounts, rdispls, recvtype, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -604,14 +600,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallw(const void *sendbuf,
                                                       const MPI_Aint * recvcounts,
                                                       const MPI_Aint * rdispls,
                                                       const MPI_Datatype recvtypes[],
-                                                      MPIR_Comm * comm, MPIR_Request ** req)
+                                                      MPIR_Comm * comm, int collattr,
+                                                      MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_ialltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
-                                     recvcounts, rdispls, recvtypes, comm, req);
+                                     recvcounts, rdispls, recvtypes, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -619,13 +616,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ialltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iexscan(const void *sendbuf, void *recvbuf,
                                                    MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                   MPIR_Comm * comm, MPIR_Request ** req)
+                                                   MPIR_Comm * comm, int collattr,
+                                                   MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_iexscan(sendbuf, recvbuf, count, datatype, op, comm, req);
+    ret = MPIDI_POSIX_mpi_iexscan(sendbuf, recvbuf, count, datatype, op, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -634,14 +632,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iexscan(const void *sendbuf, void *re
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igather(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   int root, MPIR_Comm * comm, MPIR_Request ** req)
+                                                   int root, MPIR_Comm * comm, int collattr,
+                                                   MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_igather(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                  recvtype, root, comm, req);
+                                  recvtype, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -651,14 +650,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_igatherv(const void *sendbuf, MPI_Ain
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const MPI_Aint * recvcounts,
                                                     const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                    int root, MPIR_Comm * comm, MPIR_Request ** req)
+                                                    int root, MPIR_Comm * comm, int collattr,
+                                                    MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_igatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
-                                   displs, recvtype, root, comm, req);
+                                   displs, recvtype, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -668,14 +668,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter_block(const void *sen
                                                                  void *recvbuf, MPI_Aint recvcount,
                                                                  MPI_Datatype datatype, MPI_Op op,
                                                                  MPIR_Comm * comm,
-                                                                 MPIR_Request ** req)
+                                                                 int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_ireduce_scatter_block(sendbuf, recvbuf, recvcount, datatype,
-                                                op, comm, req);
+                                                op, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -684,13 +684,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter_block(const void *sen
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter(const void *sendbuf, void *recvbuf,
                                                            const MPI_Aint * recvcounts,
                                                            MPI_Datatype datatype, MPI_Op op,
-                                                           MPIR_Comm * comm, MPIR_Request ** req)
+                                                           MPIR_Comm * comm, int collattr,
+                                                           MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_ireduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op, comm, req);
+    ret =
+        MPIDI_POSIX_mpi_ireduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op, comm, collattr,
+                                        req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -699,13 +702,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce_scatter(const void *sendbuf, 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce(const void *sendbuf, void *recvbuf,
                                                    MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
                                                    int root, MPIR_Comm * comm_ptr,
-                                                   MPIR_Request ** req)
+                                                   int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_ireduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, req);
+    ret =
+        MPIDI_POSIX_mpi_ireduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, collattr,
+                                req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -713,13 +718,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_ireduce(const void *sendbuf, void *re
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op,
-                                                 MPIR_Comm * comm, MPIR_Request ** req)
+                                                 MPIR_Comm * comm, int collattr,
+                                                 MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_iscan(sendbuf, recvbuf, count, datatype, op, comm, req);
+    ret = MPIDI_POSIX_mpi_iscan(sendbuf, recvbuf, count, datatype, op, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -728,14 +734,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscan(const void *sendbuf, void *recv
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatter(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    int root, MPIR_Comm * comm, MPIR_Request ** req)
+                                                    int root, MPIR_Comm * comm, int collattr,
+                                                    MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_iscatter(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                   recvtype, root, comm, req);
+                                   recvtype, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -746,14 +753,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iscatterv(const void *sendbuf,
                                                      const MPI_Aint * displs, MPI_Datatype sendtype,
                                                      void *recvbuf, MPI_Aint recvcount,
                                                      MPI_Datatype recvtype, int root,
-                                                     MPIR_Comm * comm_ptr, MPIR_Request ** req)
+                                                     MPIR_Comm * comm_ptr, int collattr,
+                                                     MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_iscatterv(sendbuf, sendcounts, displs, sendtype, recvbuf,
-                                    recvcount, recvtype, root, comm_ptr, req);
+                                    recvcount, recvtype, root, comm_ptr, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;

--- a/src/mpid/ch4/src/ch4_coll.h
+++ b/src/mpid/ch4/src/ch4_coll.h
@@ -99,8 +99,7 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_allcomm_composition_json(MPIR_Comm * comm,
-                                                                    MPIR_Errflag_t errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_allcomm_composition_json(MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -113,17 +112,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_allcomm_composition_json(MPIR_Comm * 
     cnt = MPIR_Csel_search(MPIDI_COMM(comm, csel_comm), coll_sig);
 
     if (cnt == NULL) {
-        mpi_errno = MPIR_Barrier_impl(comm, errflag);
+        mpi_errno = MPIR_Barrier_impl(comm, collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
     switch (cnt->id) {
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Barrier_intra_composition_alpha:
-            mpi_errno = MPIDI_Barrier_intra_composition_alpha(comm, errflag);
+            mpi_errno = MPIDI_Barrier_intra_composition_alpha(comm, collattr);
             break;
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Barrier_intra_composition_beta:
-            mpi_errno = MPIDI_Barrier_intra_composition_beta(comm, errflag);
+            mpi_errno = MPIDI_Barrier_intra_composition_beta(comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -137,7 +136,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_allcomm_composition_json(MPIR_Comm * 
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t errflag)
+MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -151,16 +150,16 @@ MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t errfl
                                            (comm->hierarchy_kind ==
                                             MPIR_COMM_HIERARCHY_KIND__PARENT), mpi_errno,
                                            "Barrier composition alpha cannot be applied.\n");
-            mpi_errno = MPIDI_Barrier_intra_composition_alpha(comm, errflag);
+            mpi_errno = MPIDI_Barrier_intra_composition_alpha(comm, collattr);
             break;
         case 2:
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank,
                                            comm->comm_kind == MPIR_COMM_KIND__INTRACOMM, mpi_errno,
                                            "Barrier composition beta cannot be applied.\n");
-            mpi_errno = MPIDI_Barrier_intra_composition_beta(comm, errflag);
+            mpi_errno = MPIDI_Barrier_intra_composition_beta(comm, collattr);
             break;
         default:
-            mpi_errno = MPIDI_Barrier_allcomm_composition_json(comm, errflag);
+            mpi_errno = MPIDI_Barrier_allcomm_composition_json(comm, collattr);
             break;
     }
 
@@ -169,9 +168,9 @@ MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t errfl
 
   fallback:
     if (comm->comm_kind == MPIR_COMM_KIND__INTERCOMM)
-        mpi_errno = MPIR_Barrier_impl(comm, errflag);
+        mpi_errno = MPIR_Barrier_impl(comm, collattr);
     else
-        mpi_errno = MPIDI_Barrier_intra_composition_beta(comm, errflag);
+        mpi_errno = MPIDI_Barrier_intra_composition_beta(comm, collattr);
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -182,8 +181,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t errfl
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_allcomm_composition_json(void *buffer, MPI_Aint count,
                                                                   MPI_Datatype datatype, int root,
-                                                                  MPIR_Comm * comm,
-                                                                  MPIR_Errflag_t errflag)
+                                                                  MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -200,7 +198,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_allcomm_composition_json(void *buffer, 
     cnt = MPIR_Csel_search(MPIDI_COMM(comm, csel_comm), coll_sig);
 
     if (cnt == NULL) {
-        mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm, errflag);
+        mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm, collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -208,15 +206,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_allcomm_composition_json(void *buffer, 
     switch (cnt->id) {
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Bcast_intra_composition_alpha:
             mpi_errno =
-                MPIDI_Bcast_intra_composition_alpha(buffer, count, datatype, root, comm, errflag);
+                MPIDI_Bcast_intra_composition_alpha(buffer, count, datatype, root, comm, collattr);
             break;
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Bcast_intra_composition_beta:
             mpi_errno =
-                MPIDI_Bcast_intra_composition_beta(buffer, count, datatype, root, comm, errflag);
+                MPIDI_Bcast_intra_composition_beta(buffer, count, datatype, root, comm, collattr);
             break;
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Bcast_intra_composition_gamma:
             mpi_errno =
-                MPIDI_Bcast_intra_composition_gamma(buffer, count, datatype, root, comm, errflag);
+                MPIDI_Bcast_intra_composition_gamma(buffer, count, datatype, root, comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -231,7 +229,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_allcomm_composition_json(void *buffer, 
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
-                                        int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                        int root, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -245,7 +243,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *buffer, MPI_Aint count, MPI_Dataty
                                             MPIR_COMM_HIERARCHY_KIND__PARENT), mpi_errno,
                                            "Bcast composition alpha cannot be applied.\n");
             mpi_errno =
-                MPIDI_Bcast_intra_composition_alpha(buffer, count, datatype, root, comm, errflag);
+                MPIDI_Bcast_intra_composition_alpha(buffer, count, datatype, root, comm, collattr);
             break;
         case 2:
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank,
@@ -254,18 +252,18 @@ MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *buffer, MPI_Aint count, MPI_Dataty
                                             MPIR_COMM_HIERARCHY_KIND__PARENT), mpi_errno,
                                            "Bcast composition beta cannot be applied.\n");
             mpi_errno =
-                MPIDI_Bcast_intra_composition_beta(buffer, count, datatype, root, comm, errflag);
+                MPIDI_Bcast_intra_composition_beta(buffer, count, datatype, root, comm, collattr);
             break;
         case 3:
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank,
                                            comm->comm_kind == MPIR_COMM_KIND__INTRACOMM, mpi_errno,
                                            "Bcast composition gamma cannot be applied.\n");
             mpi_errno =
-                MPIDI_Bcast_intra_composition_gamma(buffer, count, datatype, root, comm, errflag);
+                MPIDI_Bcast_intra_composition_gamma(buffer, count, datatype, root, comm, collattr);
             break;
         default:
             mpi_errno =
-                MPIDI_Bcast_allcomm_composition_json(buffer, count, datatype, root, comm, errflag);
+                MPIDI_Bcast_allcomm_composition_json(buffer, count, datatype, root, comm, collattr);
             break;
     }
 
@@ -274,10 +272,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *buffer, MPI_Aint count, MPI_Dataty
 
   fallback:
     if (comm->comm_kind == MPIR_COMM_KIND__INTERCOMM)
-        mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm, errflag);
+        mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm, collattr);
     else
         mpi_errno =
-            MPIDI_Bcast_intra_composition_gamma(buffer, count, datatype, root, comm, errflag);
+            MPIDI_Bcast_intra_composition_gamma(buffer, count, datatype, root, comm, collattr);
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -321,7 +319,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_allcomm_composition_json(const void
                                                                       void *recvbuf, MPI_Aint count,
                                                                       MPI_Datatype datatype,
                                                                       MPI_Op op, MPIR_Comm * comm,
-                                                                      MPIR_Errflag_t errflag)
+                                                                      int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -341,7 +339,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_allcomm_composition_json(const void
     cnt = MPIR_Csel_search(MPIDI_COMM(comm, csel_comm), coll_sig);
 
     if (cnt == NULL) {
-        mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+        mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -350,17 +348,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_allcomm_composition_json(const void
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Allreduce_intra_composition_alpha:
             mpi_errno =
                 MPIDI_Allreduce_intra_composition_alpha(sendbuf, recvbuf, count, datatype, op,
-                                                        comm, errflag);
+                                                        comm, collattr);
             break;
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Allreduce_intra_composition_beta:
             mpi_errno =
                 MPIDI_Allreduce_intra_composition_beta(sendbuf, recvbuf, count, datatype, op,
-                                                       comm, errflag);
+                                                       comm, collattr);
             break;
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Allreduce_intra_composition_gamma:
             mpi_errno =
                 MPIDI_Allreduce_intra_composition_gamma(sendbuf, recvbuf, count, datatype, op,
-                                                        comm, errflag);
+                                                        comm, collattr);
             break;
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Allreduce_intra_composition_delta:
             if (comm->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
@@ -379,10 +377,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_allcomm_composition_json(const void
                 count >= num_leads && MPIR_Op_is_commutative(op)) {
                 mpi_errno =
                     MPIDI_Allreduce_intra_composition_delta(sendbuf, recvbuf, count, datatype, op,
-                                                            num_leads, comm, errflag);
+                                                            num_leads, comm, collattr);
             } else
                 mpi_errno =
-                    MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+                    MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -398,7 +396,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_allcomm_composition_json(const void
 
 MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                            MPIR_Errflag_t errflag)
+                                            int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     int is_commutative = -1;
@@ -426,7 +424,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *sendbuf, void *recvbuf, 
                                            "Allreduce composition alpha cannot be applied.\n");
             mpi_errno =
                 MPIDI_Allreduce_intra_composition_alpha(sendbuf, recvbuf, count, datatype, op, comm,
-                                                        errflag);
+                                                        collattr);
             break;
         case 2:
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank,
@@ -434,7 +432,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *sendbuf, void *recvbuf, 
                                            "Allreduce composition beta cannot be applied.\n");
             mpi_errno =
                 MPIDI_Allreduce_intra_composition_beta(sendbuf, recvbuf, count, datatype, op, comm,
-                                                       errflag);
+                                                       collattr);
             break;
         case 3:
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank,
@@ -445,7 +443,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *sendbuf, void *recvbuf, 
                                            "Allreduce composition gamma cannot be applied.\n");
             mpi_errno =
                 MPIDI_Allreduce_intra_composition_gamma(sendbuf, recvbuf, count, datatype, op, comm,
-                                                        errflag);
+                                                        collattr);
             break;
         case 4:
             if (comm->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
@@ -470,13 +468,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *sendbuf, void *recvbuf, 
 
             mpi_errno =
                 MPIDI_Allreduce_intra_composition_delta(sendbuf, recvbuf, count, datatype, op,
-                                                        num_leads, comm, errflag);
+                                                        num_leads, comm, collattr);
             break;
 
         default:
             mpi_errno =
                 MPIDI_Allreduce_allcomm_composition_json(sendbuf, recvbuf, count, datatype, op,
-                                                         comm, errflag);
+                                                         comm, collattr);
             break;
     }
 
@@ -485,11 +483,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *sendbuf, void *recvbuf, 
 
   fallback:
     if (comm->comm_kind == MPIR_COMM_KIND__INTERCOMM)
-        mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+        mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr);
     else
         mpi_errno =
             MPIDI_Allreduce_intra_composition_beta(sendbuf, recvbuf, count, datatype, op, comm,
-                                                   errflag);
+                                                   collattr);
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -533,7 +531,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_allcomm_composition_json(const void
                                                                       MPI_Aint recvcount,
                                                                       MPI_Datatype recvtype,
                                                                       MPIR_Comm * comm,
-                                                                      MPIR_Errflag_t errflag)
+                                                                      int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -555,7 +553,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_allcomm_composition_json(const void
     if (cnt == NULL) {
         mpi_errno =
             MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm,
-                                errflag);
+                                collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -568,16 +566,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_allcomm_composition_json(const void
                 mpi_errno =
                     MPIDI_Allgather_intra_composition_alpha(sendbuf, sendcount, sendtype,
                                                             recvbuf, recvcount, recvtype,
-                                                            comm, errflag);
+                                                            comm, collattr);
             } else
                 mpi_errno =
                     MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
-                                        comm, errflag);
+                                        comm, collattr);
             break;
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Allgather_intra_composition_beta:
             mpi_errno =
                 MPIDI_Allgather_intra_composition_beta(sendbuf, sendcount, sendtype,
-                                                       recvbuf, recvcount, recvtype, comm, errflag);
+                                                       recvbuf, recvcount, recvtype, comm,
+                                                       collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -594,7 +593,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_allcomm_composition_json(const void
 MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *sendbuf, MPI_Aint sendcount,
                                             MPI_Datatype sendtype, void *recvbuf,
                                             MPI_Aint recvcount, MPI_Datatype recvtype,
-                                            MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                            MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint type_size;
@@ -625,7 +624,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *sendbuf, MPI_Aint sendco
             mpi_errno =
                 MPIDI_Allgather_intra_composition_alpha(sendbuf, sendcount, sendtype,
                                                         recvbuf, recvcount, recvtype,
-                                                        comm, errflag);
+                                                        comm, collattr);
             break;
         case 2:
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank,
@@ -633,12 +632,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *sendbuf, MPI_Aint sendco
                                            "Allgather composition beta cannot be applied.\n");
             mpi_errno =
                 MPIDI_Allgather_intra_composition_beta(sendbuf, sendcount, sendtype, recvbuf,
-                                                       recvcount, recvtype, comm, errflag);
+                                                       recvcount, recvtype, comm, collattr);
             break;
         default:
             mpi_errno = MPIDI_Allgather_allcomm_composition_json(sendbuf, sendcount, sendtype,
                                                                  recvbuf, recvcount, recvtype, comm,
-                                                                 errflag);
+                                                                 collattr);
             break;
     }
 
@@ -649,11 +648,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *sendbuf, MPI_Aint sendco
     if (comm->comm_kind == MPIR_COMM_KIND__INTERCOMM)
         mpi_errno =
             MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm,
-                                errflag);
+                                collattr);
     else
         mpi_errno =
             MPIDI_Allgather_intra_composition_beta(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                                   recvtype, comm, errflag);
+                                                   recvtype, comm, collattr);
 
   fn_exit:
     MPIR_FUNC_ENTER;
@@ -665,8 +664,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *sendbuf, MPI_Aint sendco
 MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *sendbuf, MPI_Aint sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
                                              const MPI_Aint * recvcounts, const MPI_Aint * displs,
-                                             MPI_Datatype recvtype, MPIR_Comm * comm,
-                                             MPIR_Errflag_t errflag)
+                                             MPI_Datatype recvtype, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -691,7 +689,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *sendbuf, MPI_Aint sendc
     if (cnt == NULL) {
         mpi_errno =
             MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
-                                 recvtype, comm, errflag);
+                                 recvtype, comm, collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -701,7 +699,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *sendbuf, MPI_Aint sendc
             mpi_errno =
                 MPIDI_Allgatherv_intra_composition_alpha(sendbuf, sendcount, sendtype,
                                                          recvbuf, recvcounts, displs,
-                                                         recvtype, comm, errflag);
+                                                         recvtype, comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -719,7 +717,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *sendbuf, MPI_Aint sendc
 MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                           MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                          MPIR_Errflag_t errflag)
+                                          int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -743,7 +741,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *sendbuf, MPI_Aint sendcoun
 
     if (cnt == NULL) {
         MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm,
-                          errflag);
+                          collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -752,7 +750,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *sendbuf, MPI_Aint sendcoun
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Scatter_intra_composition_alpha:
             mpi_errno =
                 MPIDI_Scatter_intra_composition_alpha(sendbuf, sendcount, sendtype, recvbuf,
-                                                      recvcount, recvtype, root, comm, errflag);
+                                                      recvcount, recvtype, root, comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -770,7 +768,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *sendbuf, MPI_Aint sendcoun
 MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *sendbuf, const MPI_Aint * sendcounts,
                                            const MPI_Aint * displs, MPI_Datatype sendtype,
                                            void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                           int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                           int root, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -795,7 +793,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *sendbuf, const MPI_Aint *
 
     if (cnt == NULL) {
         MPIR_Scatterv_impl(sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype,
-                           root, comm, errflag);
+                           root, comm, collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -805,7 +803,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *sendbuf, const MPI_Aint *
             mpi_errno =
                 MPIDI_Scatterv_intra_composition_alpha(sendbuf, sendcounts, displs, sendtype,
                                                        recvbuf, recvcount, recvtype, root,
-                                                       comm, errflag);
+                                                       comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -823,7 +821,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *sendbuf, const MPI_Aint *
 MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *sendbuf, MPI_Aint sendcount,
                                          MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                          MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                         MPIR_Errflag_t errflag)
+                                         int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -848,7 +846,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *sendbuf, MPI_Aint sendcount
     if (cnt == NULL) {
         mpi_errno =
             MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm,
-                             errflag);
+                             collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -857,7 +855,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *sendbuf, MPI_Aint sendcount
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Gather_intra_composition_alpha:
             mpi_errno =
                 MPIDI_Gather_intra_composition_alpha(sendbuf, sendcount, sendtype, recvbuf,
-                                                     recvcount, recvtype, root, comm, errflag);
+                                                     recvcount, recvtype, root, comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -876,7 +874,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *sendbuf, MPI_Aint sendcoun
                                           MPI_Datatype sendtype, void *recvbuf,
                                           const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                           MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                          MPIR_Errflag_t errflag)
+                                          int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -901,7 +899,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *sendbuf, MPI_Aint sendcoun
 
     if (cnt == NULL) {
         mpi_errno = MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
-                                      displs, recvtype, root, comm, errflag);
+                                      displs, recvtype, root, comm, collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -911,7 +909,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *sendbuf, MPI_Aint sendcoun
             mpi_errno =
                 MPIDI_Gatherv_intra_composition_alpha(sendbuf, sendcount, sendtype, recvbuf,
                                                       recvcounts, displs, recvtype, root,
-                                                      comm, errflag);
+                                                      comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -960,8 +958,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_allcomm_composition_json(const void 
                                                                      void *recvbuf,
                                                                      MPI_Aint recvcount,
                                                                      MPI_Datatype recvtype,
-                                                                     MPIR_Comm * comm,
-                                                                     MPIR_Errflag_t errflag)
+                                                                     MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -982,7 +979,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_allcomm_composition_json(const void 
 
     if (cnt == NULL) {
         mpi_errno = MPIR_Alltoall_impl(sendbuf, sendcount, sendtype,
-                                       recvbuf, recvcount, recvtype, comm, errflag);
+                                       recvbuf, recvcount, recvtype, comm, collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -995,15 +992,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_allcomm_composition_json(const void 
                 mpi_errno =
                     MPIDI_Alltoall_intra_composition_alpha(sendbuf, sendcount, sendtype,
                                                            recvbuf, recvcount, recvtype,
-                                                           comm, errflag);
+                                                           comm, collattr);
             } else
                 mpi_errno = MPIR_Alltoall_impl(sendbuf, sendcount, sendtype,
-                                               recvbuf, recvcount, recvtype, comm, errflag);
+                                               recvbuf, recvcount, recvtype, comm, collattr);
             break;
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Alltoall_intra_composition_beta:
             mpi_errno =
                 MPIDI_Alltoall_intra_composition_beta(sendbuf, sendcount, sendtype,
-                                                      recvbuf, recvcount, recvtype, comm, errflag);
+                                                      recvbuf, recvcount, recvtype, comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -1019,8 +1016,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_allcomm_composition_json(const void 
 
 MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
-                                           MPI_Datatype recvtype, MPIR_Comm * comm,
-                                           MPIR_Errflag_t errflag)
+                                           MPI_Datatype recvtype, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint type_size;
@@ -1050,7 +1046,8 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcou
 
             mpi_errno =
                 MPIDI_Alltoall_intra_composition_alpha(sendbuf, sendcount, sendtype,
-                                                       recvbuf, recvcount, recvtype, comm, errflag);
+                                                       recvbuf, recvcount, recvtype, comm,
+                                                       collattr);
             break;
         case 2:
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank,
@@ -1058,12 +1055,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcou
                                            "Alltoall composition beta cannot be applied.\n");
             mpi_errno =
                 MPIDI_Alltoall_intra_composition_beta(sendbuf, sendcount, sendtype, recvbuf,
-                                                      recvcount, recvtype, comm, errflag);
+                                                      recvcount, recvtype, comm, collattr);
             break;
         default:
             mpi_errno = MPIDI_Alltoall_allcomm_composition_json(sendbuf, sendcount, sendtype,
                                                                 recvbuf, recvcount, recvtype, comm,
-                                                                errflag);
+                                                                collattr);
             break;
     }
 
@@ -1074,10 +1071,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcou
     if (comm->comm_kind == MPIR_COMM_KIND__INTERCOMM)
         mpi_errno =
             MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm,
-                               errflag);
+                               collattr);
     else
         mpi_errno = MPIDI_Alltoall_intra_composition_beta(sendbuf, sendcount, sendtype, recvbuf,
-                                                          recvcount, recvtype, comm, errflag);
+                                                          recvcount, recvtype, comm, collattr);
 
   fn_exit:
     MPIR_FUNC_ENTER;
@@ -1090,7 +1087,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoallv(const void *sendbuf, const MPI_Aint 
                                             const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                             void *recvbuf, const MPI_Aint * recvcounts,
                                             const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                            MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                            MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1116,7 +1113,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoallv(const void *sendbuf, const MPI_Aint 
     if (cnt == NULL) {
         mpi_errno = MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls,
                                         sendtype, recvbuf, recvcounts,
-                                        rdispls, recvtype, comm, errflag);
+                                        rdispls, recvtype, comm, collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -1126,7 +1123,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoallv(const void *sendbuf, const MPI_Aint 
             mpi_errno =
                 MPIDI_Alltoallv_intra_composition_alpha(sendbuf, sendcounts, sdispls,
                                                         sendtype, recvbuf, recvcounts,
-                                                        rdispls, recvtype, comm, errflag);
+                                                        rdispls, recvtype, comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -1146,7 +1143,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoallw(const void *sendbuf, const MPI_Aint 
                                             const MPI_Datatype sendtypes[], void *recvbuf,
                                             const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                                             const MPI_Datatype recvtypes[], MPIR_Comm * comm,
-                                            MPIR_Errflag_t errflag)
+                                            int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1172,7 +1169,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoallw(const void *sendbuf, const MPI_Aint 
     if (cnt == NULL) {
         mpi_errno = MPIR_Alltoallw_impl(sendbuf, sendcounts, sdispls,
                                         sendtypes, recvbuf, recvcounts,
-                                        rdispls, recvtypes, comm, errflag);
+                                        rdispls, recvtypes, comm, collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -1182,7 +1179,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoallw(const void *sendbuf, const MPI_Aint 
             mpi_errno =
                 MPIDI_Alltoallw_intra_composition_alpha(sendbuf, sendcounts, sdispls,
                                                         sendtypes, recvbuf, recvcounts,
-                                                        rdispls, recvtypes, comm, errflag);
+                                                        rdispls, recvtypes, comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -1201,7 +1198,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_allcomm_composition_json(const void *s
                                                                    void *recvbuf, MPI_Aint count,
                                                                    MPI_Datatype datatype, MPI_Op op,
                                                                    int root, MPIR_Comm * comm,
-                                                                   MPIR_Errflag_t errflag)
+                                                                   int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1221,7 +1218,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_allcomm_composition_json(const void *s
     cnt = MPIR_Csel_search(MPIDI_COMM(comm, csel_comm), coll_sig);
 
     if (cnt == NULL) {
-        mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm, errflag);
+        mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm, collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -1230,17 +1227,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_allcomm_composition_json(const void *s
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Reduce_intra_composition_alpha:
             mpi_errno =
                 MPIDI_Reduce_intra_composition_alpha(sendbuf, recvbuf, count, datatype, op,
-                                                     root, comm, errflag);
+                                                     root, comm, collattr);
             break;
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Reduce_intra_composition_beta:
             mpi_errno =
                 MPIDI_Reduce_intra_composition_beta(sendbuf, recvbuf, count, datatype, op,
-                                                    root, comm, errflag);
+                                                    root, comm, collattr);
             break;
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Reduce_intra_composition_gamma:
             mpi_errno =
                 MPIDI_Reduce_intra_composition_gamma(sendbuf, recvbuf, count, datatype, op,
-                                                     root, comm, errflag);
+                                                     root, comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -1256,7 +1253,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_allcomm_composition_json(const void *s
 
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *sendbuf, void *recvbuf,
                                          MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                         int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                         int root, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1279,7 +1276,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *sendbuf, void *recvbuf,
                                            "Reduce composition alpha cannot be applied.\n");
             mpi_errno =
                 MPIDI_Reduce_intra_composition_alpha(sendbuf, recvbuf, count, datatype, op, root,
-                                                     comm, errflag);
+                                                     comm, collattr);
             break;
         case 2:
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, comm->comm_kind == MPIR_COMM_KIND__INTRACOMM
@@ -1289,7 +1286,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *sendbuf, void *recvbuf,
                                            "Reduce composition beta cannot be applied.\n");
             mpi_errno =
                 MPIDI_Reduce_intra_composition_beta(sendbuf, recvbuf, count, datatype, op, root,
-                                                    comm, errflag);
+                                                    comm, collattr);
             break;
         case 3:
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank,
@@ -1297,12 +1294,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *sendbuf, void *recvbuf,
                                            "Reduce composition gamma cannot be applied.\n");
             mpi_errno =
                 MPIDI_Reduce_intra_composition_gamma(sendbuf, recvbuf, count, datatype, op, root,
-                                                     comm, errflag);
+                                                     comm, collattr);
             break;
         default:
             mpi_errno =
                 MPIDI_Reduce_allcomm_composition_json(sendbuf, recvbuf, count, datatype, op,
-                                                      root, comm, errflag);
+                                                      root, comm, collattr);
             break;
     }
 
@@ -1311,11 +1308,11 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *sendbuf, void *recvbuf,
 
   fallback:
     if (comm->comm_kind == MPIR_COMM_KIND__INTERCOMM)
-        mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm, errflag);
+        mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm, collattr);
     else
         mpi_errno =
             MPIDI_Reduce_intra_composition_gamma(sendbuf, recvbuf, count, datatype, op, root, comm,
-                                                 errflag);
+                                                 collattr);
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -1326,8 +1323,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *sendbuf, void *recvbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *sendbuf, void *recvbuf,
                                                  const MPI_Aint recvcounts[], MPI_Datatype datatype,
-                                                 MPI_Op op, MPIR_Comm * comm,
-                                                 MPIR_Errflag_t errflag)
+                                                 MPI_Op op, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1349,7 +1345,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *sendbuf, void *recv
 
     if (cnt == NULL) {
         mpi_errno =
-            MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm, errflag);
+            MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm, collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -1358,7 +1354,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *sendbuf, void *recv
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Reduce_scatter_intra_composition_alpha:
             mpi_errno =
                 MPIDI_Reduce_scatter_intra_composition_alpha(sendbuf, recvbuf, recvcounts,
-                                                             datatype, op, comm, errflag);
+                                                             datatype, op, comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -1375,8 +1371,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *sendbuf, void *recv
 
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                        MPI_Aint recvcount, MPI_Datatype datatype,
-                                                       MPI_Op op, MPIR_Comm * comm,
-                                                       MPIR_Errflag_t errflag)
+                                                       MPI_Op op, MPIR_Comm * comm, int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1399,7 +1394,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *sendbuf, void
     if (cnt == NULL) {
         mpi_errno =
             MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount, datatype, op, comm,
-                                           errflag);
+                                           collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -1408,7 +1403,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *sendbuf, void
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Reduce_scatter_block_intra_composition_alpha:
             mpi_errno =
                 MPIDI_Reduce_scatter_block_intra_composition_alpha(sendbuf, recvbuf, recvcount,
-                                                                   datatype, op, comm, errflag);
+                                                                   datatype, op, comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -1425,7 +1420,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *sendbuf, void
 
 MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                       MPIR_Errflag_t errflag)
+                                       int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1446,7 +1441,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *sendbuf, void *recvbuf, MPI_A
     cnt = MPIR_Csel_search(MPIDI_COMM(comm, csel_comm), coll_sig);
 
     if (cnt == NULL) {
-        mpi_errno = MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+        mpi_errno = MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -1455,12 +1450,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *sendbuf, void *recvbuf, MPI_A
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Scan_intra_composition_alpha:
             mpi_errno =
                 MPIDI_Scan_intra_composition_alpha(sendbuf, recvbuf, count,
-                                                   datatype, op, comm, errflag);
+                                                   datatype, op, comm, collattr);
             break;
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Scan_intra_composition_beta:
             mpi_errno =
                 MPIDI_Scan_intra_composition_beta(sendbuf, recvbuf, count,
-                                                  datatype, op, comm, errflag);
+                                                  datatype, op, comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -1477,7 +1472,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *sendbuf, void *recvbuf, MPI_A
 
 MPL_STATIC_INLINE_PREFIX int MPID_Exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                         MPIR_Errflag_t errflag)
+                                         int collattr)
 {
     int mpi_errno = MPI_SUCCESS;
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1498,7 +1493,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Exscan(const void *sendbuf, void *recvbuf, MPI
     cnt = MPIR_Csel_search(MPIDI_COMM(comm, csel_comm), coll_sig);
 
     if (cnt == NULL) {
-        mpi_errno = MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);;
+        mpi_errno = MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm, collattr);;
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -1507,7 +1502,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Exscan(const void *sendbuf, void *recvbuf, MPI
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Exscan_intra_composition_alpha:
             mpi_errno =
                 MPIDI_Exscan_intra_composition_alpha(sendbuf, recvbuf, count,
-                                                     datatype, op, comm, errflag);
+                                                     datatype, op, comm, collattr);
             break;
         default:
             MPIR_Assert(0);
@@ -1702,26 +1697,27 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ineighbor_alltoallw(const void *sendbuf,
     return ret;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier(MPIR_Comm * comm, MPIR_Request ** req)
+MPL_STATIC_INLINE_PREFIX int MPID_Ibarrier(MPIR_Comm * comm, int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_NM_mpi_ibarrier(comm, req);
+    ret = MPIDI_NM_mpi_ibarrier(comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPID_Ibcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
-                                         int root, MPIR_Comm * comm, MPIR_Request ** req)
+                                         int root, MPIR_Comm * comm, int collattr,
+                                         MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_NM_mpi_ibcast(buffer, count, datatype, root, comm, req);
+    ret = MPIDI_NM_mpi_ibcast(buffer, count, datatype, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -1730,14 +1726,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ibcast(void *buffer, MPI_Aint count, MPI_Datat
 MPL_STATIC_INLINE_PREFIX int MPID_Iallgather(const void *sendbuf, MPI_Aint sendcount,
                                              MPI_Datatype sendtype, void *recvbuf,
                                              MPI_Aint recvcount, MPI_Datatype recvtype,
-                                             MPIR_Comm * comm, MPIR_Request ** req)
+                                             MPIR_Comm * comm, int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_NM_mpi_iallgather(sendbuf, sendcount, sendtype, recvbuf,
-                                  recvcount, recvtype, comm, req);
+                                  recvcount, recvtype, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -1747,14 +1743,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv(const void *sendbuf, MPI_Aint send
                                               MPI_Datatype sendtype, void *recvbuf,
                                               const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                               MPI_Datatype recvtype, MPIR_Comm * comm,
-                                              MPIR_Request ** req)
+                                              int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_NM_mpi_iallgatherv(sendbuf, sendcount, sendtype, recvbuf,
-                                   recvcounts, displs, recvtype, comm, req);
+                                   recvcounts, displs, recvtype, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -1762,13 +1758,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallgatherv(const void *sendbuf, MPI_Aint send
 
 MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                             MPIR_Request ** req)
+                                             int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_NM_mpi_iallreduce(sendbuf, recvbuf, count, datatype, op, comm, req);
+    ret = MPIDI_NM_mpi_iallreduce(sendbuf, recvbuf, count, datatype, op, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -1777,14 +1773,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iallreduce(const void *sendbuf, void *recvbuf,
 MPL_STATIC_INLINE_PREFIX int MPID_Ialltoall(const void *sendbuf, MPI_Aint sendcount,
                                             MPI_Datatype sendtype, void *recvbuf,
                                             MPI_Aint recvcount, MPI_Datatype recvtype,
-                                            MPIR_Comm * comm, MPIR_Request ** req)
+                                            MPIR_Comm * comm, int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_NM_mpi_ialltoall(sendbuf, sendcount, sendtype, recvbuf,
-                                 recvcount, recvtype, comm, req);
+                                 recvcount, recvtype, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -1794,14 +1790,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallv(const void *sendbuf, const MPI_Aint
                                              const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                              void *recvbuf, const MPI_Aint * recvcounts,
                                              const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                             MPIR_Comm * comm, MPIR_Request ** req)
+                                             MPIR_Comm * comm, int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_NM_mpi_ialltoallv(sendbuf, sendcounts, sdispls, sendtype,
-                                  recvbuf, recvcounts, rdispls, recvtype, comm, req);
+                                  recvbuf, recvcounts, rdispls, recvtype, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -1812,14 +1808,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw(const void *sendbuf, const MPI_Aint
                                              const MPI_Datatype * sendtypes, void *recvbuf,
                                              const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
                                              const MPI_Datatype * recvtypes, MPIR_Comm * comm,
-                                             MPIR_Request ** req)
+                                             int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_NM_mpi_ialltoallw(sendbuf, sendcounts, sdispls, sendtypes,
-                                  recvbuf, recvcounts, rdispls, recvtypes, comm, req);
+                                  recvbuf, recvcounts, rdispls, recvtypes, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -1827,13 +1823,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ialltoallw(const void *sendbuf, const MPI_Aint
 
 MPL_STATIC_INLINE_PREFIX int MPID_Iexscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                          MPIR_Request ** req)
+                                          int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_NM_mpi_iexscan(sendbuf, recvbuf, count, datatype, op, comm, req);
+    ret = MPIDI_NM_mpi_iexscan(sendbuf, recvbuf, count, datatype, op, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -1842,14 +1838,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iexscan(const void *sendbuf, void *recvbuf, MP
 MPL_STATIC_INLINE_PREFIX int MPID_Igather(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                           MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                          MPIR_Request ** req)
+                                          int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_NM_mpi_igather(sendbuf, sendcount, sendtype, recvbuf,
-                               recvcount, recvtype, root, comm, req);
+                               recvcount, recvtype, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -1859,14 +1855,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Igatherv(const void *sendbuf, MPI_Aint sendcou
                                            MPI_Datatype sendtype, void *recvbuf,
                                            const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                            MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                           MPIR_Request ** req)
+                                           int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_NM_mpi_igatherv(sendbuf, sendcount, sendtype, recvbuf,
-                                recvcounts, displs, recvtype, root, comm, req);
+                                recvcounts, displs, recvtype, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -1875,13 +1871,15 @@ MPL_STATIC_INLINE_PREFIX int MPID_Igatherv(const void *sendbuf, MPI_Aint sendcou
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                         MPI_Aint recvcount, MPI_Datatype datatype,
                                                         MPI_Op op, MPIR_Comm * comm,
-                                                        MPIR_Request ** req)
+                                                        int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_NM_mpi_ireduce_scatter_block(sendbuf, recvbuf, recvcount, datatype, op, comm, req);
+    ret =
+        MPIDI_NM_mpi_ireduce_scatter_block(sendbuf, recvbuf, recvcount, datatype, op, comm,
+                                           collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -1890,13 +1888,16 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter_block(const void *sendbuf, voi
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter(const void *sendbuf, void *recvbuf,
                                                   const MPI_Aint * recvcounts,
                                                   MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm, MPIR_Request ** req)
+                                                  MPIR_Comm * comm, int collattr,
+                                                  MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_NM_mpi_ireduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op, comm, req);
+    ret =
+        MPIDI_NM_mpi_ireduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op, comm, collattr,
+                                     req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -1904,13 +1905,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce_scatter(const void *sendbuf, void *rec
 
 MPL_STATIC_INLINE_PREFIX int MPID_Ireduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                           MPI_Datatype datatype, MPI_Op op, int root,
-                                          MPIR_Comm * comm, MPIR_Request ** req)
+                                          MPIR_Comm * comm, int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_NM_mpi_ireduce(sendbuf, recvbuf, count, datatype, op, root, comm, req);
+    ret = MPIDI_NM_mpi_ireduce(sendbuf, recvbuf, count, datatype, op, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -1918,13 +1919,13 @@ MPL_STATIC_INLINE_PREFIX int MPID_Ireduce(const void *sendbuf, void *recvbuf, MP
 
 MPL_STATIC_INLINE_PREFIX int MPID_Iscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                         MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                        MPIR_Request ** req)
+                                        int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_NM_mpi_iscan(sendbuf, recvbuf, count, datatype, op, comm, req);
+    ret = MPIDI_NM_mpi_iscan(sendbuf, recvbuf, count, datatype, op, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -1933,14 +1934,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscan(const void *sendbuf, void *recvbuf, MPI_
 MPL_STATIC_INLINE_PREFIX int MPID_Iscatter(const void *sendbuf, MPI_Aint sendcount,
                                            MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                            MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                           MPIR_Request ** req)
+                                           int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_NM_mpi_iscatter(sendbuf, sendcount, sendtype, recvbuf,
-                                recvcount, recvtype, root, comm, req);
+                                recvcount, recvtype, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -1950,14 +1951,14 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iscatterv(const void *sendbuf, const MPI_Aint 
                                             const MPI_Aint * displs, MPI_Datatype sendtype,
                                             void *recvbuf, MPI_Aint recvcount,
                                             MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                            MPIR_Request ** req)
+                                            int collattr, MPIR_Request ** req)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_NM_mpi_iscatterv(sendbuf, sendcounts, displs, sendtype,
-                                 recvbuf, recvcount, recvtype, root, comm, req);
+                                 recvbuf, recvcount, recvtype, root, comm, collattr, req);
 
     MPIR_FUNC_EXIT;
     return ret;

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -227,16 +227,16 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
                  * during realloc of entries, so this is easier */
                 ret_errno = MPIC_Isend(e->u.send.buf, *e->u.send.count_p, e->u.send.datatype,
                                        e->u.send.dest, s->tag, comm, &e->u.send.sreq,
-                                       r->u.nbc.errflag);
+                                       e->u.send.collattr | r->u.nbc.errflag);
             } else {
                 if (e->u.send.is_sync) {
                     ret_errno = MPIC_Issend(e->u.send.buf, e->u.send.count, e->u.send.datatype,
                                             e->u.send.dest, s->tag, comm, &e->u.send.sreq,
-                                            r->u.nbc.errflag);
+                                            e->u.send.collattr | r->u.nbc.errflag);
                 } else {
                     ret_errno = MPIC_Isend(e->u.send.buf, e->u.send.count, e->u.send.datatype,
                                            e->u.send.dest, s->tag, comm, &e->u.send.sreq,
-                                           r->u.nbc.errflag);
+                                           e->u.send.collattr | r->u.nbc.errflag);
                 }
             }
             /* Check if the error is actually fatal to the NBC or we can continue. */
@@ -259,7 +259,8 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
             MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "starting RECV entry %d\n", (int) idx);
             comm = e->u.recv.comm;
             ret_errno = MPIC_Irecv(e->u.recv.buf, e->u.recv.count, e->u.recv.datatype,
-                                   e->u.recv.src, s->tag, comm, &e->u.recv.rreq);
+                                   e->u.recv.src, s->tag, comm, e->u.recv.collattr,
+                                   &e->u.recv.rreq);
             /* Check if the error is actually fatal to the NBC or we can continue. */
             if (unlikely(ret_errno)) {
                 if (MPIR_ERR_NONE == r->u.nbc.errflag) {
@@ -643,7 +644,7 @@ static int MPIDU_Sched_add_entry(struct MPIDU_Sched *s, int *idx, struct MPIDU_S
 
 /* do these ops need an entry handle returned? */
 int MPIDU_Sched_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
-                     MPIR_Comm * comm, MPIR_Sched_t s)
+                     MPIR_Comm * comm, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     struct MPIDU_Sched_entry *e = NULL;
@@ -662,6 +663,7 @@ int MPIDU_Sched_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int
     e->u.send.dest = dest;
     e->u.send.sreq = NULL;      /* will be populated by _start_entry */
     e->u.send.comm = comm;
+    e->u.send.collattr = collattr;
     e->u.send.is_sync = FALSE;
 
     /* the user may free the comm & type after initiating but before the
@@ -720,7 +722,7 @@ int MPIDU_Sched_pt2pt_send(const void *buf, MPI_Aint count, MPI_Datatype datatyp
 }
 
 int MPIDU_Sched_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
-                      MPIR_Comm * comm, MPIR_Sched_t s)
+                      MPIR_Comm * comm, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     struct MPIDU_Sched_entry *e = NULL;
@@ -739,6 +741,7 @@ int MPIDU_Sched_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, in
     e->u.send.dest = dest;
     e->u.send.sreq = NULL;      /* will be populated by _start_entry */
     e->u.send.comm = comm;
+    e->u.send.collattr = collattr;
     e->u.send.is_sync = TRUE;
 
     /* the user may free the comm & type after initiating but before the
@@ -759,7 +762,7 @@ int MPIDU_Sched_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, in
 
 
 int MPIDU_Sched_send_defer(const void *buf, const MPI_Aint * count, MPI_Datatype datatype, int dest,
-                           MPIR_Comm * comm, MPIR_Sched_t s)
+                           MPIR_Comm * comm, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     struct MPIDU_Sched_entry *e = NULL;
@@ -778,6 +781,7 @@ int MPIDU_Sched_send_defer(const void *buf, const MPI_Aint * count, MPI_Datatype
     e->u.send.dest = dest;
     e->u.send.sreq = NULL;      /* will be populated by _start_entry */
     e->u.send.comm = comm;
+    e->u.send.collattr = collattr;
     e->u.send.is_sync = FALSE;
 
     /* the user may free the comm & type after initiating but before the
@@ -797,7 +801,7 @@ int MPIDU_Sched_send_defer(const void *buf, const MPI_Aint * count, MPI_Datatype
 }
 
 int MPIDU_Sched_recv_status(void *buf, MPI_Aint count, MPI_Datatype datatype, int src,
-                            MPIR_Comm * comm, MPI_Status * status, MPIR_Sched_t s)
+                            MPIR_Comm * comm, MPI_Status * status, int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     struct MPIDU_Sched_entry *e = NULL;
@@ -815,6 +819,7 @@ int MPIDU_Sched_recv_status(void *buf, MPI_Aint count, MPI_Datatype datatype, in
     e->u.recv.src = src;
     e->u.recv.rreq = NULL;      /* will be populated by _start_entry */
     e->u.recv.comm = comm;
+    e->u.recv.collattr = collattr;
     e->u.recv.status = status;
     status->MPI_ERROR = MPI_SUCCESS;
     MPIR_Comm_add_ref(comm);
@@ -831,7 +836,7 @@ int MPIDU_Sched_recv_status(void *buf, MPI_Aint count, MPI_Datatype datatype, in
 }
 
 int MPIDU_Sched_recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int src, MPIR_Comm * comm,
-                     MPIR_Sched_t s)
+                     int collattr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
     struct MPIDU_Sched_entry *e = NULL;
@@ -849,6 +854,7 @@ int MPIDU_Sched_recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int src, 
     e->u.recv.src = src;
     e->u.recv.rreq = NULL;      /* will be populated by _start_entry */
     e->u.recv.comm = comm;
+    e->u.recv.collattr = collattr;
     e->u.recv.status = MPI_STATUS_IGNORE;
 
     MPIR_Comm_add_ref(comm);

--- a/src/mpid/common/sched/mpidu_sched.h
+++ b/src/mpid/common/sched/mpidu_sched.h
@@ -44,6 +44,7 @@ struct MPIDU_Sched_send {
     int dest;
     struct MPIR_Comm *comm;
     struct MPIR_Request *sreq;
+    int collattr;
     int is_sync;                /* TRUE iff this send is an ssend */
 };
 
@@ -55,6 +56,7 @@ struct MPIDU_Sched_recv {
     int src;
     struct MPIR_Comm *comm;
     struct MPIR_Request *rreq;
+    int collattr;
     MPI_Status *status;
 };
 
@@ -142,9 +144,9 @@ int MPIDU_Sched_reset(MPIR_Sched_t s);
 void *MPIDU_Sched_alloc_state(MPIR_Sched_t s, MPI_Aint size);
 int MPIDU_Sched_start(MPIR_Sched_t sp, struct MPIR_Comm *comm, struct MPIR_Request **req);
 int MPIDU_Sched_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
-                     struct MPIR_Comm *comm, MPIR_Sched_t s);
+                     struct MPIR_Comm *comm, int collattr, MPIR_Sched_t s);
 int MPIDU_Sched_recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int src,
-                     struct MPIR_Comm *comm, MPIR_Sched_t s);
+                     struct MPIR_Comm *comm, int collattr, MPIR_Sched_t s);
 int MPIDU_Sched_pt2pt_send(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                            int tag, int dest, struct MPIR_Comm *comm, MPIR_Sched_t s);
 int MPIDU_Sched_pt2pt_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,


### PR DESCRIPTION
## Pull Request Description
Add and integer attribute, `collattr`, to all collective interface to allow more flexible way of decomposing the collective into sub communicator (but without actually creating the full sub-communicator). The actual sub-group information is in the `MPIR_Comm` struct and initialized at creation time. `collattr` can contain an index that points to one of the sub-group. The attribute also can annotate special communication variation, such as making collectives to work with threadcomm (PR #6326). The current `errflag` mechanism is also carried by the `collattr`.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
