### PR TITLE
ch4/ofi: correct tx + rx ctx counts under multi-domains

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -495,7 +495,12 @@ static void host_free(void *ptr)
 static void set_sep_counters(int nic)
 {
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
+#ifdef MPIDI_OFI_VNI_USE_DOMAIN
+        /* Note: currently we request a single tx and rx ctx under MPIDI_OFI_VNI_USE_DOMAIN */
+        int num_ctx_per_nic = 1;
+#else
         int num_ctx_per_nic = MPIDI_OFI_global.num_vnis;
+#endif
         int max_by_prov = MPL_MIN(MPIDI_OFI_global.prov_use[nic]->domain_attr->tx_ctx_cnt,
                                   MPIDI_OFI_global.prov_use[nic]->domain_attr->rx_ctx_cnt);
         num_ctx_per_nic = MPL_MIN(num_ctx_per_nic, max_by_prov);


### PR DESCRIPTION
Under multiple-domains, we don't want to request as many scalable endpoint endpionts as the total number of VNIs. 
We had observed problem when testing with psm2.

Currently we limit it to one.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
