### PR TITLE
binding/c: error check for intercomm reduce

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -2175,12 +2175,16 @@ def dump_validate_userbuffer_reduce(func, sbuf, rbuf, ct, dt, op):
         G.out.append("    }")
         G.out.append("}")
         # test sendbuf
+        cond_a = cond_intra
+        cond_b = cond_inter + " && root != MPI_ROOT && root != MPI_PROC_NULL"
+        dump_if_open("(" + cond_a + ") || (" + cond_b + ")")
         G.out.append("if (" + cond_inter + ") {")
         G.out.append("    MPIR_ERRTEST_SENDBUF_INPLACE(%s, %s, mpi_errno);" % (sbuf, ct))
         G.out.append("}")
         G.out.append("if (%s > 0 && %s != MPI_IN_PLACE) {" % (ct, sbuf))
         G.out.append("    MPIR_ERRTEST_USERBUFFER(%s, %s, %s, mpi_errno);" % (sbuf, ct, dt))
         G.out.append("}")
+        dump_if_close()
 
         G.out.append("DEDENT")
         G.out.append("}")


### PR DESCRIPTION
## Pull Request Description
With intercomm, we need ignore sendbuf for the root group, not just the root process.

Fixes #6351
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
