### PR TITLE
ch4: Move check for MPI_PROC_NULL in persistent path

### DIFF
--- a/src/mpid/ch4/src/ch4_startall.h
+++ b/src/mpid/ch4/src/ch4_startall.h
@@ -15,6 +15,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_prequest_start(MPIR_Request * preq)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
+    /* nothing to do if the source/dest is MPI_PROC_NULL */
+    if (MPIDI_PREQUEST(preq, rank) == MPI_PROC_NULL)
+        goto fn_exit;
+
     MPIR_Comm *comm = preq->comm;
     switch (MPIDI_PREQUEST(preq, p_type)) {
 
@@ -85,10 +89,6 @@ MPL_STATIC_INLINE_PREFIX int MPID_Startall(int count, MPIR_Request * requests[])
 
     for (i = 0; i < count; i++) {
         MPIR_Request *const preq = requests[i];
-        /* continue if the source/dest is MPI_PROC_NULL */
-        if (MPIDI_PREQUEST(preq, rank) == MPI_PROC_NULL)
-            continue;
-
         switch (preq->kind) {
             case MPIR_REQUEST_KIND__PREQUEST_SEND:
             case MPIR_REQUEST_KIND__PREQUEST_RECV:


### PR DESCRIPTION
## Pull Request Description

MPI_PROC_NULL checks are only applicable to persistent pt2pt requests. Move the branch to where we have determined the request is pt2pt, i.e. not partitioned or collective.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
