### PR TITLE
mpi/init: check NULL buffers at thread-affinity setup

### DIFF
--- a/src/mpi/init/init_async.c
+++ b/src/mpi/init/init_async.c
@@ -194,6 +194,7 @@ static int get_thread_affinity(bool * apply_affinity, int **p_thread_affinity, i
 
         async_threads_per_node = local_size;
         thread_affinity = (int *) MPL_malloc(async_threads_per_node * sizeof(int), MPL_MEM_OTHER);
+        MPIR_Assert(thread_affinity);
 
         MPL_DBG_MSG_FMT(MPIR_DBG_INIT, VERBOSE,
                         (MPL_DBG_FDEST,
@@ -276,6 +277,7 @@ int MPIR_Start_progress_thread_impl(MPIR_Stream * stream_ptr)
 #ifdef DO_ASYNC_THREAD_AFFINITY
     if (apply_affinity) {
         int thr_err;
+        MPIR_Assert(thread_affinity);
         MPL_thread_set_affinity(p->thread_id, &(thread_affinity[affinity_idx]), 1, &thr_err);
         MPIR_ERR_CHKANDJUMP1(thr_err, mpi_errno, MPI_ERR_OTHER, "**set_thread_affinity",
                              "**set_thread_affinity %d", thread_affinity[affinity_idx]);


### PR DESCRIPTION
Klocwork was complaining about the possibilities of thread_affinity being NULL.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
