### PR TITLE
binding/c: Return early in MPI_Parrived for inactive requests

### DIFF
--- a/src/binding/c/part_api.txt
+++ b/src/binding/c/part_api.txt
@@ -85,7 +85,7 @@ MPI_Parrived:
     MPIR_ERRTEST_PARTITION(partition, request_ptr, mpi_errno);
 }
 { -- early_return --
-    if (request == MPI_REQUEST_NULL) {
+    if (request == MPI_REQUEST_NULL || !MPIR_Part_request_is_active(request_ptr)) {
         *flag = TRUE;
         goto fn_exit;
     }


### PR DESCRIPTION
## Pull Request Description

MPI-4.0 states "MPI_PARRIVED may be called with a null or inactive request argument. In either case, the operation returns with flag = true".

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
