### PR TITLE
pm/hydra: Fix MPIR_proctable

### DIFF
--- a/src/pm/hydra/mpiexec/debugger.c
+++ b/src/pm/hydra/mpiexec/debugger.c
@@ -44,8 +44,9 @@ HYD_status HYDT_dbg_setup_procdesc(struct HYD_pg * pg)
      * proxy. */
 
     i = 0;
-    for (int i_proxy = 0;; i_proxy = (i_proxy + 1) % pg->proxy_count) {
-        struct HYD_proxy *proxy = &pg->proxy_list[i_proxy];
+    for (int i_proxy = 0;; i_proxy++) {
+        struct HYD_proxy *proxy = &pg->proxy_list[i_proxy % pg->proxy_count];
+        round = i_proxy / pg->proxy_count;
         j = 0;
         k = 0;
         for (exec = proxy->exec_list; exec; exec = exec->next) {


### PR DESCRIPTION
## Pull Request Description

Make sure to update the "round" variable as we construct MPIR_proctable. This was accidentally broken in [2906ecf5].

Fixes pmodels/mpich#6363.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
