### PR TITLE
ABI: add option to build libmpi_abi.so

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,9 @@ Makefile.am-stamp
 # random stuff
 /maint/gcovmerge
 /src/binding/cxx/buildiface-stamp
+/src/binding/abi/mpi_abi_internal.h
+/src/binding/abi/mpi_abi_util.c
+/src/binding/abi/c_binding_abi.c
 
 # script-generated f90 test files
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -148,6 +148,12 @@ lib_lib@MPILIBNAME@_la_LDFLAGS = $(ABIVERSIONFLAGS)
 lib_lib@MPILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) -DMPICH_MPI_FROM_PMPI
 lib_lib@MPILIBNAME@_la_LIBADD = lib/lib@PMPILIBNAME@.la $(mpi_convenience_libs)
 
+if BUILD_ROMIO
+    # libpromio contains the PMPI symbols (unlike libpmpi, which contains MPI
+    # symbols) and should be added to libpmpi
+    lib_lib@PMPILIBNAME@_la_LIBADD += src/mpi/romio/libpromio.la
+    lib_lib@MPILIBNAME@_la_LIBADD += src/mpi/romio/libromio.la
+endif
 else !BUILD_PROFILING_LIB
 
 lib_LTLIBRARIES += lib/lib@MPILIBNAME@.la
@@ -156,6 +162,10 @@ lib_lib@MPILIBNAME@_la_LDFLAGS = $(external_ldflags) $(ABIVERSIONFLAGS)
 lib_lib@MPILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS)
 lib_lib@MPILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs) $(mpi_convenience_libs)
 EXTRA_lib_lib@MPILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs) $(mpi_convenience_libs)
+
+if BUILD_ROMIO
+    lib_lib@MPILIBNAME@_la_LIBADD += src/mpi/romio/libromio.la
+endif
 endif !BUILD_PROFILING_LIB
 
 if BUILD_ABI_LIB
@@ -179,6 +189,10 @@ lib_lib@MPIABILIBNAME@_la_LDFLAGS = $(ABIVERSIONFLAGS)
 lib_lib@MPIABILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) -DMPICH_MPI_FROM_PMPI $(abi_cppflags)
 lib_lib@MPIABILIBNAME@_la_LIBADD = lib/lib@PMPIABILIBNAME@.la $(mpi_convenience_libs)
 
+if BUILD_ROMIO
+    lib_lib@PMPIABILIBNAME@_la_LIBADD += src/mpi/romio/libpromio_abi.la
+    lib_lib@MPIABILIBNAME@_la_LIBADD += src/mpi/romio/libromio_abi.la
+endif
 else !BUILD_PROFILING_LIB
 
 lib_LTLIBRARIES += lib/lib@MPIABILIBNAME@.la
@@ -187,6 +201,10 @@ lib_lib@MPIABILIBNAME@_la_LDFLAGS = $(external_ldflags) $(ABIVERSIONFLAGS)
 lib_lib@MPIABILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) $(abi_cppflags)
 lib_lib@MPIABILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs) $(mpi_convenience_libs)
 EXTRA_lib_lib@MPIABILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs) $(mpi_convenience_libs)
+
+if BUILD_ROMIO
+    lib_lib@MPIABILIBNAME@_la_LIBADD += src/mpi/romio/libromio_abi.la
+endif
 endif !BUILD_PROFILING_LIB
 endif BUILD_ABI_LIB
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -98,6 +98,9 @@ endif BUILD_F77_BINDING
 ## lib@PMPILIBNAME@ (which is the same as lib@MPILIBNAME@ on systems
 ## that support weak symbols).
 ##
+## mpi_abi_sources: similar to mpi_sources, but used to compile
+## lib@MPIABILIBNAME@.
+##
 ## mpi_f77_sources: When compiled with -DMPICH_MPI_FROM_PMPI, these
 ## files provide the "mpi_" public functions for the F77 bindings and
 ## end up in lib@MPIFCLIBNAME@.
@@ -113,6 +116,7 @@ endif BUILD_F77_BINDING
 ## mpi_core_sources: These files are internal non-public functions
 ## that are used by all bindings.
 mpi_sources =
+mpi_abi_sources =
 mpi_f77_sources =
 mpi_fc_sources =
 mpi_fc_modules =
@@ -153,6 +157,38 @@ lib_lib@MPILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS)
 lib_lib@MPILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs) $(mpi_convenience_libs)
 EXTRA_lib_lib@MPILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs) $(mpi_convenience_libs)
 endif !BUILD_PROFILING_LIB
+
+if BUILD_ABI_LIB
+abi_cppflags = -DBUILD_MPI_ABI -I$(srcdir)/src/binding/abi
+if BUILD_PROFILING_LIB
+# dropping mpi_fc_sources and mpi_cxx_sources from libmpmpi since they
+# don't contribute any PMPI symbols.
+lib_LTLIBRARIES += lib/lib@PMPIABILIBNAME@.la
+lib_lib@PMPIABILIBNAME@_la_SOURCES = $(mpi_abi_sources) $(mpi_f77_sources) $(mpi_core_sources)
+lib_lib@PMPIABILIBNAME@_la_LDFLAGS = $(external_ldflags) $(ABIVERSIONFLAGS)
+lib_lib@PMPIABILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) -DF77_USE_PMPI $(abi_cppflags)
+lib_lib@PMPIABILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs)
+EXTRA_lib_lib@PMPIABILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs)
+
+# lib@MPIABILIBNAME@.la might depend on lib@PMPIABILIBNAME@.la.  We add them
+# in that order to lib_LTLIBRARIES so libtool doesn't get
+# confused. (see https://bugzilla.redhat.com/show_bug.cgi?id=91110)
+lib_LTLIBRARIES += lib/lib@MPIABILIBNAME@.la
+lib_lib@MPIABILIBNAME@_la_SOURCES = $(mpi_abi_sources)
+lib_lib@MPIABILIBNAME@_la_LDFLAGS = $(ABIVERSIONFLAGS)
+lib_lib@MPIABILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) -DMPICH_MPI_FROM_PMPI $(abi_cppflags)
+lib_lib@MPIABILIBNAME@_la_LIBADD = lib/lib@PMPIABILIBNAME@.la $(mpi_convenience_libs)
+
+else !BUILD_PROFILING_LIB
+
+lib_LTLIBRARIES += lib/lib@MPIABILIBNAME@.la
+lib_lib@MPIABILIBNAME@_la_SOURCES = $(mpi_abi_sources) $(mpi_core_sources)
+lib_lib@MPIABILIBNAME@_la_LDFLAGS = $(external_ldflags) $(ABIVERSIONFLAGS)
+lib_lib@MPIABILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) $(abi_cppflags)
+lib_lib@MPIABILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs) $(mpi_convenience_libs)
+EXTRA_lib_lib@MPIABILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs) $(mpi_convenience_libs)
+endif !BUILD_PROFILING_LIB
+endif BUILD_ABI_LIB
 
 if BUILD_F77_BINDING
 lib_LTLIBRARIES += lib/lib@MPIFCLIBNAME@.la
@@ -209,6 +245,7 @@ install-exec-hook:
 	    . lib/lib@MPILIBNAME@.la ; \
 	fi ; \
 	for e in ${DESTDIR}${bindir}/@MPICC_NAME@ ${DESTDIR}${bindir}/@MPICXX_NAME@ \
+	        ${DESTDIR}${bindir}/@MPICC_ABI_NAME@ \
 		${DESTDIR}${bindir}/@MPIF77_NAME@ ${DESTDIR}${bindir}/@MPIFORT_NAME@ ; do \
 		if test -e $${e} ; then \
 			sed -e 's|__PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__|${prefix}|g' \

--- a/autogen.sh
+++ b/autogen.sh
@@ -462,6 +462,10 @@ fn_romio_glue() {
     echo "done"
 }
 
+fn_abi() {
+    ($PYTHON maint/gen_abi.py)
+}
+
 fn_f77() {
     set_PYTHON
     echo_n "Building Fortran 77 interface... "
@@ -1037,6 +1041,8 @@ fn_gen_binding_c
 ########################################################################
 
 # Create the bindings if necessary 
+fn_abi
+
 if [ $do_f77 = "yes" ] ; then
     fn_f77
 else

--- a/configure.ac
+++ b/configure.ac
@@ -479,6 +479,10 @@ AC_ARG_ENABLE(debuginfo,
 	AS_HELP_STRING([--enable-debuginfo], [Enable support for debuggers]),,
 	enable_debuginfo=no)
 
+AC_ARG_ENABLE(mpi-abi,
+        AS_HELP_STRING([--enable-mpi-abi], [Enable building libmpi_abi.so]),,
+        enable_mpi_abi=no)
+AM_CONDITIONAL([BUILD_ABI_LIB], [test "$enable_mpi_abi" = "yes"])
 
 ## Enable creation of libtool-style versioning or no versioning
 AC_ARG_ENABLE(versioning,
@@ -862,6 +866,8 @@ m4_map([PAC_SUBCFG_DO_PREREQ], [PAC_SUBCFG_MODULE_LIST])
 # Set default library names if names haven't already been provided
 AC_ARG_VAR([MPILIBNAME],[can be used to override the name of the MPI library (default: "mpi")])
 AC_ARG_VAR([PMPILIBNAME],[can be used to override the name of the MPI profiling library (default: "p$MPILIBNAME")])
+AC_ARG_VAR([MPIABILIBNAME],[can be used to override the name of the MPI library (default: "mpi_abi")])
+AC_ARG_VAR([PMPIABILIBNAME],[can be used to override the name of the MPI profiling library (default: "p$MPIABILIBNAME")])
 AC_ARG_VAR([MPICXXLIBNAME],[can be used to override the name of the MPI C++ library (default: "${MPILIBNAME}cxx")])
 AC_ARG_VAR([MPIFCLIBNAME],[can be used to override the name of the MPI fortran library (default: "${MPILIBNAME}fort")])
 MPILIBNAME=${MPILIBNAME:-"mpi"}
@@ -870,6 +876,8 @@ if test -n "$PMPILIBNAME" ; then
    PMPILIBNAME_set=yes
 fi
 PMPILIBNAME=${PMPILIBNAME:-"p$MPILIBNAME"}
+MPIABILIBNAME=${MPIABILIBNAME:-"mpi_abi"}
+PMPIABILIBNAME=${PMPIABILIBNAME:-"p$MPIABILIBNAME"}
 # Note that the name for this library may be updated after we check for
 # enable_shmem
 # Fortran names are set later.
@@ -3742,11 +3750,15 @@ fi
 # Setup other replaceable values
 AC_SUBST(MPILIBNAME)
 AC_SUBST(PMPILIBNAME)
+AC_SUBST(MPIABILIBNAME)
+AC_SUBST(PMPIABILIBNAME)
 
 if test "$NEEDSPLIB" = "yes" ; then
    LPMPILIBNAME="-l${PMPILIBNAME}"
+   LPMPIABILIBNAME="-l${PMPILABIIBNAME}"
 fi
 AC_SUBST(LPMPILIBNAME)
+AC_SUBST(LPMPIABILIBNAME)
 
 # ----------------------------------------------------------------------------
 
@@ -3989,12 +4001,14 @@ export MPI_NO_RMA
 
 # Attach program prefix and suffix to executable names for Makefile
 AC_SUBST(MPICC_NAME)
+AC_SUBST(MPICC_ABI_NAME)
 AC_SUBST(MPICXX_NAME)
 AC_SUBST(MPICPP_NAME)
 AC_SUBST(MPIFORT_NAME)
 AC_SUBST(MPIF90_NAME)
 AC_SUBST(MPIF77_NAME)
 PAC_GET_EXENAME("mpicc", MPICC_NAME)
+PAC_GET_EXENAME("mpicc_abi", MPICC_ABI_NAME)
 PAC_GET_EXENAME("mpicxx", MPICXX_NAME)
 PAC_GET_EXENAME("mpic++", MPICPP_NAME)
 PAC_GET_EXENAME("mpifort", MPIFORT_NAME)
@@ -4266,6 +4280,8 @@ AC_CONFIG_FILES([Makefile \
           src/env/mpixxx_opts.conf \
           src/env/mpicc.sh \
 	  src/env/mpicc.bash \
+          src/env/mpicc_abi.sh \
+	  src/env/mpicc_abi.bash \
           src/env/mpicxx.sh \
 	  src/env/mpicxx.bash \
 	  src/env/mpifort.sh \

--- a/configure.ac
+++ b/configure.ac
@@ -1460,7 +1460,11 @@ if test "$enable_romio" = "yes" ; then
        HAVE_ROMIO='#include "mpio.h"'
        # tell mpicxx.h that we have IO
        HAVE_CXX_IO=1
-       PAC_CONFIG_SUBDIR_ARGS([src/mpi/romio],[],[],[AC_MSG_ERROR([src/mpi/romio configure failed])])
+       romio_subdir_args=""
+       if test "$enable_mpi_abi" = "yes" ; then
+           romio_subdir_args="--enable-mpi-abi"
+       fi
+       PAC_CONFIG_SUBDIR_ARGS([src/mpi/romio],[$romio_subdir_args],[],[AC_MSG_ERROR([src/mpi/romio configure failed])])
    else
        AC_MSG_WARN([ROMIO src directory is not available])
    fi

--- a/maint/code-cleanup.bash
+++ b/maint/code-cleanup.bash
@@ -132,6 +132,7 @@ ignore_list="$ignore_list|src/pmi/include/pmix_abi_support_bottom.h"
 ignore_list="$ignore_list|src/pmi/include/pmix_fns.h"
 ignore_list="$ignore_list|src/pmi/include/pmix_macros.h"
 ignore_list="$ignore_list|src/pmi/include/pmix_types.h"
+ignore_list="$ignore_list|src/binding/abi/mpi_abi.h"
 
 filelist=""
 

--- a/maint/gen_abi.py
+++ b/maint/gen_abi.py
@@ -1,0 +1,221 @@
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+import re
+import os
+
+class G:
+    abi_h_lines = []
+    abi_datatypes = {}
+    abi_ops = {}
+
+class RE:
+    m = None
+    def match(pat, str, flags=0):
+        RE.m = re.match(pat, str, flags)
+        return RE.m
+    def search(pat, str, flags=0):
+        RE.m = re.search(pat, str, flags)
+        return RE.m
+
+def main():
+    load_mpi_abi_h("src/binding/abi/mpi_abi.h")
+    dump_mpi_abi_internal_h("src/binding/abi/mpi_abi_internal.h")
+    dump_romio_abi_internal_h("src/mpi/romio/include/romio_abi_internal.h")
+    dump_mpi_abi_util_c("src/binding/abi/mpi_abi_util.c")
+
+def load_mpi_abi_h(mpi_abi_h):
+    with open(mpi_abi_h, "r") as In:
+        G.abi_h_lines = In.readlines()
+
+def dump_mpi_abi_internal_h(mpi_abi_internal_h):
+    def gen_mpi_abi_internal_h(out):
+        re_Handle = r'\bMPI_(Comm|Datatype|Errhandler|Group|Info|Message|Op|Request|Session|Win|KEYVAL_INVALID|TAG_UB|IO|HOST|WTIME_IS_GLOBAL|APPNUM|LASTUSEDCODE|UNIVERSE_SIZE|WIN_BASE|WIN_DISP_UNIT|WIN_SIZE|WIN_CREATE_FLAVOR|WIN_MODEL)\b'
+        for line in G.abi_h_lines:
+            if RE.search(r'MPI_ABI_H_INCLUDED', line):
+                # skip the include guard, harmless
+                pass
+            elif RE.match(r'\s*int MPI_(SOURCE|TAG|ERROR);', line):
+                # no need to rename status fields
+                out.append(line.rstrip())
+            elif RE.match(r'\s*int (reserved|internal)\[(\d+)\];', line):
+                n = int(RE.m.group(2))
+                out.append("    int count_lo;")
+                out.append("    int count_hi_and_cancelled;")
+                out.append("    int reserved[%d];" % (n - 2))
+            elif RE.match(r'#define\s+(MPI_\w+)\s+\((MPI_\w+)\)\s*(0x\S+)', line):
+                (name, T, val) = RE.m.group(1,2,3)
+                idx = int(val, 0) & 0xff
+                if T == "MPI_Datatype":
+                    G.abi_datatypes[idx] = name
+                elif T == "MPI_Op":
+                    G.abi_ops[idx] = name
+
+                if T == "MPI_File":
+                    # pass through
+                    out.append(line.rstrip())
+                else:
+                    # replace param prefix
+                    out.append(re.sub(r'\bMPI_', 'ABI_', line.rstrip()))
+            elif RE.match(r'^typedef struct \w+\s*\*\s*(MPI_T_\w+);', line):
+                # rename to internal mpi_t struct type
+                T = RE.m.group(1)
+                out.append("typedef struct %s_s *%s;" % (re.sub(r'MPI_', 'MPIR_', T), T))
+            elif RE.match(r'^(int|double|MPI_\w+) (P?MPI\w+)\((.*)\);', line):
+                # prototypes, rename param prefix, add MPICH_API_PUBLIC
+                (T, name, param) = RE.m.group(1,2,3)
+                T=re.sub(re_Handle, r'ABI_\1', T)
+                param=re.sub(re_Handle, r'ABI_\1', param)
+                out.append("%s %s(%s) MPICH_API_PUBLIC;" % (T, name, param))
+            else:
+                # replace param prefix
+                out.append(re.sub(re_Handle, r'ABI_\1', line.rstrip()))
+
+    # ----
+    output_lines = []
+    gen_mpi_abi_internal_h(output_lines)
+
+    print(" --> [%s]" % mpi_abi_internal_h)
+    with open(mpi_abi_internal_h, "w") as Out:
+        dump_copyright(Out)
+        print("#ifndef MPI_ABI_INTERNAL_H_INCLUDED", file=Out)
+        print("#define MPI_ABI_INTERNAL_H_INCLUDED", file=Out)
+        print("", file=Out)
+
+        print("", file=Out)
+        for line in output_lines:
+            print(line, file=Out)
+        print("", file=Out)
+        
+        print("#define ABI_MAX_DATATYPE_BUILTINS %d" % len(G.abi_datatypes), file=Out)
+        print("#define ABI_MAX_OP_BUILTINS %d" % len(G.abi_ops), file=Out)
+        print("", file=Out)
+
+        print("#endif /* MPI_ABI_INTERNAL_H_INCLUDED */", file=Out)
+
+def dump_romio_abi_internal_h(romio_abi_internal_h):
+    def gen_romio_abi_internal_h(out):
+        for line in G.abi_h_lines:
+            if RE.search(r'MPI_ABI_H_INCLUDED', line):
+                # skip the include guard, harmless
+                pass
+            elif RE.match(r'typedef struct.*\bMPI_File;\s*$', line):
+                out.append("typedef struct ADIOI_FileD *MPI_File;")
+            elif RE.match(r'(int|double|MPI_\w+) (P?MPI\w+)\((.*)\);', line):
+                # prototypes, rename param prefix, add MPICH_API_PUBLIC
+                (T, name, param) = RE.m.group(1,2,3)
+                if RE.match(r'P?MPI_File_\w+', name):
+                    out.append("%s %s(%s) ROMIO_API_PUBLIC;" % (T, name, param))
+                else:
+                    out.append("%s %s(%s);" % (T, name, param))
+            else:
+                # replace param prefix
+                out.append(line.rstrip())
+
+    def add_romio_visibility(out):
+        out.append("#if defined(HAVE_VISIBILITY)")
+        out.append("#define ROMIO_API_PUBLIC __attribute__((visibility (\"default\")))")
+        out.append("#else")
+        out.append("#define ROMIO_API_PUBLIC")
+        out.append("#endif")
+        out.append("")
+
+    def add_mpix_grequest(out):
+        out.append("#define MPIO_Request MPI_Request")
+        out.append("#define MPIO_USES_MPI_REQUEST")
+        out.append("#define MPIO_Wait MPI_Wait")
+        out.append("#define MPIO_Test MPI_Test")
+        out.append("#define PMPIO_Wait PMPI_Wait")
+        out.append("#define PMPIO_Test PMPI_Test")
+        out.append("#define MPIO_REQUEST_DEFINED")
+        out.append("")
+        # they are not in the header, but they are in c_binding_abi.c
+        out.append("typedef int MPIX_Grequest_class;")
+        out.append("typedef int (MPIX_Grequest_poll_function)(void *, MPI_Status *);")
+        out.append("typedef int (MPIX_Grequest_wait_function)(int, void **, double, MPI_Status *);")
+        out.append("int MPIX_Grequest_start(MPI_Grequest_query_function *query_fn, MPI_Grequest_free_function *free_fn, MPI_Grequest_cancel_function *cancel_fn, MPIX_Grequest_poll_function *poll_fn, MPIX_Grequest_wait_function *wait_fn, void *extra_state, MPI_Request *request);")
+        out.append("int MPIX_Grequest_class_create(MPI_Grequest_query_function *query_fn, MPI_Grequest_free_function *free_fn, MPI_Grequest_cancel_function *cancel_fn, MPIX_Grequest_poll_function *poll_fn, MPIX_Grequest_wait_function *wait_fn, MPIX_Grequest_class *greq_class);")
+        out.append("int MPIX_Grequest_class_allocate(MPIX_Grequest_class greq_class, void *extra_state, MPI_Request *request);")
+        out.append("int PMPIX_Grequest_start(MPI_Grequest_query_function *query_fn, MPI_Grequest_free_function *free_fn, MPI_Grequest_cancel_function *cancel_fn, MPIX_Grequest_poll_function *poll_fn, MPIX_Grequest_wait_function *wait_fn, void *extra_state, MPI_Request *request);")
+        out.append("int PMPIX_Grequest_class_create(MPI_Grequest_query_function *query_fn, MPI_Grequest_free_function *free_fn, MPI_Grequest_cancel_function *cancel_fn, MPIX_Grequest_poll_function *poll_fn, MPIX_Grequest_wait_function *wait_fn, MPIX_Grequest_class *greq_class);")
+        out.append("int PMPIX_Grequest_class_allocate(MPIX_Grequest_class greq_class, void *extra_state, MPI_Request *request);")
+        out.append("")
+
+    def add_mpix_iov(out):
+        out.append("typedef struct MPIX_Iov {")
+        out.append("    void *iov_base;")
+        out.append("    MPI_Aint iov_len;")
+        out.append("} MPIX_Iov;")
+        out.append("")
+        out.append("int MPIX_Type_iov_len(MPI_Datatype datatype, MPI_Count max_iov_bytes, MPI_Count *iov_len, MPI_Count *actual_iov_bytes);")
+        out.append("int MPIX_Type_iov(MPI_Datatype datatype, MPI_Count iov_offset, MPIX_Iov *iov, MPI_Count max_iov_len, MPI_Count *actual_iov_len);")
+        out.append("")
+
+    def add_other(out):
+        out.append("#define MPICH")  # ref. mpi-io/mpich_fileutil.c
+        out.append("#define MPIR_ERRORS_THROW_EXCEPTIONS (MPI_Errhandler)0")
+
+    # ----
+    output_lines = []
+    add_romio_visibility(output_lines)
+    gen_romio_abi_internal_h(output_lines)
+    add_mpix_grequest(output_lines)
+    add_mpix_iov(output_lines)
+    add_other(output_lines)
+
+    print(" --> [%s]" % romio_abi_internal_h)
+    with open(romio_abi_internal_h, "w") as Out:
+        dump_copyright(Out)
+        print("#ifndef ROMIO_ABI_INTERNAL_H_INCLUDED", file=Out)
+        print("#define ROMIO_ABI_INTERNAL_H_INCLUDED", file=Out)
+        print("", file=Out)
+
+        for line in output_lines:
+            print(line, file=Out)
+        print("", file=Out)
+        
+        print("#endif /* ROMIO_ABI_INTERNAL_H_INCLUDED */", file=Out)
+
+def dump_mpi_abi_util_c(mpi_abi_util_c):
+    def dump_init_once(Out):
+        print("    static int initialized = 0;", file=Out)
+        print("    if (initialized) {", file=Out)
+        print("        return;", file=Out)
+        print("    }", file=Out)
+        print("    initialized = 1;", file=Out)
+        print("", file=Out)
+    # ----
+    print(" --> [%s]" % mpi_abi_util_c)
+    with open(mpi_abi_util_c, "w") as Out:
+        dump_copyright(Out)
+        print("#include \"mpiimpl.h\"", file=Out)
+        print("#include \"mpi_abi_util.h\"", file=Out)
+        print("", file=Out)
+        print("MPI_Datatype abi_datatype_builtins[ABI_MAX_DATATYPE_BUILTINS];", file=Out)
+        print("MPI_Op abi_op_builtins[ABI_MAX_OP_BUILTINS];", file=Out)
+        print("", file=Out)
+        print("void ABI_init_builtins(void)", file=Out)
+        print("{", file=Out)
+        dump_init_once(Out)
+        for idx in G.abi_datatypes.keys():
+            print("    abi_datatype_builtins[%d] = %s;" % (idx, G.abi_datatypes[idx]), file=Out)
+        print("", file=Out)
+        for idx in G.abi_ops.keys():
+            print("    abi_op_builtins[%d] = %s;" % (idx, G.abi_ops[idx]), file=Out)
+        print("}", file=Out)
+    num_datatypes = len(G.abi_datatypes)
+    G.abi_h_lines.append("#define ABI_MAX_DATATYPE_BUILTINS %d" % num_datatypes)
+
+def dump_copyright(Out):
+    print("/*", file=Out)
+    print(" * Copyright (C) by Argonne National Laboratory", file=Out)
+    print(" *     See COPYRIGHT in top-level directory", file=Out)
+    print(" */", file=Out)
+    print("/* This file is automatically generated. DO NOT EDIT. */", file=Out)
+    print("", file=Out)
+
+#----------------------------------------
+if __name__ == "__main__":
+    main()

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -36,7 +36,9 @@ def dump_mpi_c(func, is_large=False):
 
     process_func_parameters(func)
 
-    G.mpi_declares.append(get_declare_function(func, is_large, "proto"))
+    # for mpi_proto.h. The abi prototypes are already in mpi_abi.h.
+    if "_is_abi" not in func:
+        G.mpi_declares.append(get_declare_function(func, is_large, "proto"))
 
     # collect error codes additional from auto generated ones
     if 'error' in func:
@@ -90,9 +92,12 @@ def dump_mpi_c(func, is_large=False):
         dump_function_internal(func, kind="normal")
     G.out.append("")
 
-    # Create the MPI and QMPI wrapper functions that will call the above, "real" version of the
-    # function in the internal prefix
-    dump_qmpi_wrappers(func, func['_is_large'])
+    if '_is_abi' in func:
+        dump_abi_wrappers(func, func['_is_large'])
+    else:
+        # Create the MPI and QMPI wrapper functions that will call the above, "real" version of the
+        # function in the internal prefix
+        dump_qmpi_wrappers(func, func['_is_large'])
 
 def get_func_file_path(func, root_dir):
     file_path = None
@@ -201,6 +206,16 @@ def dump_mpir_impl_h(f):
             print(l, file=Out)
         print("", file=Out)
         print("#endif /* MPIR_IMPL_H_INCLUDED */", file=Out)
+
+def filter_out_abi():
+    funcname = None
+    for l in G.out:
+        if RE.match(r'int (\w+)\(.*', l):
+            funcname = RE.m.group(1)
+        elif RE.match(r'{'):
+            pass
+        elif RE.match(r'}'):
+            pass
 
 def get_qmpi_decl_from_func_decl(func_decl, kind=""):
     if RE.match(r'(.*) (MPIX?_\w+)\((.*?)\)(.*)', func_decl):
@@ -846,8 +861,6 @@ def dump_qmpi_wrappers(func, is_large):
     G.out.append("}")
     G.out.append("#else /* ENABLE_QMPI */")
 
-    G.out.append("")
-
     dump_line_with_break(func_decl)
     G.out.append("{")
     if func_name == "MPI_Pcontrol":
@@ -856,7 +869,236 @@ def dump_qmpi_wrappers(func, is_large):
         G.out.append("")
     G.out.append("    return " + static_call + ";")
     G.out.append("}")
+    G.out.append("")
     G.out.append("#endif /* ENABLE_QMPI */")
+
+def dump_abi_wrappers(func, is_large):
+    func_name = get_function_name(func, is_large)
+
+    mapping = get_kind_map('C', is_large)
+    param_list = []
+    assertion_types = {}
+    pre_filters = []
+    post_filters = []
+
+    # prepare for array of handles
+    array_type = None
+    array_size = None
+    is_alltoallw = False
+    is_neighbor_alltoallw = False
+    if re.match(r'mpi_i?alltoallw(_init)?', func['name'], re.IGNORECASE):
+        array_type = "Datatype"
+        array_size = "comm_size"
+        is_alltoallw = True
+        pre_filters.append("MPI_Comm comm = ABI_Comm_to_mpi(comm_abi);")
+        pre_filters.append("MPIR_Comm *comm_ptr;")
+        pre_filters.append("MPIR_Comm_get_ptr(comm, comm_ptr);")
+        pre_filters.append("int comm_size;")
+        pre_filters.append("comm_size = (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) ? comm_ptr->remote_size : comm_ptr->local_size;")
+    elif re.match(r'mpi_i?neighbor_alltoallw(_init)?', func['name'], re.IGNORECASE):
+        array_type = "Datatype"
+        is_neighbor_alltoallw = True
+        # array_size set per parameters
+        pre_filters.append("int indegree, outdegree, weighted;")
+        pre_filters.append("PMPI_Dist_graph_neighbors_count(comm_abi, &indegree, &outdegree, &weighted);")
+    elif re.match(r'mpi_type_(create_struct|struct)', func['name'], re.IGNORECASE):
+        array_type = "Datatype"
+        array_size = "count"
+    elif re.match(r'mpi_type_get_contents', func['name'], re.IGNORECASE):
+        array_type = "Datatype"
+        array_size = "max_datatypes"
+    elif re.match(r'mpi_t_event_get_info', func['name'], re.IGNORECASE):
+        # special treatment below because it is optional
+        array_type = "Datatype"
+        array_size = "(*num_elements)"
+    elif re.match(r'mpi_comm_spawn_multiple', func['name'], re.IGNORECASE):
+        array_type = "Info"
+        array_size = "count"
+    elif re.match(r'mpi_((wait|test|request_get_status_)(all|any)|startall)', func['name'], re.IGNORECASE):
+        array_type = "Request"
+        array_size = "count"
+    elif re.match(r'mpi_(wait|test|request_get_status_)some', func['name'], re.IGNORECASE):
+        array_type = "Request"
+        array_size = "incount"
+
+    # ----
+    def process_handle(p):
+        nonlocal array_size
+        name = p['name']
+        T = re.sub(r'MPI_', '', mapping[p['kind']])
+        # translate to internal parameters
+        if p['length']:
+            # neighbor_alltoallw
+            if is_neighbor_alltoallw:
+                if name == "recvtypes":
+                    array_size = "indegree"
+                elif name == "sendtypes":
+                    array_size = "outdegree"
+
+            if re.match(r'mpi_t_event_get_info', func['name'], re.IGNORECASE):
+                # array_of_datatypes[]
+                pre_filters.append("MPI_%s *%s = NULL;" % (array_type, name))
+                pre_filters.append("if (num_elements) {")
+                pre_filters.append("    %s = MPL_malloc(sizeof(MPI_%s) * %s, MPL_MEM_OTHER);" % (name, array_type, array_size))
+                pre_filters.append("}")
+                post_filters.append("if (num_elements) {")
+                post_filters.append("    for (int i = 0; i < %s; i++) {" % array_size)
+                post_filters.append("        %s_abi[i] = ABI_%s_from_mpi(%s[i]);" % (name, array_type, name))
+                post_filters.append("    }")
+                post_filters.append("}")
+            elif array_size:
+                # assume input only
+                pre_filters.append("MPI_%s *%s;" % (array_type, name))
+                if is_alltoallw:
+                    if name == "sendtypes":
+                        pre_filters.append("if (sendbuf == MPI_IN_PLACE) {")
+                        pre_filters.append("    sendtypes = NULL;")
+                        pre_filters.append("} else {")
+                        pre_filters.append("INDENT")
+                    elif name == "recvtypes":
+                        # if sendtypes == recvtypes, imitate to facilitate ALIAS check
+                        pre_filters.append("if (recvtypes_abi == sendtypes_abi) {")
+                        pre_filters.append("    recvtypes = sendtypes;")
+                        pre_filters.append("} else {")
+                        pre_filters.append("INDENT")
+                pre_filters.append("%s = MPL_malloc(sizeof(MPI_%s) * %s, MPL_MEM_OTHER);" % (name, array_type, array_size))
+                if p['param_direction'] == 'in' or p['param_direction'] == 'inout':
+                    pre_filters.append("for (int i = 0; i < %s; i++) {" % array_size)
+                    pre_filters.append("    %s[i] = ABI_%s_to_mpi(%s_abi[i]);" % (name, array_type, name))
+                    pre_filters.append("}")
+                if p['param_direction'] == 'out' or p['param_direction'] == 'inout':
+                    if RE.match(r'mpi_(Wait|Test|Request_get_status_)any', func['name'], re.IGNORECASE):
+                        if RE.m.group(1) != 'Wait':
+                            post_filters.append("if (*flag && *indx != MPI_UNDEFINED) {")
+                        else:
+                            post_filters.append("if (*indx != MPI_UNDEFINED) {")
+                        post_filters.append("    %s_abi[*indx] = ABI_%s_from_mpi(%s[*indx]);" % (name, array_type, name))
+                        post_filters.append("}")
+                    elif re.match(r'mpi_(Wait|Test|Request_get_status_)some', func['name'], re.IGNORECASE):
+                        post_filters.append("for (int i = 0; i < *outcount; i++) {")
+                        post_filters.append("    int idx = array_of_indices[i];")
+                        post_filters.append("    %s_abi[idx] = ABI_%s_from_mpi(%s[idx]);" % (name, array_type, name))
+                        post_filters.append("}")
+                    else:
+                        post_filters.append("for (int i = 0; i < %s; i++) {" % array_size)
+                        post_filters.append("    %s_abi[i] = ABI_%s_from_mpi(%s[i]);" % (name, array_type, name))
+                        post_filters.append("}")
+                if is_alltoallw:
+                    if name == "sendtypes":
+                        pre_filters.append("DEDENT")
+                        pre_filters.append("}")
+                        post_filters.append("if (sendbuf != MPI_IN_PLACE) {")
+                        post_filters.append("INDENT")
+                    elif name == "recvtypes":
+                        pre_filters.append("DEDENT")
+                        pre_filters.append("}")
+                        post_filters.append("if (recvtypes != sendtypes) {")
+                        post_filters.append("INDENT")
+                post_filters.append("MPL_free(%s);" % name)
+                if is_alltoallw and (name == "sendtypes" or name == "recvtypes"):
+                    post_filters.append("DEDENT")
+                    post_filters.append("}")
+            else:
+                # show what we are missing (hopefully none)
+                print("Function %s - array param %s" % (func['name'], p['name']))
+        else:
+            if p['param_direction'] == 'out':
+                pre_filters.append("MPI_%s %s_i;" % (T, name))
+                pre_filters.append("MPI_%s *%s = &%s_i;" % (T, name, name))
+                # pass NULL thru for error-checking
+                pre_filters.append("if (%s_abi == NULL) {" % name)
+                pre_filters.append("    %s = NULL;" % name)
+                pre_filters.append("}")
+                if RE.match(r'MPI_T_cvar_get_info', func['name']):
+                    post_filters.append("if (%s_abi) {" % name)
+                    post_filters.append("    *%s_abi = ABI_%s_from_mpi(%s_i);" % (name, T, name));
+                    post_filters.append("}")
+                else:
+                    # FIXME: which cases should we leave the output handle untouched?
+                    if T == 'Comm':
+                        post_filters.append("if (%s_abi) {" % name)
+                    else:
+                        post_filters.append("if (ret == MPI_SUCCESS) {")
+                    post_filters.append("    *%s_abi = ABI_%s_from_mpi(%s_i);" % (name, T, name));
+                    post_filters.append("}")
+            elif p['param_direction'] == 'inout' or func['name'] == "MPI_Cancel":
+                pre_filters.append("MPI_%s %s_i;" % (T, name))
+                pre_filters.append("%s_i = ABI_%s_to_mpi(*%s_abi);" % (name, T, name))
+                pre_filters.append("MPI_%s *%s = &%s_i;" % (T, name, name))
+                post_filters.append("*%s_abi = ABI_%s_from_mpi(%s_i);" % (name, T, name));
+            elif is_alltoallw and name == "comm":
+                # already done
+                pass
+            else:
+                pre_filters.append("MPI_%s %s = ABI_%s_to_mpi(%s_abi);" % (T, name, T, name))
+
+    def out_can_be_undefined(p):
+        if p['param_direction'] == 'out':
+            if 'desc' in p and re.search(r'MPI_UNDEFINED', p['desc']):
+                return True
+            elif func['name'] == "MPI_Get_count":
+                return True
+        return False
+    # ----
+    for p in func['c_parameters']:
+        skip_abi_swap = False
+        param_type = mapping[p['kind']]
+        name = p['name']
+        if RE.match(r'MPI_(Comm|Datatype|Errhandler|Group|Info|Message|Op|Request|Session|Win)\b', param_type):
+            process_handle(p)
+        elif p['kind'] == 'KEYVAL' and p['param_direction'] == 'in':
+            pre_filters.append("int %s = ABI_KEYVAL_to_mpi(%s_abi);" % (name, name))
+        else:
+            skip_abi_swap = True
+
+        # MPI_Comm comm -> ABI_Comm comm_abi
+        param = get_C_param(p, func, mapping)
+        param = re.sub(r'MPI_(Comm|Datatype|Errhandler|Group|Info|Message|Op|Request|Session|Win)\b', r'ABI_\1', param)
+        if not skip_abi_swap:
+            param = re.sub(r'\b' + name, name+"_abi", param)
+        param_list.append(param)
+
+    if not len(param_list):
+        param_list.append("void")
+
+    ret = "int"
+    if 'return' in func:
+        ret = mapping[func['return']]
+        ret = re.sub(r'MPI_(Comm|Datatype|Errhandler|Group|Info|Message|Op|Request|Session|Win)\b', r'ABI_\1', ret)
+
+    static_call = get_static_call_internal(func, is_large)
+
+    s_param = ', '.join(param_list)
+    func_decl = "%s %s(%s)" % (ret, func_name, s_param)
+    dump_line_with_break(func_decl)
+    G.out.append("{")
+    G.out.append("INDENT")
+    for T in assertion_types:
+        G.out.append("MPIR_Assert(sizeof(ABI_%s) == sizeof(MPI_%s));" % (T, T))
+
+    for l in pre_filters:
+        G.out.append(l)
+
+    if ret != 'int':
+        # MPI_Wtime, MPI_Aint_{add,diff}, MPI_{Comm,...}_{c2f,f2c}
+        if RE.match(r'..._(Comm|Datatype|Errhandler|Group|Info|Message|Op|Request|Session|Win)\b', ret):
+            G.out.append("return ABI_%s_from_mpi(%s);" % (RE.m.group(1), static_call))
+        else:
+            G.out.append("return " + static_call + ";")
+    else:
+        if func_name == "MPI_Pcontrol":
+            G.out.append("va_list varargs;")
+            G.out.append("va_start(varargs, level);")
+            G.out.append("")
+        G.out.append("int ret = " + static_call + ";")
+        for l in post_filters:
+            G.out.append(l)
+        if re.match(r'MPI_(Init|Init_thread|Session_init)$', func_name, re.IGNORECASE):
+            G.out.append("ABI_init_builtins();")
+        G.out.append("return ret;")
+    G.out.append("DEDENT")
+    G.out.append("}")
+    G.out.append("")
 
 def dump_profiling(func):
     func_name = get_function_name(func, func['_is_large'])
@@ -868,7 +1110,10 @@ def dump_profiling(func):
     G.out.append("#elif defined(HAVE_PRAGMA_CRI_DUP)")
     G.out.append("#pragma _CRI duplicate %s as P%s" % (func_name, func_name))
     G.out.append("#elif defined(HAVE_WEAK_ATTRIBUTE)")
-    s = get_declare_function(func, func['_is_large'])
+    kind = None
+    if "_is_abi" in func:
+        kind = "abi"
+    s = get_declare_function(func, func['_is_large'], kind)
     dump_line_with_break(s, " __attribute__ ((weak, alias(\"P%s\")));" % (func_name))
     G.out.append("#endif")
     G.out.append("/* -- End Profiling Symbol Block */")
@@ -1089,7 +1334,7 @@ def declare_call_replace_internal(func):
     G.out.append("")
     dump_line_with_break(s + ';')
 
-# used in dump_qmpi_wrappers, call the internal function
+# ref. dump_{qmpi,abi}_wrappers, call the internal function
 def get_static_call_internal(func, is_large):
     func_name = get_function_name(func, is_large)
     if 'replace' in func and 'body' not in func:
@@ -1800,9 +2045,12 @@ def get_fn_fail_create_code(func):
         else:
             err_fmts.append('%' + fmt)
 
-    G.mpi_errnames.append("**%s:%s failed" % (err_name, func_name))
+    if '_is_abi' not in func:
+        G.mpi_errnames.append("**%s:%s failed" % (err_name, func_name))
+        if args:
+            G.mpi_errnames.append("**%s %s:%s(%s) failed" % (err_name, ' '.join(fmts), func_name, ', '.join(err_fmts)))
+
     if args:
-        G.mpi_errnames.append("**%s %s:%s(%s) failed" % (err_name, ' '.join(fmts), func_name, ', '.join(err_fmts)))
         s += " \"**%s\", \"**%s %s\", %s);" % (err_name, err_name, ' '.join(fmts), ', '.join(args))
     else:
         s += " \"**%s\", 0);" % (err_name)
@@ -1988,7 +2236,7 @@ def dump_validate_handle_ptr(func, p):
     mpir = G.handle_mpir_types[kind]
     if kind == "REQUEST" and p['length']:
         G.err_codes['MPI_ERR_REQUEST'] = 1
-        if RE.match(r'mpix?_(test|wait)all', func['name'], re.IGNORECASE):
+        if RE.match(r'mpix?_(test|wait|request_get_status_)all', func['name'], re.IGNORECASE):
             # MPI_Testall and MPI_Waitall do pointer conversion inside MPIR_{Test,Wait}all
             pass
         else:
@@ -2569,6 +2817,8 @@ def get_declare_function(func, is_large, kind=""):
 
     params = get_C_params(func, mapping)
     s_param = ', '.join(params)
+    if kind == 'abi':
+        s_param = re.sub(r'\bMPI_', 'ABI_', s_param)
     s = "%s %s(%s)" % (ret, name, s_param)
 
     if kind == 'proto':

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -54,6 +54,9 @@ def dump_mpi_c(func, is_large=False):
     def dump_romio_reference(name):
         if G.need_dump_romio_reference:
             G.out.append("#if defined(HAVE_ROMIO) && defined(MPICH_MPI_FROM_PMPI)")
+            G.out.append("void MPIR_Comm_split_filesystem(void);")
+            G.out.append("void MPIR_ROMIO_Get_file_errhand(void);")
+            G.out.append("void MPIR_ROMIO_Set_file_errhand(void);")
             G.out.append("void *dummy_refs_%s[] = {" % name)
             G.out.append("    (void *) MPIR_Comm_split_filesystem,")
             G.out.append("    (void *) MPIR_ROMIO_Get_file_errhand,")

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -458,8 +458,9 @@ def check_func_directives(func):
             G.err_codes[a] = 1
 
     # additional exit_routines (clean up)
-    if 'code-clean_up' not in func:
-        func['code-clean_up'] = []
+    func['_clean_up'] = []
+    if 'code-clean_up' in func:
+        func['_clean_up'].extend(func['code-clean_up'])
 
     # cleanup internal states
     func.pop('_got_comm_size', None)
@@ -1298,9 +1299,8 @@ def dump_function_normal(func):
     # ----
     G.out.append("")
     G.out.append("fn_exit:")
-    for l in func['code-clean_up']:
+    for l in func['_clean_up']:
         G.out.append(l)
-    func['code-clean_up'] = []
     G.out.append("MPIR_FUNC_TERSE_EXIT;")
 
     if not '_skip_global_cs' in func:
@@ -1956,9 +1956,9 @@ def dump_convert_handle(func, p):
         G.out.append("        goto fn_fail;")
         G.out.append("    }")
         G.out.append("}")
-        func['code-clean_up'].append("if (%s > MPIR_REQUEST_PTR_ARRAY_SIZE) {" % (p['length']))
-        func['code-clean_up'].append("    MPL_free(request_ptrs);")
-        func['code-clean_up'].append("}")
+        func['_clean_up'].append("if (%s > MPIR_REQUEST_PTR_ARRAY_SIZE) {" % (p['length']))
+        func['_clean_up'].append("    MPL_free(request_ptrs);")
+        func['_clean_up'].append("}")
 
         G.out.append("")
         dump_for_open('i', p['length'])

--- a/src/binding/Makefile.mk
+++ b/src/binding/Makefile.mk
@@ -4,6 +4,7 @@
 ##
 
 include $(top_srcdir)/src/binding/c/Makefile.mk
+include $(top_srcdir)/src/binding/abi/Makefile.mk
 include $(top_srcdir)/src/binding/cxx/Makefile.mk
 include $(top_srcdir)/src/binding/fortran/mpif_h/Makefile.mk
 include $(top_srcdir)/src/binding/fortran/use_mpi/Makefile.mk

--- a/src/binding/abi/Makefile.mk
+++ b/src/binding/abi/Makefile.mk
@@ -1,0 +1,14 @@
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+if BUILD_ABI_LIB
+
+include_HEADERS += src/binding/abi/mpi_abi.h
+
+mpi_abi_sources += \
+    src/binding/abi/mpi_abi_util.c \
+    src/binding/abi/c_binding_abi.c
+
+endif BUILD_ABI_LIB

--- a/src/binding/abi/mpi_abi.h
+++ b/src/binding/abi/mpi_abi.h
@@ -1,77 +1,162 @@
-#ifndef MPI_ABI_H_INCLUDED
-#define MPI_ABI_H_INCLUDED
+#ifndef MPI_H_ABI
+#define MPI_H_ABI
+
+#include <stdint.h>
 
 #define MPI_VERSION 5
 #define MPI_SUBVERSION 0
 
-// String size constants
-#define MPI_MAX_DATAREP_STRING               128 // MPICH=OMPI=128 (MPICH has it in `mpio.h`)
-#define MPI_MAX_ERROR_STRING                 512 // MPICH was bigger
-#define MPI_MAX_INFO_KEY                     255 // MPICH was bigger
-#define MPI_MAX_INFO_VAL                    1024 // MPICH was bigger
-#define MPI_MAX_LIBRARY_VERSION_STRING      8192 // MPICH was bigger
-#define MPI_MAX_OBJECT_NAME                  128 // MPICH was bigger
-#define MPI_MAX_PORT_NAME                   1024 // OMPI was bigger
-#define MPI_MAX_PROCESSOR_NAME               256 // OMPI was bigger
-#define MPI_MAX_STRINGTAG_LEN               1024 // OMPI was bigger (v5.0+)
-#define MPI_MAX_PSET_NAME_LEN                512 // OMPI was bigger (v5.0+)
-
-#include <stdint.h>
+typedef intptr_t MPI_Aint;
+typedef int64_t  MPI_Offset;
+typedef intptr_t MPI_Count;
 
 typedef int MPI_Fint;
-typedef intptr_t MPI_Aint;
-typedef long long MPI_Offset;
-typedef MPI_Offset MPI_Count;
 
-/* FIXME: require configure */
-#define MPI_INTEGER_KIND  4
-#define MPI_ADDRESS_KIND  8
-#define MPI_OFFSET_KIND   8
-#define MPI_COUNT_KIND    8
-
-typedef struct mpi_comm_t * MPI_Comm;
-typedef struct mpi_datatype_t * MPI_Datatype;
-typedef struct mpi_errhandler_t * MPI_Errhandler;
-typedef struct mpi_file_t * MPI_File;
-typedef struct mpi_group_t * MPI_Group;
-typedef struct mpi_info_t * MPI_Info;
-typedef struct mpi_message_t * MPI_Message;
-typedef struct mpi_op_t * MPI_Op;
-typedef struct mpi_request_t * MPI_Request;
-typedef struct mpi_session_t * MPI_Session;
-typedef struct mpi_win_t * MPI_Win;
-
-typedef struct MPI_Status {
+typedef struct {
     int MPI_SOURCE;
     int MPI_TAG;
     int MPI_ERROR;
-    int reserved[5];
+    int internal[5];
 } MPI_Status;
 
-#define MPI_F_STATUS_SIZE 8
-#define MPI_F_SOURCE      0
-#define MPI_F_TAG         1
-#define MPI_F_ERROR       2
+typedef struct MPI_ABI_Op * MPI_Op;
+#define MPI_OP_NULL                    (MPI_Op)0x00000020
+#define MPI_SUM                        (MPI_Op)0x00000021
+#define MPI_MIN                        (MPI_Op)0x00000022
+#define MPI_MAX                        (MPI_Op)0x00000023
+#define MPI_PROD                       (MPI_Op)0x00000024
+#define MPI_BAND                       (MPI_Op)0x00000028
+#define MPI_BOR                        (MPI_Op)0x00000029
+#define MPI_BXOR                       (MPI_Op)0x0000002a
+#define MPI_LAND                       (MPI_Op)0x00000030
+#define MPI_LOR                        (MPI_Op)0x00000031
+#define MPI_LXOR                       (MPI_Op)0x00000032
+#define MPI_MINLOC                     (MPI_Op)0x00000038
+#define MPI_MAXLOC                     (MPI_Op)0x00000039
+#define MPI_REPLACE                    (MPI_Op)0x0000003c
+#define MPI_NO_OP                      (MPI_Op)0x0000003d
+
+typedef struct MPI_ABI_Comm * MPI_Comm;
+#define MPI_COMM_NULL                  (MPI_Comm)0x00000100
+#define MPI_COMM_WORLD                 (MPI_Comm)0x00000101
+#define MPI_COMM_SELF                  (MPI_Comm)0x00000102
+
+typedef struct MPI_ABI_Group * MPI_Group;
+#define MPI_GROUP_NULL                 (MPI_Group)0x00000108
+#define MPI_GROUP_EMPTY                (MPI_Group)0x00000109
+
+typedef struct MPI_ABI_Win * MPI_Win;
+#define MPI_WIN_NULL                   (MPI_Win)0x00000110
+
+typedef struct MPI_ABI_File * MPI_File;
+#define MPI_FILE_NULL                  (MPI_File)0x00000118
+
+typedef struct MPI_ABI_Session * MPI_Session;
+#define MPI_SESSION_NULL               (MPI_Session)0x00000120
+
+typedef struct MPI_ABI_Message * MPI_Message;
+#define MPI_MESSAGE_NULL               (MPI_Message)0x00000128
+#define MPI_MESSAGE_NO_PROC            (MPI_Message)0x00000129
+
+typedef struct MPI_ABI_Info * MPI_Info;
+#define MPI_INFO_NULL                  (MPI_Info)0x00000130
+#define MPI_INFO_ENV                   (MPI_Info)0x00000131
+
+typedef struct MPI_ABI_Errhandler * MPI_Errhandler;
+#define MPI_ERRHANDLER_NULL            (MPI_Errhandler)0x00000140
+#define MPI_ERRORS_ARE_FATAL           (MPI_Errhandler)0x00000141
+#define MPI_ERRORS_RETURN              (MPI_Errhandler)0x00000142
+#define MPI_ERRORS_ABORT               (MPI_Errhandler)0x00000143
+
+typedef struct MPI_ABI_Request * MPI_Request;
+#define MPI_REQUEST_NULL               (MPI_Request)0x00000180
+
+typedef struct MPI_ABI_Datatype * MPI_Datatype;
+#define MPI_DATATYPE_NULL              (MPI_Datatype)0x00000200
+#define MPI_AINT                       (MPI_Datatype)0x00000201
+#define MPI_COUNT                      (MPI_Datatype)0x00000202
+#define MPI_OFFSET                     (MPI_Datatype)0x00000203
+#define MPI_PACKED                     (MPI_Datatype)0x00000207
+#define MPI_SHORT                      (MPI_Datatype)0x00000208
+#define MPI_INT                        (MPI_Datatype)0x00000209
+#define MPI_LONG                       (MPI_Datatype)0x0000020a
+#define MPI_LONG_LONG                  (MPI_Datatype)0x0000020b
+#define MPI_LONG_LONG_INT              MPI_LONG_LONG
+#define MPI_UNSIGNED_SHORT             (MPI_Datatype)0x0000020c
+#define MPI_UNSIGNED                   (MPI_Datatype)0x0000020d
+#define MPI_UNSIGNED_LONG              (MPI_Datatype)0x0000020e
+#define MPI_UNSIGNED_LONG_LONG         (MPI_Datatype)0x0000020f
+#define MPI_FLOAT                      (MPI_Datatype)0x00000210
+#define MPI_C_FLOAT_COMPLEX            (MPI_Datatype)0x00000212
+#define MPI_C_COMPLEX                  MPI_C_FLOAT_COMPLEX
+#define MPI_CXX_FLOAT_COMPLEX          (MPI_Datatype)0x00000213
+#define MPI_DOUBLE                     (MPI_Datatype)0x00000214
+#define MPI_C_DOUBLE_COMPLEX           (MPI_Datatype)0x00000216
+#define MPI_CXX_DOUBLE_COMPLEX         (MPI_Datatype)0x00000217
+#define MPI_INTEGER                    (MPI_Datatype)0x00000218
+#define MPI_LOGICAL                    (MPI_Datatype)0x00000219
+#define MPI_REAL                       (MPI_Datatype)0x0000021a
+#define MPI_COMPLEX                    (MPI_Datatype)0x0000021b
+#define MPI_DOUBLE_PRECISION           (MPI_Datatype)0x0000021c
+#define MPI_DOUBLE_COMPLEX             (MPI_Datatype)0x0000021d
+#define MPI_LONG_DOUBLE                (MPI_Datatype)0x00000220
+#define MPI_C_LONG_DOUBLE_COMPLEX      (MPI_Datatype)0x00000224
+#define MPI_CXX_LONG_DOUBLE_COMPLEX    (MPI_Datatype)0x00000225
+#define MPI_FLOAT_INT                  (MPI_Datatype)0x00000228
+#define MPI_DOUBLE_INT                 (MPI_Datatype)0x00000229
+#define MPI_LONG_INT                   (MPI_Datatype)0x0000022a
+#define MPI_2INT                       (MPI_Datatype)0x0000022b
+#define MPI_SHORT_INT                  (MPI_Datatype)0x0000022c
+#define MPI_LONG_DOUBLE_INT            (MPI_Datatype)0x0000022d
+#define MPI_2REAL                      (MPI_Datatype)0x00000230
+#define MPI_2DOUBLE_PRECISION          (MPI_Datatype)0x00000231
+#define MPI_2INTEGER                   (MPI_Datatype)0x00000232
+#define MPI_C_BOOL                     (MPI_Datatype)0x00000238
+#define MPI_CXX_BOOL                   (MPI_Datatype)0x00000239
+#define MPI_WCHAR                      (MPI_Datatype)0x0000023c
+#define MPI_INT8_T                     (MPI_Datatype)0x00000240
+#define MPI_UINT8_T                    (MPI_Datatype)0x00000241
+#define MPI_CHAR                       (MPI_Datatype)0x00000243
+#define MPI_SIGNED_CHAR                (MPI_Datatype)0x00000244
+#define MPI_UNSIGNED_CHAR              (MPI_Datatype)0x00000245
+#define MPI_BYTE                       (MPI_Datatype)0x00000247
+#define MPI_INT16_T                    (MPI_Datatype)0x00000248
+#define MPI_UINT16_T                   (MPI_Datatype)0x00000249
+#define MPI_INT32_T                    (MPI_Datatype)0x00000250
+#define MPI_UINT32_T                   (MPI_Datatype)0x00000251
+#define MPI_INT64_T                    (MPI_Datatype)0x00000258
+#define MPI_UINT64_T                   (MPI_Datatype)0x00000259
+#define MPI_INTEGER1                   (MPI_Datatype)0x000002c0
+#define MPIX_LOGICAL1                  (MPI_Datatype)0x000002c1
+#define MPIX_REAL1                     (MPI_Datatype)0x000002c2
+#define MPI_CHARACTER                  (MPI_Datatype)0x000002c3
+#define MPI_INTEGER2                   (MPI_Datatype)0x000002c8
+#define MPIX_LOGICAL2                  (MPI_Datatype)0x000002c9
+#define MPIX_REAL2                     (MPI_Datatype)0x000002ca
+#define MPI_INTEGER4                   (MPI_Datatype)0x000002d0
+#define MPIX_LOGICAL4                  (MPI_Datatype)0x000002d1
+#define MPI_REAL4                      (MPI_Datatype)0x000002d2
+#define MPIX_COMPLEX4                  (MPI_Datatype)0x000002d3
+#define MPI_INTEGER8                   (MPI_Datatype)0x000002d8
+#define MPIX_LOGICAL8                  (MPI_Datatype)0x000002d9
+#define MPI_REAL8                      (MPI_Datatype)0x000002da
+#define MPI_COMPLEX8                   (MPI_Datatype)0x000002db
+#define MPI_INTEGER16                  (MPI_Datatype)0x000002e0
+#define MPI_REAL16                     (MPI_Datatype)0x000002e2
+#define MPI_COMPLEX16                  (MPI_Datatype)0x000002e3
+#define MPI_COMPLEX32                  (MPI_Datatype)0x000002eb
+
+enum {
+    // Status indexing - must match MPI_Status definition
+    MPI_F_SOURCE        = 0,
+    MPI_F_TAG           = 1,
+    MPI_F_ERROR         = 2,
+    // Fortran status array size and reserved index values (in C)
+    MPI_F_STATUS_SIZE   = 8
+};
 
 extern MPI_Fint * MPI_F_STATUS_IGNORE;
 extern MPI_Fint * MPI_F_STATUSES_IGNORE;
-
-// Buffer Address Constants
-#define MPI_BOTTOM           ((void *)0)
-#define MPI_IN_PLACE         ((void *)1)
-#define MPI_BUFFER_AUTOMATIC ((void *)2)
-
-// Other constants
-#define MPI_BSEND_OVERHEAD                   512 // MPICH=96, OMPI=128
-
-// Constants Specifying Empty or Ignored Input
-#define MPI_ARGV_NULL       ((char**)0)
-#define MPI_ARGVS_NULL      ((char***)0)
-#define MPI_ERRCODES_IGNORE ((int*)0)
-#define MPI_STATUS_IGNORE   ((MPI_Status*)0)
-#define MPI_STATUSES_IGNORE ((MPI_Status*)0)
-#define MPI_UNWEIGHTED      ((int*)2)
-#define MPI_WEIGHTS_EMPTY   ((int*)3)
 
 // Error classes
 enum {
@@ -158,11 +243,34 @@ enum {
     MPI_ERR_LASTCODE                    = 0x3fff // half of the minimum required value of INT_MAX
 };
 
-enum {
-    MPI_GRAPH,
-    MPI_CART,
-    MPI_DIST_GRAPH
-};
+// Buffer Address Constants
+#define MPI_BOTTOM           ((void*)0)
+#define MPI_IN_PLACE         ((void*)1)
+#define MPI_BUFFER_AUTOMATIC ((void*)2)
+
+// Constants Specifying Empty or Ignored Input
+#define MPI_ARGV_NULL       ((char**)0)
+#define MPI_ARGVS_NULL      ((char***)0)
+#define MPI_ERRCODES_IGNORE ((int*)0)
+#define MPI_STATUS_IGNORE   ((MPI_Status*)0)
+#define MPI_STATUSES_IGNORE ((MPI_Status*)0)
+#define MPI_UNWEIGHTED      ((int*)2)
+#define MPI_WEIGHTS_EMPTY   ((int*)3)
+
+// Other constants
+#define MPI_BSEND_OVERHEAD                   512 // MPICH=96, OMPI=128
+
+// String size constants
+#define MPI_MAX_DATAREP_STRING               128 // MPICH=OMPI=128 (MPICH has it in `mpio.h`)
+#define MPI_MAX_ERROR_STRING                 512 // MPICH was bigger
+#define MPI_MAX_INFO_KEY                     256 // MPICH was bigger
+#define MPI_MAX_INFO_VAL                    1024 // MPICH was bigger
+#define MPI_MAX_LIBRARY_VERSION_STRING      8192 // MPICH was bigger
+#define MPI_MAX_OBJECT_NAME                  128 // MPICH was bigger
+#define MPI_MAX_PORT_NAME                   1024 // OMPI was bigger
+#define MPI_MAX_PROCESSOR_NAME               256 // OMPI was bigger
+#define MPI_MAX_STRINGTAG_LEN               1024 // OMPI was bigger (v5.0+)
+#define MPI_MAX_PSET_NAME_LEN                512 // OMPI was bigger (v5.0+)
 
 // Mode Constants
 // must be powers-of-2 to support OR-ing
@@ -192,241 +300,161 @@ enum {
     MPI_ROOT            = -3,
 
     // tag sentinels - should be negative
-    MPI_ANY_TAG         = -101,
+    MPI_ANY_TAG         = -31,
 
-    // These apply to MPI_COMM_WORLD
-    MPI_TAG_UB          = -201,
-    MPI_IO              = -202,
-    MPI_HOST            = -203,
-    MPI_WTIME_IS_GLOBAL = -204,
-    MPI_APPNUM          = -205,
-    MPI_LASTUSEDCODE    = -206,
-    MPI_UNIVERSE_SIZE   = -207,
-
-    // Predefined Attribute Keys
-    // These apply to Windows
-    MPI_WIN_BASE            = -301,
-    MPI_WIN_DISP_UNIT       = -302,
-    MPI_WIN_SIZE            = -303,
-    MPI_WIN_CREATE_FLAVOR   = -304,
-    MPI_WIN_MODEL           = -305,
-
-    // attribute constant - must be negative
-    MPI_KEYVAL_INVALID  = -401,
+    // attribute constant - should be negative
+    MPI_KEYVAL_INVALID  = -127,
 
     // special displacement for sequential access file - should be negative
-    MPI_DISPLACEMENT_CURRENT = -501,
+    MPI_DISPLACEMENT_CURRENT = -255,
 
     // multi-purpose sentinel - must be negative
-    MPI_UNDEFINED       = -601,
+    MPI_UNDEFINED       = -32766 // make it match OMPI and MPICH
+};
 
-    //Results of communicator and group comparisons
-    MPI_IDENT       = -701,
-    MPI_CONGRUENT   = -702,
-    MPI_SIMILAR     = -703,
-    MPI_UNEQUAL     = -704,
-
+enum {
     // Environmental inquiry keys and Predefined Attribute Keys
     // Threads Constants
     // These values are monotonic; i.e., SINGLE < FUNNELED < SERIALIZED < MULTIPLE.
-    MPI_THREAD_MULTIPLE     = -801,
-    MPI_THREAD_SERIALIZED   = -802,
-    MPI_THREAD_FUNNELED     = -803,
-    MPI_THREAD_SINGLE       = -804,
+    MPI_THREAD_SINGLE     = 0, 
+    MPI_THREAD_FUNNELED   = 1,
+    MPI_THREAD_SERIALIZED = 2,
+    MPI_THREAD_MULTIPLE   = 7, // in case we need other threading levels below MULTIPLE
+
+    // array order
+    MPI_ORDER_C       = 0xC, // 12
+    MPI_ORDER_FORTRAN = 0xF, // 15
 
     // RMA lock constants - arbitrary values
-    MPI_LOCK_EXCLUSIVE  = -901,
-    MPI_LOCK_SHARED     = -902,
-
-    // Communicator split type constants - arbitrary values
-    MPI_COMM_TYPE_SHARED          = -1001,
-    MPI_COMM_TYPE_HW_UNGUIDED     = -1002,
-    MPI_COMM_TYPE_HW_GUIDED       = -1003,
-    MPI_COMM_TYPE_RESOURCE_GUIDED = -1004,
-
-    // MPI Window Create Flavors
-    MPI_WIN_FLAVOR_ALLOCATE = -1101,
-    MPI_WIN_FLAVOR_CREATE   = -1102,
-    MPI_WIN_FLAVOR_DYNAMIC  = -1103,
-    MPI_WIN_FLAVOR_SHARED   = -1104,
+    MPI_LOCK_SHARED    = 21,
+    MPI_LOCK_EXCLUSIVE = 22,
 
     // MPI Window Models
-    MPI_WIN_SEPARATE    = -1201,
-    MPI_WIN_UNIFIED     = -1202,
+    MPI_WIN_UNIFIED  = 31,
+    MPI_WIN_SEPARATE = 32,
+
+    // MPI Window Create Flavors
+    MPI_WIN_FLAVOR_ALLOCATE = 41,
+    MPI_WIN_FLAVOR_CREATE   = 42,
+    MPI_WIN_FLAVOR_DYNAMIC  = 43,
+    MPI_WIN_FLAVOR_SHARED   = 44,
+
+    //Results of communicator and group comparisons
+    MPI_IDENT       = 101,
+    MPI_CONGRUENT   = 102,
+    MPI_SIMILAR     = 103,
+    MPI_UNEQUAL     = 104,
+
+    // MPI_Topo_test
+    MPI_GRAPH      = 201,
+    MPI_DIST_GRAPH = 202,
+    MPI_CART       = 203,
 
     // Datatype Decoding Constants
-    MPI_COMBINER_NAMED              = -1301,
-    MPI_COMBINER_DUP                = -1302,
-    MPI_COMBINER_CONTIGUOUS         = -1303,
-    MPI_COMBINER_VECTOR             = -1304,
-    MPI_COMBINER_HVECTOR            = -1305,
-    MPI_COMBINER_INDEXED            = -1306,
-    MPI_COMBINER_HINDEXED           = -1307,
-    MPI_COMBINER_INDEXED_BLOCK      = -1308,
-    MPI_COMBINER_HINDEXED_BLOCK     = -1309,
-    MPI_COMBINER_STRUCT             = -1310,
-    MPI_COMBINER_SUBARRAY           = -1311,
-    MPI_COMBINER_DARRAY             = -1312,
-    MPI_COMBINER_F90_REAL           = -1313,
-    MPI_COMBINER_F90_COMPLEX        = -1314,
-    MPI_COMBINER_F90_INTEGER        = -1315,
-    MPI_COMBINER_RESIZED            = -1316,
-    MPI_COMBINER_VALUE_INDEX        = -1317,
+    MPI_COMBINER_NAMED              = 301,
+    MPI_COMBINER_DUP                = 302,
+    MPI_COMBINER_CONTIGUOUS         = 303,
+    MPI_COMBINER_VECTOR             = 304,
+    MPI_COMBINER_HVECTOR            = 305,
+    MPI_COMBINER_INDEXED            = 306,
+    MPI_COMBINER_HINDEXED           = 307,
+    MPI_COMBINER_INDEXED_BLOCK      = 308,
+    MPI_COMBINER_HINDEXED_BLOCK     = 309,
+    MPI_COMBINER_STRUCT             = 310,
+    MPI_COMBINER_SUBARRAY           = 311,
+    MPI_COMBINER_DARRAY             = 312,
+    MPI_COMBINER_F90_REAL           = 313,
+    MPI_COMBINER_F90_COMPLEX        = 314,
+    MPI_COMBINER_F90_INTEGER        = 315,
+    MPI_COMBINER_RESIZED            = 316,
 
     // File Operation Constants (?)
-    MPI_DISTRIBUTE_BLOCK        = -1401,
-    MPI_DISTRIBUTE_CYCLIC       = -1402,
-    MPI_DISTRIBUTE_DFLT_DARG    = -1403,
-    MPI_DISTRIBUTE_NONE         = -1404,
+    MPI_DISTRIBUTE_NONE         = 404,
+    MPI_DISTRIBUTE_BLOCK        = 401,
+    MPI_DISTRIBUTE_CYCLIC       = 402,
+    MPI_DISTRIBUTE_DFLT_DARG    = 403,
 
-    MPI_ORDER_C                 = -1501,
-    MPI_ORDER_FORTRAN           = -1502,
-
-    MPI_SEEK_CUR                = -1601,
-    MPI_SEEK_END                = -1602,
-    MPI_SEEK_SET                = -1603,
+    MPI_SEEK_CUR                = 601,
+    MPI_SEEK_END                = 602,
+    MPI_SEEK_SET                = 603,
 
     // F90 Datatype Matching Constants
-    MPI_TYPECLASS_REAL          = -1701,
-    MPI_TYPECLASS_COMPLEX       = -1702,
-    MPI_TYPECLASS_INTEGER       = -1703
+    MPI_TYPECLASS_REAL          = 801,
+    MPI_TYPECLASS_COMPLEX       = 802,
+    MPI_TYPECLASS_INTEGER       = 803,
+
+    // Communicator split type constants - arbitrary values
+    MPI_COMM_TYPE_SHARED          = 1001,
+    MPI_COMM_TYPE_HW_UNGUIDED     = 1002,
+    MPI_COMM_TYPE_HW_GUIDED       = 1003,
+    MPI_COMM_TYPE_RESOURCE_GUIDED = 1004,
+
+    // These apply to MPI_COMM_WORLD
+    MPI_TAG_UB          = 10001,
+    MPI_IO              = 10002,
+    MPI_HOST            = 10003,
+    MPI_WTIME_IS_GLOBAL = 10004,
+    MPI_APPNUM          = 10005,
+    MPI_LASTUSEDCODE    = 10006,
+    MPI_UNIVERSE_SIZE   = 10007,
+
+    // Predefined Attribute Keys
+    // These apply to Windows
+    MPI_WIN_BASE            = 20001,
+    MPI_WIN_DISP_UNIT       = 20002,
+    MPI_WIN_SIZE            = 20003,
+    MPI_WIN_CREATE_FLAVOR   = 20004,
+    MPI_WIN_MODEL           = 20005
 };
 
-#define MPI_OP_NULL          (MPI_Op)0x020
-#define MPI_SUM              (MPI_Op)0x021
-#define MPI_MIN              (MPI_Op)0x022
-#define MPI_MAX              (MPI_Op)0x023
-#define MPI_PROD             (MPI_Op)0x024
-#define MPI_BAND             (MPI_Op)0x028
-#define MPI_BOR              (MPI_Op)0x029
-#define MPI_BXOR             (MPI_Op)0x02a
-#define MPI_LAND             (MPI_Op)0x030
-#define MPI_LOR              (MPI_Op)0x031
-#define MPI_LXOR             (MPI_Op)0x032
-#define MPI_MINLOC           (MPI_Op)0x038
-#define MPI_MAXLOC           (MPI_Op)0x039
-#define MPI_REPLACE          (MPI_Op)0x03c
-#define MPI_NO_OP            (MPI_Op)0x03d
-#define MPI_COMM_NULL        (MPI_Comm)0x100
-#define MPI_COMM_WORLD       (MPI_Comm)0x101
-#define MPI_COMM_SELF        (MPI_Comm)0x102
-#define MPI_GROUP_NULL       (MPI_Group)0x104
-#define MPI_GROUP_EMPTY      (MPI_Group)0x105
-#define MPI_WIN_NULL         (MPI_Win)0x108
-#define MPI_FILE_NULL        (MPI_File)0x10c
-#define MPI_SESSION_NULL     (MPI_Session)0x110
-#define MPI_MESSAGE_NULL     (MPI_Message)0x114
-#define MPI_MESSAGE_NO_PROC  (MPI_Message)0x115
-#define MPI_ERRHANDLER_NULL  (MPI_Errhandler)0x118
-#define MPI_ERRORS_ARE_FATAL (MPI_Errhandler)0x119
-#define MPI_ERRORS_RETURN    (MPI_Errhandler)0x11a
-#define MPI_ERRORS_ABORT     (MPI_Errhandler)0x11b
-#define MPI_REQUEST_NULL     (MPI_Request)0x120
-#define MPI_INFO_NULL        (MPI_Info)0x130
-#define MPI_INFO_ENV         (MPI_Info)0x131
-#define MPI_DATATYPE_NULL           (MPI_Datatype)0x200
-#define MPI_AINT                    (MPI_Datatype)0x201
-#define MPI_COUNT                   (MPI_Datatype)0x202
-#define MPI_OFFSET                  (MPI_Datatype)0x203
-#define MPI_PACKED                  (MPI_Datatype)0x207
-#define MPI_SHORT                   (MPI_Datatype)0x208
-#define MPI_INT                     (MPI_Datatype)0x209
-#define MPI_LONG                    (MPI_Datatype)0x20a
-#define MPI_LONG_LONG               (MPI_Datatype)0x20b
-#define MPI_LONG_LONG_INT MPI_LONG_LONG
-#define MPI_UNSIGNED_SHORT          (MPI_Datatype)0x20c
-#define MPI_UNSIGNED                (MPI_Datatype)0x20d
-#define MPI_UNSIGNED_LONG           (MPI_Datatype)0x20e
-#define MPI_UNSIGNED_LONG_LONG      (MPI_Datatype)0x20f
-#define MPI_FLOAT                   (MPI_Datatype)0x210
-#define MPI_C_FLOAT_COMPLEX         (MPI_Datatype)0x212
-#define MPI_C_COMPLEX MPI_C_FLOAT_COMPLEX
-#define MPI_CXX_FLOAT_COMPLEX       (MPI_Datatype)0x213
-#define MPI_DOUBLE                  (MPI_Datatype)0x214
-#define MPI_C_DOUBLE_COMPLEX        (MPI_Datatype)0x216
-#define MPI_CXX_DOUBLE_COMPLEX      (MPI_Datatype)0x217
-#define MPI_INTEGER                 (MPI_Datatype)0x218
-#define MPI_LOGICAL                 (MPI_Datatype)0x219
-#define MPI_REAL                    (MPI_Datatype)0x21a
-#define MPI_COMPLEX                 (MPI_Datatype)0x21b
-#define MPI_DOUBLE_PRECISION        (MPI_Datatype)0x21c
-#define MPI_DOUBLE_COMPLEX          (MPI_Datatype)0x21d
-#define MPI_LONG_DOUBLE             (MPI_Datatype)0x220
-#define MPI_C_LONG_DOUBLE_COMPLEX   (MPI_Datatype)0x224
-#define MPI_CXX_LONG_DOUBLE_COMPLEX (MPI_Datatype)0x225
-#define MPI_FLOAT_INT               (MPI_Datatype)0x228
-#define MPI_DOUBLE_INT              (MPI_Datatype)0x229
-#define MPI_LONG_INT                (MPI_Datatype)0x22a
-#define MPI_2INT                    (MPI_Datatype)0x22b
-#define MPI_SHORT_INT               (MPI_Datatype)0x22c
-#define MPI_LONG_DOUBLE_INT         (MPI_Datatype)0x22d
-#define MPI_2REAL                   (MPI_Datatype)0x230
-#define MPI_2DOUBLE_PRECISION       (MPI_Datatype)0x231
-#define MPI_2INTEGER                (MPI_Datatype)0x232
-#define MPI_C_BOOL                  (MPI_Datatype)0x238
-#define MPI_CXX_BOOL                (MPI_Datatype)0x239
-#define MPI_WCHAR                   (MPI_Datatype)0x23c
-#define MPI_INT8_T                  (MPI_Datatype)0x240
-#define MPI_UINT8_T                 (MPI_Datatype)0x241
-#define MPI_CHAR                    (MPI_Datatype)0x243
-#define MPI_SIGNED_CHAR             (MPI_Datatype)0x244
-#define MPI_UNSIGNED_CHAR           (MPI_Datatype)0x245
-#define MPI_BYTE                    (MPI_Datatype)0x247
-#define MPI_INT16_T                 (MPI_Datatype)0x248
-#define MPI_UINT16_T                (MPI_Datatype)0x249
-#define MPI_INT32_T                 (MPI_Datatype)0x250
-#define MPI_UINT32_T                (MPI_Datatype)0x251
-#define MPI_INT64_T                 (MPI_Datatype)0x258
-#define MPI_UINT64_T                (MPI_Datatype)0x259
-#define MPI_INTEGER1                (MPI_Datatype)0x2c0
-#define MPI_CHARACTER               (MPI_Datatype)0x2c3
-#define MPI_INTEGER2                (MPI_Datatype)0x2c8
-#define MPI_INTEGER4                (MPI_Datatype)0x2d0
-#define MPI_REAL4                   (MPI_Datatype)0x2d2
-#define MPI_INTEGER8                (MPI_Datatype)0x2d8
-#define MPI_REAL8                   (MPI_Datatype)0x2da
-#define MPI_COMPLEX8                (MPI_Datatype)0x2db
-#define MPI_INTEGER16               (MPI_Datatype)0x2e0
-#define MPI_REAL16                  (MPI_Datatype)0x2e2
-#define MPI_COMPLEX16               (MPI_Datatype)0x2e3
-#define MPI_COMPLEX32               (MPI_Datatype)0x2eb
 
-// callback typedefs
-typedef int MPI_Comm_copy_attr_function(MPI_Comm oldcomm, int comm_keyval, void *extra_state, void *attribute_val_in, void *attribute_val_out, int *flag);
-typedef int MPI_Comm_delete_attr_function(MPI_Comm comm, int comm_keyval, void *attribute_val, void *extra_state);
-typedef void MPI_Comm_errhandler_function(MPI_Comm *comm, int *error_code, ...);
-typedef int MPI_Copy_function(MPI_Comm oldcomm, int keyval, void *extra_state, void *attribute_val_in, void *attribute_val_out, int *flag);
-typedef int MPI_Datarep_conversion_function(void *userbuf, MPI_Datatype datatype, int count, void *filebuf, MPI_Offset position, void *extra_state);
-typedef int MPI_Datarep_conversion_function_c(void *userbuf, MPI_Datatype datatype, MPI_Count count, void *filebuf, MPI_Offset position, void *extra_state);
-typedef int MPI_Datarep_extent_function(MPI_Datatype datatype, MPI_Aint *extent, void *extra_state);
-typedef int MPI_Delete_function(MPI_Comm comm, int keyval, void *attribute_val, void *extra_state);
-typedef void MPI_File_errhandler_function(MPI_File *file, int *error_code, ...);
-typedef int MPI_Grequest_cancel_function(void *extra_state, int complete);
-typedef int MPI_Grequest_free_function(void *extra_state);
-typedef int MPI_Grequest_query_function(void *extra_state, MPI_Status *status);
-typedef void MPI_Session_errhandler_function(MPI_Session *session, int *error_code, ...);
-typedef int MPI_Type_copy_attr_function(MPI_Datatype oldtype, int type_keyval, void *extra_state, void *attribute_val_in, void *attribute_val_out, int *flag);
-typedef int MPI_Type_delete_attr_function(MPI_Datatype datatype, int type_keyval, void *attribute_val, void *extra_state);
-typedef void MPI_User_function(void *invec, void *inoutvec, int *len, MPI_Datatype *datatype);
-typedef void MPI_User_function_c(void *invec, void *inoutvec, MPI_Count *len, MPI_Datatype *datatype);
-typedef int MPI_Win_copy_attr_function(MPI_Win oldwin, int win_keyval, void *extra_state, void *attribute_val_in, void *attribute_val_out, int *flag);
-typedef int MPI_Win_delete_attr_function(MPI_Win win, int win_keyval, void *attribute_val, void *extra_state);
-typedef void MPI_Win_errhandler_function(MPI_Win *win, int *error_code, ...);
+typedef int (MPI_Copy_function) ( MPI_Comm, int, void *, void *, void *, int * );
+typedef int (MPI_Delete_function) ( MPI_Comm, int, void *, void * );
 
-#define MPI_NULL_COPY_FN        ((MPI_Copy_function*)0x0)
-#define MPI_DUP_FN              ((MPI_Copy_function*)0x1)
-#define MPI_NULL_DELETE_FN      ((MPI_Delete_function*)0x0)
-#define MPI_COMM_NULL_COPY_FN   ((MPI_Comm_copy_attr_function*)0x0)
-#define MPI_COMM_DUP_FN         ((MPI_Comm_copy_attr_function*)0x1)
-#define MPI_COMM_NULL_DELETE_FN ((MPI_Comm_delete_attr_function*)0x0)
-#define MPI_TYPE_NULL_COPY_FN   ((MPI_Type_copy_attr_function*)0x0)
-#define MPI_TYPE_DUP_FN         ((MPI_Type_copy_attr_function*)0x1)
-#define MPI_TYPE_NULL_DELETE_FN ((MPI_Type_delete_attr_function*)0x0)
-#define MPI_WIN_NULL_COPY_FN    ((MPI_Win_copy_attr_function*)0x0)
-#define MPI_WIN_DUP_FN          ((MPI_Win_copy_attr_function*)0x1)
-#define MPI_WIN_NULL_DELETE_FN  ((MPI_Win_delete_attr_function*)0x0)
-#define MPI_CONVERSION_FN_NULL   ((MPI_Datarep_conversion_function *)0)
-#define MPI_CONVERSION_FN_NULL_C ((MPI_Datarep_conversion_function_c *)0)
+typedef void (MPI_User_function) ( void *, void *, int *, MPI_Datatype * );
+typedef void (MPI_User_function_c) ( void *, void *, MPI_Count *, MPI_Datatype * );
+
+typedef int (MPI_Grequest_cancel_function)(void *, int);
+typedef int (MPI_Grequest_free_function)(void *);
+typedef int (MPI_Grequest_query_function)(void *, MPI_Status *);
+
+typedef int (MPI_Datarep_conversion_function)(void *, MPI_Datatype, int, void *, MPI_Offset, void *);
+typedef int (MPI_Datarep_extent_function)(MPI_Datatype datatype, MPI_Aint *, void *);
+typedef int (MPI_Datarep_conversion_function_c)(void *, MPI_Datatype, MPI_Count, void *, MPI_Offset, void *);
+
+typedef void (MPI_Handler_function) ( MPI_Comm *, int *, ... );
+
+typedef int (MPI_Comm_copy_attr_function)(MPI_Comm, int, void *, void *, void *, int *);
+typedef int (MPI_Comm_delete_attr_function)(MPI_Comm, int, void *, void *);
+typedef int (MPI_Type_copy_attr_function)(MPI_Datatype, int, void *, void *, void *, int *);
+typedef int (MPI_Type_delete_attr_function)(MPI_Datatype, int, void *, void *);
+typedef int (MPI_Win_copy_attr_function)(MPI_Win, int, void *, void *, void *, int *);
+typedef int (MPI_Win_delete_attr_function)(MPI_Win, int, void *, void *);
+
+typedef void (MPI_Comm_errhandler_function)(MPI_Comm *, int *, ...);
+typedef void (MPI_File_errhandler_function)(MPI_File *, int *, ...);
+typedef void (MPI_Win_errhandler_function)(MPI_Win *, int *, ...);
+typedef void (MPI_Session_errhandler_function)(MPI_Session *, int *, ...);
+
+typedef MPI_Comm_errhandler_function MPI_Comm_errhandler_fn;
+typedef MPI_File_errhandler_function MPI_File_errhandler_fn;
+typedef MPI_Win_errhandler_function MPI_Win_errhandler_fn;
+typedef MPI_Session_errhandler_function MPI_Session_errhandler_fn;
+
+#define MPI_NULL_COPY_FN         ((MPI_Copy_function*)0x0)
+#define MPI_DUP_FN               ((MPI_Copy_function*)0x1)
+#define MPI_NULL_DELETE_FN       ((MPI_Delete_function*)0x0)
+#define MPI_COMM_NULL_COPY_FN    ((MPI_Comm_copy_attr_function*)0x0)
+#define MPI_COMM_DUP_FN          ((MPI_Comm_copy_attr_function*)0x1)
+#define MPI_COMM_NULL_DELETE_FN  ((MPI_Comm_delete_attr_function*)0x0)
+#define MPI_TYPE_NULL_COPY_FN    ((MPI_Type_copy_attr_function*)0x0)
+#define MPI_TYPE_DUP_FN          ((MPI_Type_copy_attr_function*)0x1)
+#define MPI_TYPE_NULL_DELETE_FN  ((MPI_Type_delete_attr_function*)0x0)
+#define MPI_WIN_NULL_COPY_FN     ((MPI_Win_copy_attr_function*)0x0)
+#define MPI_WIN_DUP_FN           ((MPI_Win_copy_attr_function*)0x1)
+#define MPI_WIN_NULL_DELETE_FN   ((MPI_Win_delete_attr_function*)0x0)
+#define MPI_CONVERSION_FN_NULL   ((MPI_Datarep_conversion_function)0x0)
+#define MPI_CONVERSION_FN_NULL_C ((MPI_Datarep_conversion_function_c)0x0)
 
 /* MPI_T */
 
@@ -512,95 +540,67 @@ typedef void (MPI_T_event_dropped_cb_function)(MPI_Count count, MPI_T_event_regi
 /* MPI functions */
 int MPI_Abort(MPI_Comm comm, int errorcode);
 int MPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
-int MPI_Accumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
 int MPI_Add_error_class(int *errorclass);
 int MPI_Add_error_code(int errorclass, int *errorcode);
 int MPI_Add_error_string(int errorcode, const char *string);
 MPI_Aint MPI_Aint_add(MPI_Aint base, MPI_Aint disp);
 MPI_Aint MPI_Aint_diff(MPI_Aint addr1, MPI_Aint addr2);
 int MPI_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Allgather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Allgather_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Allgather_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
 int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Allgatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Allgatherv_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Allgatherv_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
 int MPI_Alloc_mem(MPI_Aint size, MPI_Info info, void *baseptr);
 int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
-int MPI_Allreduce_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
-int MPI_Allreduce_init(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Allreduce_init_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
 int MPI_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Alltoall_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Alltoall_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Alltoall_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
 int MPI_Alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Alltoallv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Alltoallv_init(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Alltoallv_init_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
 int MPI_Alltoallw(const void *sendbuf, const int sendcounts[], const int sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const int rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm);
-int MPI_Alltoallw_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm);
-int MPI_Alltoallw_init(const void *sendbuf, const int sendcounts[], const int sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const int rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Alltoallw_init_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Attr_delete(MPI_Comm comm, int keyval);
-int MPI_Attr_get(MPI_Comm comm, int keyval, void *attribute_val, int *flag);
-int MPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val);
+int MPI_Ialltoallw(const void *sendbuf, const int sendcounts[], const int sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const int rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Request *request);
 int MPI_Barrier(MPI_Comm comm);
-int MPI_Barrier_init(MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Ibarrier(MPI_Comm comm, MPI_Request *request);
 int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm);
-int MPI_Bcast_c(void *buffer, MPI_Count count, MPI_Datatype datatype, int root, MPI_Comm comm);
-int MPI_Bcast_init(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Bcast_init_c(void *buffer, MPI_Count count, MPI_Datatype datatype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
 int MPI_Bsend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
-int MPI_Bsend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm, MPI_Request *request);
 int MPI_Bsend_init(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
-int MPI_Bsend_init_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
 int MPI_Buffer_attach(void *buffer, int size);
-int MPI_Buffer_attach_c(void *buffer, MPI_Count size);
-int MPI_Buffer_detach(void *buffer_addr, int *size);
-int MPI_Buffer_detach_c(void *buffer_addr, MPI_Count *size);
-int MPI_Buffer_flush(void);
-int MPI_Buffer_iflush(MPI_Request *request);
+int MPI_Buffer_detach(void *buffer, int *size);
 int MPI_Cancel(MPI_Request *request);
 int MPI_Cart_coords(MPI_Comm comm, int rank, int maxdims, int coords[]);
-int MPI_Cart_create(MPI_Comm comm_old, int ndims, const int dims[], const int periods[], int reorder, MPI_Comm *comm_cart);
+int MPI_Cart_create(MPI_Comm old_comm, int ndims, const int dims[], const int periods[], int reorder, MPI_Comm *comm_cart);
 int MPI_Cart_get(MPI_Comm comm, int maxdims, int dims[], int periods[], int coords[]);
 int MPI_Cart_map(MPI_Comm comm, int ndims, const int dims[], const int periods[], int *newrank);
 int MPI_Cart_rank(MPI_Comm comm, const int coords[], int *rank);
 int MPI_Cart_shift(MPI_Comm comm, int direction, int disp, int *rank_source, int *rank_dest);
-int MPI_Cart_sub(MPI_Comm comm, const int remain_dims[], MPI_Comm *newcomm);
+int MPI_Cart_sub(MPI_Comm comm, const int remain_dims[], MPI_Comm *new_comm);
 int MPI_Cartdim_get(MPI_Comm comm, int *ndims);
 int MPI_Close_port(const char *port_name);
 int MPI_Comm_accept(const char *port_name, MPI_Info info, int root, MPI_Comm comm, MPI_Comm *newcomm);
-int MPI_Comm_attach_buffer(MPI_Comm comm, void *buffer, int size);
-int MPI_Comm_attach_buffer_c(MPI_Comm comm, void *buffer, MPI_Count size);
 int MPI_Comm_call_errhandler(MPI_Comm comm, int errorcode);
 int MPI_Comm_compare(MPI_Comm comm1, MPI_Comm comm2, int *result);
 int MPI_Comm_connect(const char *port_name, MPI_Info info, int root, MPI_Comm comm, MPI_Comm *newcomm);
-int MPI_Comm_create(MPI_Comm comm, MPI_Group group, MPI_Comm *newcomm);
-int MPI_Comm_create_errhandler(MPI_Comm_errhandler_function *comm_errhandler_fn, MPI_Errhandler *errhandler);
-int MPI_Comm_create_from_group(MPI_Group group, const char *stringtag, MPI_Info info, MPI_Errhandler errhandler, MPI_Comm *newcomm);
-int MPI_Comm_create_group(MPI_Comm comm, MPI_Group group, int tag, MPI_Comm *newcomm);
+int MPI_Comm_create_errhandler(MPI_Comm_errhandler_function *function, MPI_Errhandler *errhandler);
 int MPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn, MPI_Comm_delete_attr_function *comm_delete_attr_fn, int *comm_keyval, void *extra_state);
+int MPI_Comm_create_group(MPI_Comm comm, MPI_Group group, int tag, MPI_Comm *newcomm);
+int MPI_Comm_create(MPI_Comm comm, MPI_Group group, MPI_Comm *newcomm);
 int MPI_Comm_delete_attr(MPI_Comm comm, int comm_keyval);
-int MPI_Comm_detach_buffer(MPI_Comm comm, void *buffer_addr, int *size);
-int MPI_Comm_detach_buffer_c(MPI_Comm comm, void *buffer_addr, MPI_Count *size);
 int MPI_Comm_disconnect(MPI_Comm *comm);
 int MPI_Comm_dup(MPI_Comm comm, MPI_Comm *newcomm);
+int MPI_Comm_idup(MPI_Comm comm, MPI_Comm *newcomm, MPI_Request *request);
 int MPI_Comm_dup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm *newcomm);
-int MPI_Comm_flush_buffer(MPI_Comm comm);
-int MPI_Comm_free(MPI_Comm *comm);
 int MPI_Comm_free_keyval(int *comm_keyval);
+int MPI_Comm_free(MPI_Comm *comm);
 int MPI_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val, int *flag);
-int MPI_Comm_get_errhandler(MPI_Comm comm, MPI_Errhandler *errhandler);
+int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int nodes[], const int degrees[], const int targets[], const int weights[], MPI_Info info, int reorder, MPI_Comm *newcomm);
+int MPI_Dist_graph_create_adjacent(MPI_Comm comm_old, int indegree, const int sources[], const int sourceweights[], int outdegree, const int destinations[], const int destweights[], MPI_Info info, int reorder, MPI_Comm *comm_dist_graph);
+int MPI_Dist_graph_neighbors(MPI_Comm comm, int maxindegree, int sources[], int sourceweights[], int maxoutdegree, int destinations[], int destweights[]);
+int MPI_Dist_graph_neighbors_count(MPI_Comm comm, int *inneighbors, int *outneighbors, int *weighted);
+int MPI_Comm_get_errhandler(MPI_Comm comm, MPI_Errhandler *erhandler);
 int MPI_Comm_get_info(MPI_Comm comm, MPI_Info *info_used);
 int MPI_Comm_get_name(MPI_Comm comm, char *comm_name, int *resultlen);
 int MPI_Comm_get_parent(MPI_Comm *parent);
 int MPI_Comm_group(MPI_Comm comm, MPI_Group *group);
-int MPI_Comm_idup(MPI_Comm comm, MPI_Comm *newcomm, MPI_Request *request);
-int MPI_Comm_idup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm *newcomm, MPI_Request *request);
-int MPI_Comm_iflush_buffer(MPI_Comm comm, MPI_Request *request);
 int MPI_Comm_join(int fd, MPI_Comm *intercomm);
 int MPI_Comm_rank(MPI_Comm comm, int *rank);
 int MPI_Comm_remote_group(MPI_Comm comm, MPI_Group *group);
@@ -617,137 +617,92 @@ int MPI_Comm_split_type(MPI_Comm comm, int split_type, int key, MPI_Info info, M
 int MPI_Comm_test_inter(MPI_Comm comm, int *flag);
 int MPI_Compare_and_swap(const void *origin_addr, const void *compare_addr, void *result_addr, MPI_Datatype datatype, int target_rank, MPI_Aint target_disp, MPI_Win win);
 int MPI_Dims_create(int nnodes, int ndims, int dims[]);
-int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[], const int degrees[], const int destinations[], const int weights[], MPI_Info info, int reorder, MPI_Comm *comm_dist_graph);
-int MPI_Dist_graph_create_adjacent(MPI_Comm comm_old, int indegree, const int sources[], const int sourceweights[], int outdegree, const int destinations[], const int destweights[], MPI_Info info, int reorder, MPI_Comm *comm_dist_graph);
-int MPI_Dist_graph_neighbors(MPI_Comm comm, int maxindegree, int sources[], int sourceweights[], int maxoutdegree, int destinations[], int destweights[]);
-int MPI_Dist_graph_neighbors_count(MPI_Comm comm, int *indegree, int *outdegree, int *weighted);
 int MPI_Errhandler_free(MPI_Errhandler *errhandler);
 int MPI_Error_class(int errorcode, int *errorclass);
 int MPI_Error_string(int errorcode, char *string, int *resultlen);
 int MPI_Exscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
-int MPI_Exscan_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
-int MPI_Exscan_init(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Exscan_init_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_F_sync_reg(void *buf);
 int MPI_Fetch_and_op(const void *origin_addr, void *result_addr, MPI_Datatype datatype, int target_rank, MPI_Aint target_disp, MPI_Op op, MPI_Win win);
+int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
 int MPI_File_call_errhandler(MPI_File fh, int errorcode);
-int MPI_File_close(MPI_File *fh);
-int MPI_File_create_errhandler(MPI_File_errhandler_function *file_errhandler_fn, MPI_Errhandler *errhandler);
-int MPI_File_delete(const char *filename, MPI_Info info);
-int MPI_File_get_amode(MPI_File fh, int *amode);
-int MPI_File_get_atomicity(MPI_File fh, int *flag);
-int MPI_File_get_byte_offset(MPI_File fh, MPI_Offset offset, MPI_Offset *disp);
-int MPI_File_get_errhandler(MPI_File file, MPI_Errhandler *errhandler);
-int MPI_File_get_group(MPI_File fh, MPI_Group *group);
-int MPI_File_get_info(MPI_File fh, MPI_Info *info_used);
-int MPI_File_get_position(MPI_File fh, MPI_Offset *offset);
-int MPI_File_get_position_shared(MPI_File fh, MPI_Offset *offset);
-int MPI_File_get_size(MPI_File fh, MPI_Offset *size);
-int MPI_File_get_type_extent(MPI_File fh, MPI_Datatype datatype, MPI_Aint *extent);
-int MPI_File_get_type_extent_c(MPI_File fh, MPI_Datatype datatype, MPI_Count *extent);
-int MPI_File_get_view(MPI_File fh, MPI_Offset *disp, MPI_Datatype *etype, MPI_Datatype *filetype, char *datarep);
-int MPI_File_iread(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iread_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iread_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iread_at_all_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iread_shared(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iread_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iwrite(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iwrite_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iwrite_all(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iwrite_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iwrite_at(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iwrite_at_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iwrite_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iwrite_shared(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_iwrite_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
-int MPI_File_open(MPI_Comm comm, const char *filename, int amode, MPI_Info info, MPI_File *fh);
-int MPI_File_preallocate(MPI_File fh, MPI_Offset size);
-int MPI_File_read(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_read_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_read_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_read_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_read_all_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype);
-int MPI_File_read_all_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype);
-int MPI_File_read_all_end(MPI_File fh, void *buf, MPI_Status *status);
-int MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_read_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_read_at_all_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_read_at_all_begin(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype);
-int MPI_File_read_at_all_begin_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype);
-int MPI_File_read_at_all_end(MPI_File fh, void *buf, MPI_Status *status);
-int MPI_File_read_ordered(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_read_ordered_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_read_ordered_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype);
-int MPI_File_read_ordered_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype);
-int MPI_File_read_ordered_end(MPI_File fh, void *buf, MPI_Status *status);
-int MPI_File_read_shared(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_read_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence);
-int MPI_File_seek_shared(MPI_File fh, MPI_Offset offset, int whence);
-int MPI_File_set_atomicity(MPI_File fh, int flag);
+int MPI_File_create_errhandler(MPI_File_errhandler_function *function, MPI_Errhandler *errhandler);
 int MPI_File_set_errhandler(MPI_File file, MPI_Errhandler errhandler);
-int MPI_File_set_info(MPI_File fh, MPI_Info info);
+int MPI_File_get_errhandler(MPI_File file, MPI_Errhandler *errhandler);
+int MPI_File_open(MPI_Comm comm, const char *filename, int amode, MPI_Info info, MPI_File *fh);
+int MPI_File_close(MPI_File *fh);
+int MPI_File_delete(const char *filename, MPI_Info info);
 int MPI_File_set_size(MPI_File fh, MPI_Offset size);
+int MPI_File_preallocate(MPI_File fh, MPI_Offset size);
+int MPI_File_get_size(MPI_File fh, MPI_Offset *size);
+int MPI_File_get_group(MPI_File fh, MPI_Group *group);
+int MPI_File_get_amode(MPI_File fh, int *amode);
+int MPI_File_set_info(MPI_File fh, MPI_Info info);
+int MPI_File_get_info(MPI_File fh, MPI_Info *info_used);
 int MPI_File_set_view(MPI_File fh, MPI_Offset disp, MPI_Datatype etype, MPI_Datatype filetype, const char *datarep, MPI_Info info);
-int MPI_File_sync(MPI_File fh);
-int MPI_File_write(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_write_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_write_all(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_write_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_write_all_begin(MPI_File fh, const void *buf, int count, MPI_Datatype datatype);
-int MPI_File_write_all_begin_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype);
-int MPI_File_write_all_end(MPI_File fh, const void *buf, MPI_Status *status);
+int MPI_File_get_view(MPI_File fh, MPI_Offset *disp, MPI_Datatype *etype, MPI_Datatype *filetype, char *datarep);
+int MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
 int MPI_File_write_at(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_write_at_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
 int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_write_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_write_at_all_begin(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype);
-int MPI_File_write_at_all_begin_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count, MPI_Datatype datatype);
-int MPI_File_write_at_all_end(MPI_File fh, const void *buf, MPI_Status *status);
-int MPI_File_write_ordered(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_write_ordered_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_write_ordered_begin(MPI_File fh, const void *buf, int count, MPI_Datatype datatype);
-int MPI_File_write_ordered_begin_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype);
-int MPI_File_write_ordered_end(MPI_File fh, const void *buf, MPI_Status *status);
+int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iwrite_at(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_read(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_read_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_write(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_write_all(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_iread(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iwrite(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iread_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iwrite_all(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence);
+int MPI_File_get_position(MPI_File fh, MPI_Offset *offset);
+int MPI_File_get_byte_offset(MPI_File fh, MPI_Offset offset, MPI_Offset *disp);
+int MPI_File_read_shared(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
 int MPI_File_write_shared(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_File_write_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
-int MPI_Finalize(void);
+int MPI_File_iread_shared(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iwrite_shared(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_read_ordered(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_write_ordered(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_seek_shared(MPI_File fh, MPI_Offset offset, int whence);
+int MPI_File_get_position_shared(MPI_File fh, MPI_Offset *offset);
+int MPI_File_read_at_all_begin(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype);
+int MPI_File_read_at_all_end(MPI_File fh, void *buf, MPI_Status *status);
+int MPI_File_write_at_all_begin(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype);
+int MPI_File_write_at_all_end(MPI_File fh, const void *buf, MPI_Status *status);
+int MPI_File_read_all_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype);
+int MPI_File_read_all_end(MPI_File fh, void *buf, MPI_Status *status);
+int MPI_File_write_all_begin(MPI_File fh, const void *buf, int count, MPI_Datatype datatype);
+int MPI_File_write_all_end(MPI_File fh, const void *buf, MPI_Status *status);
+int MPI_File_read_ordered_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype);
+int MPI_File_read_ordered_end(MPI_File fh, void *buf, MPI_Status *status);
+int MPI_File_write_ordered_begin(MPI_File fh, const void *buf, int count, MPI_Datatype datatype);
+int MPI_File_write_ordered_end(MPI_File fh, const void *buf, MPI_Status *status);
+int MPI_File_get_type_extent(MPI_File fh, MPI_Datatype datatype, MPI_Aint *extent);
+int MPI_File_set_atomicity(MPI_File fh, int flag);
+int MPI_File_get_atomicity(MPI_File fh, int *flag);
+int MPI_File_sync(MPI_File fh);
+int MPI_Finalize();
 int MPI_Finalized(int *flag);
 int MPI_Free_mem(void *base);
 int MPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
-int MPI_Gather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
-int MPI_Gather_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Gather_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
 int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, int root, MPI_Comm comm);
-int MPI_Gatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, int root, MPI_Comm comm);
-int MPI_Gatherv_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Gatherv_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Get(void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Win win);
-int MPI_Get_c(void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Win win);
-int MPI_Get_accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, void *result_addr, int result_count, MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
-int MPI_Get_accumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, void *result_addr, MPI_Count result_count, MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
+int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
 int MPI_Get_address(const void *location, MPI_Aint *address);
 int MPI_Get_count(const MPI_Status *status, MPI_Datatype datatype, int *count);
-int MPI_Get_count_c(const MPI_Status *status, MPI_Datatype datatype, MPI_Count *count);
 int MPI_Get_elements(const MPI_Status *status, MPI_Datatype datatype, int *count);
-int MPI_Get_elements_c(const MPI_Status *status, MPI_Datatype datatype, MPI_Count *count);
 int MPI_Get_elements_x(const MPI_Status *status, MPI_Datatype datatype, MPI_Count *count);
-int MPI_Get_hw_resource_info(MPI_Info *hw_info);
+int MPI_Get(void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Win win);
+int MPI_Get_accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, void *result_addr, int result_count, MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
 int MPI_Get_library_version(char *version, int *resultlen);
 int MPI_Get_processor_name(char *name, int *resultlen);
 int MPI_Get_version(int *version, int *subversion);
-int MPI_Graph_create(MPI_Comm comm_old, int nnodes, const int indx[], const int edges[], int reorder, MPI_Comm *comm_graph);
-int MPI_Graph_get(MPI_Comm comm, int maxindex, int maxedges, int indx[], int edges[]);
-int MPI_Graph_map(MPI_Comm comm, int nnodes, const int indx[], const int edges[], int *newrank);
-int MPI_Graph_neighbors(MPI_Comm comm, int rank, int maxneighbors, int neighbors[]);
+int MPI_Graph_create(MPI_Comm comm_old, int nnodes, const int index[], const int edges[], int reorder, MPI_Comm *comm_graph);
+int MPI_Graph_get(MPI_Comm comm, int maxindex, int maxedges, int index[], int edges[]);
+int MPI_Graph_map(MPI_Comm comm, int nnodes, const int index[], const int edges[], int *newrank);
 int MPI_Graph_neighbors_count(MPI_Comm comm, int rank, int *nneighbors);
+int MPI_Graph_neighbors(MPI_Comm comm, int rank, int maxneighbors, int neighbors[]);
 int MPI_Graphdims_get(MPI_Comm comm, int *nnodes, int *nedges);
 int MPI_Grequest_complete(MPI_Request request);
 int MPI_Grequest_start(MPI_Grequest_query_function *query_fn, MPI_Grequest_free_function *free_fn, MPI_Grequest_cancel_function *cancel_fn, void *extra_state, MPI_Request *request);
@@ -755,7 +710,6 @@ int MPI_Group_compare(MPI_Group group1, MPI_Group group2, int *result);
 int MPI_Group_difference(MPI_Group group1, MPI_Group group2, MPI_Group *newgroup);
 int MPI_Group_excl(MPI_Group group, int n, const int ranks[], MPI_Group *newgroup);
 int MPI_Group_free(MPI_Group *group);
-int MPI_Group_from_session_pset(MPI_Session session, const char *pset_name, MPI_Group *newgroup);
 int MPI_Group_incl(MPI_Group group, int n, const int ranks[], MPI_Group *newgroup);
 int MPI_Group_intersection(MPI_Group group1, MPI_Group group2, MPI_Group *newgroup);
 int MPI_Group_range_excl(MPI_Group group, int n, int ranges[][3], MPI_Group *newgroup);
@@ -764,229 +718,208 @@ int MPI_Group_rank(MPI_Group group, int *rank);
 int MPI_Group_size(MPI_Group group, int *size);
 int MPI_Group_translate_ranks(MPI_Group group1, int n, const int ranks1[], MPI_Group group2, int ranks2[]);
 int MPI_Group_union(MPI_Group group1, MPI_Group group2, MPI_Group *newgroup);
-int MPI_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Iallgather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Iallgatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
-int MPI_Iallreduce_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
-int MPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Ialltoall_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Ialltoallv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Ialltoallw(const void *sendbuf, const int sendcounts[], const int sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const int rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Request *request);
-int MPI_Ialltoallw_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Request *request);
-int MPI_Ibarrier(MPI_Comm comm, MPI_Request *request);
-int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm, MPI_Request *request);
-int MPI_Ibcast_c(void *buffer, MPI_Count count, MPI_Datatype datatype, int root, MPI_Comm comm, MPI_Request *request);
 int MPI_Ibsend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
-int MPI_Ibsend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
-int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
-int MPI_Iexscan_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
-int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
-int MPI_Igather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
-int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
-int MPI_Igatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
 int MPI_Improbe(int source, int tag, MPI_Comm comm, int *flag, MPI_Message *message, MPI_Status *status);
-int MPI_Imrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message *message, MPI_Request *request);
-int MPI_Imrecv_c(void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Message *message, MPI_Request *request);
-int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Ineighbor_allgather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Ineighbor_allgatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Ineighbor_alltoall_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Ineighbor_alltoallv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
-int MPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Request *request);
-int MPI_Ineighbor_alltoallw_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Request *request);
+int MPI_Imrecv(void *buf, int count, MPI_Datatype type, MPI_Message *message, MPI_Request *request);
 int MPI_Info_create(MPI_Info *info);
-int MPI_Info_create_env(int argc, char *argv[], MPI_Info *info);
 int MPI_Info_delete(MPI_Info info, const char *key);
 int MPI_Info_dup(MPI_Info info, MPI_Info *newinfo);
 int MPI_Info_free(MPI_Info *info);
 int MPI_Info_get(MPI_Info info, const char *key, int valuelen, char *value, int *flag);
 int MPI_Info_get_nkeys(MPI_Info info, int *nkeys);
 int MPI_Info_get_nthkey(MPI_Info info, int n, char *key);
-int MPI_Info_get_string(MPI_Info info, const char *key, int *buflen, char *value, int *flag);
 int MPI_Info_get_valuelen(MPI_Info info, const char *key, int *valuelen, int *flag);
 int MPI_Info_set(MPI_Info info, const char *key, const char *value);
 int MPI_Init(int *argc, char ***argv);
-int MPI_Init_thread(int *argc, char ***argv, int required, int *provided);
 int MPI_Initialized(int *flag);
-int MPI_Intercomm_create(MPI_Comm local_comm, int local_leader, MPI_Comm peer_comm, int remote_leader, int tag, MPI_Comm *newintercomm);
-int MPI_Intercomm_create_from_groups(MPI_Group local_group, int local_leader, MPI_Group remote_group, int remote_leader, const char *stringtag, MPI_Info info, MPI_Errhandler errhandler, MPI_Comm *newintercomm);
-int MPI_Intercomm_merge(MPI_Comm intercomm, int high, MPI_Comm *newintracomm);
+int MPI_Init_thread(int *argc, char ***argv, int required, int *provided);
+int MPI_Intercomm_create(MPI_Comm local_comm, int local_leader, MPI_Comm bridge_comm, int remote_leader, int tag, MPI_Comm *newintercomm);
+int MPI_Intercomm_merge(MPI_Comm intercomm, int high, MPI_Comm *newintercomm);
 int MPI_Iprobe(int source, int tag, MPI_Comm comm, int *flag, MPI_Status *status);
 int MPI_Irecv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request);
-int MPI_Irecv_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request);
-int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm, MPI_Request *request);
-int MPI_Ireduce_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm, MPI_Request *request);
-int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
-int MPI_Ireduce_scatter_c(const void *sendbuf, void *recvbuf, const MPI_Count recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
-int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
-int MPI_Ireduce_scatter_block_c(const void *sendbuf, void *recvbuf, MPI_Count recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
 int MPI_Irsend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
-int MPI_Irsend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
-int MPI_Is_thread_main(int *flag);
-int MPI_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
-int MPI_Iscan_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
-int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
-int MPI_Iscatter_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
-int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[], MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
-int MPI_Iscatterv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
 int MPI_Isend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
-int MPI_Isend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
-int MPI_Isendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, int dest, int sendtag, void *recvbuf, int recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Request *request);
-int MPI_Isendrecv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, int dest, int sendtag, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Request *request);
-int MPI_Isendrecv_replace(void *buf, int count, MPI_Datatype datatype, int dest, int sendtag, int source, int recvtag, MPI_Comm comm, MPI_Request *request);
-int MPI_Isendrecv_replace_c(void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int sendtag, int source, int recvtag, MPI_Comm comm, MPI_Request *request);
 int MPI_Issend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
-int MPI_Issend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
-int MPI_Keyval_create(MPI_Copy_function *copy_fn, MPI_Delete_function *delete_fn, int *keyval, void *extra_state);
-int MPI_Keyval_free(int *keyval);
+int MPI_Is_thread_main(int *flag);
 int MPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name);
 int MPI_Mprobe(int source, int tag, MPI_Comm comm, MPI_Message *message, MPI_Status *status);
-int MPI_Mrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message *message, MPI_Status *status);
-int MPI_Mrecv_c(void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Message *message, MPI_Status *status);
+int MPI_Mrecv(void *buf, int count, MPI_Datatype type, MPI_Message *message, MPI_Status *status);
 int MPI_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Neighbor_allgather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Neighbor_allgather_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Neighbor_allgather_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
 int MPI_Neighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Neighbor_allgatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Neighbor_allgatherv_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Neighbor_allgatherv_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
 int MPI_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Neighbor_alltoall_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Neighbor_alltoall_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Neighbor_alltoall_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
 int MPI_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Neighbor_alltoallv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm);
-int MPI_Neighbor_alltoallv_init(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Neighbor_alltoallv_init_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
 int MPI_Neighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm);
-int MPI_Neighbor_alltoallw_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm);
-int MPI_Neighbor_alltoallw_init(const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Neighbor_alltoallw_init_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Request *request);
 int MPI_Op_commutative(MPI_Op op, int *commute);
-int MPI_Op_create(MPI_User_function *user_fn, int commute, MPI_Op *op);
-int MPI_Op_create_c(MPI_User_function_c *user_fn, int commute, MPI_Op *op);
-int MPI_Op_free(MPI_Op *op);
+int MPI_Op_create(MPI_User_function *function, int commute, MPI_Op *op);
 int MPI_Open_port(MPI_Info info, char *port_name);
+int MPI_Op_free(MPI_Op *op);
+int MPI_Pack_external(const char datarep[], const void *inbuf, int incount, MPI_Datatype datatype, void *outbuf, MPI_Aint outsize, MPI_Aint *position);
+int MPI_Pack_external_size(const char datarep[], int incount, MPI_Datatype datatype, MPI_Aint *size);
 int MPI_Pack(const void *inbuf, int incount, MPI_Datatype datatype, void *outbuf, int outsize, int *position, MPI_Comm comm);
-int MPI_Pack_c(const void *inbuf, MPI_Count incount, MPI_Datatype datatype, void *outbuf, MPI_Count outsize, MPI_Count *position, MPI_Comm comm);
-int MPI_Pack_external(const char *datarep, const void *inbuf, int incount, MPI_Datatype datatype, void *outbuf, MPI_Aint outsize, MPI_Aint *position);
-int MPI_Pack_external_c(const char *datarep, const void *inbuf, MPI_Count incount, MPI_Datatype datatype, void *outbuf, MPI_Count outsize, MPI_Count *position);
-int MPI_Pack_external_size(const char *datarep, int incount, MPI_Datatype datatype, MPI_Aint *size);
-int MPI_Pack_external_size_c(const char *datarep, MPI_Count incount, MPI_Datatype datatype, MPI_Count *size);
 int MPI_Pack_size(int incount, MPI_Datatype datatype, MPI_Comm comm, int *size);
-int MPI_Pack_size_c(MPI_Count incount, MPI_Datatype datatype, MPI_Comm comm, MPI_Count *size);
-int MPI_Parrived(MPI_Request request, int partition, int *flag);
 int MPI_Pcontrol(const int level, ...);
-int MPI_Pready(int partition, MPI_Request request);
-int MPI_Pready_list(int length, const int array_of_partitions[], MPI_Request request);
-int MPI_Pready_range(int partition_low, int partition_high, MPI_Request request);
-int MPI_Precv_init(void *buf, int partitions, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Info info, MPI_Request *request);
 int MPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status *status);
-int MPI_Psend_init(const void *buf, int partitions, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Info info, MPI_Request *request);
 int MPI_Publish_name(const char *service_name, MPI_Info info, const char *port_name);
 int MPI_Put(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Win win);
-int MPI_Put_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Win win);
 int MPI_Query_thread(int *provided);
 int MPI_Raccumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win, MPI_Request *request);
-int MPI_Raccumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win, MPI_Request *request);
-int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status *status);
-int MPI_Recv_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status *status);
 int MPI_Recv_init(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request);
-int MPI_Recv_init_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status *status);
 int MPI_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm);
-int MPI_Reduce_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm);
-int MPI_Reduce_init(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Reduce_init_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm, MPI_Request *request);
 int MPI_Reduce_local(const void *inbuf, void *inoutbuf, int count, MPI_Datatype datatype, MPI_Op op);
-int MPI_Reduce_local_c(const void *inbuf, void *inoutbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op);
 int MPI_Reduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
-int MPI_Reduce_scatter_c(const void *sendbuf, void *recvbuf, const MPI_Count recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
 int MPI_Reduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
-int MPI_Reduce_scatter_block_c(const void *sendbuf, void *recvbuf, MPI_Count recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
-int MPI_Reduce_scatter_block_init(const void *sendbuf, void *recvbuf, int recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Reduce_scatter_block_init_c(const void *sendbuf, void *recvbuf, MPI_Count recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Reduce_scatter_init(const void *sendbuf, void *recvbuf, const int recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Reduce_scatter_init_c(const void *sendbuf, void *recvbuf, const MPI_Count recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
 int MPI_Register_datarep(const char *datarep, MPI_Datarep_conversion_function *read_conversion_fn, MPI_Datarep_conversion_function *write_conversion_fn, MPI_Datarep_extent_function *dtype_file_extent_fn, void *extra_state);
-int MPI_Register_datarep_c(const char *datarep, MPI_Datarep_conversion_function_c *read_conversion_fn, MPI_Datarep_conversion_function_c *write_conversion_fn, MPI_Datarep_extent_function *dtype_file_extent_fn, void *extra_state);
-int MPI_Remove_error_class(int errorclass);
-int MPI_Remove_error_code(int errorcode);
-int MPI_Remove_error_string(int errorcode);
 int MPI_Request_free(MPI_Request *request);
 int MPI_Request_get_status(MPI_Request request, int *flag, MPI_Status *status);
-int MPI_Request_get_status_all(int count, MPI_Request array_of_requests[], int *flag, MPI_Status *array_of_statuses);
-int MPI_Request_get_status_any(int count, MPI_Request array_of_requests[], int *indx, int *flag, MPI_Status *status);
-int MPI_Request_get_status_some(int incount, MPI_Request array_of_requests[], int *outcount, int array_of_indices[], MPI_Status *array_of_statuses);
 int MPI_Rget(void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Win win, MPI_Request *request);
-int MPI_Rget_c(void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Win win, MPI_Request *request);
 int MPI_Rget_accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, void *result_addr, int result_count, MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win, MPI_Request *request);
-int MPI_Rget_accumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, void *result_addr, MPI_Count result_count, MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win, MPI_Request *request);
-int MPI_Rput(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Win win, MPI_Request *request);
-int MPI_Rput_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Win win, MPI_Request *request);
-int MPI_Rsend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
-int MPI_Rsend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int MPI_Rput(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_cout, MPI_Datatype target_datatype, MPI_Win win, MPI_Request *request);
+int MPI_Rsend(const void *ibuf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
 int MPI_Rsend_init(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
-int MPI_Rsend_init_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
 int MPI_Scan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
-int MPI_Scan_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
-int MPI_Scan_init(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Scan_init_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
 int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
-int MPI_Scatter_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
-int MPI_Scatter_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Scatter_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
 int MPI_Scatterv(const void *sendbuf, const int sendcounts[], const int displs[], MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
-int MPI_Scatterv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
-int MPI_Scatterv_init(const void *sendbuf, const int sendcounts[], const int displs[], MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Scatterv_init_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
-int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
-int MPI_Send_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[], MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
 int MPI_Send_init(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
-int MPI_Send_init_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
 int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, int dest, int sendtag, void *recvbuf, int recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Status *status);
-int MPI_Sendrecv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, int dest, int sendtag, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Status *status);
 int MPI_Sendrecv_replace(void *buf, int count, MPI_Datatype datatype, int dest, int sendtag, int source, int recvtag, MPI_Comm comm, MPI_Status *status);
-int MPI_Sendrecv_replace_c(void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int sendtag, int source, int recvtag, MPI_Comm comm, MPI_Status *status);
-int MPI_Session_attach_buffer(MPI_Session session, void *buffer, int size);
-int MPI_Session_attach_buffer_c(MPI_Session session, void *buffer, MPI_Count size);
-int MPI_Session_call_errhandler(MPI_Session session, int errorcode);
-int MPI_Session_create_errhandler(MPI_Session_errhandler_function *session_errhandler_fn, MPI_Errhandler *errhandler);
-int MPI_Session_detach_buffer(MPI_Session session, void *buffer_addr, int *size);
-int MPI_Session_detach_buffer_c(MPI_Session session, void *buffer_addr, MPI_Count *size);
-int MPI_Session_finalize(MPI_Session *session);
-int MPI_Session_flush_buffer(MPI_Session session);
-int MPI_Session_get_errhandler(MPI_Session session, MPI_Errhandler *errhandler);
-int MPI_Session_get_info(MPI_Session session, MPI_Info *info_used);
-int MPI_Session_get_nth_pset(MPI_Session session, MPI_Info info, int n, int *pset_len, char *pset_name);
-int MPI_Session_get_num_psets(MPI_Session session, MPI_Info info, int *npset_names);
-int MPI_Session_get_pset_info(MPI_Session session, const char *pset_name, MPI_Info *info);
-int MPI_Session_iflush_buffer(MPI_Session session, MPI_Request *request);
-int MPI_Session_init(MPI_Info info, MPI_Errhandler errhandler, MPI_Session *session);
-int MPI_Session_set_errhandler(MPI_Session session, MPI_Errhandler errhandler);
-int MPI_Sizeof(void *x, int *size);
-int MPI_Ssend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
-int MPI_Ssend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
 int MPI_Ssend_init(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
-int MPI_Ssend_init_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Ssend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
 int MPI_Start(MPI_Request *request);
 int MPI_Startall(int count, MPI_Request array_of_requests[]);
-int MPI_Status_get_error(MPI_Status *status, int *error);
-int MPI_Status_get_source(MPI_Status *status, int *source);
-int MPI_Status_get_tag(MPI_Status *status, int *tag);
 int MPI_Status_set_cancelled(MPI_Status *status, int flag);
 int MPI_Status_set_elements(MPI_Status *status, MPI_Datatype datatype, int count);
-int MPI_Status_set_elements_c(MPI_Status *status, MPI_Datatype datatype, MPI_Count count);
 int MPI_Status_set_elements_x(MPI_Status *status, MPI_Datatype datatype, MPI_Count count);
-int MPI_Status_set_error(MPI_Status *status, int error);
-int MPI_Status_set_source(MPI_Status *status, int source);
-int MPI_Status_set_tag(MPI_Status *status, int tag);
+int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag, MPI_Status array_of_statuses[]);
+int MPI_Testany(int count, MPI_Request array_of_requests[], int *index, int *flag, MPI_Status *status);
+int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status);
+int MPI_Test_cancelled(const MPI_Status *status, int *flag);
+int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount, int array_of_indices[], MPI_Status array_of_statuses[]);
+int MPI_Topo_test(MPI_Comm comm, int *status);
+int MPI_Type_commit(MPI_Datatype *type);
+int MPI_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_darray(int size, int rank, int ndims, const int gsize_array[], const int distrib_array[], const int darg_array[], const int psize_array[], int order, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_f90_complex(int p, int r, MPI_Datatype *newtype);
+int MPI_Type_create_f90_integer(int r, MPI_Datatype *newtype);
+int MPI_Type_create_f90_real(int p, int r, MPI_Datatype *newtype);
+int MPI_Type_create_hindexed_block(int count, int blocklength, const MPI_Aint array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_hindexed(int count, const int array_of_blocklengths[], const MPI_Aint array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_hvector(int count, int blocklength, MPI_Aint stride, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_keyval(MPI_Type_copy_attr_function *type_copy_attr_fn, MPI_Type_delete_attr_function *type_delete_attr_fn, int *type_keyval, void *extra_state);
+int MPI_Type_create_indexed_block(int count, int blocklength, const int array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_struct(int count, const int array_of_block_lengths[], const MPI_Aint array_of_displacements[], const MPI_Datatype array_of_types[], MPI_Datatype *newtype);
+int MPI_Type_create_subarray(int ndims, const int size_array[], const int subsize_array[], const int start_array[], int order, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent, MPI_Datatype *newtype);
+int MPI_Type_delete_attr(MPI_Datatype type, int type_keyval);
+int MPI_Type_dup(MPI_Datatype type, MPI_Datatype *newtype);
+int MPI_Type_free(MPI_Datatype *type);
+int MPI_Type_free_keyval(int *type_keyval);
+int MPI_Type_get_attr(MPI_Datatype type, int type_keyval, void *attribute_val, int *flag);
+int MPI_Type_get_contents(MPI_Datatype mtype, int max_integers, int max_addresses, int max_datatypes, int array_of_integers[], MPI_Aint array_of_addresses[], MPI_Datatype array_of_datatypes[]);
+int MPI_Type_get_envelope(MPI_Datatype type, int *num_integers, int *num_addresses, int *num_datatypes, int *combiner);
+int MPI_Type_get_extent(MPI_Datatype type, MPI_Aint *lb, MPI_Aint *extent);
+int MPI_Type_get_extent_x(MPI_Datatype type, MPI_Count *lb, MPI_Count *extent);
+int MPI_Type_get_name(MPI_Datatype type, char *type_name, int *resultlen);
+int MPI_Type_get_true_extent(MPI_Datatype datatype, MPI_Aint *true_lb, MPI_Aint *true_extent);
+int MPI_Type_get_true_extent_x(MPI_Datatype datatype, MPI_Count *true_lb, MPI_Count *true_extent);
+int MPI_Type_indexed(int count, const int array_of_blocklengths[], const int array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_match_size(int typeclass, int size, MPI_Datatype *type);
+int MPI_Type_set_attr(MPI_Datatype type, int type_keyval, void *attr_val);
+int MPI_Type_set_name(MPI_Datatype type, const char *type_name);
+int MPI_Type_size(MPI_Datatype type, int *size);
+int MPI_Type_size_x(MPI_Datatype type, MPI_Count *size);
+int MPI_Type_vector(int count, int blocklength, int stride, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Unpack(const void *inbuf, int insize, int *position, void *outbuf, int outcount, MPI_Datatype datatype, MPI_Comm comm);
+int MPI_Unpublish_name(const char *service_name, MPI_Info info, const char *port_name);
+int MPI_Unpack_external(const char datarep[], const void *inbuf, MPI_Aint insize, MPI_Aint *position, void *outbuf, int outcount, MPI_Datatype datatype);
+int MPI_Waitall(int count, MPI_Request array_of_requests[], MPI_Status *array_of_statuses);
+int MPI_Waitany(int count, MPI_Request array_of_requests[], int *index, MPI_Status *status);
+int MPI_Wait(MPI_Request *request, MPI_Status *status);
+int MPI_Waitsome(int incount, MPI_Request array_of_requests[], int *outcount, int array_of_indices[], MPI_Status array_of_statuses[]);
+int MPI_Win_allocate(MPI_Aint size, int disp_unit, MPI_Info info, MPI_Comm comm, void *baseptr, MPI_Win *win);
+int MPI_Win_allocate_shared(MPI_Aint size, int disp_unit, MPI_Info info, MPI_Comm comm, void *baseptr, MPI_Win *win);
+int MPI_Win_attach(MPI_Win win, void *base, MPI_Aint size);
+int MPI_Win_call_errhandler(MPI_Win win, int errorcode);
+int MPI_Win_complete(MPI_Win win);
+int MPI_Win_create(void *base, MPI_Aint size, int disp_unit, MPI_Info info, MPI_Comm comm, MPI_Win *win);
+int MPI_Win_create_dynamic(MPI_Info info, MPI_Comm comm, MPI_Win *win);
+int MPI_Win_create_errhandler(MPI_Win_errhandler_function *function, MPI_Errhandler *errhandler);
+int MPI_Win_create_keyval(MPI_Win_copy_attr_function *win_copy_attr_fn, MPI_Win_delete_attr_function *win_delete_attr_fn, int *win_keyval, void *extra_state);
+int MPI_Win_delete_attr(MPI_Win win, int win_keyval);
+int MPI_Win_detach(MPI_Win win, const void *base);
+int MPI_Win_fence(int assert, MPI_Win win);
+int MPI_Win_flush(int rank, MPI_Win win);
+int MPI_Win_flush_all(MPI_Win win);
+int MPI_Win_flush_local(int rank, MPI_Win win);
+int MPI_Win_flush_local_all(MPI_Win win);
+int MPI_Win_free(MPI_Win *win);
+int MPI_Win_free_keyval(int *win_keyval);
+int MPI_Win_get_attr(MPI_Win win, int win_keyval, void *attribute_val, int *flag);
+int MPI_Win_get_errhandler(MPI_Win win, MPI_Errhandler *errhandler);
+int MPI_Win_get_group(MPI_Win win, MPI_Group *group);
+int MPI_Win_get_info(MPI_Win win, MPI_Info *info_used);
+int MPI_Win_get_name(MPI_Win win, char *win_name, int *resultlen);
+int MPI_Win_lock(int lock_type, int rank, int assert, MPI_Win win);
+int MPI_Win_lock_all(int assert, MPI_Win win);
+int MPI_Win_post(MPI_Group group, int assert, MPI_Win win);
+int MPI_Win_set_attr(MPI_Win win, int win_keyval, void *attribute_val);
+int MPI_Win_set_errhandler(MPI_Win win, MPI_Errhandler errhandler);
+int MPI_Win_set_info(MPI_Win win, MPI_Info info);
+int MPI_Win_set_name(MPI_Win win, const char *win_name);
+int MPI_Win_shared_query(MPI_Win win, int rank, MPI_Aint *size, int *disp_unit, void *baseptr);
+int MPI_Win_start(MPI_Group group, int assert, MPI_Win win);
+int MPI_Win_sync(MPI_Win win);
+int MPI_Win_test(MPI_Win win, int *flag);
+int MPI_Win_unlock(int rank, MPI_Win win);
+int MPI_Win_unlock_all(MPI_Win win);
+int MPI_Win_wait(MPI_Win win);
+double MPI_Wtick();
+double MPI_Wtime();
+int MPI_Attr_delete(MPI_Comm comm, int keyval);
+int MPI_Attr_get(MPI_Comm comm, int keyval, void *attribute_val, int *flag);
+int MPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val);
+int MPI_Keyval_create(MPI_Copy_function *copy_fn, MPI_Delete_function *delete_fn, int *keyval, void *extra_state);
+int MPI_Keyval_free(int *keyval);
+
+int MPI_Status_c2f(const MPI_Status *c_status, MPI_Fint *f_status);
+int MPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status);
+
+MPI_Fint MPI_Comm_c2f(MPI_Comm comm);
+MPI_Comm MPI_Comm_f2c(MPI_Fint comm);
+MPI_Fint MPI_Errhandler_c2f(MPI_Errhandler errhandler);
+MPI_Errhandler MPI_Errhandler_f2c(MPI_Fint errhandler);
+MPI_Fint MPI_Type_c2f(MPI_Datatype datatype);
+MPI_Datatype MPI_Type_f2c(MPI_Fint datatype);
+MPI_Fint MPI_File_c2f(MPI_File file);
+MPI_File MPI_File_f2c(MPI_Fint file);
+MPI_Fint MPI_Group_c2f(MPI_Group group);
+MPI_Group MPI_Group_f2c(MPI_Fint group);
+MPI_Fint MPI_Info_c2f(MPI_Info info);
+MPI_Info MPI_Info_f2c(MPI_Fint info);
+MPI_Fint MPI_Message_c2f(MPI_Message message);
+MPI_Message MPI_Message_f2c(MPI_Fint message);
+MPI_Fint MPI_Op_c2f(MPI_Op op);
+MPI_Op MPI_Op_f2c(MPI_Fint op);
+MPI_Fint MPI_Request_c2f(MPI_Request request);
+MPI_Request MPI_Request_f2c(MPI_Fint request);
+MPI_Fint MPI_Session_c2f(MPI_Session session);
+MPI_Session MPI_Session_f2c(MPI_Fint session);
+MPI_Fint MPI_Win_c2f(MPI_Win win);
+MPI_Win MPI_Win_f2c(MPI_Fint win);
+
+/* MPI_T functions */
 int MPI_T_category_changed(int *update_number);
 int MPI_T_category_get_categories(int cat_index, int len, int indices[]);
 int MPI_T_category_get_cvars(int cat_index, int len, int indices[]);
@@ -1038,141 +971,6 @@ int MPI_T_pvar_write(MPI_T_pvar_session session, MPI_T_pvar_handle handle, const
 int MPI_T_source_get_info(int source_index, char *name, int *name_len, char *desc, int *desc_len, MPI_T_source_order *ordering, MPI_Count *ticks_per_second, MPI_Count *max_ticks, MPI_Info *info);
 int MPI_T_source_get_num(int *num_sources);
 int MPI_T_source_get_timestamp(int source_index, MPI_Count *timestamp);
-int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status);
-int MPI_Test_cancelled(const MPI_Status *status, int *flag);
-int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag, MPI_Status *array_of_statuses);
-int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx, int *flag, MPI_Status *status);
-int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount, int array_of_indices[], MPI_Status *array_of_statuses);
-int MPI_Topo_test(MPI_Comm comm, int *status);
-int MPI_Type_commit(MPI_Datatype *datatype);
-int MPI_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_contiguous_c(MPI_Count count, MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_create_darray(int size, int rank, int ndims, const int array_of_gsizes[], const int array_of_distribs[], const int array_of_dargs[], const int array_of_psizes[], int order, MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_create_darray_c(int size, int rank, int ndims, const MPI_Count array_of_gsizes[], const int array_of_distribs[], const int array_of_dargs[], const int array_of_psizes[], int order, MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_create_f90_complex(int p, int r, MPI_Datatype *newtype);
-int MPI_Type_create_f90_integer(int r, MPI_Datatype *newtype);
-int MPI_Type_create_f90_real(int p, int r, MPI_Datatype *newtype);
-int MPI_Type_create_hindexed(int count, const int array_of_blocklengths[], const MPI_Aint array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_create_hindexed_c(MPI_Count count, const MPI_Count array_of_blocklengths[], const MPI_Count array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_create_hindexed_block(int count, int blocklength, const MPI_Aint array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_create_hindexed_block_c(MPI_Count count, MPI_Count blocklength, const MPI_Count array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_create_hvector(int count, int blocklength, MPI_Aint stride, MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_create_hvector_c(MPI_Count count, MPI_Count blocklength, MPI_Count stride, MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_create_indexed_block(int count, int blocklength, const int array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_create_indexed_block_c(MPI_Count count, MPI_Count blocklength, const MPI_Count array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_create_keyval(MPI_Type_copy_attr_function *type_copy_attr_fn, MPI_Type_delete_attr_function *type_delete_attr_fn, int *type_keyval, void *extra_state);
-int MPI_Type_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent, MPI_Datatype *newtype);
-int MPI_Type_create_resized_c(MPI_Datatype oldtype, MPI_Count lb, MPI_Count extent, MPI_Datatype *newtype);
-int MPI_Type_create_struct(int count, const int array_of_blocklengths[], const MPI_Aint array_of_displacements[], const MPI_Datatype array_of_types[], MPI_Datatype *newtype);
-int MPI_Type_create_struct_c(MPI_Count count, const MPI_Count array_of_blocklengths[], const MPI_Count array_of_displacements[], const MPI_Datatype array_of_types[], MPI_Datatype *newtype);
-int MPI_Type_create_subarray(int ndims, const int array_of_sizes[], const int array_of_subsizes[], const int array_of_starts[], int order, MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_create_subarray_c(int ndims, const MPI_Count array_of_sizes[], const MPI_Count array_of_subsizes[], const MPI_Count array_of_starts[], int order, MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_delete_attr(MPI_Datatype datatype, int type_keyval);
-int MPI_Type_dup(MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_free(MPI_Datatype *datatype);
-int MPI_Type_free_keyval(int *type_keyval);
-int MPI_Type_get_attr(MPI_Datatype datatype, int type_keyval, void *attribute_val, int *flag);
-int MPI_Type_get_contents(MPI_Datatype datatype, int max_integers, int max_addresses, int max_datatypes, int array_of_integers[], MPI_Aint array_of_addresses[], MPI_Datatype array_of_datatypes[]);
-int MPI_Type_get_contents_c(MPI_Datatype datatype, MPI_Count max_integers, MPI_Count max_addresses, MPI_Count max_large_counts, MPI_Count max_datatypes, int array_of_integers[], MPI_Aint array_of_addresses[], MPI_Count array_of_large_counts[], MPI_Datatype array_of_datatypes[]);
-int MPI_Type_get_envelope(MPI_Datatype datatype, int *num_integers, int *num_addresses, int *num_datatypes, int *combiner);
-int MPI_Type_get_envelope_c(MPI_Datatype datatype, MPI_Count *num_integers, MPI_Count *num_addresses, MPI_Count *num_large_counts, MPI_Count *num_datatypes, int *combiner);
-int MPI_Type_get_extent(MPI_Datatype datatype, MPI_Aint *lb, MPI_Aint *extent);
-int MPI_Type_get_extent_c(MPI_Datatype datatype, MPI_Count *lb, MPI_Count *extent);
-int MPI_Type_get_extent_x(MPI_Datatype datatype, MPI_Count *lb, MPI_Count *extent);
-int MPI_Type_get_name(MPI_Datatype datatype, char *type_name, int *resultlen);
-int MPI_Type_get_true_extent(MPI_Datatype datatype, MPI_Aint *true_lb, MPI_Aint *true_extent);
-int MPI_Type_get_true_extent_c(MPI_Datatype datatype, MPI_Count *true_lb, MPI_Count *true_extent);
-int MPI_Type_get_true_extent_x(MPI_Datatype datatype, MPI_Count *true_lb, MPI_Count *true_extent);
-int MPI_Type_get_value_index(MPI_Datatype value_type, MPI_Datatype index_type, MPI_Datatype *pair_type);
-int MPI_Type_indexed(int count, const int array_of_blocklengths[], const int array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_indexed_c(MPI_Count count, const MPI_Count array_of_blocklengths[], const MPI_Count array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_match_size(int typeclass, int size, MPI_Datatype *datatype);
-int MPI_Type_set_attr(MPI_Datatype datatype, int type_keyval, void *attribute_val);
-int MPI_Type_set_name(MPI_Datatype datatype, const char *type_name);
-int MPI_Type_size(MPI_Datatype datatype, int *size);
-int MPI_Type_size_c(MPI_Datatype datatype, MPI_Count *size);
-int MPI_Type_size_x(MPI_Datatype datatype, MPI_Count *size);
-int MPI_Type_vector(int count, int blocklength, int stride, MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Type_vector_c(MPI_Count count, MPI_Count blocklength, MPI_Count stride, MPI_Datatype oldtype, MPI_Datatype *newtype);
-int MPI_Unpack(const void *inbuf, int insize, int *position, void *outbuf, int outcount, MPI_Datatype datatype, MPI_Comm comm);
-int MPI_Unpack_c(const void *inbuf, MPI_Count insize, MPI_Count *position, void *outbuf, MPI_Count outcount, MPI_Datatype datatype, MPI_Comm comm);
-int MPI_Unpack_external(const char datarep[], const void *inbuf, MPI_Aint insize, MPI_Aint *position, void *outbuf, int outcount, MPI_Datatype datatype);
-int MPI_Unpack_external_c(const char datarep[], const void *inbuf, MPI_Count insize, MPI_Count *position, void *outbuf, MPI_Count outcount, MPI_Datatype datatype);
-int MPI_Unpublish_name(const char *service_name, MPI_Info info, const char *port_name);
-int MPI_Wait(MPI_Request *request, MPI_Status *status);
-int MPI_Waitall(int count, MPI_Request array_of_requests[], MPI_Status *array_of_statuses);
-int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx, MPI_Status *status);
-int MPI_Waitsome(int incount, MPI_Request array_of_requests[], int *outcount, int array_of_indices[], MPI_Status *array_of_statuses);
-int MPI_Win_allocate(MPI_Aint size, int disp_unit, MPI_Info info, MPI_Comm comm, void *baseptr, MPI_Win *win);
-int MPI_Win_allocate_c(MPI_Aint size, MPI_Aint disp_unit, MPI_Info info, MPI_Comm comm, void *baseptr, MPI_Win *win);
-int MPI_Win_allocate_shared(MPI_Aint size, int disp_unit, MPI_Info info, MPI_Comm comm, void *baseptr, MPI_Win *win);
-int MPI_Win_allocate_shared_c(MPI_Aint size, MPI_Aint disp_unit, MPI_Info info, MPI_Comm comm, void *baseptr, MPI_Win *win);
-int MPI_Win_attach(MPI_Win win, void *base, MPI_Aint size);
-int MPI_Win_call_errhandler(MPI_Win win, int errorcode);
-int MPI_Win_complete(MPI_Win win);
-int MPI_Win_create(void *base, MPI_Aint size, int disp_unit, MPI_Info info, MPI_Comm comm, MPI_Win *win);
-int MPI_Win_create_c(void *base, MPI_Aint size, MPI_Aint disp_unit, MPI_Info info, MPI_Comm comm, MPI_Win *win);
-int MPI_Win_create_dynamic(MPI_Info info, MPI_Comm comm, MPI_Win *win);
-int MPI_Win_create_errhandler(MPI_Win_errhandler_function *win_errhandler_fn, MPI_Errhandler *errhandler);
-int MPI_Win_create_keyval(MPI_Win_copy_attr_function *win_copy_attr_fn, MPI_Win_delete_attr_function *win_delete_attr_fn, int *win_keyval, void *extra_state);
-int MPI_Win_delete_attr(MPI_Win win, int win_keyval);
-int MPI_Win_detach(MPI_Win win, const void *base);
-int MPI_Win_fence(int assert, MPI_Win win);
-int MPI_Win_flush(int rank, MPI_Win win);
-int MPI_Win_flush_all(MPI_Win win);
-int MPI_Win_flush_local(int rank, MPI_Win win);
-int MPI_Win_flush_local_all(MPI_Win win);
-int MPI_Win_free(MPI_Win *win);
-int MPI_Win_free_keyval(int *win_keyval);
-int MPI_Win_get_attr(MPI_Win win, int win_keyval, void *attribute_val, int *flag);
-int MPI_Win_get_errhandler(MPI_Win win, MPI_Errhandler *errhandler);
-int MPI_Win_get_group(MPI_Win win, MPI_Group *group);
-int MPI_Win_get_info(MPI_Win win, MPI_Info *info_used);
-int MPI_Win_get_name(MPI_Win win, char *win_name, int *resultlen);
-int MPI_Win_lock(int lock_type, int rank, int assert, MPI_Win win);
-int MPI_Win_lock_all(int assert, MPI_Win win);
-int MPI_Win_post(MPI_Group group, int assert, MPI_Win win);
-int MPI_Win_set_attr(MPI_Win win, int win_keyval, void *attribute_val);
-int MPI_Win_set_errhandler(MPI_Win win, MPI_Errhandler errhandler);
-int MPI_Win_set_info(MPI_Win win, MPI_Info info);
-int MPI_Win_set_name(MPI_Win win, const char *win_name);
-int MPI_Win_shared_query(MPI_Win win, int rank, MPI_Aint *size, int *disp_unit, void *baseptr);
-int MPI_Win_shared_query_c(MPI_Win win, int rank, MPI_Aint *size, MPI_Aint *disp_unit, void *baseptr);
-int MPI_Win_start(MPI_Group group, int assert, MPI_Win win);
-int MPI_Win_sync(MPI_Win win);
-int MPI_Win_test(MPI_Win win, int *flag);
-int MPI_Win_unlock(int rank, MPI_Win win);
-int MPI_Win_unlock_all(MPI_Win win);
-int MPI_Win_wait(MPI_Win win);
-double MPI_Wtick(void);
-double MPI_Wtime(void);
-
-int MPI_Status_c2f(const MPI_Status *c_status, MPI_Fint *f_status);
-int MPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status);
-
-MPI_Fint MPI_Comm_c2f(MPI_Comm comm);
-MPI_Comm MPI_Comm_f2c(MPI_Fint comm);
-MPI_Fint MPI_Errhandler_c2f(MPI_Errhandler errhandler);
-MPI_Errhandler MPI_Errhandler_f2c(MPI_Fint errhandler);
-MPI_Fint MPI_Type_c2f(MPI_Datatype datatype);
-MPI_Datatype MPI_Type_f2c(MPI_Fint datatype);
-MPI_Fint MPI_File_c2f(MPI_File file);
-MPI_File MPI_File_f2c(MPI_Fint file);
-MPI_Fint MPI_Group_c2f(MPI_Group group);
-MPI_Group MPI_Group_f2c(MPI_Fint group);
-MPI_Fint MPI_Info_c2f(MPI_Info info);
-MPI_Info MPI_Info_f2c(MPI_Fint info);
-MPI_Fint MPI_Message_c2f(MPI_Message message);
-MPI_Message MPI_Message_f2c(MPI_Fint message);
-MPI_Fint MPI_Op_c2f(MPI_Op op);
-MPI_Op MPI_Op_f2c(MPI_Fint op);
-MPI_Fint MPI_Request_c2f(MPI_Request request);
-MPI_Request MPI_Request_f2c(MPI_Fint request);
-MPI_Fint MPI_Session_c2f(MPI_Session session);
-MPI_Session MPI_Session_f2c(MPI_Fint session);
-MPI_Fint MPI_Win_c2f(MPI_Win win);
-MPI_Win MPI_Win_f2c(MPI_Fint win);
-
 /* PMPI functions */
 int PMPI_Abort(MPI_Comm comm, int errorcode);
 int PMPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
@@ -1809,4 +1607,56 @@ MPI_Session PMPI_Session_f2c(MPI_Fint session);
 MPI_Fint PMPI_Win_c2f(MPI_Win win);
 MPI_Win PMPI_Win_f2c(MPI_Fint win);
 
-#endif /* MPI_ABI_H_INCLUDED */
+int PMPI_T_category_changed(int *update_number);
+int PMPI_T_category_get_categories(int cat_index, int len, int indices[]);
+int PMPI_T_category_get_cvars(int cat_index, int len, int indices[]);
+int PMPI_T_category_get_events(int cat_index, int len, int indices[]);
+int PMPI_T_category_get_index(const char *name, int *cat_index);
+int PMPI_T_category_get_info(int cat_index, char *name, int *name_len, char *desc, int *desc_len, int *num_cvars, int *num_pvars, int *num_categories);
+int PMPI_T_category_get_num(int *num_cat);
+int PMPI_T_category_get_num_events(int cat_index, int *num_events);
+int PMPI_T_category_get_pvars(int cat_index, int len, int indices[]);
+int PMPI_T_cvar_get_index(const char *name, int *cvar_index);
+int PMPI_T_cvar_get_info(int cvar_index, char *name, int *name_len, int *verbosity, MPI_Datatype *datatype, MPI_T_enum *enumtype, char *desc, int *desc_len, int *bind, int *scope);
+int PMPI_T_cvar_get_num(int *num_cvar);
+int PMPI_T_cvar_handle_alloc(int cvar_index, void *obj_handle, MPI_T_cvar_handle *handle, int *count);
+int PMPI_T_cvar_handle_free(MPI_T_cvar_handle *handle);
+int PMPI_T_cvar_read(MPI_T_cvar_handle handle, void *buf);
+int PMPI_T_cvar_write(MPI_T_cvar_handle handle, const void *buf);
+int PMPI_T_enum_get_info(MPI_T_enum enumtype, int *num, char *name, int *name_len);
+int PMPI_T_enum_get_item(MPI_T_enum enumtype, int indx, int *value, char *name, int *name_len);
+int PMPI_T_event_callback_get_info(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, MPI_Info *info_used);
+int PMPI_T_event_callback_set_info(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, MPI_Info info);
+int PMPI_T_event_copy(MPI_T_event_instance event_instance, void *buffer);
+int PMPI_T_event_get_index(const char *name, int *event_index);
+int PMPI_T_event_get_info(int event_index, char *name, int *name_len, int *verbosity, MPI_Datatype array_of_datatypes[], MPI_Aint array_of_displacements[], int *num_elements, MPI_T_enum *enumtype, MPI_Info *info, char *desc, int *desc_len, int *bind);
+int PMPI_T_event_get_num(int *num_events);
+int PMPI_T_event_get_source(MPI_T_event_instance event_instance, int *source_index);
+int PMPI_T_event_get_timestamp(MPI_T_event_instance event_instance, MPI_Count *event_timestamp);
+int PMPI_T_event_handle_alloc(int event_index, void *obj_handle, MPI_Info info, MPI_T_event_registration *event_registration);
+int PMPI_T_event_handle_free(MPI_T_event_registration event_registration, void *user_data, MPI_T_event_free_cb_function free_cb_function);
+int PMPI_T_event_handle_get_info(MPI_T_event_registration event_registration, MPI_Info *info_used);
+int PMPI_T_event_handle_set_info(MPI_T_event_registration event_registration, MPI_Info info);
+int PMPI_T_event_read(MPI_T_event_instance event_instance, int element_index, void *buffer);
+int PMPI_T_event_register_callback(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, MPI_Info info, void *user_data, MPI_T_event_cb_function event_cb_function);
+int PMPI_T_event_set_dropped_handler(MPI_T_event_registration event_registration, MPI_T_event_dropped_cb_function dropped_cb_function);
+int PMPI_T_finalize(void);
+int PMPI_T_init_thread(int required, int *provided);
+int PMPI_T_pvar_get_index(const char *name, int var_class, int *pvar_index);
+int PMPI_T_pvar_get_info(int pvar_index, char *name, int *name_len, int *verbosity, int *var_class, MPI_Datatype *datatype, MPI_T_enum *enumtype, char *desc, int *desc_len, int *bind, int *readonly, int *continuous, int *atomic);
+int PMPI_T_pvar_get_num(int *num_pvar);
+int PMPI_T_pvar_handle_alloc(MPI_T_pvar_session session, int pvar_index, void *obj_handle, MPI_T_pvar_handle *handle, int *count);
+int PMPI_T_pvar_handle_free(MPI_T_pvar_session session, MPI_T_pvar_handle *handle);
+int PMPI_T_pvar_read(MPI_T_pvar_session session, MPI_T_pvar_handle handle, void *buf);
+int PMPI_T_pvar_readreset(MPI_T_pvar_session session, MPI_T_pvar_handle handle, void *buf);
+int PMPI_T_pvar_reset(MPI_T_pvar_session session, MPI_T_pvar_handle handle);
+int PMPI_T_pvar_session_create(MPI_T_pvar_session *session);
+int PMPI_T_pvar_session_free(MPI_T_pvar_session *session);
+int PMPI_T_pvar_start(MPI_T_pvar_session session, MPI_T_pvar_handle handle);
+int PMPI_T_pvar_stop(MPI_T_pvar_session session, MPI_T_pvar_handle handle);
+int PMPI_T_pvar_write(MPI_T_pvar_session session, MPI_T_pvar_handle handle, const void *buf);
+int PMPI_T_source_get_info(int source_index, char *name, int *name_len, char *desc, int *desc_len, MPI_T_source_order *ordering, MPI_Count *ticks_per_second, MPI_Count *max_ticks, MPI_Info *info);
+int PMPI_T_source_get_num(int *num_sources);
+int PMPI_T_source_get_timestamp(int source_index, MPI_Count *timestamp);
+
+#endif  /* MPI_H_ABI */

--- a/src/binding/abi/mpi_abi.h
+++ b/src/binding/abi/mpi_abi.h
@@ -1,0 +1,1820 @@
+#ifndef MPI_ABI_H_INCLUDED
+#define MPI_ABI_H_INCLUDED
+
+#define MPI_VERSION 5
+#define MPI_SUBVERSION 0
+
+#define MPI_MAX_PROCESSOR_NAME         128
+#define MPI_MAX_LIBRARY_VERSION_STRING 8192
+#define MPI_MAX_ERROR_STRING           512
+#define MPI_MAX_DATAREP_STRING         128
+#define MPI_MAX_PORT_NAME              1024
+#define MPI_MAX_OBJECT_NAME            128
+#define MPI_MAX_STRINGTAG_LEN          256
+#define MPI_MAX_PSET_NAME_LEN          256
+#define MPI_MAX_INFO_KEY               255
+#define MPI_MAX_INFO_VAL               1024
+
+#include <stdint.h>
+
+typedef int MPI_Fint;
+typedef intptr_t MPI_Aint;
+typedef long long MPI_Offset;
+typedef MPI_Offset MPI_Count;
+
+/* FIXME: require configure */
+#define MPI_INTEGER_KIND  4
+#define MPI_ADDRESS_KIND  8
+#define MPI_OFFSET_KIND   8
+#define MPI_COUNT_KIND    8
+
+typedef struct mpi_comm_t * MPI_Comm;
+typedef struct mpi_datatype_t * MPI_Datatype;
+typedef struct mpi_errhandler_t * MPI_Errhandler;
+typedef struct mpi_file_t * MPI_File;
+typedef struct mpi_group_t * MPI_Group;
+typedef struct mpi_info_t * MPI_Info;
+typedef struct mpi_message_t * MPI_Message;
+typedef struct mpi_op_t * MPI_Op;
+typedef struct mpi_request_t * MPI_Request;
+typedef struct mpi_session_t * MPI_Session;
+typedef struct mpi_win_t * MPI_Win;
+
+typedef struct MPI_Status {
+    int MPI_SOURCE;
+    int MPI_TAG;
+    int MPI_ERROR;
+    int reserved[5];
+} MPI_Status;
+
+#define MPI_F_STATUS_SIZE 8
+#define MPI_F_SOURCE      0
+#define MPI_F_TAG         1
+#define MPI_F_ERROR       2
+
+extern MPI_Fint * MPI_F_STATUS_IGNORE;
+extern MPI_Fint * MPI_F_STATUSES_IGNORE;
+
+/* constants */
+#define MPI_BOTTOM     (void *)0
+#define MPI_IN_PLACE   (void *)1
+#define MPI_BUFFER_AUTOMATIC (void *)2
+#define MPI_PROC_NULL  -1
+#define MPI_ANY_SOURCE -2
+#define MPI_ROOT       -3
+#define MPI_ANY_TAG    -1
+#define MPI_UNDEFINED  -1
+#define MPI_BSEND_OVERHEAD 96  /* FIXME */
+
+#define MPI_STATUS_IGNORE   (MPI_Status *)0
+#define MPI_STATUSES_IGNORE (MPI_Status *)0
+#define MPI_ERRCODES_IGNORE (int *)0
+#define MPI_UNWEIGHTED      (int *)1
+#define MPI_WEIGHTS_EMPTY   (int *)2
+#define MPI_ARGV_NULL       (char **)0
+#define MPI_ARGVS_NULL      (char ***)0
+
+/* error codes */
+enum {
+    MPI_SUCCESS = 0,
+    MPI_ERR_BUFFER,
+    MPI_ERR_COUNT,
+    MPI_ERR_TYPE,
+    MPI_ERR_TAG,
+    MPI_ERR_COMM,
+    MPI_ERR_RANK,
+    MPI_ERR_REQUEST,
+    MPI_ERR_ROOT,
+    MPI_ERR_GROUP,
+    MPI_ERR_OP,
+    MPI_ERR_TOPOLOGY,
+    MPI_ERR_DIMS,
+    MPI_ERR_ARG,
+    MPI_ERR_UNKNOWN,
+    MPI_ERR_TRUNCATE,
+    MPI_ERR_OTHER,
+    MPI_ERR_INTERN,
+    MPI_ERR_PENDING,
+    MPI_ERR_IN_STATUS,
+    MPI_ERR_ACCESS,
+    MPI_ERR_AMODE,
+    MPI_ERR_ASSERT,
+    MPI_ERR_BAD_FILE,
+    MPI_ERR_BASE,
+    MPI_ERR_CONVERSION,
+    MPI_ERR_DISP,
+    MPI_ERR_DUP_DATAREP,
+    MPI_ERR_ERRHANDLER,
+    MPI_ERR_FILE_EXISTS,
+    MPI_ERR_FILE_IN_USE,
+    MPI_ERR_FILE,
+    MPI_ERR_INFO_KEY,
+    MPI_ERR_INFO_NOKEY,
+    MPI_ERR_INFO_VALUE,
+    MPI_ERR_INFO,
+    MPI_ERR_IO,
+    MPI_ERR_KEYVAL,
+    MPI_ERR_LOCKTYPE,
+    MPI_ERR_NAME,
+    MPI_ERR_NO_MEM,
+    MPI_ERR_NOT_SAME,
+    MPI_ERR_NO_SPACE,
+    MPI_ERR_NO_SUCH_FILE,
+    MPI_ERR_PORT,
+    MPI_ERR_PROC_ABORTED,
+    MPI_ERR_QUOTA,
+    MPI_ERR_READ_ONLY,
+    MPI_ERR_RMA_ATTACH,
+    MPI_ERR_RMA_CONFLICT,
+    MPI_ERR_RMA_RANGE,
+    MPI_ERR_RMA_SHARED,
+    MPI_ERR_RMA_SYNC,
+    MPI_ERR_RMA_FLAVOR,
+    MPI_ERR_SERVICE,
+    MPI_ERR_SESSION,
+    MPI_ERR_SIZE,
+    MPI_ERR_SPAWN,
+    MPI_ERR_UNSUPPORTED_DATAREP,
+    MPI_ERR_UNSUPPORTED_OPERATION,
+    MPI_ERR_VALUE_TOO_LARGE,
+    MPI_ERR_WIN,
+    MPI_T_ERR_CANNOT_INIT,
+    MPI_T_ERR_NOT_ACCESSIBLE,
+    MPI_T_ERR_NOT_INITIALIZED,
+    MPI_T_ERR_NOT_SUPPORTED,
+    MPI_T_ERR_MEMORY,
+    MPI_T_ERR_INVALID,
+    MPI_T_ERR_INVALID_INDEX,
+    MPI_T_ERR_INVALID_ITEM,
+    MPI_T_ERR_INVALID_SESSION,
+    MPI_T_ERR_INVALID_HANDLE,
+    MPI_T_ERR_INVALID_NAME,
+    MPI_T_ERR_OUT_OF_HANDLES,
+    MPI_T_ERR_OUT_OF_SESSIONS,
+    MPI_T_ERR_CVAR_SET_NOT_NOW,
+    MPI_T_ERR_CVAR_SET_NEVER,
+    MPI_T_ERR_PVAR_NO_WRITE,
+    MPI_T_ERR_PVAR_NO_STARTSTOP,
+    MPI_T_ERR_PVAR_NO_ATOMIC,
+    MPI_ERR_LASTCODE
+};
+
+enum {
+    MPI_LOCK_EXCLUSIVE,
+    MPI_LOCK_SHARED
+};
+
+enum {
+    MPI_COMM_TYPE_SHARED,
+    MPI_COMM_TYPE_HW_UNGUIDED,
+    MPI_COMM_TYPE_HW_GUIDED,
+    MPI_COMM_TYPE_RESOURCE_GUIDED
+};
+
+enum {
+    MPI_IDENT,
+    MPI_CONGRUENT,
+    MPI_SIMILAR,
+    MPI_UNEQUAL
+};
+
+enum {
+    MPI_GRAPH,
+    MPI_CART,
+    MPI_DIST_GRAPH
+};
+
+enum {
+    MPI_KEYVAL_INVALID,
+    MPI_TAG_UB,
+    MPI_IO,
+    MPI_HOST,
+    MPI_WTIME_IS_GLOBAL,
+    MPI_APPNUM,
+    MPI_LASTUSEDCODE,
+    MPI_UNIVERSE_SIZE,
+    MPI_WIN_BASE,
+    MPI_WIN_DISP_UNIT,
+    MPI_WIN_SIZE,
+    MPI_WIN_CREATE_FLAVOR,
+    MPI_WIN_MODEL
+};
+
+enum {
+    MPI_WIN_FLAVOR_CREATE,
+    MPI_WIN_FLAVOR_ALLOCATE,
+    MPI_WIN_FLAVOR_DYNAMIC,
+    MPI_WIN_FLAVOR_SHARED
+};
+
+enum {
+    MPI_WIN_SEPARATE,
+    MPI_WIN_UNIFIED
+};
+
+enum {
+    MPI_MODE_NOCHECK = 1,
+    MPI_MODE_NOPRECEDE = 2,
+    MPI_MODE_NOPUT = 4,
+    MPI_MODE_NOSTORE = 8,
+    MPI_MODE_NOSUCCEED = 16
+};
+
+enum {
+    MPI_MODE_APPEND = 1,
+    MPI_MODE_CREATE = 2,
+    MPI_MODE_DELETE_ON_CLOSE = 4,
+    MPI_MODE_EXCL = 8,
+    MPI_MODE_RDONLY = 16,
+    MPI_MODE_RDWR = 32,
+    MPI_MODE_SEQUENTIAL = 64,
+    MPI_MODE_UNIQUE_OPEN = 128,
+    MPI_MODE_WRONLY = 256
+};
+
+enum {
+    MPI_COMBINER_CONTIGUOUS,
+    MPI_COMBINER_DARRAY,
+    MPI_COMBINER_DUP,
+    MPI_COMBINER_F90_COMPLEX,
+    MPI_COMBINER_F90_INTEGER,
+    MPI_COMBINER_F90_REAL,
+    MPI_COMBINER_HINDEXED,
+    MPI_COMBINER_HVECTOR,
+    MPI_COMBINER_INDEXED_BLOCK,
+    MPI_COMBINER_HINDEXED_BLOCK,
+    MPI_COMBINER_INDEXED,
+    MPI_COMBINER_NAMED,
+    MPI_COMBINER_RESIZED,
+    MPI_COMBINER_STRUCT,
+    MPI_COMBINER_SUBARRAY,
+    MPI_COMBINER_VALUE_INDEX,
+    MPI_COMBINER_VECTOR
+};
+
+enum {
+    MPI_THREAD_FUNNELED,
+    MPI_THREAD_MULTIPLE,
+    MPI_THREAD_SERIALIZED,
+    MPI_THREAD_SINGLE
+};
+
+enum {
+    MPI_DISTRIBUTE_BLOCK,
+    MPI_DISTRIBUTE_CYCLIC,
+    MPI_DISTRIBUTE_NONE
+};
+
+#define MPI_DISTRIBUTE_DFLT_DARG -1
+#define MPI_DISPLACEMENT_CURRENT -1
+
+enum {
+    MPI_ORDER_C,
+    MPI_ORDER_FORTRAN
+};
+
+enum {
+    MPI_SEEK_CUR,
+    MPI_SEEK_END,
+    MPI_SEEK_SET
+};
+
+enum {
+    MPI_TYPECLASS_COMPLEX,
+    MPI_TYPECLASS_INTEGER,
+    MPI_TYPECLASS_REAL
+};
+
+/* Handle constants: 4 bit kind + 8 bit index
+ * Kind values:
+ *     0x1 MPI_Comm
+ *     0x2 MPI_Group
+ *     0x3 MPI_Datatype
+ *     0x4 MPI_File
+ *     0x5 MPI_Errhandler
+ *     0x6 MPI_Op
+ *     0x7 MPI_Info
+ *     0x8 MPI_Win
+ *     0x9 MPI_Request
+ *     0xa MPI_Message
+ *     0xb MPI_Session
+ */
+#define MPI_COMM_NULL       (MPI_Comm) 0x100
+#define MPI_GROUP_NULL      (MPI_Group)0x200
+#define MPI_DATATYPE_NULL   (MPI_Datatype)0x300
+#define MPI_FILE_NULL       (MPI_File)0x400
+#define MPI_ERRHANDLER_NULL (MPI_Errhandler)0x500
+#define MPI_OP_NULL         (MPI_Op)0x600
+#define MPI_INFO_NULL       (MPI_Info)0x700
+#define MPI_WIN_NULL        (MPI_Win)0x800
+#define MPI_REQUEST_NULL    (MPI_Request)0x900
+#define MPI_MESSAGE_NULL    (MPI_Message)0xa00
+#define MPI_SESSION_NULL    (MPI_Session)0xb00
+
+#define MPI_COMM_WORLD (MPI_Comm)0x101
+#define MPI_COMM_SELF  (MPI_Comm)0x102
+#define MPI_GROUP_EMPTY (MPI_Group)0x201
+#define MPI_ERRORS_ARE_FATAL (MPI_Errhandler)0x501
+#define MPI_ERRORS_ABORT     (MPI_Errhandler)0x502
+#define MPI_ERRORS_RETURN    (MPI_Errhandler)0x503
+#define MPI_CHAR                    (MPI_Datatype)0x301
+#define MPI_SHORT                   (MPI_Datatype)0x302
+#define MPI_INT                     (MPI_Datatype)0x303
+#define MPI_LONG                    (MPI_Datatype)0x304
+#define MPI_LONG_LONG_INT           (MPI_Datatype)0x305
+#define MPI_LONG_LONG               MPI_LONG_LONG_INT
+#define MPI_SIGNED_CHAR             (MPI_Datatype)0x306
+#define MPI_UNSIGNED_CHAR           (MPI_Datatype)0x307
+#define MPI_UNSIGNED_SHORT          (MPI_Datatype)0x308
+#define MPI_UNSIGNED                (MPI_Datatype)0x309
+#define MPI_UNSIGNED_LONG           (MPI_Datatype)0x30a
+#define MPI_UNSIGNED_LONG_LONG      (MPI_Datatype)0x30b
+#define MPI_FLOAT                   (MPI_Datatype)0x30c
+#define MPI_DOUBLE                  (MPI_Datatype)0x30d
+#define MPI_LONG_DOUBLE             (MPI_Datatype)0x30e
+#define MPI_WCHAR                   (MPI_Datatype)0x30f
+#define MPI_C_BOOL                  (MPI_Datatype)0x310
+#define MPI_INT8_T                  (MPI_Datatype)0x311
+#define MPI_INT16_T                 (MPI_Datatype)0x312
+#define MPI_INT32_T                 (MPI_Datatype)0x313
+#define MPI_INT64_T                 (MPI_Datatype)0x314
+#define MPI_UINT8_T                 (MPI_Datatype)0x315
+#define MPI_UINT16_T                (MPI_Datatype)0x316
+#define MPI_UINT32_T                (MPI_Datatype)0x317
+#define MPI_UINT64_T                (MPI_Datatype)0x318
+#define MPI_AINT                    (MPI_Datatype)0x319
+#define MPI_COUNT                   (MPI_Datatype)0x31a
+#define MPI_OFFSET                  (MPI_Datatype)0x31b
+#define MPI_C_COMPLEX               (MPI_Datatype)0x31c
+#define MPI_C_FLOAT_COMPLEX         (MPI_Datatype)0x31d
+#define MPI_C_DOUBLE_COMPLEX        (MPI_Datatype)0x31e
+#define MPI_C_LONG_DOUBLE_COMPLEX   (MPI_Datatype)0x31f
+#define MPI_BYTE                    (MPI_Datatype)0x320
+#define MPI_PACKED                  (MPI_Datatype)0x321
+#define MPI_INTEGER                 (MPI_Datatype)0x322
+#define MPI_REAL                    (MPI_Datatype)0x323
+#define MPI_DOUBLE_PRECISION        (MPI_Datatype)0x324
+#define MPI_COMPLEX                 (MPI_Datatype)0x325
+#define MPI_LOGICAL                 (MPI_Datatype)0x326
+#define MPI_CHARACTER               (MPI_Datatype)0x327
+#define MPI_CXX_BOOL                (MPI_Datatype)0x328
+#define MPI_CXX_FLOAT_COMPLEX       (MPI_Datatype)0x329
+#define MPI_CXX_DOUBLE_COMPLEX      (MPI_Datatype)0x32a
+#define MPI_CXX_LONG_DOUBLE_COMPLEX (MPI_Datatype)0x32b
+#define MPI_DOUBLE_COMPLEX          (MPI_Datatype)0x32c
+#define MPI_INTEGER1                (MPI_Datatype)0x32d
+#define MPI_INTEGER2                (MPI_Datatype)0x32e
+#define MPI_INTEGER4                (MPI_Datatype)0x32f
+#define MPI_INTEGER8                (MPI_Datatype)0x330
+#define MPI_INTEGER16               (MPI_Datatype)0x331
+#define MPI_REAL4                   (MPI_Datatype)0x333
+#define MPI_REAL8                   (MPI_Datatype)0x334
+#define MPI_REAL16                  (MPI_Datatype)0x335
+#define MPI_COMPLEX8                (MPI_Datatype)0x337
+#define MPI_COMPLEX16               (MPI_Datatype)0x338
+#define MPI_COMPLEX32               (MPI_Datatype)0x339
+#define MPI_FLOAT_INT               (MPI_Datatype)0x33a
+#define MPI_DOUBLE_INT              (MPI_Datatype)0x33b
+#define MPI_LONG_INT                (MPI_Datatype)0x33c
+#define MPI_2INT                    (MPI_Datatype)0x33d
+#define MPI_SHORT_INT               (MPI_Datatype)0x33e
+#define MPI_LONG_DOUBLE_INT         (MPI_Datatype)0x33f
+#define MPI_2REAL                   (MPI_Datatype)0x340
+#define MPI_2DOUBLE_PRECISION       (MPI_Datatype)0x341
+#define MPI_2INTEGER                (MPI_Datatype)0x342
+#define MPI_MAX     (MPI_Op)0x601
+#define MPI_MIN     (MPI_Op)0x602
+#define MPI_SUM     (MPI_Op)0x603
+#define MPI_PROD    (MPI_Op)0x604
+#define MPI_LAND    (MPI_Op)0x605
+#define MPI_BAND    (MPI_Op)0x606
+#define MPI_LOR     (MPI_Op)0x607
+#define MPI_BOR     (MPI_Op)0x608
+#define MPI_LXOR    (MPI_Op)0x609
+#define MPI_BXOR    (MPI_Op)0x60a
+#define MPI_MAXLOC  (MPI_Op)0x60b
+#define MPI_MINLOC  (MPI_Op)0x60c
+#define MPI_REPLACE (MPI_Op)0x60d
+#define MPI_NO_OP   (MPI_Op)0x60e
+#define MPI_INFO_ENV (MPI_Info)0x701
+#define MPI_MESSAGE_NO_PROC (MPI_Message) 0xb01
+
+// callback typedefs
+typedef int MPI_Comm_copy_attr_function(MPI_Comm oldcomm, int comm_keyval, void *extra_state, void *attribute_val_in, void *attribute_val_out, int *flag);
+typedef int MPI_Comm_delete_attr_function(MPI_Comm comm, int comm_keyval, void *attribute_val, void *extra_state);
+typedef void MPI_Comm_errhandler_function(MPI_Comm *comm, int *error_code, ...);
+typedef int MPI_Copy_function(MPI_Comm oldcomm, int keyval, void *extra_state, void *attribute_val_in, void *attribute_val_out, int *flag);
+typedef int MPI_Datarep_conversion_function(void *userbuf, MPI_Datatype datatype, int count, void *filebuf, MPI_Offset position, void *extra_state);
+typedef int MPI_Datarep_conversion_function_c(void *userbuf, MPI_Datatype datatype, MPI_Count count, void *filebuf, MPI_Offset position, void *extra_state);
+typedef int MPI_Datarep_extent_function(MPI_Datatype datatype, MPI_Aint *extent, void *extra_state);
+typedef int MPI_Delete_function(MPI_Comm comm, int keyval, void *attribute_val, void *extra_state);
+typedef void MPI_File_errhandler_function(MPI_File *file, int *error_code, ...);
+typedef int MPI_Grequest_cancel_function(void *extra_state, int complete);
+typedef int MPI_Grequest_free_function(void *extra_state);
+typedef int MPI_Grequest_query_function(void *extra_state, MPI_Status *status);
+typedef void MPI_Session_errhandler_function(MPI_Session *session, int *error_code, ...);
+typedef int MPI_Type_copy_attr_function(MPI_Datatype oldtype, int type_keyval, void *extra_state, void *attribute_val_in, void *attribute_val_out, int *flag);
+typedef int MPI_Type_delete_attr_function(MPI_Datatype datatype, int type_keyval, void *attribute_val, void *extra_state);
+typedef void MPI_User_function(void *invec, void *inoutvec, int *len, MPI_Datatype *datatype);
+typedef void MPI_User_function_c(void *invec, void *inoutvec, MPI_Count *len, MPI_Datatype *datatype);
+typedef int MPI_Win_copy_attr_function(MPI_Win oldwin, int win_keyval, void *extra_state, void *attribute_val_in, void *attribute_val_out, int *flag);
+typedef int MPI_Win_delete_attr_function(MPI_Win win, int win_keyval, void *attribute_val, void *extra_state);
+typedef void MPI_Win_errhandler_function(MPI_Win *win, int *error_code, ...);
+
+#define MPI_DUP_FN         ((MPI_Copy_function *)1)
+#define MPI_NULL_COPY_FN   ((MPI_Copy_function *)0)
+#define MPI_NULL_DELETE_FN ((MPI_Delete_function *)0)
+#define MPI_COMM_DUP_FN         ((MPI_Comm_copy_attr_function *)1)
+#define MPI_COMM_NULL_COPY_FN   ((MPI_Comm_copy_attr_function *)0)
+#define MPI_COMM_NULL_DELETE_FN ((MPI_Comm_delete_attr_function *)0)
+#define MPI_TYPE_DUP_FN         ((MPI_Type_copy_attr_function *)1)
+#define MPI_TYPE_NULL_COPY_FN   ((MPI_Type_copy_attr_function *)0)
+#define MPI_TYPE_NULL_DELETE_FN ((MPI_Type_delete_attr_function *)0)
+#define MPI_WIN_DUP_FN         ((MPI_Win_copy_attr_function *)1)
+#define MPI_WIN_NULL_COPY_FN   ((MPI_Win_copy_attr_function *)0)
+#define MPI_WIN_NULL_DELETE_FN ((MPI_Win_delete_attr_function *)0)
+#define MPI_CONVERSION_FN_NULL   ((MPI_Datarep_conversion_function *)0)
+#define MPI_CONVERSION_FN_NULL_C ((MPI_Datarep_conversion_function_c *)0)
+
+/* MPI_T */
+
+typedef struct MPI_T_enum_t * MPI_T_enum;
+typedef struct MPI_T_cvar_handle_t * MPI_T_cvar_handle;
+typedef struct MPI_T_pvar_handle_t * MPI_T_pvar_handle;
+typedef struct MPI_T_pvar_session_t * MPI_T_pvar_session;
+typedef struct MPI_T_event_registration_t * MPI_T_event_registration;
+typedef struct MPI_T_event_instance_t * MPI_T_event_instance;
+
+typedef enum  MPI_T_cb_safety {
+    MPI_T_CB_REQUIRE_NONE,
+    MPI_T_CB_REQUIRE_MPI_RESTRICTED,
+    MPI_T_CB_REQUIRE_THREAD_SAFE,
+    MPI_T_CB_REQUIRE_ASYNC_SIGNAL_SAFE
+} MPI_T_cb_safety;
+
+typedef enum MPI_T_source_order {
+    MPI_T_SOURCE_ORDERED,
+    MPI_T_SOURCE_UNORDERED
+} MPI_T_source_order;
+
+#define MPI_T_ENUM_NULL (MPI_T_enum)0
+#define MPI_T_CVAR_HANDLE_NULL (MPI_T_cvar_handle)0
+#define MPI_T_PVAR_SESSION_NULL (MPI_T_pvar_session)0
+#define MPI_T_PVAR_HANDLE_NULL (MPI_T_pvar_handle)0
+#define MPI_T_PVAR_ALL_HANDLES (MPI_T_pvar_handle)1
+
+enum {
+    MPI_T_VERBOSITY_USER_BASIC,
+    MPI_T_VERBOSITY_USER_DETAIL,
+    MPI_T_VERBOSITY_USER_ALL,
+    MPI_T_VERBOSITY_TUNER_BASIC,
+    MPI_T_VERBOSITY_TUNER_DETAIL,
+    MPI_T_VERBOSITY_TUNER_ALL,
+    MPI_T_VERBOSITY_MPIDEV_BASIC,
+    MPI_T_VERBOSITY_MPIDEV_DETAIL,
+    MPI_T_VERBOSITY_MPIDEV_ALL
+};
+
+enum {
+    MPI_T_BIND_NO_OBJECT,
+    MPI_T_BIND_MPI_COMM,
+    MPI_T_BIND_MPI_DATATYPE,
+    MPI_T_BIND_MPI_ERRHANDLER,
+    MPI_T_BIND_MPI_FILE,
+    MPI_T_BIND_MPI_GROUP,
+    MPI_T_BIND_MPI_OP,
+    MPI_T_BIND_MPI_REQUEST,
+    MPI_T_BIND_MPI_SESSION,
+    MPI_T_BIND_MPI_WIN,
+    MPI_T_BIND_MPI_MESSAGE,
+    MPI_T_BIND_MPI_INFO
+};
+
+enum {
+    MPI_T_SCOPE_CONSTANT,
+    MPI_T_SCOPE_READONLY,
+    MPI_T_SCOPE_LOCAL,
+    MPI_T_SCOPE_GROUP,
+    MPI_T_SCOPE_GROUP_EQ,
+    MPI_T_SCOPE_ALL,
+    MPI_T_SCOPE_ALL_EQ
+};
+
+enum {
+    MPI_T_PVAR_CLASS_STATE,
+    MPI_T_PVAR_CLASS_LEVEL,
+    MPI_T_PVAR_CLASS_SIZE,
+    MPI_T_PVAR_CLASS_PERCENTAGE,
+    MPI_T_PVAR_CLASS_HIGHWATERMARK,
+    MPI_T_PVAR_CLASS_LOWWATERMARK,
+    MPI_T_PVAR_CLASS_COUNTER,
+    MPI_T_PVAR_CLASS_AGGREGATE,
+    MPI_T_PVAR_CLASS_TIMER,
+    MPI_T_PVAR_CLASS_GENERIC
+};
+
+typedef void (MPI_T_event_cb_function)(MPI_T_event_instance event_instance, MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, void *user_data);
+typedef void (MPI_T_event_free_cb_function)(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, void *user_data);
+typedef void (MPI_T_event_dropped_cb_function)(MPI_Count count, MPI_T_event_registration event_registration, int source_index, MPI_T_cb_safety cb_safety, void *user_data);
+
+/* MPI functions */
+int MPI_Abort(MPI_Comm comm, int errorcode);
+int MPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
+int MPI_Accumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
+int MPI_Add_error_class(int *errorclass);
+int MPI_Add_error_code(int errorclass, int *errorcode);
+int MPI_Add_error_string(int errorcode, const char *string);
+MPI_Aint MPI_Aint_add(MPI_Aint base, MPI_Aint disp);
+MPI_Aint MPI_Aint_diff(MPI_Aint addr1, MPI_Aint addr2);
+int MPI_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Allgather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Allgather_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Allgather_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Allgatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Allgatherv_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Allgatherv_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Alloc_mem(MPI_Aint size, MPI_Info info, void *baseptr);
+int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int MPI_Allreduce_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int MPI_Allreduce_init(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Allreduce_init_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Alltoall_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Alltoall_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Alltoall_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Alltoallv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Alltoallv_init(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Alltoallv_init_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Alltoallw(const void *sendbuf, const int sendcounts[], const int sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const int rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm);
+int MPI_Alltoallw_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm);
+int MPI_Alltoallw_init(const void *sendbuf, const int sendcounts[], const int sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const int rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Alltoallw_init_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Attr_delete(MPI_Comm comm, int keyval);
+int MPI_Attr_get(MPI_Comm comm, int keyval, void *attribute_val, int *flag);
+int MPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val);
+int MPI_Barrier(MPI_Comm comm);
+int MPI_Barrier_init(MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm);
+int MPI_Bcast_c(void *buffer, MPI_Count count, MPI_Datatype datatype, int root, MPI_Comm comm);
+int MPI_Bcast_init(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Bcast_init_c(void *buffer, MPI_Count count, MPI_Datatype datatype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Bsend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int MPI_Bsend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int MPI_Bsend_init(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Bsend_init_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Buffer_attach(void *buffer, int size);
+int MPI_Buffer_attach_c(void *buffer, MPI_Count size);
+int MPI_Buffer_detach(void *buffer_addr, int *size);
+int MPI_Buffer_detach_c(void *buffer_addr, MPI_Count *size);
+int MPI_Buffer_flush(void);
+int MPI_Buffer_iflush(MPI_Request *request);
+int MPI_Cancel(MPI_Request *request);
+int MPI_Cart_coords(MPI_Comm comm, int rank, int maxdims, int coords[]);
+int MPI_Cart_create(MPI_Comm comm_old, int ndims, const int dims[], const int periods[], int reorder, MPI_Comm *comm_cart);
+int MPI_Cart_get(MPI_Comm comm, int maxdims, int dims[], int periods[], int coords[]);
+int MPI_Cart_map(MPI_Comm comm, int ndims, const int dims[], const int periods[], int *newrank);
+int MPI_Cart_rank(MPI_Comm comm, const int coords[], int *rank);
+int MPI_Cart_shift(MPI_Comm comm, int direction, int disp, int *rank_source, int *rank_dest);
+int MPI_Cart_sub(MPI_Comm comm, const int remain_dims[], MPI_Comm *newcomm);
+int MPI_Cartdim_get(MPI_Comm comm, int *ndims);
+int MPI_Close_port(const char *port_name);
+int MPI_Comm_accept(const char *port_name, MPI_Info info, int root, MPI_Comm comm, MPI_Comm *newcomm);
+int MPI_Comm_attach_buffer(MPI_Comm comm, void *buffer, int size);
+int MPI_Comm_attach_buffer_c(MPI_Comm comm, void *buffer, MPI_Count size);
+int MPI_Comm_call_errhandler(MPI_Comm comm, int errorcode);
+int MPI_Comm_compare(MPI_Comm comm1, MPI_Comm comm2, int *result);
+int MPI_Comm_connect(const char *port_name, MPI_Info info, int root, MPI_Comm comm, MPI_Comm *newcomm);
+int MPI_Comm_create(MPI_Comm comm, MPI_Group group, MPI_Comm *newcomm);
+int MPI_Comm_create_errhandler(MPI_Comm_errhandler_function *comm_errhandler_fn, MPI_Errhandler *errhandler);
+int MPI_Comm_create_from_group(MPI_Group group, const char *stringtag, MPI_Info info, MPI_Errhandler errhandler, MPI_Comm *newcomm);
+int MPI_Comm_create_group(MPI_Comm comm, MPI_Group group, int tag, MPI_Comm *newcomm);
+int MPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn, MPI_Comm_delete_attr_function *comm_delete_attr_fn, int *comm_keyval, void *extra_state);
+int MPI_Comm_delete_attr(MPI_Comm comm, int comm_keyval);
+int MPI_Comm_detach_buffer(MPI_Comm comm, void *buffer_addr, int *size);
+int MPI_Comm_detach_buffer_c(MPI_Comm comm, void *buffer_addr, MPI_Count *size);
+int MPI_Comm_disconnect(MPI_Comm *comm);
+int MPI_Comm_dup(MPI_Comm comm, MPI_Comm *newcomm);
+int MPI_Comm_dup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm *newcomm);
+int MPI_Comm_flush_buffer(MPI_Comm comm);
+int MPI_Comm_free(MPI_Comm *comm);
+int MPI_Comm_free_keyval(int *comm_keyval);
+int MPI_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val, int *flag);
+int MPI_Comm_get_errhandler(MPI_Comm comm, MPI_Errhandler *errhandler);
+int MPI_Comm_get_info(MPI_Comm comm, MPI_Info *info_used);
+int MPI_Comm_get_name(MPI_Comm comm, char *comm_name, int *resultlen);
+int MPI_Comm_get_parent(MPI_Comm *parent);
+int MPI_Comm_group(MPI_Comm comm, MPI_Group *group);
+int MPI_Comm_idup(MPI_Comm comm, MPI_Comm *newcomm, MPI_Request *request);
+int MPI_Comm_idup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm *newcomm, MPI_Request *request);
+int MPI_Comm_iflush_buffer(MPI_Comm comm, MPI_Request *request);
+int MPI_Comm_join(int fd, MPI_Comm *intercomm);
+int MPI_Comm_rank(MPI_Comm comm, int *rank);
+int MPI_Comm_remote_group(MPI_Comm comm, MPI_Group *group);
+int MPI_Comm_remote_size(MPI_Comm comm, int *size);
+int MPI_Comm_set_attr(MPI_Comm comm, int comm_keyval, void *attribute_val);
+int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler);
+int MPI_Comm_set_info(MPI_Comm comm, MPI_Info info);
+int MPI_Comm_set_name(MPI_Comm comm, const char *comm_name);
+int MPI_Comm_size(MPI_Comm comm, int *size);
+int MPI_Comm_spawn(const char *command, char *argv[], int maxprocs, MPI_Info info, int root, MPI_Comm comm, MPI_Comm *intercomm, int array_of_errcodes[]);
+int MPI_Comm_spawn_multiple(int count, char *array_of_commands[], char **array_of_argv[], const int array_of_maxprocs[], const MPI_Info array_of_info[], int root, MPI_Comm comm, MPI_Comm *intercomm, int array_of_errcodes[]);
+int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *newcomm);
+int MPI_Comm_split_type(MPI_Comm comm, int split_type, int key, MPI_Info info, MPI_Comm *newcomm);
+int MPI_Comm_test_inter(MPI_Comm comm, int *flag);
+int MPI_Compare_and_swap(const void *origin_addr, const void *compare_addr, void *result_addr, MPI_Datatype datatype, int target_rank, MPI_Aint target_disp, MPI_Win win);
+int MPI_Dims_create(int nnodes, int ndims, int dims[]);
+int MPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[], const int degrees[], const int destinations[], const int weights[], MPI_Info info, int reorder, MPI_Comm *comm_dist_graph);
+int MPI_Dist_graph_create_adjacent(MPI_Comm comm_old, int indegree, const int sources[], const int sourceweights[], int outdegree, const int destinations[], const int destweights[], MPI_Info info, int reorder, MPI_Comm *comm_dist_graph);
+int MPI_Dist_graph_neighbors(MPI_Comm comm, int maxindegree, int sources[], int sourceweights[], int maxoutdegree, int destinations[], int destweights[]);
+int MPI_Dist_graph_neighbors_count(MPI_Comm comm, int *indegree, int *outdegree, int *weighted);
+int MPI_Errhandler_free(MPI_Errhandler *errhandler);
+int MPI_Error_class(int errorcode, int *errorclass);
+int MPI_Error_string(int errorcode, char *string, int *resultlen);
+int MPI_Exscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int MPI_Exscan_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int MPI_Exscan_init(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Exscan_init_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_F_sync_reg(void *buf);
+int MPI_Fetch_and_op(const void *origin_addr, void *result_addr, MPI_Datatype datatype, int target_rank, MPI_Aint target_disp, MPI_Op op, MPI_Win win);
+int MPI_File_call_errhandler(MPI_File fh, int errorcode);
+int MPI_File_close(MPI_File *fh);
+int MPI_File_create_errhandler(MPI_File_errhandler_function *file_errhandler_fn, MPI_Errhandler *errhandler);
+int MPI_File_delete(const char *filename, MPI_Info info);
+int MPI_File_get_amode(MPI_File fh, int *amode);
+int MPI_File_get_atomicity(MPI_File fh, int *flag);
+int MPI_File_get_byte_offset(MPI_File fh, MPI_Offset offset, MPI_Offset *disp);
+int MPI_File_get_errhandler(MPI_File file, MPI_Errhandler *errhandler);
+int MPI_File_get_group(MPI_File fh, MPI_Group *group);
+int MPI_File_get_info(MPI_File fh, MPI_Info *info_used);
+int MPI_File_get_position(MPI_File fh, MPI_Offset *offset);
+int MPI_File_get_position_shared(MPI_File fh, MPI_Offset *offset);
+int MPI_File_get_size(MPI_File fh, MPI_Offset *size);
+int MPI_File_get_type_extent(MPI_File fh, MPI_Datatype datatype, MPI_Aint *extent);
+int MPI_File_get_type_extent_c(MPI_File fh, MPI_Datatype datatype, MPI_Count *extent);
+int MPI_File_get_view(MPI_File fh, MPI_Offset *disp, MPI_Datatype *etype, MPI_Datatype *filetype, char *datarep);
+int MPI_File_iread(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iread_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iread_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iread_at_all_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iread_shared(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iread_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iwrite(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iwrite_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iwrite_all(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iwrite_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iwrite_at(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iwrite_at_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iwrite_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iwrite_shared(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_iwrite_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int MPI_File_open(MPI_Comm comm, const char *filename, int amode, MPI_Info info, MPI_File *fh);
+int MPI_File_preallocate(MPI_File fh, MPI_Offset size);
+int MPI_File_read(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_read_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_read_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_read_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_read_all_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype);
+int MPI_File_read_all_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype);
+int MPI_File_read_all_end(MPI_File fh, void *buf, MPI_Status *status);
+int MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_read_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_read_at_all_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_read_at_all_begin(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype);
+int MPI_File_read_at_all_begin_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype);
+int MPI_File_read_at_all_end(MPI_File fh, void *buf, MPI_Status *status);
+int MPI_File_read_ordered(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_read_ordered_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_read_ordered_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype);
+int MPI_File_read_ordered_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype);
+int MPI_File_read_ordered_end(MPI_File fh, void *buf, MPI_Status *status);
+int MPI_File_read_shared(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_read_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence);
+int MPI_File_seek_shared(MPI_File fh, MPI_Offset offset, int whence);
+int MPI_File_set_atomicity(MPI_File fh, int flag);
+int MPI_File_set_errhandler(MPI_File file, MPI_Errhandler errhandler);
+int MPI_File_set_info(MPI_File fh, MPI_Info info);
+int MPI_File_set_size(MPI_File fh, MPI_Offset size);
+int MPI_File_set_view(MPI_File fh, MPI_Offset disp, MPI_Datatype etype, MPI_Datatype filetype, const char *datarep, MPI_Info info);
+int MPI_File_sync(MPI_File fh);
+int MPI_File_write(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_write_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_write_all(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_write_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_write_all_begin(MPI_File fh, const void *buf, int count, MPI_Datatype datatype);
+int MPI_File_write_all_begin_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype);
+int MPI_File_write_all_end(MPI_File fh, const void *buf, MPI_Status *status);
+int MPI_File_write_at(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_write_at_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_write_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_write_at_all_begin(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype);
+int MPI_File_write_at_all_begin_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count, MPI_Datatype datatype);
+int MPI_File_write_at_all_end(MPI_File fh, const void *buf, MPI_Status *status);
+int MPI_File_write_ordered(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_write_ordered_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_write_ordered_begin(MPI_File fh, const void *buf, int count, MPI_Datatype datatype);
+int MPI_File_write_ordered_begin_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype);
+int MPI_File_write_ordered_end(MPI_File fh, const void *buf, MPI_Status *status);
+int MPI_File_write_shared(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_File_write_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int MPI_Finalize(void);
+int MPI_Finalized(int *flag);
+int MPI_Free_mem(void *base);
+int MPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
+int MPI_Gather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
+int MPI_Gather_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Gather_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, int root, MPI_Comm comm);
+int MPI_Gatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, int root, MPI_Comm comm);
+int MPI_Gatherv_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Gatherv_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Get(void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Win win);
+int MPI_Get_c(void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Win win);
+int MPI_Get_accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, void *result_addr, int result_count, MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
+int MPI_Get_accumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, void *result_addr, MPI_Count result_count, MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
+int MPI_Get_address(const void *location, MPI_Aint *address);
+int MPI_Get_count(const MPI_Status *status, MPI_Datatype datatype, int *count);
+int MPI_Get_count_c(const MPI_Status *status, MPI_Datatype datatype, MPI_Count *count);
+int MPI_Get_elements(const MPI_Status *status, MPI_Datatype datatype, int *count);
+int MPI_Get_elements_c(const MPI_Status *status, MPI_Datatype datatype, MPI_Count *count);
+int MPI_Get_elements_x(const MPI_Status *status, MPI_Datatype datatype, MPI_Count *count);
+int MPI_Get_hw_resource_info(MPI_Info *hw_info);
+int MPI_Get_library_version(char *version, int *resultlen);
+int MPI_Get_processor_name(char *name, int *resultlen);
+int MPI_Get_version(int *version, int *subversion);
+int MPI_Graph_create(MPI_Comm comm_old, int nnodes, const int indx[], const int edges[], int reorder, MPI_Comm *comm_graph);
+int MPI_Graph_get(MPI_Comm comm, int maxindex, int maxedges, int indx[], int edges[]);
+int MPI_Graph_map(MPI_Comm comm, int nnodes, const int indx[], const int edges[], int *newrank);
+int MPI_Graph_neighbors(MPI_Comm comm, int rank, int maxneighbors, int neighbors[]);
+int MPI_Graph_neighbors_count(MPI_Comm comm, int rank, int *nneighbors);
+int MPI_Graphdims_get(MPI_Comm comm, int *nnodes, int *nedges);
+int MPI_Grequest_complete(MPI_Request request);
+int MPI_Grequest_start(MPI_Grequest_query_function *query_fn, MPI_Grequest_free_function *free_fn, MPI_Grequest_cancel_function *cancel_fn, void *extra_state, MPI_Request *request);
+int MPI_Group_compare(MPI_Group group1, MPI_Group group2, int *result);
+int MPI_Group_difference(MPI_Group group1, MPI_Group group2, MPI_Group *newgroup);
+int MPI_Group_excl(MPI_Group group, int n, const int ranks[], MPI_Group *newgroup);
+int MPI_Group_free(MPI_Group *group);
+int MPI_Group_from_session_pset(MPI_Session session, const char *pset_name, MPI_Group *newgroup);
+int MPI_Group_incl(MPI_Group group, int n, const int ranks[], MPI_Group *newgroup);
+int MPI_Group_intersection(MPI_Group group1, MPI_Group group2, MPI_Group *newgroup);
+int MPI_Group_range_excl(MPI_Group group, int n, int ranges[][3], MPI_Group *newgroup);
+int MPI_Group_range_incl(MPI_Group group, int n, int ranges[][3], MPI_Group *newgroup);
+int MPI_Group_rank(MPI_Group group, int *rank);
+int MPI_Group_size(MPI_Group group, int *size);
+int MPI_Group_translate_ranks(MPI_Group group1, int n, const int ranks1[], MPI_Group group2, int ranks2[]);
+int MPI_Group_union(MPI_Group group1, MPI_Group group2, MPI_Group *newgroup);
+int MPI_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Iallgather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Iallgatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Iallreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int MPI_Iallreduce_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int MPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Ialltoall_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Ialltoallv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Ialltoallw(const void *sendbuf, const int sendcounts[], const int sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const int rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Request *request);
+int MPI_Ialltoallw_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Request *request);
+int MPI_Ibarrier(MPI_Comm comm, MPI_Request *request);
+int MPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm, MPI_Request *request);
+int MPI_Ibcast_c(void *buffer, MPI_Count count, MPI_Datatype datatype, int root, MPI_Comm comm, MPI_Request *request);
+int MPI_Ibsend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Ibsend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int MPI_Iexscan_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int MPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int MPI_Igather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int MPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int MPI_Igatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int MPI_Improbe(int source, int tag, MPI_Comm comm, int *flag, MPI_Message *message, MPI_Status *status);
+int MPI_Imrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message *message, MPI_Request *request);
+int MPI_Imrecv_c(void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Message *message, MPI_Request *request);
+int MPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Ineighbor_allgather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Ineighbor_allgatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Ineighbor_alltoall_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Ineighbor_alltoallv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int MPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Request *request);
+int MPI_Ineighbor_alltoallw_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Request *request);
+int MPI_Info_create(MPI_Info *info);
+int MPI_Info_create_env(int argc, char *argv[], MPI_Info *info);
+int MPI_Info_delete(MPI_Info info, const char *key);
+int MPI_Info_dup(MPI_Info info, MPI_Info *newinfo);
+int MPI_Info_free(MPI_Info *info);
+int MPI_Info_get(MPI_Info info, const char *key, int valuelen, char *value, int *flag);
+int MPI_Info_get_nkeys(MPI_Info info, int *nkeys);
+int MPI_Info_get_nthkey(MPI_Info info, int n, char *key);
+int MPI_Info_get_string(MPI_Info info, const char *key, int *buflen, char *value, int *flag);
+int MPI_Info_get_valuelen(MPI_Info info, const char *key, int *valuelen, int *flag);
+int MPI_Info_set(MPI_Info info, const char *key, const char *value);
+int MPI_Init(int *argc, char ***argv);
+int MPI_Init_thread(int *argc, char ***argv, int required, int *provided);
+int MPI_Initialized(int *flag);
+int MPI_Intercomm_create(MPI_Comm local_comm, int local_leader, MPI_Comm peer_comm, int remote_leader, int tag, MPI_Comm *newintercomm);
+int MPI_Intercomm_create_from_groups(MPI_Group local_group, int local_leader, MPI_Group remote_group, int remote_leader, const char *stringtag, MPI_Info info, MPI_Errhandler errhandler, MPI_Comm *newintercomm);
+int MPI_Intercomm_merge(MPI_Comm intercomm, int high, MPI_Comm *newintracomm);
+int MPI_Iprobe(int source, int tag, MPI_Comm comm, int *flag, MPI_Status *status);
+int MPI_Irecv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Irecv_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm, MPI_Request *request);
+int MPI_Ireduce_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm, MPI_Request *request);
+int MPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int MPI_Ireduce_scatter_c(const void *sendbuf, void *recvbuf, const MPI_Count recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int MPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int MPI_Ireduce_scatter_block_c(const void *sendbuf, void *recvbuf, MPI_Count recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int MPI_Irsend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Irsend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Is_thread_main(int *flag);
+int MPI_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int MPI_Iscan_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int MPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int MPI_Iscatter_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int MPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[], MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int MPI_Iscatterv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int MPI_Isend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Isend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Isendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, int dest, int sendtag, void *recvbuf, int recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Request *request);
+int MPI_Isendrecv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, int dest, int sendtag, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Request *request);
+int MPI_Isendrecv_replace(void *buf, int count, MPI_Datatype datatype, int dest, int sendtag, int source, int recvtag, MPI_Comm comm, MPI_Request *request);
+int MPI_Isendrecv_replace_c(void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int sendtag, int source, int recvtag, MPI_Comm comm, MPI_Request *request);
+int MPI_Issend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Issend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Keyval_create(MPI_Copy_function *copy_fn, MPI_Delete_function *delete_fn, int *keyval, void *extra_state);
+int MPI_Keyval_free(int *keyval);
+int MPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name);
+int MPI_Mprobe(int source, int tag, MPI_Comm comm, MPI_Message *message, MPI_Status *status);
+int MPI_Mrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message *message, MPI_Status *status);
+int MPI_Mrecv_c(void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Message *message, MPI_Status *status);
+int MPI_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Neighbor_allgather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Neighbor_allgather_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Neighbor_allgather_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Neighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Neighbor_allgatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Neighbor_allgatherv_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Neighbor_allgatherv_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Neighbor_alltoall_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Neighbor_alltoall_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Neighbor_alltoall_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Neighbor_alltoallv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm);
+int MPI_Neighbor_alltoallv_init(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Neighbor_alltoallv_init_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Neighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm);
+int MPI_Neighbor_alltoallw_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm);
+int MPI_Neighbor_alltoallw_init(const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Neighbor_alltoallw_init_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Op_commutative(MPI_Op op, int *commute);
+int MPI_Op_create(MPI_User_function *user_fn, int commute, MPI_Op *op);
+int MPI_Op_create_c(MPI_User_function_c *user_fn, int commute, MPI_Op *op);
+int MPI_Op_free(MPI_Op *op);
+int MPI_Open_port(MPI_Info info, char *port_name);
+int MPI_Pack(const void *inbuf, int incount, MPI_Datatype datatype, void *outbuf, int outsize, int *position, MPI_Comm comm);
+int MPI_Pack_c(const void *inbuf, MPI_Count incount, MPI_Datatype datatype, void *outbuf, MPI_Count outsize, MPI_Count *position, MPI_Comm comm);
+int MPI_Pack_external(const char *datarep, const void *inbuf, int incount, MPI_Datatype datatype, void *outbuf, MPI_Aint outsize, MPI_Aint *position);
+int MPI_Pack_external_c(const char *datarep, const void *inbuf, MPI_Count incount, MPI_Datatype datatype, void *outbuf, MPI_Count outsize, MPI_Count *position);
+int MPI_Pack_external_size(const char *datarep, int incount, MPI_Datatype datatype, MPI_Aint *size);
+int MPI_Pack_external_size_c(const char *datarep, MPI_Count incount, MPI_Datatype datatype, MPI_Count *size);
+int MPI_Pack_size(int incount, MPI_Datatype datatype, MPI_Comm comm, int *size);
+int MPI_Pack_size_c(MPI_Count incount, MPI_Datatype datatype, MPI_Comm comm, MPI_Count *size);
+int MPI_Parrived(MPI_Request request, int partition, int *flag);
+int MPI_Pcontrol(const int level, ...);
+int MPI_Pready(int partition, MPI_Request request);
+int MPI_Pready_list(int length, const int array_of_partitions[], MPI_Request request);
+int MPI_Pready_range(int partition_low, int partition_high, MPI_Request request);
+int MPI_Precv_init(void *buf, int partitions, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status *status);
+int MPI_Psend_init(const void *buf, int partitions, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Publish_name(const char *service_name, MPI_Info info, const char *port_name);
+int MPI_Put(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Win win);
+int MPI_Put_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Win win);
+int MPI_Query_thread(int *provided);
+int MPI_Raccumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win, MPI_Request *request);
+int MPI_Raccumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win, MPI_Request *request);
+int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status *status);
+int MPI_Recv_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status *status);
+int MPI_Recv_init(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Recv_init_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm);
+int MPI_Reduce_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm);
+int MPI_Reduce_init(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Reduce_init_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Reduce_local(const void *inbuf, void *inoutbuf, int count, MPI_Datatype datatype, MPI_Op op);
+int MPI_Reduce_local_c(const void *inbuf, void *inoutbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op);
+int MPI_Reduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int MPI_Reduce_scatter_c(const void *sendbuf, void *recvbuf, const MPI_Count recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int MPI_Reduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int MPI_Reduce_scatter_block_c(const void *sendbuf, void *recvbuf, MPI_Count recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int MPI_Reduce_scatter_block_init(const void *sendbuf, void *recvbuf, int recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Reduce_scatter_block_init_c(const void *sendbuf, void *recvbuf, MPI_Count recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Reduce_scatter_init(const void *sendbuf, void *recvbuf, const int recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Reduce_scatter_init_c(const void *sendbuf, void *recvbuf, const MPI_Count recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Register_datarep(const char *datarep, MPI_Datarep_conversion_function *read_conversion_fn, MPI_Datarep_conversion_function *write_conversion_fn, MPI_Datarep_extent_function *dtype_file_extent_fn, void *extra_state);
+int MPI_Register_datarep_c(const char *datarep, MPI_Datarep_conversion_function_c *read_conversion_fn, MPI_Datarep_conversion_function_c *write_conversion_fn, MPI_Datarep_extent_function *dtype_file_extent_fn, void *extra_state);
+int MPI_Remove_error_class(int errorclass);
+int MPI_Remove_error_code(int errorcode);
+int MPI_Remove_error_string(int errorcode);
+int MPI_Request_free(MPI_Request *request);
+int MPI_Request_get_status(MPI_Request request, int *flag, MPI_Status *status);
+int MPI_Request_get_status_all(int count, MPI_Request array_of_requests[], int *flag, MPI_Status *array_of_statuses);
+int MPI_Request_get_status_any(int count, MPI_Request array_of_requests[], int *indx, int *flag, MPI_Status *status);
+int MPI_Request_get_status_some(int incount, MPI_Request array_of_requests[], int *outcount, int array_of_indices[], MPI_Status *array_of_statuses);
+int MPI_Rget(void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Win win, MPI_Request *request);
+int MPI_Rget_c(void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Win win, MPI_Request *request);
+int MPI_Rget_accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, void *result_addr, int result_count, MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win, MPI_Request *request);
+int MPI_Rget_accumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, void *result_addr, MPI_Count result_count, MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win, MPI_Request *request);
+int MPI_Rput(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Win win, MPI_Request *request);
+int MPI_Rput_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Win win, MPI_Request *request);
+int MPI_Rsend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int MPI_Rsend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int MPI_Rsend_init(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Rsend_init_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Scan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int MPI_Scan_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int MPI_Scan_init(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Scan_init_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
+int MPI_Scatter_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
+int MPI_Scatter_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Scatter_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Scatterv(const void *sendbuf, const int sendcounts[], const int displs[], MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
+int MPI_Scatterv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
+int MPI_Scatterv_init(const void *sendbuf, const int sendcounts[], const int displs[], MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Scatterv_init_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int MPI_Send_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int MPI_Send_init(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Send_init_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, int dest, int sendtag, void *recvbuf, int recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Status *status);
+int MPI_Sendrecv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, int dest, int sendtag, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Status *status);
+int MPI_Sendrecv_replace(void *buf, int count, MPI_Datatype datatype, int dest, int sendtag, int source, int recvtag, MPI_Comm comm, MPI_Status *status);
+int MPI_Sendrecv_replace_c(void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int sendtag, int source, int recvtag, MPI_Comm comm, MPI_Status *status);
+int MPI_Session_attach_buffer(MPI_Session session, void *buffer, int size);
+int MPI_Session_attach_buffer_c(MPI_Session session, void *buffer, MPI_Count size);
+int MPI_Session_call_errhandler(MPI_Session session, int errorcode);
+int MPI_Session_create_errhandler(MPI_Session_errhandler_function *session_errhandler_fn, MPI_Errhandler *errhandler);
+int MPI_Session_detach_buffer(MPI_Session session, void *buffer_addr, int *size);
+int MPI_Session_detach_buffer_c(MPI_Session session, void *buffer_addr, MPI_Count *size);
+int MPI_Session_finalize(MPI_Session *session);
+int MPI_Session_flush_buffer(MPI_Session session);
+int MPI_Session_get_errhandler(MPI_Session session, MPI_Errhandler *errhandler);
+int MPI_Session_get_info(MPI_Session session, MPI_Info *info_used);
+int MPI_Session_get_nth_pset(MPI_Session session, MPI_Info info, int n, int *pset_len, char *pset_name);
+int MPI_Session_get_num_psets(MPI_Session session, MPI_Info info, int *npset_names);
+int MPI_Session_get_pset_info(MPI_Session session, const char *pset_name, MPI_Info *info);
+int MPI_Session_iflush_buffer(MPI_Session session, MPI_Request *request);
+int MPI_Session_init(MPI_Info info, MPI_Errhandler errhandler, MPI_Session *session);
+int MPI_Session_set_errhandler(MPI_Session session, MPI_Errhandler errhandler);
+int MPI_Sizeof(void *x, int *size);
+int MPI_Ssend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int MPI_Ssend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int MPI_Ssend_init(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Ssend_init_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int MPI_Start(MPI_Request *request);
+int MPI_Startall(int count, MPI_Request array_of_requests[]);
+int MPI_Status_get_error(MPI_Status *status, int *error);
+int MPI_Status_get_source(MPI_Status *status, int *source);
+int MPI_Status_get_tag(MPI_Status *status, int *tag);
+int MPI_Status_set_cancelled(MPI_Status *status, int flag);
+int MPI_Status_set_elements(MPI_Status *status, MPI_Datatype datatype, int count);
+int MPI_Status_set_elements_c(MPI_Status *status, MPI_Datatype datatype, MPI_Count count);
+int MPI_Status_set_elements_x(MPI_Status *status, MPI_Datatype datatype, MPI_Count count);
+int MPI_Status_set_error(MPI_Status *status, int error);
+int MPI_Status_set_source(MPI_Status *status, int source);
+int MPI_Status_set_tag(MPI_Status *status, int tag);
+int MPI_T_category_changed(int *update_number);
+int MPI_T_category_get_categories(int cat_index, int len, int indices[]);
+int MPI_T_category_get_cvars(int cat_index, int len, int indices[]);
+int MPI_T_category_get_events(int cat_index, int len, int indices[]);
+int MPI_T_category_get_index(const char *name, int *cat_index);
+int MPI_T_category_get_info(int cat_index, char *name, int *name_len, char *desc, int *desc_len, int *num_cvars, int *num_pvars, int *num_categories);
+int MPI_T_category_get_num(int *num_cat);
+int MPI_T_category_get_num_events(int cat_index, int *num_events);
+int MPI_T_category_get_pvars(int cat_index, int len, int indices[]);
+int MPI_T_cvar_get_index(const char *name, int *cvar_index);
+int MPI_T_cvar_get_info(int cvar_index, char *name, int *name_len, int *verbosity, MPI_Datatype *datatype, MPI_T_enum *enumtype, char *desc, int *desc_len, int *bind, int *scope);
+int MPI_T_cvar_get_num(int *num_cvar);
+int MPI_T_cvar_handle_alloc(int cvar_index, void *obj_handle, MPI_T_cvar_handle *handle, int *count);
+int MPI_T_cvar_handle_free(MPI_T_cvar_handle *handle);
+int MPI_T_cvar_read(MPI_T_cvar_handle handle, void *buf);
+int MPI_T_cvar_write(MPI_T_cvar_handle handle, const void *buf);
+int MPI_T_enum_get_info(MPI_T_enum enumtype, int *num, char *name, int *name_len);
+int MPI_T_enum_get_item(MPI_T_enum enumtype, int indx, int *value, char *name, int *name_len);
+int MPI_T_event_callback_get_info(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, MPI_Info *info_used);
+int MPI_T_event_callback_set_info(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, MPI_Info info);
+int MPI_T_event_copy(MPI_T_event_instance event_instance, void *buffer);
+int MPI_T_event_get_index(const char *name, int *event_index);
+int MPI_T_event_get_info(int event_index, char *name, int *name_len, int *verbosity, MPI_Datatype array_of_datatypes[], MPI_Aint array_of_displacements[], int *num_elements, MPI_T_enum *enumtype, MPI_Info *info, char *desc, int *desc_len, int *bind);
+int MPI_T_event_get_num(int *num_events);
+int MPI_T_event_get_source(MPI_T_event_instance event_instance, int *source_index);
+int MPI_T_event_get_timestamp(MPI_T_event_instance event_instance, MPI_Count *event_timestamp);
+int MPI_T_event_handle_alloc(int event_index, void *obj_handle, MPI_Info info, MPI_T_event_registration *event_registration);
+int MPI_T_event_handle_free(MPI_T_event_registration event_registration, void *user_data, MPI_T_event_free_cb_function free_cb_function);
+int MPI_T_event_handle_get_info(MPI_T_event_registration event_registration, MPI_Info *info_used);
+int MPI_T_event_handle_set_info(MPI_T_event_registration event_registration, MPI_Info info);
+int MPI_T_event_read(MPI_T_event_instance event_instance, int element_index, void *buffer);
+int MPI_T_event_register_callback(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, MPI_Info info, void *user_data, MPI_T_event_cb_function event_cb_function);
+int MPI_T_event_set_dropped_handler(MPI_T_event_registration event_registration, MPI_T_event_dropped_cb_function dropped_cb_function);
+int MPI_T_finalize(void);
+int MPI_T_init_thread(int required, int *provided);
+int MPI_T_pvar_get_index(const char *name, int var_class, int *pvar_index);
+int MPI_T_pvar_get_info(int pvar_index, char *name, int *name_len, int *verbosity, int *var_class, MPI_Datatype *datatype, MPI_T_enum *enumtype, char *desc, int *desc_len, int *bind, int *readonly, int *continuous, int *atomic);
+int MPI_T_pvar_get_num(int *num_pvar);
+int MPI_T_pvar_handle_alloc(MPI_T_pvar_session session, int pvar_index, void *obj_handle, MPI_T_pvar_handle *handle, int *count);
+int MPI_T_pvar_handle_free(MPI_T_pvar_session session, MPI_T_pvar_handle *handle);
+int MPI_T_pvar_read(MPI_T_pvar_session session, MPI_T_pvar_handle handle, void *buf);
+int MPI_T_pvar_readreset(MPI_T_pvar_session session, MPI_T_pvar_handle handle, void *buf);
+int MPI_T_pvar_reset(MPI_T_pvar_session session, MPI_T_pvar_handle handle);
+int MPI_T_pvar_session_create(MPI_T_pvar_session *session);
+int MPI_T_pvar_session_free(MPI_T_pvar_session *session);
+int MPI_T_pvar_start(MPI_T_pvar_session session, MPI_T_pvar_handle handle);
+int MPI_T_pvar_stop(MPI_T_pvar_session session, MPI_T_pvar_handle handle);
+int MPI_T_pvar_write(MPI_T_pvar_session session, MPI_T_pvar_handle handle, const void *buf);
+int MPI_T_source_get_info(int source_index, char *name, int *name_len, char *desc, int *desc_len, MPI_T_source_order *ordering, MPI_Count *ticks_per_second, MPI_Count *max_ticks, MPI_Info *info);
+int MPI_T_source_get_num(int *num_sources);
+int MPI_T_source_get_timestamp(int source_index, MPI_Count *timestamp);
+int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status);
+int MPI_Test_cancelled(const MPI_Status *status, int *flag);
+int MPI_Testall(int count, MPI_Request array_of_requests[], int *flag, MPI_Status *array_of_statuses);
+int MPI_Testany(int count, MPI_Request array_of_requests[], int *indx, int *flag, MPI_Status *status);
+int MPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount, int array_of_indices[], MPI_Status *array_of_statuses);
+int MPI_Topo_test(MPI_Comm comm, int *status);
+int MPI_Type_commit(MPI_Datatype *datatype);
+int MPI_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_contiguous_c(MPI_Count count, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_darray(int size, int rank, int ndims, const int array_of_gsizes[], const int array_of_distribs[], const int array_of_dargs[], const int array_of_psizes[], int order, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_darray_c(int size, int rank, int ndims, const MPI_Count array_of_gsizes[], const int array_of_distribs[], const int array_of_dargs[], const int array_of_psizes[], int order, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_f90_complex(int p, int r, MPI_Datatype *newtype);
+int MPI_Type_create_f90_integer(int r, MPI_Datatype *newtype);
+int MPI_Type_create_f90_real(int p, int r, MPI_Datatype *newtype);
+int MPI_Type_create_hindexed(int count, const int array_of_blocklengths[], const MPI_Aint array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_hindexed_c(MPI_Count count, const MPI_Count array_of_blocklengths[], const MPI_Count array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_hindexed_block(int count, int blocklength, const MPI_Aint array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_hindexed_block_c(MPI_Count count, MPI_Count blocklength, const MPI_Count array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_hvector(int count, int blocklength, MPI_Aint stride, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_hvector_c(MPI_Count count, MPI_Count blocklength, MPI_Count stride, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_indexed_block(int count, int blocklength, const int array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_indexed_block_c(MPI_Count count, MPI_Count blocklength, const MPI_Count array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_keyval(MPI_Type_copy_attr_function *type_copy_attr_fn, MPI_Type_delete_attr_function *type_delete_attr_fn, int *type_keyval, void *extra_state);
+int MPI_Type_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent, MPI_Datatype *newtype);
+int MPI_Type_create_resized_c(MPI_Datatype oldtype, MPI_Count lb, MPI_Count extent, MPI_Datatype *newtype);
+int MPI_Type_create_struct(int count, const int array_of_blocklengths[], const MPI_Aint array_of_displacements[], const MPI_Datatype array_of_types[], MPI_Datatype *newtype);
+int MPI_Type_create_struct_c(MPI_Count count, const MPI_Count array_of_blocklengths[], const MPI_Count array_of_displacements[], const MPI_Datatype array_of_types[], MPI_Datatype *newtype);
+int MPI_Type_create_subarray(int ndims, const int array_of_sizes[], const int array_of_subsizes[], const int array_of_starts[], int order, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_create_subarray_c(int ndims, const MPI_Count array_of_sizes[], const MPI_Count array_of_subsizes[], const MPI_Count array_of_starts[], int order, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_delete_attr(MPI_Datatype datatype, int type_keyval);
+int MPI_Type_dup(MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_free(MPI_Datatype *datatype);
+int MPI_Type_free_keyval(int *type_keyval);
+int MPI_Type_get_attr(MPI_Datatype datatype, int type_keyval, void *attribute_val, int *flag);
+int MPI_Type_get_contents(MPI_Datatype datatype, int max_integers, int max_addresses, int max_datatypes, int array_of_integers[], MPI_Aint array_of_addresses[], MPI_Datatype array_of_datatypes[]);
+int MPI_Type_get_contents_c(MPI_Datatype datatype, MPI_Count max_integers, MPI_Count max_addresses, MPI_Count max_large_counts, MPI_Count max_datatypes, int array_of_integers[], MPI_Aint array_of_addresses[], MPI_Count array_of_large_counts[], MPI_Datatype array_of_datatypes[]);
+int MPI_Type_get_envelope(MPI_Datatype datatype, int *num_integers, int *num_addresses, int *num_datatypes, int *combiner);
+int MPI_Type_get_envelope_c(MPI_Datatype datatype, MPI_Count *num_integers, MPI_Count *num_addresses, MPI_Count *num_large_counts, MPI_Count *num_datatypes, int *combiner);
+int MPI_Type_get_extent(MPI_Datatype datatype, MPI_Aint *lb, MPI_Aint *extent);
+int MPI_Type_get_extent_c(MPI_Datatype datatype, MPI_Count *lb, MPI_Count *extent);
+int MPI_Type_get_extent_x(MPI_Datatype datatype, MPI_Count *lb, MPI_Count *extent);
+int MPI_Type_get_name(MPI_Datatype datatype, char *type_name, int *resultlen);
+int MPI_Type_get_true_extent(MPI_Datatype datatype, MPI_Aint *true_lb, MPI_Aint *true_extent);
+int MPI_Type_get_true_extent_c(MPI_Datatype datatype, MPI_Count *true_lb, MPI_Count *true_extent);
+int MPI_Type_get_true_extent_x(MPI_Datatype datatype, MPI_Count *true_lb, MPI_Count *true_extent);
+int MPI_Type_get_value_index(MPI_Datatype value_type, MPI_Datatype index_type, MPI_Datatype *pair_type);
+int MPI_Type_indexed(int count, const int array_of_blocklengths[], const int array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_indexed_c(MPI_Count count, const MPI_Count array_of_blocklengths[], const MPI_Count array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_match_size(int typeclass, int size, MPI_Datatype *datatype);
+int MPI_Type_set_attr(MPI_Datatype datatype, int type_keyval, void *attribute_val);
+int MPI_Type_set_name(MPI_Datatype datatype, const char *type_name);
+int MPI_Type_size(MPI_Datatype datatype, int *size);
+int MPI_Type_size_c(MPI_Datatype datatype, MPI_Count *size);
+int MPI_Type_size_x(MPI_Datatype datatype, MPI_Count *size);
+int MPI_Type_vector(int count, int blocklength, int stride, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Type_vector_c(MPI_Count count, MPI_Count blocklength, MPI_Count stride, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int MPI_Unpack(const void *inbuf, int insize, int *position, void *outbuf, int outcount, MPI_Datatype datatype, MPI_Comm comm);
+int MPI_Unpack_c(const void *inbuf, MPI_Count insize, MPI_Count *position, void *outbuf, MPI_Count outcount, MPI_Datatype datatype, MPI_Comm comm);
+int MPI_Unpack_external(const char datarep[], const void *inbuf, MPI_Aint insize, MPI_Aint *position, void *outbuf, int outcount, MPI_Datatype datatype);
+int MPI_Unpack_external_c(const char datarep[], const void *inbuf, MPI_Count insize, MPI_Count *position, void *outbuf, MPI_Count outcount, MPI_Datatype datatype);
+int MPI_Unpublish_name(const char *service_name, MPI_Info info, const char *port_name);
+int MPI_Wait(MPI_Request *request, MPI_Status *status);
+int MPI_Waitall(int count, MPI_Request array_of_requests[], MPI_Status *array_of_statuses);
+int MPI_Waitany(int count, MPI_Request array_of_requests[], int *indx, MPI_Status *status);
+int MPI_Waitsome(int incount, MPI_Request array_of_requests[], int *outcount, int array_of_indices[], MPI_Status *array_of_statuses);
+int MPI_Win_allocate(MPI_Aint size, int disp_unit, MPI_Info info, MPI_Comm comm, void *baseptr, MPI_Win *win);
+int MPI_Win_allocate_c(MPI_Aint size, MPI_Aint disp_unit, MPI_Info info, MPI_Comm comm, void *baseptr, MPI_Win *win);
+int MPI_Win_allocate_shared(MPI_Aint size, int disp_unit, MPI_Info info, MPI_Comm comm, void *baseptr, MPI_Win *win);
+int MPI_Win_allocate_shared_c(MPI_Aint size, MPI_Aint disp_unit, MPI_Info info, MPI_Comm comm, void *baseptr, MPI_Win *win);
+int MPI_Win_attach(MPI_Win win, void *base, MPI_Aint size);
+int MPI_Win_call_errhandler(MPI_Win win, int errorcode);
+int MPI_Win_complete(MPI_Win win);
+int MPI_Win_create(void *base, MPI_Aint size, int disp_unit, MPI_Info info, MPI_Comm comm, MPI_Win *win);
+int MPI_Win_create_c(void *base, MPI_Aint size, MPI_Aint disp_unit, MPI_Info info, MPI_Comm comm, MPI_Win *win);
+int MPI_Win_create_dynamic(MPI_Info info, MPI_Comm comm, MPI_Win *win);
+int MPI_Win_create_errhandler(MPI_Win_errhandler_function *win_errhandler_fn, MPI_Errhandler *errhandler);
+int MPI_Win_create_keyval(MPI_Win_copy_attr_function *win_copy_attr_fn, MPI_Win_delete_attr_function *win_delete_attr_fn, int *win_keyval, void *extra_state);
+int MPI_Win_delete_attr(MPI_Win win, int win_keyval);
+int MPI_Win_detach(MPI_Win win, const void *base);
+int MPI_Win_fence(int assert, MPI_Win win);
+int MPI_Win_flush(int rank, MPI_Win win);
+int MPI_Win_flush_all(MPI_Win win);
+int MPI_Win_flush_local(int rank, MPI_Win win);
+int MPI_Win_flush_local_all(MPI_Win win);
+int MPI_Win_free(MPI_Win *win);
+int MPI_Win_free_keyval(int *win_keyval);
+int MPI_Win_get_attr(MPI_Win win, int win_keyval, void *attribute_val, int *flag);
+int MPI_Win_get_errhandler(MPI_Win win, MPI_Errhandler *errhandler);
+int MPI_Win_get_group(MPI_Win win, MPI_Group *group);
+int MPI_Win_get_info(MPI_Win win, MPI_Info *info_used);
+int MPI_Win_get_name(MPI_Win win, char *win_name, int *resultlen);
+int MPI_Win_lock(int lock_type, int rank, int assert, MPI_Win win);
+int MPI_Win_lock_all(int assert, MPI_Win win);
+int MPI_Win_post(MPI_Group group, int assert, MPI_Win win);
+int MPI_Win_set_attr(MPI_Win win, int win_keyval, void *attribute_val);
+int MPI_Win_set_errhandler(MPI_Win win, MPI_Errhandler errhandler);
+int MPI_Win_set_info(MPI_Win win, MPI_Info info);
+int MPI_Win_set_name(MPI_Win win, const char *win_name);
+int MPI_Win_shared_query(MPI_Win win, int rank, MPI_Aint *size, int *disp_unit, void *baseptr);
+int MPI_Win_shared_query_c(MPI_Win win, int rank, MPI_Aint *size, MPI_Aint *disp_unit, void *baseptr);
+int MPI_Win_start(MPI_Group group, int assert, MPI_Win win);
+int MPI_Win_sync(MPI_Win win);
+int MPI_Win_test(MPI_Win win, int *flag);
+int MPI_Win_unlock(int rank, MPI_Win win);
+int MPI_Win_unlock_all(MPI_Win win);
+int MPI_Win_wait(MPI_Win win);
+double MPI_Wtick(void);
+double MPI_Wtime(void);
+
+int MPI_Status_c2f(const MPI_Status *c_status, MPI_Fint *f_status);
+int MPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status);
+
+MPI_Fint MPI_Comm_c2f(MPI_Comm comm);
+MPI_Comm MPI_Comm_f2c(MPI_Fint comm);
+MPI_Fint MPI_Errhandler_c2f(MPI_Errhandler errhandler);
+MPI_Errhandler MPI_Errhandler_f2c(MPI_Fint errhandler);
+MPI_Fint MPI_Type_c2f(MPI_Datatype datatype);
+MPI_Datatype MPI_Type_f2c(MPI_Fint datatype);
+MPI_Fint MPI_File_c2f(MPI_File file);
+MPI_File MPI_File_f2c(MPI_Fint file);
+MPI_Fint MPI_Group_c2f(MPI_Group group);
+MPI_Group MPI_Group_f2c(MPI_Fint group);
+MPI_Fint MPI_Info_c2f(MPI_Info info);
+MPI_Info MPI_Info_f2c(MPI_Fint info);
+MPI_Fint MPI_Message_c2f(MPI_Message message);
+MPI_Message MPI_Message_f2c(MPI_Fint message);
+MPI_Fint MPI_Op_c2f(MPI_Op op);
+MPI_Op MPI_Op_f2c(MPI_Fint op);
+MPI_Fint MPI_Request_c2f(MPI_Request request);
+MPI_Request MPI_Request_f2c(MPI_Fint request);
+MPI_Fint MPI_Session_c2f(MPI_Session session);
+MPI_Session MPI_Session_f2c(MPI_Fint session);
+MPI_Fint MPI_Win_c2f(MPI_Win win);
+MPI_Win MPI_Win_f2c(MPI_Fint win);
+
+/* PMPI functions */
+int PMPI_Abort(MPI_Comm comm, int errorcode);
+int PMPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
+int PMPI_Accumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
+int PMPI_Add_error_class(int *errorclass);
+int PMPI_Add_error_code(int errorclass, int *errorcode);
+int PMPI_Add_error_string(int errorcode, const char *string);
+MPI_Aint PMPI_Aint_add(MPI_Aint base, MPI_Aint disp);
+MPI_Aint PMPI_Aint_diff(MPI_Aint addr1, MPI_Aint addr2);
+int PMPI_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Allgather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Allgather_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Allgather_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Allgatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Allgatherv_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Allgatherv_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Alloc_mem(MPI_Aint size, MPI_Info info, void *baseptr);
+int PMPI_Allreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int PMPI_Allreduce_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int PMPI_Allreduce_init(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Allreduce_init_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Alltoall_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Alltoall_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Alltoall_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Alltoallv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Alltoallv_init(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Alltoallv_init_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Alltoallw(const void *sendbuf, const int sendcounts[], const int sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const int rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm);
+int PMPI_Alltoallw_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm);
+int PMPI_Alltoallw_init(const void *sendbuf, const int sendcounts[], const int sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const int rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Alltoallw_init_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Attr_delete(MPI_Comm comm, int keyval);
+int PMPI_Attr_get(MPI_Comm comm, int keyval, void *attribute_val, int *flag);
+int PMPI_Attr_put(MPI_Comm comm, int keyval, void *attribute_val);
+int PMPI_Barrier(MPI_Comm comm);
+int PMPI_Barrier_init(MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Bcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm);
+int PMPI_Bcast_c(void *buffer, MPI_Count count, MPI_Datatype datatype, int root, MPI_Comm comm);
+int PMPI_Bcast_init(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Bcast_init_c(void *buffer, MPI_Count count, MPI_Datatype datatype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Bsend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int PMPI_Bsend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int PMPI_Bsend_init(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Bsend_init_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Buffer_attach(void *buffer, int size);
+int PMPI_Buffer_attach_c(void *buffer, MPI_Count size);
+int PMPI_Buffer_detach(void *buffer_addr, int *size);
+int PMPI_Buffer_detach_c(void *buffer_addr, MPI_Count *size);
+int PMPI_Cancel(MPI_Request *request);
+int PMPI_Cart_coords(MPI_Comm comm, int rank, int maxdims, int coords[]);
+int PMPI_Cart_create(MPI_Comm comm_old, int ndims, const int dims[], const int periods[], int reorder, MPI_Comm *comm_cart);
+int PMPI_Cart_get(MPI_Comm comm, int maxdims, int dims[], int periods[], int coords[]);
+int PMPI_Cart_map(MPI_Comm comm, int ndims, const int dims[], const int periods[], int *newrank);
+int PMPI_Cart_rank(MPI_Comm comm, const int coords[], int *rank);
+int PMPI_Cart_shift(MPI_Comm comm, int direction, int disp, int *rank_source, int *rank_dest);
+int PMPI_Cart_sub(MPI_Comm comm, const int remain_dims[], MPI_Comm *newcomm);
+int PMPI_Cartdim_get(MPI_Comm comm, int *ndims);
+int PMPI_Close_port(const char *port_name);
+int PMPI_Comm_accept(const char *port_name, MPI_Info info, int root, MPI_Comm comm, MPI_Comm *newcomm);
+int PMPI_Comm_call_errhandler(MPI_Comm comm, int errorcode);
+int PMPI_Comm_compare(MPI_Comm comm1, MPI_Comm comm2, int *result);
+int PMPI_Comm_connect(const char *port_name, MPI_Info info, int root, MPI_Comm comm, MPI_Comm *newcomm);
+int PMPI_Comm_create(MPI_Comm comm, MPI_Group group, MPI_Comm *newcomm);
+int PMPI_Comm_create_errhandler(MPI_Comm_errhandler_function *comm_errhandler_fn, MPI_Errhandler *errhandler);
+int PMPI_Comm_create_from_group(MPI_Group group, const char *stringtag, MPI_Info info, MPI_Errhandler errhandler, MPI_Comm *newcomm);
+int PMPI_Comm_create_group(MPI_Comm comm, MPI_Group group, int tag, MPI_Comm *newcomm);
+int PMPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn, MPI_Comm_delete_attr_function *comm_delete_attr_fn, int *comm_keyval, void *extra_state);
+int PMPI_Comm_delete_attr(MPI_Comm comm, int comm_keyval);
+int PMPI_Comm_disconnect(MPI_Comm *comm);
+int PMPI_Comm_dup(MPI_Comm comm, MPI_Comm *newcomm);
+int PMPI_Comm_dup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm *newcomm);
+int PMPI_Comm_free(MPI_Comm *comm);
+int PMPI_Comm_free_keyval(int *comm_keyval);
+int PMPI_Comm_get_attr(MPI_Comm comm, int comm_keyval, void *attribute_val, int *flag);
+int PMPI_Comm_get_errhandler(MPI_Comm comm, MPI_Errhandler *errhandler);
+int PMPI_Comm_get_info(MPI_Comm comm, MPI_Info *info_used);
+int PMPI_Comm_get_name(MPI_Comm comm, char *comm_name, int *resultlen);
+int PMPI_Comm_get_parent(MPI_Comm *parent);
+int PMPI_Comm_group(MPI_Comm comm, MPI_Group *group);
+int PMPI_Comm_idup(MPI_Comm comm, MPI_Comm *newcomm, MPI_Request *request);
+int PMPI_Comm_idup_with_info(MPI_Comm comm, MPI_Info info, MPI_Comm *newcomm, MPI_Request *request);
+int PMPI_Comm_join(int fd, MPI_Comm *intercomm);
+int PMPI_Comm_rank(MPI_Comm comm, int *rank);
+int PMPI_Comm_remote_group(MPI_Comm comm, MPI_Group *group);
+int PMPI_Comm_remote_size(MPI_Comm comm, int *size);
+int PMPI_Comm_set_attr(MPI_Comm comm, int comm_keyval, void *attribute_val);
+int PMPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler);
+int PMPI_Comm_set_info(MPI_Comm comm, MPI_Info info);
+int PMPI_Comm_set_name(MPI_Comm comm, const char *comm_name);
+int PMPI_Comm_size(MPI_Comm comm, int *size);
+int PMPI_Comm_spawn(const char *command, char *argv[], int maxprocs, MPI_Info info, int root, MPI_Comm comm, MPI_Comm *intercomm, int array_of_errcodes[]);
+int PMPI_Comm_spawn_multiple(int count, char *array_of_commands[], char **array_of_argv[], const int array_of_maxprocs[], const MPI_Info array_of_info[], int root, MPI_Comm comm, MPI_Comm *intercomm, int array_of_errcodes[]);
+int PMPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *newcomm);
+int PMPI_Comm_split_type(MPI_Comm comm, int split_type, int key, MPI_Info info, MPI_Comm *newcomm);
+int PMPI_Comm_test_inter(MPI_Comm comm, int *flag);
+int PMPI_Compare_and_swap(const void *origin_addr, const void *compare_addr, void *result_addr, MPI_Datatype datatype, int target_rank, MPI_Aint target_disp, MPI_Win win);
+int PMPI_Dims_create(int nnodes, int ndims, int dims[]);
+int PMPI_Dist_graph_create(MPI_Comm comm_old, int n, const int sources[], const int degrees[], const int destinations[], const int weights[], MPI_Info info, int reorder, MPI_Comm *comm_dist_graph);
+int PMPI_Dist_graph_create_adjacent(MPI_Comm comm_old, int indegree, const int sources[], const int sourceweights[], int outdegree, const int destinations[], const int destweights[], MPI_Info info, int reorder, MPI_Comm *comm_dist_graph);
+int PMPI_Dist_graph_neighbors(MPI_Comm comm, int maxindegree, int sources[], int sourceweights[], int maxoutdegree, int destinations[], int destweights[]);
+int PMPI_Dist_graph_neighbors_count(MPI_Comm comm, int *indegree, int *outdegree, int *weighted);
+int PMPI_Errhandler_free(MPI_Errhandler *errhandler);
+int PMPI_Error_class(int errorcode, int *errorclass);
+int PMPI_Error_string(int errorcode, char *string, int *resultlen);
+int PMPI_Exscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int PMPI_Exscan_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int PMPI_Exscan_init(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Exscan_init_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_F_sync_reg(void *buf);
+int PMPI_Fetch_and_op(const void *origin_addr, void *result_addr, MPI_Datatype datatype, int target_rank, MPI_Aint target_disp, MPI_Op op, MPI_Win win);
+int PMPI_File_call_errhandler(MPI_File fh, int errorcode);
+int PMPI_File_close(MPI_File *fh);
+int PMPI_File_create_errhandler(MPI_File_errhandler_function *file_errhandler_fn, MPI_Errhandler *errhandler);
+int PMPI_File_delete(const char *filename, MPI_Info info);
+int PMPI_File_get_amode(MPI_File fh, int *amode);
+int PMPI_File_get_atomicity(MPI_File fh, int *flag);
+int PMPI_File_get_byte_offset(MPI_File fh, MPI_Offset offset, MPI_Offset *disp);
+int PMPI_File_get_errhandler(MPI_File file, MPI_Errhandler *errhandler);
+int PMPI_File_get_group(MPI_File fh, MPI_Group *group);
+int PMPI_File_get_info(MPI_File fh, MPI_Info *info_used);
+int PMPI_File_get_position(MPI_File fh, MPI_Offset *offset);
+int PMPI_File_get_position_shared(MPI_File fh, MPI_Offset *offset);
+int PMPI_File_get_size(MPI_File fh, MPI_Offset *size);
+int PMPI_File_get_type_extent(MPI_File fh, MPI_Datatype datatype, MPI_Aint *extent);
+int PMPI_File_get_type_extent_c(MPI_File fh, MPI_Datatype datatype, MPI_Count *extent);
+int PMPI_File_get_view(MPI_File fh, MPI_Offset *disp, MPI_Datatype *etype, MPI_Datatype *filetype, char *datarep);
+int PMPI_File_iread(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iread_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iread_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iread_at_all_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iread_shared(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iread_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iwrite(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iwrite_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iwrite_all(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iwrite_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iwrite_at(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iwrite_at_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iwrite_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iwrite_shared(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_iwrite_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Request *request);
+int PMPI_File_open(MPI_Comm comm, const char *filename, int amode, MPI_Info info, MPI_File *fh);
+int PMPI_File_preallocate(MPI_File fh, MPI_Offset size);
+int PMPI_File_read(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_read_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_read_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_read_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_read_all_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype);
+int PMPI_File_read_all_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype);
+int PMPI_File_read_all_end(MPI_File fh, void *buf, MPI_Status *status);
+int PMPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_read_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_read_at_all(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_read_at_all_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_read_at_all_begin(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype);
+int PMPI_File_read_at_all_begin_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count count, MPI_Datatype datatype);
+int PMPI_File_read_at_all_end(MPI_File fh, void *buf, MPI_Status *status);
+int PMPI_File_read_ordered(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_read_ordered_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_read_ordered_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype);
+int PMPI_File_read_ordered_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype);
+int PMPI_File_read_ordered_end(MPI_File fh, void *buf, MPI_Status *status);
+int PMPI_File_read_shared(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_read_shared_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_seek(MPI_File fh, MPI_Offset offset, int whence);
+int PMPI_File_seek_shared(MPI_File fh, MPI_Offset offset, int whence);
+int PMPI_File_set_atomicity(MPI_File fh, int flag);
+int PMPI_File_set_errhandler(MPI_File file, MPI_Errhandler errhandler);
+int PMPI_File_set_info(MPI_File fh, MPI_Info info);
+int PMPI_File_set_size(MPI_File fh, MPI_Offset size);
+int PMPI_File_set_view(MPI_File fh, MPI_Offset disp, MPI_Datatype etype, MPI_Datatype filetype, const char *datarep, MPI_Info info);
+int PMPI_File_sync(MPI_File fh);
+int PMPI_File_write(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_write_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_write_all(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_write_all_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_write_all_begin(MPI_File fh, const void *buf, int count, MPI_Datatype datatype);
+int PMPI_File_write_all_begin_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype);
+int PMPI_File_write_all_end(MPI_File fh, const void *buf, MPI_Status *status);
+int PMPI_File_write_at(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_write_at_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_write_at_all(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_write_at_all_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_write_at_all_begin(MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype);
+int PMPI_File_write_at_all_begin_c(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Count count, MPI_Datatype datatype);
+int PMPI_File_write_at_all_end(MPI_File fh, const void *buf, MPI_Status *status);
+int PMPI_File_write_ordered(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_write_ordered_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_write_ordered_begin(MPI_File fh, const void *buf, int count, MPI_Datatype datatype);
+int PMPI_File_write_ordered_begin_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype);
+int PMPI_File_write_ordered_end(MPI_File fh, const void *buf, MPI_Status *status);
+int PMPI_File_write_shared(MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_File_write_shared_c(MPI_File fh, const void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Status *status);
+int PMPI_Finalize(void);
+int PMPI_Finalized(int *flag);
+int PMPI_Free_mem(void *base);
+int PMPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
+int PMPI_Gather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
+int PMPI_Gather_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Gather_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Gatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, int root, MPI_Comm comm);
+int PMPI_Gatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, int root, MPI_Comm comm);
+int PMPI_Gatherv_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Gatherv_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Get(void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Win win);
+int PMPI_Get_c(void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Win win);
+int PMPI_Get_accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, void *result_addr, int result_count, MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
+int PMPI_Get_accumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, void *result_addr, MPI_Count result_count, MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
+int PMPI_Get_address(const void *location, MPI_Aint *address);
+int PMPI_Get_count(const MPI_Status *status, MPI_Datatype datatype, int *count);
+int PMPI_Get_count_c(const MPI_Status *status, MPI_Datatype datatype, MPI_Count *count);
+int PMPI_Get_elements(const MPI_Status *status, MPI_Datatype datatype, int *count);
+int PMPI_Get_elements_c(const MPI_Status *status, MPI_Datatype datatype, MPI_Count *count);
+int PMPI_Get_elements_x(const MPI_Status *status, MPI_Datatype datatype, MPI_Count *count);
+int PMPI_Get_library_version(char *version, int *resultlen);
+int PMPI_Get_processor_name(char *name, int *resultlen);
+int PMPI_Get_version(int *version, int *subversion);
+int PMPI_Graph_create(MPI_Comm comm_old, int nnodes, const int indx[], const int edges[], int reorder, MPI_Comm *comm_graph);
+int PMPI_Graph_get(MPI_Comm comm, int maxindex, int maxedges, int indx[], int edges[]);
+int PMPI_Graph_map(MPI_Comm comm, int nnodes, const int indx[], const int edges[], int *newrank);
+int PMPI_Graph_neighbors(MPI_Comm comm, int rank, int maxneighbors, int neighbors[]);
+int PMPI_Graph_neighbors_count(MPI_Comm comm, int rank, int *nneighbors);
+int PMPI_Graphdims_get(MPI_Comm comm, int *nnodes, int *nedges);
+int PMPI_Grequest_complete(MPI_Request request);
+int PMPI_Grequest_start(MPI_Grequest_query_function *query_fn, MPI_Grequest_free_function *free_fn, MPI_Grequest_cancel_function *cancel_fn, void *extra_state, MPI_Request *request);
+int PMPI_Group_compare(MPI_Group group1, MPI_Group group2, int *result);
+int PMPI_Group_difference(MPI_Group group1, MPI_Group group2, MPI_Group *newgroup);
+int PMPI_Group_excl(MPI_Group group, int n, const int ranks[], MPI_Group *newgroup);
+int PMPI_Group_free(MPI_Group *group);
+int PMPI_Group_from_session_pset(MPI_Session session, const char *pset_name, MPI_Group *newgroup);
+int PMPI_Group_incl(MPI_Group group, int n, const int ranks[], MPI_Group *newgroup);
+int PMPI_Group_intersection(MPI_Group group1, MPI_Group group2, MPI_Group *newgroup);
+int PMPI_Group_range_excl(MPI_Group group, int n, int ranges[][3], MPI_Group *newgroup);
+int PMPI_Group_range_incl(MPI_Group group, int n, int ranges[][3], MPI_Group *newgroup);
+int PMPI_Group_rank(MPI_Group group, int *rank);
+int PMPI_Group_size(MPI_Group group, int *size);
+int PMPI_Group_translate_ranks(MPI_Group group1, int n, const int ranks1[], MPI_Group group2, int ranks2[]);
+int PMPI_Group_union(MPI_Group group1, MPI_Group group2, MPI_Group *newgroup);
+int PMPI_Iallgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Iallgather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Iallgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Iallgatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Iallreduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int PMPI_Iallreduce_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ialltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ialltoall_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ialltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ialltoallv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ialltoallw(const void *sendbuf, const int sendcounts[], const int sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const int rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Request *request);
+int PMPI_Ialltoallw_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Request *request);
+int PMPI_Ibarrier(MPI_Comm comm, MPI_Request *request);
+int PMPI_Ibcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ibcast_c(void *buffer, MPI_Count count, MPI_Datatype datatype, int root, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ibsend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ibsend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Iexscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int PMPI_Iexscan_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int PMPI_Igather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int PMPI_Igather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int PMPI_Igatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int PMPI_Igatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int PMPI_Improbe(int source, int tag, MPI_Comm comm, int *flag, MPI_Message *message, MPI_Status *status);
+int PMPI_Imrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message *message, MPI_Request *request);
+int PMPI_Imrecv_c(void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Message *message, MPI_Request *request);
+int PMPI_Ineighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ineighbor_allgather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ineighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ineighbor_allgatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ineighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ineighbor_alltoall_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ineighbor_alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ineighbor_alltoallv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ineighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Request *request);
+int PMPI_Ineighbor_alltoallw_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Request *request);
+int PMPI_Info_create(MPI_Info *info);
+int PMPI_Info_create_env(int argc, char *argv[], MPI_Info *info);
+int PMPI_Info_delete(MPI_Info info, const char *key);
+int PMPI_Info_dup(MPI_Info info, MPI_Info *newinfo);
+int PMPI_Info_free(MPI_Info *info);
+int PMPI_Info_get(MPI_Info info, const char *key, int valuelen, char *value, int *flag);
+int PMPI_Info_get_nkeys(MPI_Info info, int *nkeys);
+int PMPI_Info_get_nthkey(MPI_Info info, int n, char *key);
+int PMPI_Info_get_string(MPI_Info info, const char *key, int *buflen, char *value, int *flag);
+int PMPI_Info_get_valuelen(MPI_Info info, const char *key, int *valuelen, int *flag);
+int PMPI_Info_set(MPI_Info info, const char *key, const char *value);
+int PMPI_Init(int *argc, char ***argv);
+int PMPI_Init_thread(int *argc, char ***argv, int required, int *provided);
+int PMPI_Initialized(int *flag);
+int PMPI_Intercomm_create(MPI_Comm local_comm, int local_leader, MPI_Comm peer_comm, int remote_leader, int tag, MPI_Comm *newintercomm);
+int PMPI_Intercomm_create_from_groups(MPI_Group local_group, int local_leader, MPI_Group remote_group, int remote_leader, const char *stringtag, MPI_Info info, MPI_Errhandler errhandler, MPI_Comm *newintercomm);
+int PMPI_Intercomm_merge(MPI_Comm intercomm, int high, MPI_Comm *newintracomm);
+int PMPI_Iprobe(int source, int tag, MPI_Comm comm, int *flag, MPI_Status *status);
+int PMPI_Irecv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Irecv_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ireduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ireduce_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ireduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ireduce_scatter_c(const void *sendbuf, void *recvbuf, const MPI_Count recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ireduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ireduce_scatter_block_c(const void *sendbuf, void *recvbuf, MPI_Count recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int PMPI_Irsend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Irsend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Is_thread_main(int *flag);
+int PMPI_Iscan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int PMPI_Iscan_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request *request);
+int PMPI_Iscatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int PMPI_Iscatter_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int PMPI_Iscatterv(const void *sendbuf, const int sendcounts[], const int displs[], MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int PMPI_Iscatterv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request);
+int PMPI_Isend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Isend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Isendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, int dest, int sendtag, void *recvbuf, int recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Isendrecv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, int dest, int sendtag, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Isendrecv_replace(void *buf, int count, MPI_Datatype datatype, int dest, int sendtag, int source, int recvtag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Isendrecv_replace_c(void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int sendtag, int source, int recvtag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Issend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Issend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Keyval_create(MPI_Copy_function *copy_fn, MPI_Delete_function *delete_fn, int *keyval, void *extra_state);
+int PMPI_Keyval_free(int *keyval);
+int PMPI_Lookup_name(const char *service_name, MPI_Info info, char *port_name);
+int PMPI_Mprobe(int source, int tag, MPI_Comm comm, MPI_Message *message, MPI_Status *status);
+int PMPI_Mrecv(void *buf, int count, MPI_Datatype datatype, MPI_Message *message, MPI_Status *status);
+int PMPI_Mrecv_c(void *buf, MPI_Count count, MPI_Datatype datatype, MPI_Message *message, MPI_Status *status);
+int PMPI_Neighbor_allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Neighbor_allgather_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Neighbor_allgather_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Neighbor_allgather_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Neighbor_allgatherv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Neighbor_allgatherv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Neighbor_allgatherv_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Neighbor_allgatherv_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint displs[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Neighbor_alltoall(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Neighbor_alltoall_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Neighbor_alltoall_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Neighbor_alltoall_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Neighbor_alltoallv(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Neighbor_alltoallv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm);
+int PMPI_Neighbor_alltoallv_init(const void *sendbuf, const int sendcounts[], const int sdispls[], MPI_Datatype sendtype, void *recvbuf, const int recvcounts[], const int rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Neighbor_alltoallv_init_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], MPI_Datatype sendtype, void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], MPI_Datatype recvtype, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Neighbor_alltoallw(const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm);
+int PMPI_Neighbor_alltoallw_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm);
+int PMPI_Neighbor_alltoallw_init(const void *sendbuf, const int sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const int recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Neighbor_alltoallw_init_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint sdispls[], const MPI_Datatype sendtypes[], void *recvbuf, const MPI_Count recvcounts[], const MPI_Aint rdispls[], const MPI_Datatype recvtypes[], MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Op_commutative(MPI_Op op, int *commute);
+int PMPI_Op_create(MPI_User_function *user_fn, int commute, MPI_Op *op);
+int PMPI_Op_create_c(MPI_User_function_c *user_fn, int commute, MPI_Op *op);
+int PMPI_Op_free(MPI_Op *op);
+int PMPI_Open_port(MPI_Info info, char *port_name);
+int PMPI_Pack(const void *inbuf, int incount, MPI_Datatype datatype, void *outbuf, int outsize, int *position, MPI_Comm comm);
+int PMPI_Pack_c(const void *inbuf, MPI_Count incount, MPI_Datatype datatype, void *outbuf, MPI_Count outsize, MPI_Count *position, MPI_Comm comm);
+int PMPI_Pack_external(const char *datarep, const void *inbuf, int incount, MPI_Datatype datatype, void *outbuf, MPI_Aint outsize, MPI_Aint *position);
+int PMPI_Pack_external_c(const char *datarep, const void *inbuf, MPI_Count incount, MPI_Datatype datatype, void *outbuf, MPI_Count outsize, MPI_Count *position);
+int PMPI_Pack_external_size(const char *datarep, int incount, MPI_Datatype datatype, MPI_Aint *size);
+int PMPI_Pack_external_size_c(const char *datarep, MPI_Count incount, MPI_Datatype datatype, MPI_Count *size);
+int PMPI_Pack_size(int incount, MPI_Datatype datatype, MPI_Comm comm, int *size);
+int PMPI_Pack_size_c(MPI_Count incount, MPI_Datatype datatype, MPI_Comm comm, MPI_Count *size);
+int PMPI_Parrived(MPI_Request request, int partition, int *flag);
+int PMPI_Pcontrol(const int level, ...);
+int PMPI_Pready(int partition, MPI_Request request);
+int PMPI_Pready_list(int length, const int array_of_partitions[], MPI_Request request);
+int PMPI_Pready_range(int partition_low, int partition_high, MPI_Request request);
+int PMPI_Precv_init(void *buf, int partitions, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Probe(int source, int tag, MPI_Comm comm, MPI_Status *status);
+int PMPI_Psend_init(const void *buf, int partitions, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Publish_name(const char *service_name, MPI_Info info, const char *port_name);
+int PMPI_Put(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Win win);
+int PMPI_Put_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Win win);
+int PMPI_Query_thread(int *provided);
+int PMPI_Raccumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win, MPI_Request *request);
+int PMPI_Raccumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win, MPI_Request *request);
+int PMPI_Recv(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status *status);
+int PMPI_Recv_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Status *status);
+int PMPI_Recv_init(void *buf, int count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Recv_init_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Reduce(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm);
+int PMPI_Reduce_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm);
+int PMPI_Reduce_init(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Reduce_init_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Reduce_local(const void *inbuf, void *inoutbuf, int count, MPI_Datatype datatype, MPI_Op op);
+int PMPI_Reduce_local_c(const void *inbuf, void *inoutbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op);
+int PMPI_Reduce_scatter(const void *sendbuf, void *recvbuf, const int recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int PMPI_Reduce_scatter_c(const void *sendbuf, void *recvbuf, const MPI_Count recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int PMPI_Reduce_scatter_block(const void *sendbuf, void *recvbuf, int recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int PMPI_Reduce_scatter_block_c(const void *sendbuf, void *recvbuf, MPI_Count recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int PMPI_Reduce_scatter_block_init(const void *sendbuf, void *recvbuf, int recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Reduce_scatter_block_init_c(const void *sendbuf, void *recvbuf, MPI_Count recvcount, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Reduce_scatter_init(const void *sendbuf, void *recvbuf, const int recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Reduce_scatter_init_c(const void *sendbuf, void *recvbuf, const MPI_Count recvcounts[], MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Register_datarep(const char *datarep, MPI_Datarep_conversion_function *read_conversion_fn, MPI_Datarep_conversion_function *write_conversion_fn, MPI_Datarep_extent_function *dtype_file_extent_fn, void *extra_state);
+int PMPI_Register_datarep_c(const char *datarep, MPI_Datarep_conversion_function_c *read_conversion_fn, MPI_Datarep_conversion_function_c *write_conversion_fn, MPI_Datarep_extent_function *dtype_file_extent_fn, void *extra_state);
+int PMPI_Request_free(MPI_Request *request);
+int PMPI_Request_get_status(MPI_Request request, int *flag, MPI_Status *status);
+int PMPI_Rget(void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Win win, MPI_Request *request);
+int PMPI_Rget_c(void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Win win, MPI_Request *request);
+int PMPI_Rget_accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, void *result_addr, int result_count, MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win, MPI_Request *request);
+int PMPI_Rget_accumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, void *result_addr, MPI_Count result_count, MPI_Datatype result_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win, MPI_Request *request);
+int PMPI_Rput(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Win win, MPI_Request *request);
+int PMPI_Rput_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Win win, MPI_Request *request);
+int PMPI_Rsend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int PMPI_Rsend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int PMPI_Rsend_init(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Rsend_init_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Scan(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int PMPI_Scan_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+int PMPI_Scan_init(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Scan_init_c(const void *sendbuf, void *recvbuf, MPI_Count count, MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
+int PMPI_Scatter_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
+int PMPI_Scatter_init(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Scatter_init_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Scatterv(const void *sendbuf, const int sendcounts[], const int displs[], MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
+int PMPI_Scatterv_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm);
+int PMPI_Scatterv_init(const void *sendbuf, const int sendcounts[], const int displs[], MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Scatterv_init_c(const void *sendbuf, const MPI_Count sendcounts[], const MPI_Aint displs[], MPI_Datatype sendtype, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Info info, MPI_Request *request);
+int PMPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int PMPI_Send_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int PMPI_Send_init(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Send_init_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Sendrecv(const void *sendbuf, int sendcount, MPI_Datatype sendtype, int dest, int sendtag, void *recvbuf, int recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Status *status);
+int PMPI_Sendrecv_c(const void *sendbuf, MPI_Count sendcount, MPI_Datatype sendtype, int dest, int sendtag, void *recvbuf, MPI_Count recvcount, MPI_Datatype recvtype, int source, int recvtag, MPI_Comm comm, MPI_Status *status);
+int PMPI_Sendrecv_replace(void *buf, int count, MPI_Datatype datatype, int dest, int sendtag, int source, int recvtag, MPI_Comm comm, MPI_Status *status);
+int PMPI_Sendrecv_replace_c(void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int sendtag, int source, int recvtag, MPI_Comm comm, MPI_Status *status);
+int PMPI_Session_call_errhandler(MPI_Session session, int errorcode);
+int PMPI_Session_create_errhandler(MPI_Session_errhandler_function *session_errhandler_fn, MPI_Errhandler *errhandler);
+int PMPI_Session_finalize(MPI_Session *session);
+int PMPI_Session_get_errhandler(MPI_Session session, MPI_Errhandler *errhandler);
+int PMPI_Session_get_info(MPI_Session session, MPI_Info *info_used);
+int PMPI_Session_get_nth_pset(MPI_Session session, MPI_Info info, int n, int *pset_len, char *pset_name);
+int PMPI_Session_get_num_psets(MPI_Session session, MPI_Info info, int *npset_names);
+int PMPI_Session_get_pset_info(MPI_Session session, const char *pset_name, MPI_Info *info);
+int PMPI_Session_init(MPI_Info info, MPI_Errhandler errhandler, MPI_Session *session);
+int PMPI_Session_set_errhandler(MPI_Session session, MPI_Errhandler errhandler);
+int PMPI_Sizeof(void *x, int *size);
+int PMPI_Ssend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int PMPI_Ssend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm);
+int PMPI_Ssend_init(const void *buf, int count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Ssend_init_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag, MPI_Comm comm, MPI_Request *request);
+int PMPI_Start(MPI_Request *request);
+int PMPI_Startall(int count, MPI_Request array_of_requests[]);
+int PMPI_Status_set_cancelled(MPI_Status *status, int flag);
+int PMPI_Status_set_elements(MPI_Status *status, MPI_Datatype datatype, int count);
+int PMPI_Status_set_elements_c(MPI_Status *status, MPI_Datatype datatype, MPI_Count count);
+int PMPI_Status_set_elements_x(MPI_Status *status, MPI_Datatype datatype, MPI_Count count);
+int PMPI_T_category_changed(int *update_number);
+int PMPI_T_category_get_categories(int cat_index, int len, int indices[]);
+int PMPI_T_category_get_cvars(int cat_index, int len, int indices[]);
+int PMPI_T_category_get_events(int cat_index, int len, int indices[]);
+int PMPI_T_category_get_index(const char *name, int *cat_index);
+int PMPI_T_category_get_info(int cat_index, char *name, int *name_len, char *desc, int *desc_len, int *num_cvars, int *num_pvars, int *num_categories);
+int PMPI_T_category_get_num(int *num_cat);
+int PMPI_T_category_get_num_events(int cat_index, int *num_events);
+int PMPI_T_category_get_pvars(int cat_index, int len, int indices[]);
+int PMPI_T_cvar_get_index(const char *name, int *cvar_index);
+int PMPI_T_cvar_get_info(int cvar_index, char *name, int *name_len, int *verbosity, MPI_Datatype *datatype, MPI_T_enum *enumtype, char *desc, int *desc_len, int *bind, int *scope);
+int PMPI_T_cvar_get_num(int *num_cvar);
+int PMPI_T_cvar_handle_alloc(int cvar_index, void *obj_handle, MPI_T_cvar_handle *handle, int *count);
+int PMPI_T_cvar_handle_free(MPI_T_cvar_handle *handle);
+int PMPI_T_cvar_read(MPI_T_cvar_handle handle, void *buf);
+int PMPI_T_cvar_write(MPI_T_cvar_handle handle, const void *buf);
+int PMPI_T_enum_get_info(MPI_T_enum enumtype, int *num, char *name, int *name_len);
+int PMPI_T_enum_get_item(MPI_T_enum enumtype, int indx, int *value, char *name, int *name_len);
+int PMPI_T_event_callback_get_info(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, MPI_Info *info_used);
+int PMPI_T_event_callback_set_info(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, MPI_Info info);
+int PMPI_T_event_copy(MPI_T_event_instance event_instance, void *buffer);
+int PMPI_T_event_get_index(const char *name, int *event_index);
+int PMPI_T_event_get_info(int event_index, char *name, int *name_len, int *verbosity, MPI_Datatype array_of_datatypes[], MPI_Aint array_of_displacements[], int *num_elements, MPI_T_enum *enumtype, MPI_Info *info, char *desc, int *desc_len, int *bind);
+int PMPI_T_event_get_num(int *num_events);
+int PMPI_T_event_get_source(MPI_T_event_instance event_instance, int *source_index);
+int PMPI_T_event_get_timestamp(MPI_T_event_instance event_instance, MPI_Count *event_timestamp);
+int PMPI_T_event_handle_alloc(int event_index, void *obj_handle, MPI_Info info, MPI_T_event_registration *event_registration);
+int PMPI_T_event_handle_free(MPI_T_event_registration event_registration, void *user_data, MPI_T_event_free_cb_function free_cb_function);
+int PMPI_T_event_handle_get_info(MPI_T_event_registration event_registration, MPI_Info *info_used);
+int PMPI_T_event_handle_set_info(MPI_T_event_registration event_registration, MPI_Info info);
+int PMPI_T_event_read(MPI_T_event_instance event_instance, int element_index, void *buffer);
+int PMPI_T_event_register_callback(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, MPI_Info info, void *user_data, MPI_T_event_cb_function event_cb_function);
+int PMPI_T_event_set_dropped_handler(MPI_T_event_registration event_registration, MPI_T_event_dropped_cb_function dropped_cb_function);
+int PMPI_T_finalize(void);
+int PMPI_T_init_thread(int required, int *provided);
+int PMPI_T_pvar_get_index(const char *name, int var_class, int *pvar_index);
+int PMPI_T_pvar_get_info(int pvar_index, char *name, int *name_len, int *verbosity, int *var_class, MPI_Datatype *datatype, MPI_T_enum *enumtype, char *desc, int *desc_len, int *bind, int *readonly, int *continuous, int *atomic);
+int PMPI_T_pvar_get_num(int *num_pvar);
+int PMPI_T_pvar_handle_alloc(MPI_T_pvar_session session, int pvar_index, void *obj_handle, MPI_T_pvar_handle *handle, int *count);
+int PMPI_T_pvar_handle_free(MPI_T_pvar_session session, MPI_T_pvar_handle *handle);
+int PMPI_T_pvar_read(MPI_T_pvar_session session, MPI_T_pvar_handle handle, void *buf);
+int PMPI_T_pvar_readreset(MPI_T_pvar_session session, MPI_T_pvar_handle handle, void *buf);
+int PMPI_T_pvar_reset(MPI_T_pvar_session session, MPI_T_pvar_handle handle);
+int PMPI_T_pvar_session_create(MPI_T_pvar_session *session);
+int PMPI_T_pvar_session_free(MPI_T_pvar_session *session);
+int PMPI_T_pvar_start(MPI_T_pvar_session session, MPI_T_pvar_handle handle);
+int PMPI_T_pvar_stop(MPI_T_pvar_session session, MPI_T_pvar_handle handle);
+int PMPI_T_pvar_write(MPI_T_pvar_session session, MPI_T_pvar_handle handle, const void *buf);
+int PMPI_T_source_get_info(int source_index, char *name, int *name_len, char *desc, int *desc_len, MPI_T_source_order *ordering, MPI_Count *ticks_per_second, MPI_Count *max_ticks, MPI_Info *info);
+int PMPI_T_source_get_num(int *num_sources);
+int PMPI_T_source_get_timestamp(int source_index, MPI_Count *timestamp);
+int PMPI_Test(MPI_Request *request, int *flag, MPI_Status *status);
+int PMPI_Test_cancelled(const MPI_Status *status, int *flag);
+int PMPI_Testall(int count, MPI_Request array_of_requests[], int *flag, MPI_Status *array_of_statuses);
+int PMPI_Testany(int count, MPI_Request array_of_requests[], int *indx, int *flag, MPI_Status *status);
+int PMPI_Testsome(int incount, MPI_Request array_of_requests[], int *outcount, int array_of_indices[], MPI_Status *array_of_statuses);
+int PMPI_Topo_test(MPI_Comm comm, int *status);
+int PMPI_Type_commit(MPI_Datatype *datatype);
+int PMPI_Type_contiguous(int count, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_contiguous_c(MPI_Count count, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_create_darray(int size, int rank, int ndims, const int array_of_gsizes[], const int array_of_distribs[], const int array_of_dargs[], const int array_of_psizes[], int order, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_create_darray_c(int size, int rank, int ndims, const MPI_Count array_of_gsizes[], const int array_of_distribs[], const int array_of_dargs[], const int array_of_psizes[], int order, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_create_f90_complex(int p, int r, MPI_Datatype *newtype);
+int PMPI_Type_create_f90_integer(int r, MPI_Datatype *newtype);
+int PMPI_Type_create_f90_real(int p, int r, MPI_Datatype *newtype);
+int PMPI_Type_create_hindexed(int count, const int array_of_blocklengths[], const MPI_Aint array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_create_hindexed_c(MPI_Count count, const MPI_Count array_of_blocklengths[], const MPI_Count array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_create_hindexed_block(int count, int blocklength, const MPI_Aint array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_create_hindexed_block_c(MPI_Count count, MPI_Count blocklength, const MPI_Count array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_create_hvector(int count, int blocklength, MPI_Aint stride, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_create_hvector_c(MPI_Count count, MPI_Count blocklength, MPI_Count stride, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_create_indexed_block(int count, int blocklength, const int array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_create_indexed_block_c(MPI_Count count, MPI_Count blocklength, const MPI_Count array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_create_keyval(MPI_Type_copy_attr_function *type_copy_attr_fn, MPI_Type_delete_attr_function *type_delete_attr_fn, int *type_keyval, void *extra_state);
+int PMPI_Type_create_resized(MPI_Datatype oldtype, MPI_Aint lb, MPI_Aint extent, MPI_Datatype *newtype);
+int PMPI_Type_create_resized_c(MPI_Datatype oldtype, MPI_Count lb, MPI_Count extent, MPI_Datatype *newtype);
+int PMPI_Type_create_struct(int count, const int array_of_blocklengths[], const MPI_Aint array_of_displacements[], const MPI_Datatype array_of_types[], MPI_Datatype *newtype);
+int PMPI_Type_create_struct_c(MPI_Count count, const MPI_Count array_of_blocklengths[], const MPI_Count array_of_displacements[], const MPI_Datatype array_of_types[], MPI_Datatype *newtype);
+int PMPI_Type_create_subarray(int ndims, const int array_of_sizes[], const int array_of_subsizes[], const int array_of_starts[], int order, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_create_subarray_c(int ndims, const MPI_Count array_of_sizes[], const MPI_Count array_of_subsizes[], const MPI_Count array_of_starts[], int order, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_delete_attr(MPI_Datatype datatype, int type_keyval);
+int PMPI_Type_dup(MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_free(MPI_Datatype *datatype);
+int PMPI_Type_free_keyval(int *type_keyval);
+int PMPI_Type_get_attr(MPI_Datatype datatype, int type_keyval, void *attribute_val, int *flag);
+int PMPI_Type_get_contents(MPI_Datatype datatype, int max_integers, int max_addresses, int max_datatypes, int array_of_integers[], MPI_Aint array_of_addresses[], MPI_Datatype array_of_datatypes[]);
+int PMPI_Type_get_contents_c(MPI_Datatype datatype, MPI_Count max_integers, MPI_Count max_addresses, MPI_Count max_large_counts, MPI_Count max_datatypes, int array_of_integers[], MPI_Aint array_of_addresses[], MPI_Count array_of_large_counts[], MPI_Datatype array_of_datatypes[]);
+int PMPI_Type_get_envelope(MPI_Datatype datatype, int *num_integers, int *num_addresses, int *num_datatypes, int *combiner);
+int PMPI_Type_get_envelope_c(MPI_Datatype datatype, MPI_Count *num_integers, MPI_Count *num_addresses, MPI_Count *num_large_counts, MPI_Count *num_datatypes, int *combiner);
+int PMPI_Type_get_extent(MPI_Datatype datatype, MPI_Aint *lb, MPI_Aint *extent);
+int PMPI_Type_get_extent_c(MPI_Datatype datatype, MPI_Count *lb, MPI_Count *extent);
+int PMPI_Type_get_extent_x(MPI_Datatype datatype, MPI_Count *lb, MPI_Count *extent);
+int PMPI_Type_get_name(MPI_Datatype datatype, char *type_name, int *resultlen);
+int PMPI_Type_get_true_extent(MPI_Datatype datatype, MPI_Aint *true_lb, MPI_Aint *true_extent);
+int PMPI_Type_get_true_extent_c(MPI_Datatype datatype, MPI_Count *true_lb, MPI_Count *true_extent);
+int PMPI_Type_get_true_extent_x(MPI_Datatype datatype, MPI_Count *true_lb, MPI_Count *true_extent);
+int PMPI_Type_indexed(int count, const int array_of_blocklengths[], const int array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_indexed_c(MPI_Count count, const MPI_Count array_of_blocklengths[], const MPI_Count array_of_displacements[], MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_match_size(int typeclass, int size, MPI_Datatype *datatype);
+int PMPI_Type_set_attr(MPI_Datatype datatype, int type_keyval, void *attribute_val);
+int PMPI_Type_set_name(MPI_Datatype datatype, const char *type_name);
+int PMPI_Type_size(MPI_Datatype datatype, int *size);
+int PMPI_Type_size_c(MPI_Datatype datatype, MPI_Count *size);
+int PMPI_Type_size_x(MPI_Datatype datatype, MPI_Count *size);
+int PMPI_Type_vector(int count, int blocklength, int stride, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Type_vector_c(MPI_Count count, MPI_Count blocklength, MPI_Count stride, MPI_Datatype oldtype, MPI_Datatype *newtype);
+int PMPI_Unpack(const void *inbuf, int insize, int *position, void *outbuf, int outcount, MPI_Datatype datatype, MPI_Comm comm);
+int PMPI_Unpack_c(const void *inbuf, MPI_Count insize, MPI_Count *position, void *outbuf, MPI_Count outcount, MPI_Datatype datatype, MPI_Comm comm);
+int PMPI_Unpack_external(const char datarep[], const void *inbuf, MPI_Aint insize, MPI_Aint *position, void *outbuf, int outcount, MPI_Datatype datatype);
+int PMPI_Unpack_external_c(const char datarep[], const void *inbuf, MPI_Count insize, MPI_Count *position, void *outbuf, MPI_Count outcount, MPI_Datatype datatype);
+int PMPI_Unpublish_name(const char *service_name, MPI_Info info, const char *port_name);
+int PMPI_Wait(MPI_Request *request, MPI_Status *status);
+int PMPI_Waitall(int count, MPI_Request array_of_requests[], MPI_Status *array_of_statuses);
+int PMPI_Waitany(int count, MPI_Request array_of_requests[], int *indx, MPI_Status *status);
+int PMPI_Waitsome(int incount, MPI_Request array_of_requests[], int *outcount, int array_of_indices[], MPI_Status *array_of_statuses);
+int PMPI_Win_allocate(MPI_Aint size, int disp_unit, MPI_Info info, MPI_Comm comm, void *baseptr, MPI_Win *win);
+int PMPI_Win_allocate_c(MPI_Aint size, MPI_Aint disp_unit, MPI_Info info, MPI_Comm comm, void *baseptr, MPI_Win *win);
+int PMPI_Win_allocate_shared(MPI_Aint size, int disp_unit, MPI_Info info, MPI_Comm comm, void *baseptr, MPI_Win *win);
+int PMPI_Win_allocate_shared_c(MPI_Aint size, MPI_Aint disp_unit, MPI_Info info, MPI_Comm comm, void *baseptr, MPI_Win *win);
+int PMPI_Win_attach(MPI_Win win, void *base, MPI_Aint size);
+int PMPI_Win_call_errhandler(MPI_Win win, int errorcode);
+int PMPI_Win_complete(MPI_Win win);
+int PMPI_Win_create(void *base, MPI_Aint size, int disp_unit, MPI_Info info, MPI_Comm comm, MPI_Win *win);
+int PMPI_Win_create_c(void *base, MPI_Aint size, MPI_Aint disp_unit, MPI_Info info, MPI_Comm comm, MPI_Win *win);
+int PMPI_Win_create_dynamic(MPI_Info info, MPI_Comm comm, MPI_Win *win);
+int PMPI_Win_create_errhandler(MPI_Win_errhandler_function *win_errhandler_fn, MPI_Errhandler *errhandler);
+int PMPI_Win_create_keyval(MPI_Win_copy_attr_function *win_copy_attr_fn, MPI_Win_delete_attr_function *win_delete_attr_fn, int *win_keyval, void *extra_state);
+int PMPI_Win_delete_attr(MPI_Win win, int win_keyval);
+int PMPI_Win_detach(MPI_Win win, const void *base);
+int PMPI_Win_fence(int assert, MPI_Win win);
+int PMPI_Win_flush(int rank, MPI_Win win);
+int PMPI_Win_flush_all(MPI_Win win);
+int PMPI_Win_flush_local(int rank, MPI_Win win);
+int PMPI_Win_flush_local_all(MPI_Win win);
+int PMPI_Win_free(MPI_Win *win);
+int PMPI_Win_free_keyval(int *win_keyval);
+int PMPI_Win_get_attr(MPI_Win win, int win_keyval, void *attribute_val, int *flag);
+int PMPI_Win_get_errhandler(MPI_Win win, MPI_Errhandler *errhandler);
+int PMPI_Win_get_group(MPI_Win win, MPI_Group *group);
+int PMPI_Win_get_info(MPI_Win win, MPI_Info *info_used);
+int PMPI_Win_get_name(MPI_Win win, char *win_name, int *resultlen);
+int PMPI_Win_lock(int lock_type, int rank, int assert, MPI_Win win);
+int PMPI_Win_lock_all(int assert, MPI_Win win);
+int PMPI_Win_post(MPI_Group group, int assert, MPI_Win win);
+int PMPI_Win_set_attr(MPI_Win win, int win_keyval, void *attribute_val);
+int PMPI_Win_set_errhandler(MPI_Win win, MPI_Errhandler errhandler);
+int PMPI_Win_set_info(MPI_Win win, MPI_Info info);
+int PMPI_Win_set_name(MPI_Win win, const char *win_name);
+int PMPI_Win_shared_query(MPI_Win win, int rank, MPI_Aint *size, int *disp_unit, void *baseptr);
+int PMPI_Win_shared_query_c(MPI_Win win, int rank, MPI_Aint *size, MPI_Aint *disp_unit, void *baseptr);
+int PMPI_Win_start(MPI_Group group, int assert, MPI_Win win);
+int PMPI_Win_sync(MPI_Win win);
+int PMPI_Win_test(MPI_Win win, int *flag);
+int PMPI_Win_unlock(int rank, MPI_Win win);
+int PMPI_Win_unlock_all(MPI_Win win);
+int PMPI_Win_wait(MPI_Win win);
+double PMPI_Wtick(void);
+double PMPI_Wtime(void);
+
+int PMPI_Status_c2f(const MPI_Status *c_status, MPI_Fint *f_status);
+int PMPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status);
+
+MPI_Fint PMPI_Comm_c2f(MPI_Comm comm);
+MPI_Comm PMPI_Comm_f2c(MPI_Fint comm);
+MPI_Fint PMPI_Errhandler_c2f(MPI_Errhandler errhandler);
+MPI_Errhandler PMPI_Errhandler_f2c(MPI_Fint errhandler);
+MPI_Fint PMPI_Type_c2f(MPI_Datatype datatype);
+MPI_Datatype PMPI_Type_f2c(MPI_Fint datatype);
+MPI_Fint PMPI_File_c2f(MPI_File file);
+MPI_File PMPI_File_f2c(MPI_Fint file);
+MPI_Fint PMPI_Group_c2f(MPI_Group group);
+MPI_Group PMPI_Group_f2c(MPI_Fint group);
+MPI_Fint PMPI_Info_c2f(MPI_Info info);
+MPI_Info PMPI_Info_f2c(MPI_Fint info);
+MPI_Fint PMPI_Message_c2f(MPI_Message message);
+MPI_Message PMPI_Message_f2c(MPI_Fint message);
+MPI_Fint PMPI_Op_c2f(MPI_Op op);
+MPI_Op PMPI_Op_f2c(MPI_Fint op);
+MPI_Fint PMPI_Request_c2f(MPI_Request request);
+MPI_Request PMPI_Request_f2c(MPI_Fint request);
+MPI_Fint PMPI_Session_c2f(MPI_Session session);
+MPI_Session PMPI_Session_f2c(MPI_Fint session);
+MPI_Fint PMPI_Win_c2f(MPI_Win win);
+MPI_Win PMPI_Win_f2c(MPI_Fint win);
+
+#endif /* MPI_ABI_H_INCLUDED */

--- a/src/binding/abi/mpi_abi.h
+++ b/src/binding/abi/mpi_abi.h
@@ -285,119 +285,105 @@ enum {
     MPI_TYPECLASS_REAL
 };
 
-/* Handle constants: 4 bit kind + 8 bit index
- * Kind values:
- *     0x1 MPI_Comm
- *     0x2 MPI_Group
- *     0x3 MPI_Datatype
- *     0x4 MPI_File
- *     0x5 MPI_Errhandler
- *     0x6 MPI_Op
- *     0x7 MPI_Info
- *     0x8 MPI_Win
- *     0x9 MPI_Request
- *     0xa MPI_Message
- *     0xb MPI_Session
- */
-#define MPI_COMM_NULL       (MPI_Comm) 0x100
-#define MPI_GROUP_NULL      (MPI_Group)0x200
-#define MPI_DATATYPE_NULL   (MPI_Datatype)0x300
-#define MPI_FILE_NULL       (MPI_File)0x400
-#define MPI_ERRHANDLER_NULL (MPI_Errhandler)0x500
-#define MPI_OP_NULL         (MPI_Op)0x600
-#define MPI_INFO_NULL       (MPI_Info)0x700
-#define MPI_WIN_NULL        (MPI_Win)0x800
-#define MPI_REQUEST_NULL    (MPI_Request)0x900
-#define MPI_MESSAGE_NULL    (MPI_Message)0xa00
-#define MPI_SESSION_NULL    (MPI_Session)0xb00
 
-#define MPI_COMM_WORLD (MPI_Comm)0x101
-#define MPI_COMM_SELF  (MPI_Comm)0x102
-#define MPI_GROUP_EMPTY (MPI_Group)0x201
-#define MPI_ERRORS_ARE_FATAL (MPI_Errhandler)0x501
-#define MPI_ERRORS_ABORT     (MPI_Errhandler)0x502
-#define MPI_ERRORS_RETURN    (MPI_Errhandler)0x503
-#define MPI_CHAR                    (MPI_Datatype)0x301
-#define MPI_SHORT                   (MPI_Datatype)0x302
-#define MPI_INT                     (MPI_Datatype)0x303
-#define MPI_LONG                    (MPI_Datatype)0x304
-#define MPI_LONG_LONG_INT           (MPI_Datatype)0x305
-#define MPI_LONG_LONG               MPI_LONG_LONG_INT
-#define MPI_SIGNED_CHAR             (MPI_Datatype)0x306
-#define MPI_UNSIGNED_CHAR           (MPI_Datatype)0x307
-#define MPI_UNSIGNED_SHORT          (MPI_Datatype)0x308
-#define MPI_UNSIGNED                (MPI_Datatype)0x309
-#define MPI_UNSIGNED_LONG           (MPI_Datatype)0x30a
-#define MPI_UNSIGNED_LONG_LONG      (MPI_Datatype)0x30b
-#define MPI_FLOAT                   (MPI_Datatype)0x30c
-#define MPI_DOUBLE                  (MPI_Datatype)0x30d
-#define MPI_LONG_DOUBLE             (MPI_Datatype)0x30e
-#define MPI_WCHAR                   (MPI_Datatype)0x30f
-#define MPI_C_BOOL                  (MPI_Datatype)0x310
-#define MPI_INT8_T                  (MPI_Datatype)0x311
-#define MPI_INT16_T                 (MPI_Datatype)0x312
-#define MPI_INT32_T                 (MPI_Datatype)0x313
-#define MPI_INT64_T                 (MPI_Datatype)0x314
-#define MPI_UINT8_T                 (MPI_Datatype)0x315
-#define MPI_UINT16_T                (MPI_Datatype)0x316
-#define MPI_UINT32_T                (MPI_Datatype)0x317
-#define MPI_UINT64_T                (MPI_Datatype)0x318
-#define MPI_AINT                    (MPI_Datatype)0x319
-#define MPI_COUNT                   (MPI_Datatype)0x31a
-#define MPI_OFFSET                  (MPI_Datatype)0x31b
-#define MPI_C_COMPLEX               (MPI_Datatype)0x31c
-#define MPI_C_FLOAT_COMPLEX         (MPI_Datatype)0x31d
-#define MPI_C_DOUBLE_COMPLEX        (MPI_Datatype)0x31e
-#define MPI_C_LONG_DOUBLE_COMPLEX   (MPI_Datatype)0x31f
-#define MPI_BYTE                    (MPI_Datatype)0x320
-#define MPI_PACKED                  (MPI_Datatype)0x321
-#define MPI_INTEGER                 (MPI_Datatype)0x322
-#define MPI_REAL                    (MPI_Datatype)0x323
-#define MPI_DOUBLE_PRECISION        (MPI_Datatype)0x324
-#define MPI_COMPLEX                 (MPI_Datatype)0x325
-#define MPI_LOGICAL                 (MPI_Datatype)0x326
-#define MPI_CHARACTER               (MPI_Datatype)0x327
-#define MPI_CXX_BOOL                (MPI_Datatype)0x328
-#define MPI_CXX_FLOAT_COMPLEX       (MPI_Datatype)0x329
-#define MPI_CXX_DOUBLE_COMPLEX      (MPI_Datatype)0x32a
-#define MPI_CXX_LONG_DOUBLE_COMPLEX (MPI_Datatype)0x32b
-#define MPI_DOUBLE_COMPLEX          (MPI_Datatype)0x32c
-#define MPI_INTEGER1                (MPI_Datatype)0x32d
-#define MPI_INTEGER2                (MPI_Datatype)0x32e
-#define MPI_INTEGER4                (MPI_Datatype)0x32f
-#define MPI_INTEGER8                (MPI_Datatype)0x330
-#define MPI_INTEGER16               (MPI_Datatype)0x331
-#define MPI_REAL4                   (MPI_Datatype)0x333
-#define MPI_REAL8                   (MPI_Datatype)0x334
-#define MPI_REAL16                  (MPI_Datatype)0x335
-#define MPI_COMPLEX8                (MPI_Datatype)0x337
-#define MPI_COMPLEX16               (MPI_Datatype)0x338
-#define MPI_COMPLEX32               (MPI_Datatype)0x339
-#define MPI_FLOAT_INT               (MPI_Datatype)0x33a
-#define MPI_DOUBLE_INT              (MPI_Datatype)0x33b
-#define MPI_LONG_INT                (MPI_Datatype)0x33c
-#define MPI_2INT                    (MPI_Datatype)0x33d
-#define MPI_SHORT_INT               (MPI_Datatype)0x33e
-#define MPI_LONG_DOUBLE_INT         (MPI_Datatype)0x33f
-#define MPI_2REAL                   (MPI_Datatype)0x340
-#define MPI_2DOUBLE_PRECISION       (MPI_Datatype)0x341
-#define MPI_2INTEGER                (MPI_Datatype)0x342
-#define MPI_MAX     (MPI_Op)0x601
-#define MPI_MIN     (MPI_Op)0x602
-#define MPI_SUM     (MPI_Op)0x603
-#define MPI_PROD    (MPI_Op)0x604
-#define MPI_LAND    (MPI_Op)0x605
-#define MPI_BAND    (MPI_Op)0x606
-#define MPI_LOR     (MPI_Op)0x607
-#define MPI_BOR     (MPI_Op)0x608
-#define MPI_LXOR    (MPI_Op)0x609
-#define MPI_BXOR    (MPI_Op)0x60a
-#define MPI_MAXLOC  (MPI_Op)0x60b
-#define MPI_MINLOC  (MPI_Op)0x60c
-#define MPI_REPLACE (MPI_Op)0x60d
-#define MPI_NO_OP   (MPI_Op)0x60e
-#define MPI_INFO_ENV (MPI_Info)0x701
-#define MPI_MESSAGE_NO_PROC (MPI_Message) 0xb01
+#define MPI_OP_NULL          (MPI_Op)0x020
+#define MPI_SUM              (MPI_Op)0x021
+#define MPI_MIN              (MPI_Op)0x022
+#define MPI_MAX              (MPI_Op)0x023
+#define MPI_PROD             (MPI_Op)0x024
+#define MPI_BAND             (MPI_Op)0x028
+#define MPI_BOR              (MPI_Op)0x029
+#define MPI_BXOR             (MPI_Op)0x02a
+#define MPI_LAND             (MPI_Op)0x030
+#define MPI_LOR              (MPI_Op)0x031
+#define MPI_LXOR             (MPI_Op)0x032
+#define MPI_MINLOC           (MPI_Op)0x038
+#define MPI_MAXLOC           (MPI_Op)0x039
+#define MPI_REPLACE          (MPI_Op)0x03c
+#define MPI_NO_OP            (MPI_Op)0x03d
+#define MPI_COMM_NULL        (MPI_Comm)0x100
+#define MPI_COMM_WORLD       (MPI_Comm)0x101
+#define MPI_COMM_SELF        (MPI_Comm)0x102
+#define MPI_GROUP_NULL       (MPI_Group)0x104
+#define MPI_GROUP_EMPTY      (MPI_Group)0x105
+#define MPI_WIN_NULL         (MPI_Win)0x108
+#define MPI_FILE_NULL        (MPI_File)0x10c
+#define MPI_SESSION_NULL     (MPI_Session)0x110
+#define MPI_MESSAGE_NULL     (MPI_Message)0x114
+#define MPI_MESSAGE_NO_PROC  (MPI_Message)0x115
+#define MPI_ERRHANDLER_NULL  (MPI_Errhandler)0x118
+#define MPI_ERRORS_ARE_FATAL (MPI_Errhandler)0x119
+#define MPI_ERRORS_RETURN    (MPI_Errhandler)0x11a
+#define MPI_ERRORS_ABORT     (MPI_Errhandler)0x11b
+#define MPI_REQUEST_NULL     (MPI_Request)0x120
+#define MPI_INFO_NULL        (MPI_Info)0x130
+#define MPI_INFO_ENV         (MPI_Info)0x131
+#define MPI_DATATYPE_NULL           (MPI_Datatype)0x200
+#define MPI_AINT                    (MPI_Datatype)0x201
+#define MPI_COUNT                   (MPI_Datatype)0x202
+#define MPI_OFFSET                  (MPI_Datatype)0x203
+#define MPI_PACKED                  (MPI_Datatype)0x207
+#define MPI_SHORT                   (MPI_Datatype)0x208
+#define MPI_INT                     (MPI_Datatype)0x209
+#define MPI_LONG                    (MPI_Datatype)0x20a
+#define MPI_LONG_LONG               (MPI_Datatype)0x20b
+#define MPI_LONG_LONG_INT MPI_LONG_LONG
+#define MPI_UNSIGNED_SHORT          (MPI_Datatype)0x20c
+#define MPI_UNSIGNED                (MPI_Datatype)0x20d
+#define MPI_UNSIGNED_LONG           (MPI_Datatype)0x20e
+#define MPI_UNSIGNED_LONG_LONG      (MPI_Datatype)0x20f
+#define MPI_FLOAT                   (MPI_Datatype)0x210
+#define MPI_C_FLOAT_COMPLEX         (MPI_Datatype)0x212
+#define MPI_C_COMPLEX MPI_C_FLOAT_COMPLEX
+#define MPI_CXX_FLOAT_COMPLEX       (MPI_Datatype)0x213
+#define MPI_DOUBLE                  (MPI_Datatype)0x214
+#define MPI_C_DOUBLE_COMPLEX        (MPI_Datatype)0x216
+#define MPI_CXX_DOUBLE_COMPLEX      (MPI_Datatype)0x217
+#define MPI_INTEGER                 (MPI_Datatype)0x218
+#define MPI_LOGICAL                 (MPI_Datatype)0x219
+#define MPI_REAL                    (MPI_Datatype)0x21a
+#define MPI_COMPLEX                 (MPI_Datatype)0x21b
+#define MPI_DOUBLE_PRECISION        (MPI_Datatype)0x21c
+#define MPI_DOUBLE_COMPLEX          (MPI_Datatype)0x21d
+#define MPI_LONG_DOUBLE             (MPI_Datatype)0x220
+#define MPI_C_LONG_DOUBLE_COMPLEX   (MPI_Datatype)0x224
+#define MPI_CXX_LONG_DOUBLE_COMPLEX (MPI_Datatype)0x225
+#define MPI_FLOAT_INT               (MPI_Datatype)0x228
+#define MPI_DOUBLE_INT              (MPI_Datatype)0x229
+#define MPI_LONG_INT                (MPI_Datatype)0x22a
+#define MPI_2INT                    (MPI_Datatype)0x22b
+#define MPI_SHORT_INT               (MPI_Datatype)0x22c
+#define MPI_LONG_DOUBLE_INT         (MPI_Datatype)0x22d
+#define MPI_2REAL                   (MPI_Datatype)0x230
+#define MPI_2DOUBLE_PRECISION       (MPI_Datatype)0x231
+#define MPI_2INTEGER                (MPI_Datatype)0x232
+#define MPI_C_BOOL                  (MPI_Datatype)0x238
+#define MPI_CXX_BOOL                (MPI_Datatype)0x239
+#define MPI_WCHAR                   (MPI_Datatype)0x23c
+#define MPI_INT8_T                  (MPI_Datatype)0x240
+#define MPI_UINT8_T                 (MPI_Datatype)0x241
+#define MPI_CHAR                    (MPI_Datatype)0x243
+#define MPI_SIGNED_CHAR             (MPI_Datatype)0x244
+#define MPI_UNSIGNED_CHAR           (MPI_Datatype)0x245
+#define MPI_BYTE                    (MPI_Datatype)0x247
+#define MPI_INT16_T                 (MPI_Datatype)0x248
+#define MPI_UINT16_T                (MPI_Datatype)0x249
+#define MPI_INT32_T                 (MPI_Datatype)0x250
+#define MPI_UINT32_T                (MPI_Datatype)0x251
+#define MPI_INT64_T                 (MPI_Datatype)0x258
+#define MPI_UINT64_T                (MPI_Datatype)0x259
+#define MPI_INTEGER1                (MPI_Datatype)0x2c0
+#define MPI_CHARACTER               (MPI_Datatype)0x2c3
+#define MPI_INTEGER2                (MPI_Datatype)0x2c8
+#define MPI_INTEGER4                (MPI_Datatype)0x2d0
+#define MPI_REAL4                   (MPI_Datatype)0x2d2
+#define MPI_INTEGER8                (MPI_Datatype)0x2d8
+#define MPI_REAL8                   (MPI_Datatype)0x2da
+#define MPI_COMPLEX8                (MPI_Datatype)0x2db
+#define MPI_INTEGER16               (MPI_Datatype)0x2e0
+#define MPI_REAL16                  (MPI_Datatype)0x2e2
+#define MPI_COMPLEX16               (MPI_Datatype)0x2e3
+#define MPI_COMPLEX32               (MPI_Datatype)0x2eb
 
 // callback typedefs
 typedef int MPI_Comm_copy_attr_function(MPI_Comm oldcomm, int comm_keyval, void *extra_state, void *attribute_val_in, void *attribute_val_out, int *flag);

--- a/src/binding/abi/mpi_abi.h
+++ b/src/binding/abi/mpi_abi.h
@@ -4,16 +4,17 @@
 #define MPI_VERSION 5
 #define MPI_SUBVERSION 0
 
-#define MPI_MAX_PROCESSOR_NAME         128
-#define MPI_MAX_LIBRARY_VERSION_STRING 8192
-#define MPI_MAX_ERROR_STRING           512
-#define MPI_MAX_DATAREP_STRING         128
-#define MPI_MAX_PORT_NAME              1024
-#define MPI_MAX_OBJECT_NAME            128
-#define MPI_MAX_STRINGTAG_LEN          256
-#define MPI_MAX_PSET_NAME_LEN          256
-#define MPI_MAX_INFO_KEY               255
-#define MPI_MAX_INFO_VAL               1024
+// String size constants
+#define MPI_MAX_DATAREP_STRING               128 // MPICH=OMPI=128 (MPICH has it in `mpio.h`)
+#define MPI_MAX_ERROR_STRING                 512 // MPICH was bigger
+#define MPI_MAX_INFO_KEY                     255 // MPICH was bigger
+#define MPI_MAX_INFO_VAL                    1024 // MPICH was bigger
+#define MPI_MAX_LIBRARY_VERSION_STRING      8192 // MPICH was bigger
+#define MPI_MAX_OBJECT_NAME                  128 // MPICH was bigger
+#define MPI_MAX_PORT_NAME                   1024 // OMPI was bigger
+#define MPI_MAX_PROCESSOR_NAME               256 // OMPI was bigger
+#define MPI_MAX_STRINGTAG_LEN               1024 // OMPI was bigger (v5.0+)
+#define MPI_MAX_PSET_NAME_LEN                512 // OMPI was bigger (v5.0+)
 
 #include <stdint.h>
 
@@ -55,127 +56,106 @@ typedef struct MPI_Status {
 extern MPI_Fint * MPI_F_STATUS_IGNORE;
 extern MPI_Fint * MPI_F_STATUSES_IGNORE;
 
-/* constants */
-#define MPI_BOTTOM     (void *)0
-#define MPI_IN_PLACE   (void *)1
-#define MPI_BUFFER_AUTOMATIC (void *)2
-#define MPI_PROC_NULL  -1
-#define MPI_ANY_SOURCE -2
-#define MPI_ROOT       -3
-#define MPI_ANY_TAG    -1
-#define MPI_UNDEFINED  -1
-#define MPI_BSEND_OVERHEAD 96  /* FIXME */
+// Buffer Address Constants
+#define MPI_BOTTOM           ((void *)0)
+#define MPI_IN_PLACE         ((void *)1)
+#define MPI_BUFFER_AUTOMATIC ((void *)2)
 
-#define MPI_STATUS_IGNORE   (MPI_Status *)0
-#define MPI_STATUSES_IGNORE (MPI_Status *)0
-#define MPI_ERRCODES_IGNORE (int *)0
-#define MPI_UNWEIGHTED      (int *)1
-#define MPI_WEIGHTS_EMPTY   (int *)2
-#define MPI_ARGV_NULL       (char **)0
-#define MPI_ARGVS_NULL      (char ***)0
+// Other constants
+#define MPI_BSEND_OVERHEAD                   512 // MPICH=96, OMPI=128
 
-/* error codes */
+// Constants Specifying Empty or Ignored Input
+#define MPI_ARGV_NULL       ((char**)0)
+#define MPI_ARGVS_NULL      ((char***)0)
+#define MPI_ERRCODES_IGNORE ((int*)0)
+#define MPI_STATUS_IGNORE   ((MPI_Status*)0)
+#define MPI_STATUSES_IGNORE ((MPI_Status*)0)
+#define MPI_UNWEIGHTED      ((int*)2)
+#define MPI_WEIGHTS_EMPTY   ((int*)3)
+
+// Error classes
 enum {
-    MPI_SUCCESS = 0,
-    MPI_ERR_BUFFER,
-    MPI_ERR_COUNT,
-    MPI_ERR_TYPE,
-    MPI_ERR_TAG,
-    MPI_ERR_COMM,
-    MPI_ERR_RANK,
-    MPI_ERR_REQUEST,
-    MPI_ERR_ROOT,
-    MPI_ERR_GROUP,
-    MPI_ERR_OP,
-    MPI_ERR_TOPOLOGY,
-    MPI_ERR_DIMS,
-    MPI_ERR_ARG,
-    MPI_ERR_UNKNOWN,
-    MPI_ERR_TRUNCATE,
-    MPI_ERR_OTHER,
-    MPI_ERR_INTERN,
-    MPI_ERR_PENDING,
-    MPI_ERR_IN_STATUS,
-    MPI_ERR_ACCESS,
-    MPI_ERR_AMODE,
-    MPI_ERR_ASSERT,
-    MPI_ERR_BAD_FILE,
-    MPI_ERR_BASE,
-    MPI_ERR_CONVERSION,
-    MPI_ERR_DISP,
-    MPI_ERR_DUP_DATAREP,
-    MPI_ERR_ERRHANDLER,
-    MPI_ERR_FILE_EXISTS,
-    MPI_ERR_FILE_IN_USE,
-    MPI_ERR_FILE,
-    MPI_ERR_INFO_KEY,
-    MPI_ERR_INFO_NOKEY,
-    MPI_ERR_INFO_VALUE,
-    MPI_ERR_INFO,
-    MPI_ERR_IO,
-    MPI_ERR_KEYVAL,
-    MPI_ERR_LOCKTYPE,
-    MPI_ERR_NAME,
-    MPI_ERR_NO_MEM,
-    MPI_ERR_NOT_SAME,
-    MPI_ERR_NO_SPACE,
-    MPI_ERR_NO_SUCH_FILE,
-    MPI_ERR_PORT,
-    MPI_ERR_PROC_ABORTED,
-    MPI_ERR_QUOTA,
-    MPI_ERR_READ_ONLY,
-    MPI_ERR_RMA_ATTACH,
-    MPI_ERR_RMA_CONFLICT,
-    MPI_ERR_RMA_RANGE,
-    MPI_ERR_RMA_SHARED,
-    MPI_ERR_RMA_SYNC,
-    MPI_ERR_RMA_FLAVOR,
-    MPI_ERR_SERVICE,
-    MPI_ERR_SESSION,
-    MPI_ERR_SIZE,
-    MPI_ERR_SPAWN,
-    MPI_ERR_UNSUPPORTED_DATAREP,
-    MPI_ERR_UNSUPPORTED_OPERATION,
-    MPI_ERR_VALUE_TOO_LARGE,
-    MPI_ERR_WIN,
-    MPI_T_ERR_CANNOT_INIT,
-    MPI_T_ERR_NOT_ACCESSIBLE,
-    MPI_T_ERR_NOT_INITIALIZED,
-    MPI_T_ERR_NOT_SUPPORTED,
-    MPI_T_ERR_MEMORY,
-    MPI_T_ERR_INVALID,
-    MPI_T_ERR_INVALID_INDEX,
-    MPI_T_ERR_INVALID_ITEM,
-    MPI_T_ERR_INVALID_SESSION,
-    MPI_T_ERR_INVALID_HANDLE,
-    MPI_T_ERR_INVALID_NAME,
-    MPI_T_ERR_OUT_OF_HANDLES,
-    MPI_T_ERR_OUT_OF_SESSIONS,
-    MPI_T_ERR_CVAR_SET_NOT_NOW,
-    MPI_T_ERR_CVAR_SET_NEVER,
-    MPI_T_ERR_PVAR_NO_WRITE,
-    MPI_T_ERR_PVAR_NO_STARTSTOP,
-    MPI_T_ERR_PVAR_NO_ATOMIC,
-    MPI_ERR_LASTCODE
-};
-
-enum {
-    MPI_LOCK_EXCLUSIVE,
-    MPI_LOCK_SHARED
-};
-
-enum {
-    MPI_COMM_TYPE_SHARED,
-    MPI_COMM_TYPE_HW_UNGUIDED,
-    MPI_COMM_TYPE_HW_GUIDED,
-    MPI_COMM_TYPE_RESOURCE_GUIDED
-};
-
-enum {
-    MPI_IDENT,
-    MPI_CONGRUENT,
-    MPI_SIMILAR,
-    MPI_UNEQUAL
+    MPI_SUCCESS                         = 0,
+    MPI_ERR_BUFFER                      = 1,
+    MPI_ERR_COUNT                       = 2,
+    MPI_ERR_TYPE                        = 3,
+    MPI_ERR_TAG                         = 4,
+    MPI_ERR_COMM                        = 5,
+    MPI_ERR_RANK                        = 6,
+    MPI_ERR_REQUEST                     = 7,
+    MPI_ERR_ROOT                        = 8,
+    MPI_ERR_GROUP                       = 9,
+    MPI_ERR_OP                          = 10,
+    MPI_ERR_TOPOLOGY                    = 11,
+    MPI_ERR_DIMS                        = 12,
+    MPI_ERR_ARG                         = 13,
+    MPI_ERR_UNKNOWN                     = 14,
+    MPI_ERR_TRUNCATE                    = 15,
+    MPI_ERR_OTHER                       = 16,
+    MPI_ERR_INTERN                      = 17,
+    MPI_ERR_PENDING                     = 18,
+    MPI_ERR_IN_STATUS                   = 19,
+    MPI_ERR_ACCESS                      = 20,
+    MPI_ERR_AMODE                       = 21,
+    MPI_ERR_ASSERT                      = 22,
+    MPI_ERR_BAD_FILE                    = 23,
+    MPI_ERR_BASE                        = 24,
+    MPI_ERR_CONVERSION                  = 25,
+    MPI_ERR_DISP                        = 26,
+    MPI_ERR_DUP_DATAREP                 = 27,
+    MPI_ERR_FILE_EXISTS                 = 28,
+    MPI_ERR_FILE_IN_USE                 = 29,
+    MPI_ERR_FILE                        = 30,
+    MPI_ERR_INFO_KEY                    = 31,
+    MPI_ERR_INFO_NOKEY                  = 32,
+    MPI_ERR_INFO_VALUE                  = 33,
+    MPI_ERR_INFO                        = 34,
+    MPI_ERR_IO                          = 35,
+    MPI_ERR_KEYVAL                      = 36,
+    MPI_ERR_LOCKTYPE                    = 37,
+    MPI_ERR_NAME                        = 38,
+    MPI_ERR_NO_MEM                      = 39,
+    MPI_ERR_NOT_SAME                    = 40,
+    MPI_ERR_NO_SPACE                    = 41,
+    MPI_ERR_NO_SUCH_FILE                = 42,
+    MPI_ERR_PORT                        = 43,
+    MPI_ERR_PROC_ABORTED                = 44,
+    MPI_ERR_QUOTA                       = 45,
+    MPI_ERR_READ_ONLY                   = 46,
+    MPI_ERR_RMA_ATTACH                  = 47,
+    MPI_ERR_RMA_CONFLICT                = 48,
+    MPI_ERR_RMA_RANGE                   = 49,
+    MPI_ERR_RMA_SHARED                  = 50,
+    MPI_ERR_RMA_SYNC                    = 51,
+    MPI_ERR_RMA_FLAVOR                  = 52,
+    MPI_ERR_SERVICE                     = 53,
+    MPI_ERR_SESSION                     = 54,
+    MPI_ERR_SIZE                        = 55,
+    MPI_ERR_SPAWN                       = 56,
+    MPI_ERR_UNSUPPORTED_DATAREP         = 57,
+    MPI_ERR_UNSUPPORTED_OPERATION       = 58,
+    MPI_ERR_VALUE_TOO_LARGE             = 59,
+    MPI_ERR_WIN                         = 60,
+    MPI_ERR_ERRHANDLER                  = 61,
+    MPI_T_ERR_CANNOT_INIT               = 1000,
+    MPI_T_ERR_NOT_ACCESSIBLE            = 1001,
+    MPI_T_ERR_NOT_INITIALIZED           = 1002,
+    MPI_T_ERR_NOT_SUPPORTED             = 1003,
+    MPI_T_ERR_MEMORY                    = 1004,
+    MPI_T_ERR_INVALID                   = 1005,
+    MPI_T_ERR_INVALID_INDEX             = 1006,
+    MPI_T_ERR_INVALID_ITEM              = 1007,
+    MPI_T_ERR_INVALID_SESSION           = 1008,
+    MPI_T_ERR_INVALID_HANDLE            = 1009,
+    MPI_T_ERR_INVALID_NAME              = 1010,
+    MPI_T_ERR_OUT_OF_HANDLES            = 1011,
+    MPI_T_ERR_OUT_OF_SESSIONS           = 1012,
+    MPI_T_ERR_CVAR_SET_NOT_NOW          = 1013,
+    MPI_T_ERR_CVAR_SET_NEVER            = 1014,
+    MPI_T_ERR_PVAR_NO_WRITE             = 1015,
+    MPI_T_ERR_PVAR_NO_STARTSTOP         = 1016,
+    MPI_T_ERR_PVAR_NO_ATOMIC            = 1017,
+    MPI_ERR_LASTCODE                    = 0x3fff // half of the minimum required value of INT_MAX
 };
 
 enum {
@@ -184,107 +164,133 @@ enum {
     MPI_DIST_GRAPH
 };
 
+// Mode Constants
+// must be powers-of-2 to support OR-ing
 enum {
-    MPI_KEYVAL_INVALID,
-    MPI_TAG_UB,
-    MPI_IO,
-    MPI_HOST,
-    MPI_WTIME_IS_GLOBAL,
-    MPI_APPNUM,
-    MPI_LASTUSEDCODE,
-    MPI_UNIVERSE_SIZE,
-    MPI_WIN_BASE,
-    MPI_WIN_DISP_UNIT,
-    MPI_WIN_SIZE,
-    MPI_WIN_CREATE_FLAVOR,
-    MPI_WIN_MODEL
+    // Files
+    MPI_MODE_APPEND             = 1,
+    MPI_MODE_CREATE             = 2,
+    MPI_MODE_DELETE_ON_CLOSE    = 4,
+    MPI_MODE_EXCL               = 8,
+    MPI_MODE_RDONLY             = 16,
+    MPI_MODE_RDWR               = 32,
+    MPI_MODE_SEQUENTIAL         = 64,
+    MPI_MODE_UNIQUE_OPEN        = 128,
+    MPI_MODE_WRONLY             = 256,
+    // Windows
+    MPI_MODE_NOCHECK            = 1024,
+    MPI_MODE_NOPRECEDE          = 2048,
+    MPI_MODE_NOPUT              = 4096,
+    MPI_MODE_NOSTORE            = 8192,
+    MPI_MODE_NOSUCCEED          = 16384
 };
 
 enum {
-    MPI_WIN_FLAVOR_CREATE,
-    MPI_WIN_FLAVOR_ALLOCATE,
-    MPI_WIN_FLAVOR_DYNAMIC,
-    MPI_WIN_FLAVOR_SHARED
+    // rank sentinels - must be negative
+    MPI_ANY_SOURCE      = -1,
+    MPI_PROC_NULL       = -2,
+    MPI_ROOT            = -3,
+
+    // tag sentinels - should be negative
+    MPI_ANY_TAG         = -101,
+
+    // These apply to MPI_COMM_WORLD
+    MPI_TAG_UB          = -201,
+    MPI_IO              = -202,
+    MPI_HOST            = -203,
+    MPI_WTIME_IS_GLOBAL = -204,
+    MPI_APPNUM          = -205,
+    MPI_LASTUSEDCODE    = -206,
+    MPI_UNIVERSE_SIZE   = -207,
+
+    // Predefined Attribute Keys
+    // These apply to Windows
+    MPI_WIN_BASE            = -301,
+    MPI_WIN_DISP_UNIT       = -302,
+    MPI_WIN_SIZE            = -303,
+    MPI_WIN_CREATE_FLAVOR   = -304,
+    MPI_WIN_MODEL           = -305,
+
+    // attribute constant - must be negative
+    MPI_KEYVAL_INVALID  = -401,
+
+    // special displacement for sequential access file - should be negative
+    MPI_DISPLACEMENT_CURRENT = -501,
+
+    // multi-purpose sentinel - must be negative
+    MPI_UNDEFINED       = -601,
+
+    //Results of communicator and group comparisons
+    MPI_IDENT       = -701,
+    MPI_CONGRUENT   = -702,
+    MPI_SIMILAR     = -703,
+    MPI_UNEQUAL     = -704,
+
+    // Environmental inquiry keys and Predefined Attribute Keys
+    // Threads Constants
+    // These values are monotonic; i.e., SINGLE < FUNNELED < SERIALIZED < MULTIPLE.
+    MPI_THREAD_MULTIPLE     = -801,
+    MPI_THREAD_SERIALIZED   = -802,
+    MPI_THREAD_FUNNELED     = -803,
+    MPI_THREAD_SINGLE       = -804,
+
+    // RMA lock constants - arbitrary values
+    MPI_LOCK_EXCLUSIVE  = -901,
+    MPI_LOCK_SHARED     = -902,
+
+    // Communicator split type constants - arbitrary values
+    MPI_COMM_TYPE_SHARED          = -1001,
+    MPI_COMM_TYPE_HW_UNGUIDED     = -1002,
+    MPI_COMM_TYPE_HW_GUIDED       = -1003,
+    MPI_COMM_TYPE_RESOURCE_GUIDED = -1004,
+
+    // MPI Window Create Flavors
+    MPI_WIN_FLAVOR_ALLOCATE = -1101,
+    MPI_WIN_FLAVOR_CREATE   = -1102,
+    MPI_WIN_FLAVOR_DYNAMIC  = -1103,
+    MPI_WIN_FLAVOR_SHARED   = -1104,
+
+    // MPI Window Models
+    MPI_WIN_SEPARATE    = -1201,
+    MPI_WIN_UNIFIED     = -1202,
+
+    // Datatype Decoding Constants
+    MPI_COMBINER_NAMED              = -1301,
+    MPI_COMBINER_DUP                = -1302,
+    MPI_COMBINER_CONTIGUOUS         = -1303,
+    MPI_COMBINER_VECTOR             = -1304,
+    MPI_COMBINER_HVECTOR            = -1305,
+    MPI_COMBINER_INDEXED            = -1306,
+    MPI_COMBINER_HINDEXED           = -1307,
+    MPI_COMBINER_INDEXED_BLOCK      = -1308,
+    MPI_COMBINER_HINDEXED_BLOCK     = -1309,
+    MPI_COMBINER_STRUCT             = -1310,
+    MPI_COMBINER_SUBARRAY           = -1311,
+    MPI_COMBINER_DARRAY             = -1312,
+    MPI_COMBINER_F90_REAL           = -1313,
+    MPI_COMBINER_F90_COMPLEX        = -1314,
+    MPI_COMBINER_F90_INTEGER        = -1315,
+    MPI_COMBINER_RESIZED            = -1316,
+    MPI_COMBINER_VALUE_INDEX        = -1317,
+
+    // File Operation Constants (?)
+    MPI_DISTRIBUTE_BLOCK        = -1401,
+    MPI_DISTRIBUTE_CYCLIC       = -1402,
+    MPI_DISTRIBUTE_DFLT_DARG    = -1403,
+    MPI_DISTRIBUTE_NONE         = -1404,
+
+    MPI_ORDER_C                 = -1501,
+    MPI_ORDER_FORTRAN           = -1502,
+
+    MPI_SEEK_CUR                = -1601,
+    MPI_SEEK_END                = -1602,
+    MPI_SEEK_SET                = -1603,
+
+    // F90 Datatype Matching Constants
+    MPI_TYPECLASS_REAL          = -1701,
+    MPI_TYPECLASS_COMPLEX       = -1702,
+    MPI_TYPECLASS_INTEGER       = -1703
 };
-
-enum {
-    MPI_WIN_SEPARATE,
-    MPI_WIN_UNIFIED
-};
-
-enum {
-    MPI_MODE_NOCHECK = 1,
-    MPI_MODE_NOPRECEDE = 2,
-    MPI_MODE_NOPUT = 4,
-    MPI_MODE_NOSTORE = 8,
-    MPI_MODE_NOSUCCEED = 16
-};
-
-enum {
-    MPI_MODE_APPEND = 1,
-    MPI_MODE_CREATE = 2,
-    MPI_MODE_DELETE_ON_CLOSE = 4,
-    MPI_MODE_EXCL = 8,
-    MPI_MODE_RDONLY = 16,
-    MPI_MODE_RDWR = 32,
-    MPI_MODE_SEQUENTIAL = 64,
-    MPI_MODE_UNIQUE_OPEN = 128,
-    MPI_MODE_WRONLY = 256
-};
-
-enum {
-    MPI_COMBINER_CONTIGUOUS,
-    MPI_COMBINER_DARRAY,
-    MPI_COMBINER_DUP,
-    MPI_COMBINER_F90_COMPLEX,
-    MPI_COMBINER_F90_INTEGER,
-    MPI_COMBINER_F90_REAL,
-    MPI_COMBINER_HINDEXED,
-    MPI_COMBINER_HVECTOR,
-    MPI_COMBINER_INDEXED_BLOCK,
-    MPI_COMBINER_HINDEXED_BLOCK,
-    MPI_COMBINER_INDEXED,
-    MPI_COMBINER_NAMED,
-    MPI_COMBINER_RESIZED,
-    MPI_COMBINER_STRUCT,
-    MPI_COMBINER_SUBARRAY,
-    MPI_COMBINER_VALUE_INDEX,
-    MPI_COMBINER_VECTOR
-};
-
-enum {
-    MPI_THREAD_FUNNELED,
-    MPI_THREAD_MULTIPLE,
-    MPI_THREAD_SERIALIZED,
-    MPI_THREAD_SINGLE
-};
-
-enum {
-    MPI_DISTRIBUTE_BLOCK,
-    MPI_DISTRIBUTE_CYCLIC,
-    MPI_DISTRIBUTE_NONE
-};
-
-#define MPI_DISTRIBUTE_DFLT_DARG -1
-#define MPI_DISPLACEMENT_CURRENT -1
-
-enum {
-    MPI_ORDER_C,
-    MPI_ORDER_FORTRAN
-};
-
-enum {
-    MPI_SEEK_CUR,
-    MPI_SEEK_END,
-    MPI_SEEK_SET
-};
-
-enum {
-    MPI_TYPECLASS_COMPLEX,
-    MPI_TYPECLASS_INTEGER,
-    MPI_TYPECLASS_REAL
-};
-
 
 #define MPI_OP_NULL          (MPI_Op)0x020
 #define MPI_SUM              (MPI_Op)0x021
@@ -407,18 +413,18 @@ typedef int MPI_Win_copy_attr_function(MPI_Win oldwin, int win_keyval, void *ext
 typedef int MPI_Win_delete_attr_function(MPI_Win win, int win_keyval, void *attribute_val, void *extra_state);
 typedef void MPI_Win_errhandler_function(MPI_Win *win, int *error_code, ...);
 
-#define MPI_DUP_FN         ((MPI_Copy_function *)1)
-#define MPI_NULL_COPY_FN   ((MPI_Copy_function *)0)
-#define MPI_NULL_DELETE_FN ((MPI_Delete_function *)0)
-#define MPI_COMM_DUP_FN         ((MPI_Comm_copy_attr_function *)1)
-#define MPI_COMM_NULL_COPY_FN   ((MPI_Comm_copy_attr_function *)0)
-#define MPI_COMM_NULL_DELETE_FN ((MPI_Comm_delete_attr_function *)0)
-#define MPI_TYPE_DUP_FN         ((MPI_Type_copy_attr_function *)1)
-#define MPI_TYPE_NULL_COPY_FN   ((MPI_Type_copy_attr_function *)0)
-#define MPI_TYPE_NULL_DELETE_FN ((MPI_Type_delete_attr_function *)0)
-#define MPI_WIN_DUP_FN         ((MPI_Win_copy_attr_function *)1)
-#define MPI_WIN_NULL_COPY_FN   ((MPI_Win_copy_attr_function *)0)
-#define MPI_WIN_NULL_DELETE_FN ((MPI_Win_delete_attr_function *)0)
+#define MPI_NULL_COPY_FN        ((MPI_Copy_function*)0x0)
+#define MPI_DUP_FN              ((MPI_Copy_function*)0x1)
+#define MPI_NULL_DELETE_FN      ((MPI_Delete_function*)0x0)
+#define MPI_COMM_NULL_COPY_FN   ((MPI_Comm_copy_attr_function*)0x0)
+#define MPI_COMM_DUP_FN         ((MPI_Comm_copy_attr_function*)0x1)
+#define MPI_COMM_NULL_DELETE_FN ((MPI_Comm_delete_attr_function*)0x0)
+#define MPI_TYPE_NULL_COPY_FN   ((MPI_Type_copy_attr_function*)0x0)
+#define MPI_TYPE_DUP_FN         ((MPI_Type_copy_attr_function*)0x1)
+#define MPI_TYPE_NULL_DELETE_FN ((MPI_Type_delete_attr_function*)0x0)
+#define MPI_WIN_NULL_COPY_FN    ((MPI_Win_copy_attr_function*)0x0)
+#define MPI_WIN_DUP_FN          ((MPI_Win_copy_attr_function*)0x1)
+#define MPI_WIN_NULL_DELETE_FN  ((MPI_Win_delete_attr_function*)0x0)
 #define MPI_CONVERSION_FN_NULL   ((MPI_Datarep_conversion_function *)0)
 #define MPI_CONVERSION_FN_NULL_C ((MPI_Datarep_conversion_function_c *)0)
 

--- a/src/binding/abi/mpi_abi_util.h
+++ b/src/binding/abi/mpi_abi_util.h
@@ -6,6 +6,11 @@
 
 #define ABI_IS_BUILTIN(h)  ((intptr_t)(h) < 0x1000)
 
+#define ABI_DATATYPE_BUILTIN_MASK 0x1ff
+#define ABI_OP_BUILTIN_MASK 0x1f
+#define ABI_MAX_DATATYPE_BUILTINS 512
+#define ABI_MAX_OP_BUILTINS 32
+
 /* only datatype and op have many builtins to deserve a table lookup */
 extern MPI_Datatype abi_datatype_builtins[];
 extern MPI_Op abi_op_builtins[];
@@ -46,7 +51,7 @@ static inline MPI_Datatype ABI_Datatype_to_mpi(ABI_Datatype in)
 {
     if (ABI_IS_BUILTIN(in)) {
         /* TODO: error check */
-        return abi_datatype_builtins[(intptr_t) in & 0xff];
+        return abi_datatype_builtins[(intptr_t) in & ABI_DATATYPE_BUILTIN_MASK];
     }
     return ((MPIR_Datatype *) in)->handle;
 }
@@ -59,7 +64,7 @@ static inline ABI_Datatype ABI_Datatype_from_mpi(MPI_Datatype in)
     if (HANDLE_IS_BUILTIN(in)) {
         for (int i = 0; i < ABI_MAX_DATATYPE_BUILTINS; i++) {
             if (abi_datatype_builtins[i] == in) {
-                return (ABI_Datatype) (intptr_t) (0x300 + i);
+                return (ABI_Datatype) ((intptr_t) ABI_DATATYPE_NULL + i);
             }
         }
     }
@@ -172,7 +177,7 @@ static inline MPI_Op ABI_Op_to_mpi(ABI_Op in)
 {
     if (ABI_IS_BUILTIN(in)) {
         /* TODO: error check */
-        return abi_op_builtins[(intptr_t) in & 0xff];
+        return abi_op_builtins[(intptr_t) in & ABI_OP_BUILTIN_MASK];
     }
     return ((MPIR_Op *) in)->handle;
 }
@@ -185,7 +190,7 @@ static inline ABI_Op ABI_Op_from_mpi(MPI_Op in)
     if (HANDLE_IS_BUILTIN(in)) {
         for (int i = 0; i < ABI_MAX_OP_BUILTINS; i++) {
             if (abi_op_builtins[i] == in) {
-                return (ABI_Op) (intptr_t) (0x600 + i);
+                return (ABI_Op) ((intptr_t) ABI_OP_NULL + i);
             }
         }
     }

--- a/src/binding/abi/mpi_abi_util.h
+++ b/src/binding/abi/mpi_abi_util.h
@@ -1,0 +1,304 @@
+#ifndef MPI_ABI_UTIL_H_INCLUDED
+#define MPI_ABI_UTIL_H_INCLUDED
+
+#include "mpi_abi_internal.h"
+#include "mpiimpl.h"
+
+#define ABI_IS_BUILTIN(h)  ((intptr_t)(h) < 0x1000)
+
+/* only datatype and op have many builtins to deserve a table lookup */
+extern MPI_Datatype abi_datatype_builtins[];
+extern MPI_Op abi_op_builtins[];
+
+void ABI_init_builtins(void);
+
+static inline MPI_Comm ABI_Comm_to_mpi(ABI_Comm in)
+{
+    if (ABI_IS_BUILTIN(in)) {
+        if (in == ABI_COMM_NULL) {
+            return MPI_COMM_NULL;
+        } else if (in == ABI_COMM_WORLD) {
+            return MPI_COMM_WORLD;
+        } else if (in == ABI_COMM_SELF) {
+            return MPI_COMM_SELF;
+        } else {
+            return MPI_COMM_NULL;
+        }
+    }
+    return ((MPIR_Comm *) in)->handle;
+}
+
+static inline ABI_Comm ABI_Comm_from_mpi(MPI_Comm in)
+{
+    if (in == MPI_COMM_NULL) {
+        return ABI_COMM_NULL;
+    } else if (in == MPI_COMM_WORLD) {
+        return ABI_COMM_WORLD;
+    } else if (in == MPI_COMM_SELF) {
+        return ABI_COMM_SELF;
+    }
+    MPIR_Comm *ptr;
+    MPIR_Comm_get_ptr(in, ptr);
+    return (ABI_Comm) (void *) ptr;
+}
+
+static inline MPI_Datatype ABI_Datatype_to_mpi(ABI_Datatype in)
+{
+    if (ABI_IS_BUILTIN(in)) {
+        /* TODO: error check */
+        return abi_datatype_builtins[(intptr_t) in & 0xff];
+    }
+    return ((MPIR_Datatype *) in)->handle;
+}
+
+static inline ABI_Datatype ABI_Datatype_from_mpi(MPI_Datatype in)
+{
+    if (in == MPI_DATATYPE_NULL) {
+        return ABI_DATATYPE_NULL;
+    }
+    if (HANDLE_IS_BUILTIN(in)) {
+        for (int i = 0; i < ABI_MAX_DATATYPE_BUILTINS; i++) {
+            if (abi_datatype_builtins[i] == in) {
+                return (ABI_Datatype) (intptr_t) (0x300 + i);
+            }
+        }
+    }
+    MPIR_Datatype *ptr;
+    MPIR_Datatype_get_ptr(in, ptr);
+    return (ABI_Datatype) (void *) ptr;
+}
+
+static inline MPI_Errhandler ABI_Errhandler_to_mpi(ABI_Errhandler in)
+{
+    if (in == ABI_ERRHANDLER_NULL) {
+        return MPI_ERRHANDLER_NULL;
+    } else if (in == ABI_ERRORS_ARE_FATAL) {
+        return MPI_ERRORS_ARE_FATAL;
+    } else if (in == ABI_ERRORS_ABORT) {
+        return MPI_ERRORS_ABORT;
+    } else if (in == ABI_ERRORS_RETURN) {
+        return MPI_ERRORS_RETURN;
+    }
+    return ((MPIR_Errhandler *) in)->handle;
+}
+
+static inline ABI_Errhandler ABI_Errhandler_from_mpi(MPI_Errhandler in)
+{
+    if (in == MPI_ERRHANDLER_NULL) {
+        return ABI_ERRHANDLER_NULL;
+    } else if (in == MPI_ERRORS_ARE_FATAL) {
+        return ABI_ERRORS_ARE_FATAL;
+    } else if (in == MPI_ERRORS_ABORT) {
+        return ABI_ERRORS_ABORT;
+    } else if (in == MPI_ERRORS_RETURN) {
+        return ABI_ERRORS_RETURN;
+    }
+    MPIR_Errhandler *ptr;
+    MPIR_Errhandler_get_ptr(in, ptr);
+    return (ABI_Errhandler) (void *) ptr;
+}
+
+static inline MPI_Group ABI_Group_to_mpi(ABI_Group in)
+{
+    if (ABI_IS_BUILTIN(in)) {
+        if (in == ABI_GROUP_NULL) {
+            return MPI_GROUP_NULL;
+        } else if (in == ABI_GROUP_EMPTY) {
+            return MPI_GROUP_EMPTY;
+        } else {
+            return MPI_GROUP_NULL;
+        }
+    }
+    return ((MPIR_Group *) in)->handle;
+}
+
+static inline ABI_Group ABI_Group_from_mpi(MPI_Group in)
+{
+    if (in == MPI_GROUP_NULL) {
+        return ABI_GROUP_NULL;
+    } else if (in == MPI_GROUP_EMPTY) {
+        return ABI_GROUP_EMPTY;
+    }
+    MPIR_Group *ptr;
+    MPIR_Group_get_ptr(in, ptr);
+    return (ABI_Group) (void *) ptr;
+}
+
+static inline MPI_Info ABI_Info_to_mpi(ABI_Info in)
+{
+    if (in == ABI_INFO_NULL) {
+        return MPI_INFO_NULL;
+    } else if (in == ABI_INFO_ENV) {
+        return MPI_INFO_ENV;
+    }
+    return ((MPIR_Info *) in)->handle;
+}
+
+static inline ABI_Info ABI_Info_from_mpi(MPI_Info in)
+{
+    if (in == MPI_INFO_NULL) {
+        return ABI_INFO_NULL;
+    } else if (in == MPI_INFO_ENV) {
+        return ABI_INFO_ENV;
+    }
+    MPIR_Info *ptr;
+    MPIR_Info_get_ptr(in, ptr);
+    return (ABI_Info) (void *) ptr;
+}
+
+static inline MPI_Message ABI_Message_to_mpi(ABI_Message in)
+{
+    if (in == ABI_MESSAGE_NULL) {
+        return MPI_MESSAGE_NULL;
+    } else if (in == ABI_MESSAGE_NO_PROC) {
+        return MPI_MESSAGE_NO_PROC;
+    }
+    return ((MPIR_Request *) in)->handle;
+}
+
+static inline ABI_Message ABI_Message_from_mpi(MPI_Message in)
+{
+    if (in == MPI_MESSAGE_NULL) {
+        return ABI_MESSAGE_NULL;
+    } else if (in == MPI_MESSAGE_NO_PROC) {
+        return ABI_MESSAGE_NO_PROC;
+    }
+    MPIR_Request *ptr;
+    MPIR_Request_get_ptr(in, ptr);
+    return (ABI_Message) (void *) ptr;
+}
+
+static inline MPI_Op ABI_Op_to_mpi(ABI_Op in)
+{
+    if (ABI_IS_BUILTIN(in)) {
+        /* TODO: error check */
+        return abi_op_builtins[(intptr_t) in & 0xff];
+    }
+    return ((MPIR_Op *) in)->handle;
+}
+
+static inline ABI_Op ABI_Op_from_mpi(MPI_Op in)
+{
+    if (in == MPI_OP_NULL) {
+        return ABI_OP_NULL;
+    }
+    if (HANDLE_IS_BUILTIN(in)) {
+        for (int i = 0; i < ABI_MAX_OP_BUILTINS; i++) {
+            if (abi_op_builtins[i] == in) {
+                return (ABI_Op) (intptr_t) (0x600 + i);
+            }
+        }
+    }
+    MPIR_Op *ptr;
+    MPIR_Op_get_ptr(in, ptr);
+    return (ABI_Op) (void *) ptr;
+}
+
+static inline MPI_Request ABI_Request_to_mpi(ABI_Request in)
+{
+    if (in == ABI_REQUEST_NULL) {
+        return MPI_REQUEST_NULL;
+    }
+    return ((MPIR_Request *) in)->handle;
+}
+
+static inline ABI_Request ABI_Request_from_mpi(MPI_Request in)
+{
+    if (in == MPI_REQUEST_NULL) {
+        return ABI_REQUEST_NULL;
+    }
+    MPIR_Request *ptr;
+    MPIR_Request_get_ptr(in, ptr);
+    return (ABI_Request) (void *) ptr;
+}
+
+static inline MPI_Session ABI_Session_to_mpi(ABI_Session in)
+{
+    if (in == ABI_SESSION_NULL) {
+        return MPI_SESSION_NULL;
+    }
+    return ((MPIR_Session *) in)->handle;
+}
+
+static inline ABI_Session ABI_Session_from_mpi(MPI_Session in)
+{
+    if (in == MPI_SESSION_NULL) {
+        return ABI_SESSION_NULL;
+    }
+    MPIR_Session *ptr;
+    MPIR_Session_get_ptr(in, ptr);
+    return (ABI_Session) (void *) ptr;
+}
+
+static inline MPI_Win ABI_Win_to_mpi(ABI_Win in)
+{
+    if (in == ABI_WIN_NULL) {
+        return MPI_WIN_NULL;
+    }
+    return ((MPIR_Win *) in)->handle;
+}
+
+static inline ABI_Win ABI_Win_from_mpi(MPI_Win in)
+{
+    if (in == MPI_WIN_NULL) {
+        return ABI_WIN_NULL;
+    }
+    MPIR_Win *ptr;
+    MPIR_Win_get_ptr(in, ptr);
+    return (ABI_Win) (void *) ptr;
+}
+
+/* MPICH internal callbacks does not differentiate handle types, so we need
+ * a general conversion routine */
+static inline void *ABI_Handle_from_mpi(int in)
+{
+    switch (HANDLE_GET_MPI_KIND(in)) {
+        case MPIR_COMM:
+            return ABI_Comm_from_mpi(in);
+        case MPIR_DATATYPE:
+            return ABI_Datatype_from_mpi(in);
+        case MPIR_WIN:
+            return ABI_Win_from_mpi(in);
+        case MPIR_SESSION:
+            return ABI_Session_from_mpi(in);
+        default:
+            MPIR_Assert(0);
+            return NULL;
+    }
+}
+
+static inline int ABI_KEYVAL_to_mpi(int keyval)
+{
+    switch (keyval) {
+        case ABI_KEYVAL_INVALID:
+            return MPI_KEYVAL_INVALID;
+        case ABI_TAG_UB:
+            return MPI_TAG_UB;
+        case ABI_HOST:
+            return MPI_HOST;
+        case ABI_IO:
+            return MPI_IO;
+        case ABI_WTIME_IS_GLOBAL:
+            return MPI_WTIME_IS_GLOBAL;
+        case ABI_UNIVERSE_SIZE:
+            return MPI_UNIVERSE_SIZE;
+        case ABI_LASTUSEDCODE:
+            return MPI_LASTUSEDCODE;
+        case ABI_APPNUM:
+            return MPI_APPNUM;
+        case ABI_WIN_BASE:
+            return MPI_WIN_BASE;
+        case ABI_WIN_SIZE:
+            return MPI_WIN_SIZE;
+        case ABI_WIN_DISP_UNIT:
+            return MPI_WIN_DISP_UNIT;
+        case ABI_WIN_CREATE_FLAVOR:
+            return MPI_WIN_CREATE_FLAVOR;
+        case ABI_WIN_MODEL:
+            return MPI_WIN_MODEL;
+        default:
+            return keyval;
+    }
+}
+
+#endif /* MPI_ABI_UTIL_H_INCLUDED */

--- a/src/env/Makefile.mk
+++ b/src/env/Makefile.mk
@@ -7,6 +7,10 @@ bin_SCRIPTS +=           \
     src/env/mpicc        \
     src/env/parkill
 
+if BUILD_ABI_LIB
+    bin_SCRIPTS += src/env/mpicc_abi
+endif
+
 bin_PROGRAMS += src/env/mpichversion \
     src/env/mpivars
 
@@ -31,12 +35,16 @@ endif INSTALL_MPICXX
 if BUILD_BASH_SCRIPTS
 src/env/mpicc: $(top_builddir)/src/env/mpicc.bash
 	cp -p $? $@
+src/env/mpicc_abi: $(top_builddir)/src/env/mpicc_abi.bash
+	cp -p $? $@
 src/env/mpicxx: $(top_builddir)/src/env/mpicxx.bash
 	cp -p $? $@
 src/env/mpifort: $(top_builddir)/src/env/mpifort.bash
 	cp -p $? $@
 else !BUILD_BASH_SCRIPTS
 src/env/mpicc: $(top_builddir)/src/env/mpicc.sh
+	cp -p $? $@
+src/env/mpicc_abi: $(top_builddir)/src/env/mpicc_abi.sh
 	cp -p $? $@
 src/env/mpicxx: $(top_builddir)/src/env/mpicxx.sh
 	cp -p $? $@

--- a/src/env/mpicc_abi.bash.in
+++ b/src/env/mpicc_abi.bash.in
@@ -1,0 +1,300 @@
+#! @BASH_SHELL@
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+# Simple script to compile and/or link MPI programs.
+# This script knows the default flags and libraries, and can handle
+# alternative C compilers and the associated flags and libraries.
+# The important terms are:
+#    includedir, libdir - Directories containing an *installed* mpich
+#    prefix, execprefix - Often used to define includedir and libdir
+#    CC                 - C compiler
+#    WRAPPER_CFLAGS        - Any special flags needed to compile 
+#    WRAPPER_LDFLAGS       - Any special flags needed to link
+#    WRAPPER_LIBS          - Any special libraries needed in order to link
+#    
+# We assume that (a) the C compiler can both compile and link programs
+#
+# Handling of command-line options:
+#   This is a little tricky because some options may contain blanks.
+#
+# Special issues with shared libraries - todo
+#
+# --------------------------------------------------------------------------
+# Set the default values of all variables.
+#
+# Directory locations: Fixed for any MPI implementation.
+# Set from the directory arguments to configure (e.g., --prefix=/usr/local)
+prefix=__PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__
+exec_prefix=__EXEC_PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__
+sysconfdir=__SYSCONFDIR_TO_BE_FILLED_AT_INSTALL_TIME__
+includedir=__INCLUDEDIR_TO_BE_FILLED_AT_INSTALL_TIME__
+libdir=__LIBDIR_TO_BE_FILLED_AT_INSTALL_TIME__
+
+# Default settings for compiler, flags, and libraries.
+# Determined by a combination of environment variables and tests within
+# configure (e.g., determining whether -lsocket is needee)
+CC="@CC@"
+MPICH_VERSION="@MPICH_VERSION@"
+
+@cc_shlib_conf@
+
+# Attempt to construct dynamic loading info, based on the user
+# preference of rpath, runpath or none and on the detected libdir
+# flags.
+with_wrapper_dl_type=@with_wrapper_dl_type@
+if test "X${with_wrapper_dl_type}" = "Xrunpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${enable_dtags_flag}\"
+elif test "X${with_wrapper_dl_type}" = "Xrpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${disable_dtags_flag}\"
+else
+    wrapper_dl_type_flags=""
+fi
+
+# Internal variables
+# Show is set to echo to cause the compilation command to be echoed instead 
+# of executed.
+Show=
+#
+# End of initialization of variables
+#---------------------------------------------------------------------
+
+# Environment Variables.
+# The environment variables MPICH_CC may be used to override the 
+# default choices.
+# In addition, if there is a file $sysconfdir/mpicc-$CCname.conf, 
+# where CCname is the name of the compiler with all spaces replaced by hyphens
+# (e.g., "cc -64" becomes "cc--64", that file is sources, allowing other
+# changes to the compilation environment.  See the variables used by the 
+# script (defined above)
+# Added MPICH_CC_OLD, MPICH_CC can be used to prefix CC with external utility,
+# e.g. setenv MPICH_CC 'eval linkcache $MPICH_CC_OLD'
+if [ -n "$MPICH_CC" ] ; then
+    MPICH_CC_OLD="$CC"
+    CC="$MPICH_CC"
+    CCname=`echo $CC | sed 's/ /-/g'`
+    if [ -s $sysconfdir/mpicc-$CCname.conf ] ; then
+        . $sysconfdir/mpicc-$CCname.conf
+    fi
+fi
+# Allow a profiling option to be selected through an environment variable
+if [ -n "$MPICC_PROFILE" ] ; then
+    profConf=$MPICC_PROFILE
+fi
+#
+# ------------------------------------------------------------------------
+# Argument processing.
+# This is somewhat awkward because of the handling of arguments within
+# the shell.  We want to handle arguments that include spaces without 
+# losing the spacing (an alternative would be to use a more powerful
+# scripting language that would allow us to retain the array of values, 
+# which the basic (rather than enhanced) Bourne shell does not.  
+#
+# Look through the arguments for arguments that indicate compile only.
+# If these are *not* found, add the library options
+
+linking=yes
+allargs=("$@")
+argno=0
+interlib_deps=yes
+static_mpi=no
+showinfo=""
+for arg in "$@" ; do
+    # Set addarg to no if this arg should be ignored by the C compiler
+    addarg=yes
+    case "$arg" in 
+ 	# ----------------------------------------------------------------
+	# Compiler options that affect whether we are linking or no
+    -c|-S|-E|-M|-MM)
+    # The compiler links by default
+    linking=no
+    ;;
+	# ----------------------------------------------------------------
+	# Options that control how we use mpicc (e.g., -show, 
+	# -cc=* -config=*
+    -static)
+    interlib_deps=no
+    ;;
+    -static-mpi)
+    interlib_deps=no
+    static_mpi=yes
+    addarg=no
+    ;;
+    -echo)
+    addarg=no
+    set -x
+    ;;
+    -cc=*)
+    CC=`echo A$arg | sed -e 's/A-cc=//g'`
+    addarg=no
+    ;;
+    -show)
+    addarg=no
+    Show=echo
+    ;;
+    -show-compile-info)
+    addarg=no
+    Show=echo
+    show_info=compile
+    ;;
+    -show-link-info)
+    addarg=no
+    Show=echo
+    show_info=link
+    ;;
+    -config=*)
+    addarg=no
+    CCname=`echo A$arg | sed -e 's/A-config=//g'`
+    if [ -s "$sysconfdir/mpicc-$CCname.conf" ] ; then
+        . "$sysconfdir/mpicc-$CCname.conf"
+    else
+	echo "Configuration file mpicc-$CCname.conf not found"
+    fi
+    ;;
+    -compile-info|-compile_info)
+    # -compile_info included for backward compatibility
+    Show=echo
+    addarg=no
+    ;;
+    -link-info|-link_info)
+    # -link_info included for backward compatibility
+    Show=echo
+    addarg=no
+    ;;
+    -v)
+    # Pass this argument to the compiler as well.
+    echo "mpicc for MPICH version $MPICH_VERSION"
+    # if there is only 1 argument, it must be -v.
+    if [ "$#" -eq "1" ] ; then
+        linking=no
+    fi
+    ;;
+    -profile=*)
+    # Pass the name of a profiling configuration.  As
+    # a special case, lib<name>.so or lib<name>.la may be used
+    # if the library is in $libdir
+    profConf=`echo A$arg | sed -e 's/A-profile=//g'`
+    addarg=no
+    # Loading the profConf file is handled below
+    ;;
+    -nativelinking)
+    # Internal option to use native compiler for linking without MPI libraries
+    nativelinking=yes
+    addarg=no
+    ;;
+    -help)
+    NC=`echo "$CC" | sed 's%\/% %g' | awk '{print $NF}' -`
+    if [ -f "$sysconfdir/mpixxx_opts.conf" ] ; then
+        . $sysconfdir/mpixxx_opts.conf
+        echo "    -cc=xxx       - Reset the native compiler to xxx."
+    else
+        if [ -f "./mpixxx_opts.conf" ] ; then
+            . ./mpixxx_opts.conf
+            echo "    -cc=xxx       - Reset the native compiler to xxx."
+        fi
+    fi
+    exit 0
+    ;;
+    *)
+    ;;
+
+    esac
+    if [ $addarg = no ] ; then
+	unset allargs[$argno]
+    fi
+    # Some versions of bash do not accept ((argno++))
+    argno=`expr $argno + 1`
+done
+
+if [ $# -eq 0 ] ; then
+    echo "Error: Command line argument is needed!"
+    "$0" -help
+    exit 1
+fi
+
+# Check recursive situations
+# User mistakes, e.g. setting MPICH_CC=mpicc, may end up recursively running
+# this script. A simple check to bail if that's the case.
+if [ -n "$MPICH_RECURSION_CHECK" ] ; then
+    echo "This script ($0) is being called recursively, check that MPICH_CC does not refer to mpicc."
+    exit 1
+fi
+MPICH_RECURSION_CHECK=1
+export MPICH_RECURSION_CHECK
+
+# -----------------------------------------------------------------------
+# Derived variables.  These are assembled from variables set from the
+# default, environment, configuration file (if any) and command-line
+# options (if any)
+
+PROFILE_FOO=
+# Handle the case of a profile switch
+if [ -n "$profConf" ] ; then
+    profConffile=
+    if [ -s "$libdir/lib$profConf.a" -o -s "$libdir/lib$profConf.so" ] ; then
+	PROFILE_FOO="-l$profConf"
+    elif [ -s "$sysconfdir/$profConf.conf" ] ; then
+	profConffile="$sysconfdir/$profConf.conf"
+    elif [ -s "$profConf.conf" ] ; then
+        profConffile="$profConf.conf"
+    else
+        echo "Profiling configuration file $profConf.conf not found in $sysconfdir"
+    fi
+    if [ -n "$profConffile" -a -s "$profConffile" ] ; then
+	. $profConffile
+    fi
+fi
+
+final_cflags="@MPICH_MPICC_CFLAGS@ @WRAPPER_CFLAGS@"
+final_cppflags="-DMPI_ABI @MPICH_MPICC_CPPFLAGS@ @WRAPPER_CPPFLAGS@"
+final_ldflags="@MPICH_MPICC_LDFLAGS@ @WRAPPER_LDFLAGS@"
+final_libs="@MPICH_MPICC_LIBS@"
+if test "@INTERLIB_DEPS@" = "no" -o "${interlib_deps}" = "no" ; then
+    final_ldflags="${final_ldflags} @LDFLAGS@"
+    final_libs="${final_libs} __LIBS_TO_BE_FILLED_AT_INSTALL_TIME__"
+fi
+
+# -----------------------------------------------------------------------
+#
+# A temporary statement to invoke the compiler
+# Place the -L before any args in case there are any mpi libraries in there.
+# Eventually, we'll want to move this after any non-MPI implementation 
+# libraries.
+# We use a single invocation of the compiler.  This will be adequate until
+# we run into a system that uses a separate linking command.  With any luck,
+# such archaic systems are no longer with us.  This also lets us
+# accept any argument; we don't need to know if we've seen a source
+# file or an object file.  Instead, we just check for an option that
+# suppressing linking, such as -c or -M.
+if [ "$show_info" = compile ] ; then
+    echo ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} -I$includedir
+elif [ "$show_info" = link ] ; then
+    if [ "$nativelinking" = yes ] ; then
+        echo ${final_ldflags}
+    else
+        if [ "$static_mpi" = no ] ; then
+            echo ${final_ldflags} -L$libdir $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} -l@MPIABILIBNAME@ @LPMPIABILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+        else
+            echo ${final_ldflags} -L$libdir $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} $libdir/lib@MPIABILIBNAME@.a @LPMPIABILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+        fi
+    fi
+elif [ "$linking" = yes ] ; then
+    if [ "$nativelinking" = yes ] ; then
+        $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} "${allargs[@]}" -I$includedir
+        rc=$?
+    else
+        if [ "$static_mpi" = no ] ; then
+          $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} -l@MPIABILIBNAME@ @LPMPIABILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+        else
+          $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} "${allargs[@]}" -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} $libdir/lib@MPIABILIBNAME@.a @LPMPIABILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+        fi
+        rc=$?
+    fi
+else
+    $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} "${allargs[@]}" -I$includedir
+    rc=$?
+fi
+
+exit $rc

--- a/src/env/mpicc_abi.sh.in
+++ b/src/env/mpicc_abi.sh.in
@@ -1,0 +1,306 @@
+#! /bin/sh
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+# Simple script to compile and/or link MPI programs.
+# This script knows the default flags and libraries, and can handle
+# alternative C compilers and the associated flags and libraries.
+# The important terms are:
+#    includedir, libdir - Directories containing an *installed* mpich
+#    prefix, execprefix - Often used to define includedir and libdir
+#    CC                 - C compiler
+#    WRAPPER_CFLAGS        - Any special flags needed to compile 
+#    WRAPPER_LDFLAGS       - Any special flags needed to link
+#    WRAPPER_LIBS          - Any special libraries needed in order to link
+#    
+# We assume that (a) the C compiler can both compile and link programs
+#
+# Handling of command-line options:
+#   This is a little tricky because some options may contain blanks.
+#
+# Special issues with shared libraries - todo
+#
+# --------------------------------------------------------------------------
+# Set the default values of all variables.
+#
+# Directory locations: Fixed for any MPI implementation.
+# Set from the directory arguments to configure (e.g., --prefix=/usr/local)
+prefix=__PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__
+exec_prefix=__EXEC_PREFIX_TO_BE_FILLED_AT_INSTALL_TIME__
+sysconfdir=__SYSCONFDIR_TO_BE_FILLED_AT_INSTALL_TIME__
+includedir=__INCLUDEDIR_TO_BE_FILLED_AT_INSTALL_TIME__
+libdir=__LIBDIR_TO_BE_FILLED_AT_INSTALL_TIME__
+
+# Default settings for compiler, flags, and libraries.
+# Determined by a combination of environment variables and tests within
+# configure (e.g., determining whether -lsocket is needee)
+CC="@CC@"
+MPICH_VERSION="@MPICH_VERSION@"
+
+@cc_shlib_conf@
+
+# Attempt to construct dynamic loading info, based on the user
+# preference of rpath, runpath or none and on the detected libdir
+# flags.
+with_wrapper_dl_type=@with_wrapper_dl_type@
+if test "X${with_wrapper_dl_type}" = "Xrunpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${enable_dtags_flag}\"
+elif test "X${with_wrapper_dl_type}" = "Xrpath" ; then
+    eval wrapper_dl_type_flags=\"${hardcode_libdir_flag_spec} ${disable_dtags_flag}\"
+else
+    wrapper_dl_type_flags=""
+fi
+
+# Internal variables
+# Show is set to echo to cause the compilation command to be echoed instead 
+# of executed.
+Show=eval
+#
+# End of initialization of variables
+#---------------------------------------------------------------------
+
+# Environment Variables.
+# The environment variables MPICH_CC may be used to override the 
+# default choices.
+# In addition, if there is a file $sysconfdir/mpicc-$CCname.conf, 
+# where CCname is the name of the compiler with all spaces replaced by hyphens
+# (e.g., "cc -64" becomes "cc--64", that file is sources, allowing other
+# changes to the compilation environment.  See the variables used by the 
+# script (defined above)
+# Added MPICH_CC_OLD, MPICH_CC can be used to prefix CC with external utility, 
+# e.g. setenv MPICH_CC 'eval linkcache $MPICH_CC_OLD'
+if [ -n "$MPICH_CC" ] ; then
+    MPICH_CC_OLD="$CC"
+    CC="$MPICH_CC"
+    CCname=`echo $CC | sed 's/ /-/g'`
+    if [ -s $sysconfdir/mpicc-$CCname.conf ] ; then
+        . $sysconfdir/mpicc-$CCname.conf
+    fi
+fi
+# Allow a profiling option to be selected through an environment variable
+if [ -n "$MPICC_PROFILE" ] ; then
+    profConf=$MPICC_PROFILE
+fi
+#
+# ------------------------------------------------------------------------
+# Argument processing.
+# This is somewhat awkward because of the handling of arguments within
+# the shell.  We want to handle arguments that include spaces without 
+# losing the spacing (an alternative would be to use a more powerful
+# scripting language that would allow us to retain the array of values, 
+# which the basic (rather than enhanced) Bourne shell does not.  
+#
+# Look through the arguments for arguments that indicate compile only.
+# If these are *not* found, add the library options
+
+linking=yes
+allargs=""
+interlib_deps=yes
+static_mpi=no
+showinfo=""
+for arg in "$@" ; do
+    # Set addarg to no if this arg should be ignored by the C compiler
+    addarg=yes
+    qarg=$arg
+    case $arg in 
+ 	# ----------------------------------------------------------------
+	# Compiler options that affect whether we are linking or no
+    -c|-S|-E|-M|-MM)
+    # The compiler links by default
+    linking=no
+    ;;
+	# ----------------------------------------------------------------
+	# Options that control how we use mpicc (e.g., -show, 
+	# -cc=* -config=*
+    -static)
+    interlib_deps=no
+    ;;
+    -static-mpi)
+    interlib_deps=no
+    static_mpi=yes
+    addarg=no
+    ;;
+    -echo)
+    addarg=no
+    set -x
+    ;;
+    -cc=*)
+    CC=`echo A$arg | sed -e 's/A-cc=//g'`
+    addarg=no
+    ;;
+    -show)
+    addarg=no
+    Show=echo
+    ;;
+    -show-compile-info)
+    addarg=no
+    Show=echo
+    show_info=compile
+    ;;
+    -show-link-info)
+    addarg=no
+    Show=echo
+    show_info=link
+    ;;
+    -config=*)
+    addarg=no
+    CCname=`echo A$arg | sed -e 's/A-config=//g'`
+    if [ -s "$sysconfdir/mpicc-$CCname.conf" ] ; then
+        . "$sysconfdir/mpicc-$CCname.conf"
+    else
+	echo "Configuration file mpicc-$CCname.conf not found"
+    fi
+    ;;
+    -compile-info|-compile_info)
+    # -compile_info included for backward compatibility
+    Show=echo
+    addarg=no
+    ;;
+    -link-info|-link_info)
+    # -link_info included for backward compatibility
+    Show=echo
+    addarg=no
+    ;;
+    -v)
+    # Pass this argument to the compiler as well.
+    echo "mpicc for MPICH version $MPICH_VERSION"
+    # if there is only 1 argument, it must be -v.
+    if [ "$#" -eq "1" ] ; then
+        linking=no
+    fi
+    ;;
+    -profile=*)
+    # Pass the name of a profiling configuration.  As
+    # a special case, lib<name>.so or lib<name>.la may be used
+    # if the library is in $libdir
+    profConf=`echo A$arg | sed -e 's/A-profile=//g'`
+    addarg=no
+    # Loading the profConf file is handled below
+    ;;
+    -nativelinking)
+    # Internal option to use native compiler for linking without MPI libraries
+    nativelinking=yes
+    addarg=no
+    ;;
+    -help)
+    NC=`echo "$CC" | sed 's%\/% %g' | awk '{print $NF}' -`
+    if [ -f "$sysconfdir/mpixxx_opts.conf" ] ; then
+        . $sysconfdir/mpixxx_opts.conf
+        echo "    -cc=xxx       - Reset the native compiler to xxx."
+    else
+        if [ -f "./mpixxx_opts.conf" ] ; then
+            . ./mpixxx_opts.conf
+            echo "    -cc=xxx       - Reset the native compiler to xxx."
+        fi
+    fi
+    exit 0
+    ;;
+        # -----------------------------------------------------------------
+	# Other arguments.  We are careful to handle arguments with 
+	# quotes (we try to quote all arguments in case they include 
+	# any spaces)
+    *\'*) 
+    qarg="'"`echo $arg | sed -e "s/'/'\"'\"'/g"`"'"
+    ;;
+    *)
+    qarg="'$arg'"
+    ;;
+
+    esac
+    if [ $addarg = yes ] ; then
+        allargs="$allargs $qarg"
+    fi
+done
+
+if [ $# -eq 0 ] ; then
+    echo "Error: Command line argument is needed!"
+    "$0" -help
+    exit 1
+fi
+
+# Check recursive situations
+# User mistakes, e.g. setting MPICH_CC=mpicc, may end up recursively running
+# this script. A simple check to bail if that's the case.
+if [ -n "$MPICH_RECURSION_CHECK" ] ; then
+    echo "This script ($0) is being called recursively, check that MPICH_CC does not refer to mpicc."
+    exit 1
+fi
+MPICH_RECURSION_CHECK=1
+export MPICH_RECURSION_CHECK
+
+# -----------------------------------------------------------------------
+# Derived variables.  These are assembled from variables set from the
+# default, environment, configuration file (if any) and command-line
+# options (if any)
+
+PROFILE_FOO=
+# Handle the case of a profile switch
+if [ -n "$profConf" ] ; then
+    profConffile=
+    if [ -s "$libdir/lib$profConf.a" -o -s "$libdir/lib$profConf.so" ] ; then
+	PROFILE_FOO="-l$profConf"
+    elif [ -s "$sysconfdir/$profConf.conf" ] ; then
+	profConffile="$sysconfdir/$profConf.conf"
+    elif [ -s "$profConf.conf" ] ; then
+        profConffile="$profConf.conf"
+    else
+        echo "Profiling configuration file $profConf.conf not found in $sysconfdir"
+    fi
+    if [ -n "$profConffile" -a -s "$profConffile" ] ; then
+	. $profConffile
+    fi
+fi
+
+final_cflags="@MPICH_MPICC_CFLAGS@ @WRAPPER_CFLAGS@"
+final_cppflags="-DMPI_ABI @MPICH_MPICC_CPPFLAGS@ @WRAPPER_CPPFLAGS@"
+final_ldflags="@MPICH_MPICC_LDFLAGS@ @WRAPPER_LDFLAGS@"
+final_libs="@MPICH_MPICC_LIBS@"
+if test "@INTERLIB_DEPS@" = "no" -o "${interlib_deps}" = "no" ; then
+    final_ldflags="${final_ldflags} @LDFLAGS@"
+    final_libs="${final_libs} __LIBS_TO_BE_FILLED_AT_INSTALL_TIME__"
+fi
+
+# -----------------------------------------------------------------------
+#
+# A temporary statement to invoke the compiler
+# Place the -L before any args in case there are any mpi libraries in there.
+# Eventually, we'll want to move this after any non-MPI implementation 
+# libraries.
+# We use a single invocation of the compiler.  This will be adequate until
+# we run into a system that uses a separate linking command.  With any luck,
+# such archaic systems are no longer with us.  This also lets us
+# accept any argument; we don't need to know if we've seen a source
+# file or an object file.  Instead, we just check for an option that
+# suppressing linking, such as -c or -M.
+if [ "$show_info" = compile ] ; then
+    echo ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} -I$includedir
+elif [ "$show_info" = link ] ; then
+    if [ "$nativelinking" = yes ] ; then
+        echo ${final_ldflags}
+    else
+        if [ "$static_mpi" = no ] ; then
+            echo ${final_ldflags} -L$libdir $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} -l@MPIABILIBNAME@ @LPMPIABILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+        else
+            echo ${final_ldflags} -L$libdir $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} $libdir/lib@MPIABILIBNAME@.a @LPMPIABILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+        fi
+    fi
+elif [ "$linking" = yes ] ; then
+    if [ "$nativelinking" = yes ] ; then
+        $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} $allargs -I$includedir
+        rc=$?
+    else
+        if [ "$static_mpi" = no ] ; then
+          $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} $allargs -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} -l@MPIABILIBNAME@ @LPMPIABILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+        else
+          $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} ${final_ldflags} $allargs -I$includedir -L$libdir $PROFILE_PRELIB $PROFILE_FOO ${wrapper_dl_type_flags} $libdir/lib@MPIABILIBNAME@.a @LPMPIABILIBNAME@ $PROFILE_POSTLIB ${final_libs}
+        fi
+        rc=$?
+    fi
+else
+    $Show $CC ${final_cppflags} $PROFILE_INCPATHS ${final_cflags} $allargs -I$includedir
+    rc=$?
+fi
+
+exit $rc

--- a/src/glue/romio/all_romio_symbols
+++ b/src/glue/romio/all_romio_symbols
@@ -72,6 +72,7 @@ print OUTFD <<EOT;
  */
 
 #include "mpiimpl.h"
+#include "mpir_ext.h"
 
 #include <stdio.h>
 

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -3,6 +3,10 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#ifdef MPI_ABI
+#include "mpi_abi.h"
+#else
+
 /* @configure_input@ */
 #ifndef MPI_INCLUDED
 #define MPI_INCLUDED
@@ -982,4 +986,5 @@ typedef struct MPIX_Iov {
 #endif
 #endif
 
-#endif
+#endif  /* MPI_INCLUDED */
+#endif  /* MPI_ABI */

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -19,8 +19,26 @@
 #define MPICH_API_PUBLIC
 #endif
 
+#ifdef BUILD_MPI_ABI
+/* include adapted version of mpi_abi.h, which -
+ *     * defines handle types with ABI_ prefix
+ *         - internally we will type convert
+ *     * MPI and PMPI prototypes use ABI_ handle types
+ *         - we implement them in c_binding_abi.c
+ *         - Note that we need MPICH_API_PUBLIC defined (and mpichconf.h included)
+ *     * all defined constants and enum values
+ *         - all internal objects will be (re)compiled using the new constants
+ *
+ * It needs to be included after MPICH_API_PUBLIC since it defines the API prototypes.
+ */
+#include "mpi_abi_internal.h"
+#endif
+
+#ifndef BUILD_MPI_ABI
 #define MPI_VERSION    4
 #define MPI_SUBVERSION 1
+#endif /* BUILD_MPI_ABI */
+
 #define MPICH_NAME     4
 #define MPICH         1
 #define MPICH_HAS_C2F  1
@@ -251,6 +269,7 @@ typedef int MPI_Win;
 typedef int MPI_Session;
 #define MPI_SESSION_NULL     ((MPI_Session)0x38000000)
 
+#ifndef BUILD_MPI_ABI
 /* File and IO */
 /* This define lets ROMIO know that MPI_File has been defined */
 #define MPI_FILE_DEFINED
@@ -258,6 +277,7 @@ typedef int MPI_Session;
    as in src/mpi/romio/include/mpio.h.in  */
 typedef struct ADIOI_FileD *MPI_File;
 #define MPI_FILE_NULL ((MPI_File)0)
+#endif
 
 /* Collective operations */
 typedef int MPI_Op;
@@ -412,6 +432,7 @@ static const MPI_Datatype mpich_mpi_aint   MPICH_ATTR_TYPE_TAG(MPI_Aint)   = MPI
 static const MPI_Datatype mpich_mpi_offset MPICH_ATTR_TYPE_TAG(MPI_Offset) = MPI_OFFSET;
 #endif
 
+#ifndef BUILD_MPI_ABI
 /* Definitions that are determined by configure. */
 typedef @MPI_AINT@ MPI_Aint;
 typedef @MPI_FINT@ MPI_Fint;
@@ -463,12 +484,15 @@ typedef struct {
 extern MPI_F08_status *MPI_F08_STATUS_IGNORE;
 extern MPI_F08_status *MPI_F08_STATUSES_IGNORE;
 
+#endif /* BUILD_MPI_ABI */
+
 /* FIXME: The following two definition are not defined by MPI and must not be
    included in the mpi.h file, as the MPI namespace is reserved to the MPI
    standard */
 #define MPI_AINT_FMT_DEC_SPEC "@MPI_AINT_FMT_DEC_SPEC@"
 #define MPI_AINT_FMT_HEX_SPEC "@MPI_AINT_FMT_HEX_SPEC@"
 
+#ifndef BUILD_MPI_ABI
 /* These are only guesses; make sure you change them in mpif.h as well */
 #define MPI_MAX_PROCESSOR_NAME @MPI_MAX_PROCESSOR_NAME@
 #define MPI_MAX_LIBRARY_VERSION_STRING @MPI_MAX_LIBRARY_VERSION_STRING@
@@ -586,8 +610,10 @@ enum MPIR_Combiner_enum {
 #define MPI_COMM_TYPE_HW_UNGUIDED 3
 #define MPI_COMM_TYPE_RESOURCE_GUIDED 4
 
+#endif /* BUILD_MPI_ABI */
 /* MPICH-specific types */
 #define MPIX_COMM_TYPE_NEIGHBORHOOD 5
+#ifndef BUILD_MPI_ABI
 
 /* For supported thread levels */
 #define MPI_THREAD_SINGLE 0
@@ -708,9 +734,11 @@ enum MPIR_Combiner_enum {
 
 #define MPI_ERR_LASTCODE    0x3fffffff  /* Last valid error code for a
 					   predefined error class */
+#endif /* BUILD_MPI_ABI */
+
+
 #define MPICH_ERR_LAST_CLASS 80     /* It is also helpful to know the
 				       last valid class */
-
 #define MPICH_ERR_FIRST_MPIX 100 /* Define a gap here because sock is
                                   * already using some of the values in this
                                   * range. All MPIX error codes will be
@@ -746,6 +774,7 @@ enum MPIR_Combiner_enum {
 #define MPIIMPL_HAVE_STATUS_SET_BYTES 1
 #define MPIIMPL_HAVE_STATUS_SET_INFO 1
 
+#ifndef BUILD_MPI_ABI
 /* C callback functions */
 typedef void (MPI_Handler_function) ( MPI_Comm *, int *, ... );
 typedef int (MPI_Comm_copy_attr_function)(MPI_Comm, int, void *, void *,
@@ -780,8 +809,10 @@ typedef void (MPI_User_function_c) ( void *, void *, MPI_Count *, MPI_Datatype *
 typedef int (MPI_Grequest_cancel_function)(void *, int);
 typedef int (MPI_Grequest_free_function)(void *);
 typedef int (MPI_Grequest_query_function)(void *, MPI_Status *);
+#endif /* BUILD_MPI_ABI */
 typedef int (MPIX_Grequest_poll_function)(void *, MPI_Status *);
 typedef int (MPIX_Grequest_wait_function)(int, void **, double, MPI_Status *);
+#ifndef BUILD_MPI_ABI
 
 /* Function type defs */
 typedef int (MPI_Datarep_conversion_function)(void *, MPI_Datatype, int,
@@ -812,6 +843,9 @@ typedef int (MPI_Datarep_conversion_function_c)(void *, MPI_Datatype, MPI_Count,
 #define MPI_CONVERSION_FN_NULL ((MPI_Datarep_conversion_function *)0)
 #define MPI_CONVERSION_FN_NULL_C ((MPI_Datarep_conversion_function_c *)0)
 
+#endif /* BUILD_MPI_ABI */
+
+#ifndef BUILD_MPI_ABI
 /* types for the MPI_T_ interface */
 struct MPIR_T_enum_s;
 struct MPIR_T_cvar_handle_s;
@@ -928,6 +962,13 @@ typedef void (MPI_T_event_cb_function)(MPI_T_event_instance event_instance, MPI_
 typedef void (MPI_T_event_free_cb_function)(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, void *user_data);
 typedef void (MPI_T_event_dropped_cb_function)(MPI_Count count, MPI_T_event_registration event_registration, int source_index, MPI_T_cb_safety cb_safety, void *user_data);
 
+#else  /* BUILD_MPI_ABI */
+/* FIXME: make it less hacky (fix the implementation) */
+#define MPIR_T_PVAR_CLASS_FIRST MPI_T_PVAR_CLASS_STATE
+#define MPIR_T_PVAR_CLASS_LAST  MPI_T_PVAR_CLASS_GENERIC
+#define MPIR_T_PVAR_CLASS_NUMBER 10
+#endif /* BUILD_MPI_ABI */
+
 typedef struct {
     void **storage_stack;
 } QMPI_Context;
@@ -961,12 +1002,12 @@ typedef struct MPIX_Iov {
  * Normally, we provide prototypes for all MPI routines.  In a few weird
  * cases, we need to suppress the prototypes.
  */
-#ifndef MPICH_SUPPRESS_PROTOTYPES
+#ifndef BUILD_MPI_ABI
 /* We require that the C compiler support prototypes */
 #include <mpi_proto.h>
-#endif /* MPICH_SUPPRESS_PROTOTYPES */
 
 @HAVE_ROMIO@
+#endif /* BUILD_MPI_ABI */
 
 #if defined(__cplusplus)
 }

--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -175,7 +175,6 @@ typedef struct MPIR_Stream MPIR_Stream;
 #include "mpir_topo.h"
 #include "mpir_tags.h"
 #include "mpir_pt2pt.h"
-#include "mpir_ext.h"
 #include "mpir_gpu.h"
 
 #ifdef HAVE_CXX_BINDING

--- a/src/include/mpir_attr.h
+++ b/src/include/mpir_attr.h
@@ -204,4 +204,15 @@ int MPIR_Call_attr_copy(int, MPIR_Attribute *, void **, int *);
 
 void MPIR_free_keyval(MPII_Keyval * keyval_ptr);
 
+int MPIR_Dup_fn(MPI_Comm comm, int keyval, void *extra_state,
+                void *attr_in, void *attr_out, int *flag);
+#ifdef BUILD_MPI_ABI
+int MPIR_Comm_dup_fn(ABI_Comm comm, int keyval, void *extra_state,
+                     void *attr_in, void *attr_out, int *flag);
+int MPIR_Type_dup_fn(ABI_Datatype datatype, int keyval, void *extra_state,
+                     void *attr_in, void *attr_out, int *flag);
+int MPIR_Win_dup_fn(ABI_Win win, int keyval, void *extra_state,
+                    void *attr_in, void *attr_out, int *flag);
+#endif
+
 #endif /* MPIR_ATTR_H_INCLUDED */

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -374,10 +374,6 @@ int MPIR_Comm_is_parent_comm(MPIR_Comm *);
 int MPIR_peer_intercomm_create(MPIR_Context_id_t context_id, MPIR_Context_id_t recvcontext_id,
                                uint64_t remote_lpid, int is_low_group, MPIR_Comm ** newcomm);
 
-#if defined(HAVE_ROMIO)
-int MPIR_Comm_split_filesystem(MPI_Comm comm, int key, const char *dirname, MPI_Comm * newcomm);
-#endif
-
 #define MPIR_Comm_rank(comm_ptr) ((comm_ptr)->rank)
 #define MPIR_Comm_size(comm_ptr) ((comm_ptr)->local_size)
 

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -223,13 +223,13 @@ cvars:
     }
 
 #ifdef ENABLE_THREADCOMM
-#define MPIR_ERRTEST_RANK_internal(min,comm_ptr,rank,err) \
+#define MPIR_ERRTEST_RANK(comm_ptr,rank,err) \
     do { \
         int comm_size = (comm_ptr)->remote_size; \
         if (comm_ptr->threadcomm) { \
             comm_size = comm_ptr->threadcomm->rank_offset_table[comm_size - 1]; \
         } \
-        if ((rank) < (min) || (rank) >= comm_size) { \
+        if ((rank) < 0 || (rank) >= comm_size) { \
             err = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__, \
                                     MPI_ERR_RANK, "**rank", "**rank %d %d", rank, \
                                     comm_size); \
@@ -237,10 +237,10 @@ cvars:
         } \
     } while (0)
 #else
-#define MPIR_ERRTEST_RANK_internal(min,comm_ptr,rank,err) \
+#define MPIR_ERRTEST_RANK(comm_ptr,rank,err) \
     do { \
         int comm_size = (comm_ptr)->remote_size; \
-        if ((rank) < (min) || (rank) >= comm_size) { \
+        if ((rank) < 0 || (rank) >= comm_size) { \
             err = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__, \
                                     MPI_ERR_RANK, "**rank", "**rank %d %d", rank, \
                                     comm_size); \
@@ -249,14 +249,19 @@ cvars:
     } while (0)
 #endif
 
-#define MPIR_ERRTEST_RANK(comm_ptr,rank,err) \
-    MPIR_ERRTEST_RANK_internal(0, comm_ptr, rank, err)
-
 #define MPIR_ERRTEST_SEND_RANK(comm_ptr,rank,err) \
-    MPIR_ERRTEST_RANK_internal(MPI_PROC_NULL, comm_ptr, rank, err)
+    do { \
+        if (rank != MPI_PROC_NULL) { \
+            MPIR_ERRTEST_RANK(comm_ptr, rank, err); \
+        } \
+    } while (0)
 
 #define MPIR_ERRTEST_RECV_RANK(comm_ptr,rank,err) \
-    MPIR_ERRTEST_RANK_internal(MPI_ANY_SOURCE, comm_ptr, rank, err)
+    do { \
+        if (rank != MPI_PROC_NULL && rank != MPI_ANY_SOURCE) { \
+            MPIR_ERRTEST_RANK(comm_ptr, rank, err); \
+        } \
+    } while (0)
 
 #define MPIR_ERRTEST_COUNT(count,err)                           \
     if ((count) < 0) {                                          \

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -110,10 +110,11 @@ MPICH_API_PUBLIC int MPIR_Err_return_file(MPI_File, const char[], int); /* Romio
 MPICH_API_PUBLIC int MPIR_Err_create_code(int, int, const char[], int, int, const char[],
                                           const char[], ...);
 
-#ifdef USE_ERR_CODE_VALIST
 int MPIR_Err_create_code_valist(int, int, const char[], int, int, const char[], const char[],
                                 va_list);
-#endif
+
+typedef int (*MPIR_Err_get_class_string_func_t) (int error, char *str, int length);
+void MPIR_Err_get_string(int, char *, int, MPIR_Err_get_class_string_func_t);
 
 /*@
   MPIR_Err_combine_codes - Combine two error codes, or more importantly

--- a/src/include/mpir_errhandler.h
+++ b/src/include/mpir_errhandler.h
@@ -29,11 +29,11 @@
 
   E*/
 typedef union errhandler_fn {
-    void (*C_Comm_Handler_function) (MPI_Comm *, int *, ...);
+    MPI_Comm_errhandler_function *C_Comm_Handler_function;
+    MPI_File_errhandler_function *C_File_Handler_function;
+    MPI_Win_errhandler_function *C_Win_Handler_function;
+    MPI_Session_errhandler_function *C_Session_Handler_function;
     void (*F77_Handler_function) (MPI_Fint *, MPI_Fint *);
-    void (*C_Win_Handler_function) (MPI_Win *, int *, ...);
-    void (*C_Session_Handler_function) (MPI_Session *, int *, ...);
-    void (*C_File_Handler_function) (MPI_File *, int *, ...);
 } errhandler_fn;
 
 /*S

--- a/src/include/mpir_ext.h.in
+++ b/src/include/mpir_ext.h.in
@@ -12,6 +12,11 @@
 
 #include <stdarg.h>
 
+/* Routines defined in romio, used in MPICH */
+int MPIR_ROMIO_Get_file_errhand(MPI_File, MPI_Errhandler *);
+int MPIR_ROMIO_Set_file_errhand(MPI_File, MPI_Errhandler);
+int MPIR_Comm_split_filesystem(MPI_Comm comm, int key, const char *dirname, MPI_Comm * newcomm);
+
 /* This routine, given an MPI_Errhandler (from a file), returns
    a pointer to the user-supplied error function.  The last argument
    is set to an integer indicating that the function is MPI_ERRORS_RETURN
@@ -28,12 +33,6 @@ void MPIR_Get_file_error_routine(MPI_Errhandler, void (**)(MPI_File *, int *, ..
  code from throwing an exception when the user routine returns.
 */
 int MPIR_File_call_cxx_errhandler(MPI_File *, int *, void (*)(MPI_File *, int *, ...));
-/*
-   These routines provide access to the MPI_Errhandler field within the
-   ROMIO MPI_File structure
- */
-int MPIR_ROMIO_Get_file_errhand(MPI_File, MPI_Errhandler *);
-int MPIR_ROMIO_Set_file_errhand(MPI_File, MPI_Errhandler);
 
 /* FIXME: This routine is also defined in adio.h */
 int MPIO_Err_return_file(MPI_File, int);

--- a/src/include/mpir_ext.h.in
+++ b/src/include/mpir_ext.h.in
@@ -80,6 +80,7 @@ void MPIR_Ext_cs_yield(void);
 
 /* to facilitate error checking */
 int MPIR_Ext_datatype_iscommitted(MPI_Datatype datatype);
+int MPIR_Ext_datatype_iscontig(MPI_Datatype datatype, int *flag);
 
 /* make comm split based on access to a common file system easier */
 int MPIR_Get_node_id(MPI_Comm comm, int rank, int *id);

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -79,8 +79,13 @@ typedef enum MPIR_Op_kind {
   Collective-DS
   S*/
 typedef union MPIR_User_function {
+#ifndef BUILD_MPI_ABI
     void (*c_function) (const void *, void *, const int *, const MPI_Datatype *);
     void (*c_large_function) (const void *, void *, const MPI_Count *, const MPI_Datatype *);
+#else
+    void (*c_function) (const void *, void *, const int *, const ABI_Datatype *);
+    void (*c_large_function) (const void *, void *, const MPI_Count *, const ABI_Datatype *);
+#endif
     void (*f77_function) (const void *, void *, const MPI_Fint *, const MPI_Fint *);
 } MPIR_User_function;
 /* FIXME: Should there be "restrict" in the definitions above, e.g.,

--- a/src/include/mpir_process.h
+++ b/src/include/mpir_process.h
@@ -82,7 +82,11 @@ typedef struct MPIR_Process_t {
      * and the C function to call (itself a function defined by the
      * C++ interface and exported to C).  The first argument is used
      * to specify the kind (comm,file,win) */
+#ifndef BUILD_MPI_ABI
     void (*cxx_call_errfn) (int, int *, int *, void (*)(void));
+#else
+    void (*cxx_call_errfn) (int, ABI_Comm *, int *, void (*)(void));
+#endif
 #endif                          /* HAVE_CXX_BINDING */
 } MPIR_Process_t;
 extern MPIR_Process_t MPIR_Process;

--- a/src/include/mpir_topo.h
+++ b/src/include/mpir_topo.h
@@ -72,8 +72,8 @@ int MPIR_Topo_canon_nhb_count(MPIR_Comm * comm_ptr, int *indegree, int *outdegre
  * works for any topology type by canonicalizing according to the rules in
  * Section 7.6 of the MPI-3.0 standard. */
 int MPIR_Topo_canon_nhb(MPIR_Comm * comm_ptr,
-                        int indegree, int sources[], int inweights[],
-                        int outdegree, int dests[], int outweights[]);
+                        int indegree, int sources[], int *inweights,
+                        int outdegree, int dests[], int *outweights);
 
 #define MAX_CART_DIM 16
 

--- a/src/mpi/Makefile.mk
+++ b/src/mpi/Makefile.mk
@@ -27,13 +27,6 @@ SUBDIRS += src/mpi/romio
 DIST_SUBDIRS += src/mpi/romio
 MANDOC_SUBDIRS += src/mpi/romio
 HTMLDOC_SUBDIRS += src/mpi/romio
-mpi_convenience_libs += src/mpi/romio/libromio.la
-
-# libpromio contains the PMPI symbols (unlike libpmpi, which contains MPI
-# symbols) and should be added to libmpi as well
-if BUILD_PROFILING_LIB
-pmpi_convenience_libs += src/mpi/romio/libpromio.la
-endif BUILD_PROFILING_LIB
 
 # This was previously a hard copy (not a symlink) performed by config.status
 # (specified via AC_CONFIG_COMMANDS).  Ideally we would eliminate this "copy"

--- a/src/mpi/attr/attr_impl.c
+++ b/src/mpi/attr/attr_impl.c
@@ -98,11 +98,11 @@ int MPIR_Type_create_keyval_impl(MPI_Type_copy_attr_function * type_copy_attr_fn
     keyval_ptr->was_freed = 0;
     keyval_ptr->kind = MPIR_DATATYPE;
     keyval_ptr->extra_state = extra_state;
-    /* add (void *) cast since we are assigning MPI_Type_copy_attr_function to
+    /* Cast since we are assigning MPI_Type_copy_attr_function to
      * MPI_Comm_copy_attr_function */
-    keyval_ptr->copyfn.user_function = (void *) type_copy_attr_fn;
+    keyval_ptr->copyfn.user_function = (MPI_Comm_copy_attr_function *) type_copy_attr_fn;
     keyval_ptr->copyfn.proxy = MPII_Attr_copy_c_proxy;
-    keyval_ptr->delfn.user_function = (void *) type_delete_attr_fn;
+    keyval_ptr->delfn.user_function = (MPI_Comm_delete_attr_function *) type_delete_attr_fn;
     keyval_ptr->delfn.proxy = MPII_Attr_delete_c_proxy;
 
     /* Tell finalize to check for attributes on permanent types */
@@ -139,11 +139,11 @@ int MPIR_Win_create_keyval_impl(MPI_Win_copy_attr_function * win_copy_attr_fn,
     keyval_ptr->was_freed = 0;
     keyval_ptr->kind = MPIR_WIN;
     keyval_ptr->extra_state = extra_state;
-    /* add (void *) cast since we are assigning MPI_Win_copy_attr_function to
+    /* Cast since we are assigning MPI_Win_copy_attr_function to
      * MPI_Comm_copy_attr_function */
-    keyval_ptr->copyfn.user_function = (void *) win_copy_attr_fn;
+    keyval_ptr->copyfn.user_function = (MPI_Comm_copy_attr_function *) win_copy_attr_fn;
     keyval_ptr->copyfn.proxy = MPII_Attr_copy_c_proxy;
-    keyval_ptr->delfn.user_function = (void *) win_delete_attr_fn;
+    keyval_ptr->delfn.user_function = (MPI_Comm_delete_attr_function *) win_delete_attr_fn;
     keyval_ptr->delfn.proxy = MPII_Attr_delete_c_proxy;
 
     MPIR_OBJ_PUBLISH_HANDLE(*win_keyval, keyval_ptr->handle);

--- a/src/mpi/attr/attr_impl.c
+++ b/src/mpi/attr/attr_impl.c
@@ -53,6 +53,16 @@ int MPIR_Comm_create_keyval_impl(MPI_Comm_copy_attr_function * comm_copy_attr_fn
         MPIR_Process.attr_dup = MPIR_Attr_dup_list;
         MPIR_Process.attr_free = MPIR_Attr_delete_list;
     }
+#ifdef BUILD_MPI_ABI
+    if (comm_copy_attr_fn == MPI_COMM_NULL_COPY_FN) {
+        comm_copy_attr_fn = NULL;
+    } else if (comm_copy_attr_fn == MPI_COMM_DUP_FN) {
+        comm_copy_attr_fn = MPIR_Comm_dup_fn;
+    }
+    if (comm_delete_attr_fn == MPI_COMM_NULL_DELETE_FN) {
+        comm_delete_attr_fn = NULL;
+    }
+#endif
 
     /* The handle encodes the keyval kind.  Modify it to have the correct
      * field */
@@ -90,6 +100,16 @@ int MPIR_Type_create_keyval_impl(MPI_Type_copy_attr_function * type_copy_attr_fn
         MPIR_Process.attr_dup = MPIR_Attr_dup_list;
         MPIR_Process.attr_free = MPIR_Attr_delete_list;
     }
+#ifdef BUILD_MPI_ABI
+    if (type_copy_attr_fn == MPI_TYPE_NULL_COPY_FN) {
+        type_copy_attr_fn = NULL;
+    } else if (type_copy_attr_fn == MPI_TYPE_DUP_FN) {
+        type_copy_attr_fn = MPIR_Type_dup_fn;
+    }
+    if (type_delete_attr_fn == MPI_TYPE_NULL_DELETE_FN) {
+        type_delete_attr_fn = NULL;
+    }
+#endif
 
     /* The handle encodes the keyval kind.  Modify it to have the correct
      * field */
@@ -131,6 +151,16 @@ int MPIR_Win_create_keyval_impl(MPI_Win_copy_attr_function * win_copy_attr_fn,
         MPIR_Process.attr_dup = MPIR_Attr_dup_list;
         MPIR_Process.attr_free = MPIR_Attr_delete_list;
     }
+#ifdef BUILD_MPI_ABI
+    if (win_copy_attr_fn == MPI_WIN_NULL_COPY_FN) {
+        win_copy_attr_fn = NULL;
+    } else if (win_copy_attr_fn == MPI_WIN_DUP_FN) {
+        win_copy_attr_fn = MPIR_Win_dup_fn;
+    }
+    if (win_delete_attr_fn == MPI_WIN_NULL_DELETE_FN) {
+        win_delete_attr_fn = NULL;
+    }
+#endif
 
     /* The handle encodes the keyval kind.  Modify it to have the correct
      * field */

--- a/src/mpi/attr/attr_impl.c
+++ b/src/mpi/attr/attr_impl.c
@@ -98,9 +98,11 @@ int MPIR_Type_create_keyval_impl(MPI_Type_copy_attr_function * type_copy_attr_fn
     keyval_ptr->was_freed = 0;
     keyval_ptr->kind = MPIR_DATATYPE;
     keyval_ptr->extra_state = extra_state;
-    keyval_ptr->copyfn.user_function = type_copy_attr_fn;
+    /* add (void *) cast since we are assigning MPI_Type_copy_attr_function to
+     * MPI_Comm_copy_attr_function */
+    keyval_ptr->copyfn.user_function = (void *) type_copy_attr_fn;
     keyval_ptr->copyfn.proxy = MPII_Attr_copy_c_proxy;
-    keyval_ptr->delfn.user_function = type_delete_attr_fn;
+    keyval_ptr->delfn.user_function = (void *) type_delete_attr_fn;
     keyval_ptr->delfn.proxy = MPII_Attr_delete_c_proxy;
 
     /* Tell finalize to check for attributes on permanent types */
@@ -137,9 +139,11 @@ int MPIR_Win_create_keyval_impl(MPI_Win_copy_attr_function * win_copy_attr_fn,
     keyval_ptr->was_freed = 0;
     keyval_ptr->kind = MPIR_WIN;
     keyval_ptr->extra_state = extra_state;
-    keyval_ptr->copyfn.user_function = win_copy_attr_fn;
+    /* add (void *) cast since we are assigning MPI_Win_copy_attr_function to
+     * MPI_Comm_copy_attr_function */
+    keyval_ptr->copyfn.user_function = (void *) win_copy_attr_fn;
     keyval_ptr->copyfn.proxy = MPII_Attr_copy_c_proxy;
-    keyval_ptr->delfn.user_function = win_delete_attr_fn;
+    keyval_ptr->delfn.user_function = (void *) win_delete_attr_fn;
     keyval_ptr->delfn.proxy = MPII_Attr_delete_c_proxy;
 
     MPIR_OBJ_PUBLISH_HANDLE(*win_keyval, keyval_ptr->handle);

--- a/src/mpi/attr/attrutil.c
+++ b/src/mpi/attr/attrutil.c
@@ -4,6 +4,9 @@
  */
 
 #include "mpiimpl.h"
+#ifdef BUILD_MPI_ABI
+#include "mpi_abi_util.h"
+#endif
 /*
  * Keyvals.  These are handled just like the other opaque objects in MPICH
  * The predefined keyvals (and their associated attributes) are handled
@@ -297,8 +300,12 @@ MPII_Attr_copy_c_proxy(MPI_Comm_copy_attr_function * user_function,
     } else {
         attrib_val = attrib;
     }
-
+#ifndef BUILD_MPI_ABI
     ret = user_function(handle, keyval, extra_state, attrib_val, attrib_copy, flag);
+#else
+    ret = user_function(ABI_Handle_from_mpi(handle), keyval, extra_state, attrib_val,
+                        attrib_copy, flag);
+#endif
 
     return ret;
 }
@@ -317,8 +324,11 @@ MPII_Attr_delete_c_proxy(MPI_Comm_delete_attr_function * user_function,
         attrib_val = &attrib;
     else
         attrib_val = attrib;
-
+#ifndef BUILD_MPI_ABI
     ret = user_function(handle, keyval, attrib_val, extra_state);
+#else
+    ret = user_function(ABI_Handle_from_mpi(handle), keyval, attrib_val, extra_state);
+#endif
 
     return ret;
 }

--- a/src/mpi/attr/dup_fn.c
+++ b/src/mpi/attr/dup_fn.c
@@ -5,6 +5,14 @@
 
 #include "mpiimpl.h"
 
+static int attr_dup_fn(void *attr_in, void *attr_out, int *flag)
+{
+    /* Set attr_out, the flag and return success */
+    (*(void **) attr_out) = attr_in;
+    (*flag) = 1;
+    return (MPI_SUCCESS);
+}
+
 /*D
 
 MPI_DUP_FN - A function to simple-mindedly copy attributes
@@ -20,8 +28,25 @@ int MPIR_Dup_fn(MPI_Comm comm ATTRIBUTE((unused)),
     MPL_UNREFERENCED_ARG(keyval);
     MPL_UNREFERENCED_ARG(extra_state);
 
-    /* Set attr_out, the flag and return success */
-    (*(void **) attr_out) = attr_in;
-    (*flag) = 1;
-    return (MPI_SUCCESS);
+    return attr_dup_fn(attr_in, attr_out, flag);
 }
+
+#ifdef BUILD_MPI_ABI
+int MPIR_Comm_dup_fn(ABI_Comm comm, int keyval, void *extra_state,
+                     void *attr_in, void *attr_out, int *flag)
+{
+    return attr_dup_fn(attr_in, attr_out, flag);
+}
+
+int MPIR_Type_dup_fn(ABI_Datatype datatype, int keyval, void *extra_state,
+                     void *attr_in, void *attr_out, int *flag)
+{
+    return attr_dup_fn(attr_in, attr_out, flag);
+}
+
+int MPIR_Win_dup_fn(ABI_Win win, int keyval, void *extra_state,
+                    void *attr_in, void *attr_out, int *flag)
+{
+    return attr_dup_fn(attr_in, attr_out, flag);
+}
+#endif

--- a/src/mpi/coll/op/op_impl.c
+++ b/src/mpi/coll/op/op_impl.c
@@ -58,8 +58,13 @@ int MPIR_Op_create_impl(MPI_User_function * user_fn, int commute, MPIR_Op ** p_o
 
     op_ptr->language = MPIR_LANG__C;
     op_ptr->kind = commute ? MPIR_OP_KIND__USER : MPIR_OP_KIND__USER_NONCOMMUTE;
+#ifndef BUILD_MPI_ABI
     op_ptr->function.c_function = (void (*)(const void *, void *,
                                             const int *, const MPI_Datatype *)) user_fn;
+#else
+    op_ptr->function.c_function = (void (*)(const void *, void *,
+                                            const int *, const ABI_Datatype *)) user_fn;
+#endif
     MPIR_Object_set_ref(op_ptr, 1);
 
     MPID_Op_commit_hook(op_ptr);
@@ -78,9 +83,15 @@ int MPIR_Op_create_large_impl(MPI_User_function_c * user_fn, int commute, MPIR_O
     if (mpi_errno == MPI_SUCCESS) {
         (*p_op_ptr)->kind =
             commute ? MPIR_OP_KIND__USER_LARGE : MPIR_OP_KIND__USER_NONCOMMUTE_LARGE;
+#ifndef BUILD_MPI_ABI
         (*p_op_ptr)->function.c_large_function = (void (*)(const void *, void *,
                                                            const MPI_Count *,
                                                            const MPI_Datatype *)) user_fn;
+#else
+        (*p_op_ptr)->function.c_large_function = (void (*)(const void *, void *,
+                                                           const MPI_Count *,
+                                                           const ABI_Datatype *)) user_fn;
+#endif
     }
     return mpi_errno;
 }

--- a/src/mpi/datatype/datatype.h
+++ b/src/mpi/datatype/datatype.h
@@ -12,7 +12,6 @@
 int MPIR_Datatype_builtintype_alignment(MPI_Datatype type);
 extern int MPIR_Datatype_init_predefined(void);
 extern int MPIR_Datatype_commit_pairtypes(void);
-extern void MPIR_Datatype_iscontig(MPI_Datatype, int *);
 
 /* LB/UB calculation helper macros */
 

--- a/src/mpi/datatype/get_elements_x.c
+++ b/src/mpi/datatype/get_elements_x.c
@@ -255,9 +255,11 @@ static MPI_Count MPIR_Type_get_elements(MPI_Count * bytes_p, MPI_Count count, MP
             case MPI_COMBINER_F90_REAL:
             case MPI_COMBINER_F90_COMPLEX:
             case MPI_COMBINER_F90_INTEGER:
+#ifndef BUILD_MPI_ABI
             case MPI_COMBINER_HVECTOR_INTEGER:
             case MPI_COMBINER_HINDEXED_INTEGER:
             case MPI_COMBINER_STRUCT_INTEGER:
+#endif
             default:
                 /* --BEGIN ERROR HANDLING-- */
                 MPIR_Assert(0);

--- a/src/mpi/datatype/type_debug.c
+++ b/src/mpi/datatype/type_debug.c
@@ -244,16 +244,18 @@ char *MPIR_Datatype_combiner_to_string(int combiner)
         return c_struct;
     if (combiner == MPI_COMBINER_DUP)
         return c_dup;
+#ifndef BUILD_MPI_ABI
     if (combiner == MPI_COMBINER_HVECTOR_INTEGER)
         return c_hvector_integer;
     if (combiner == MPI_COMBINER_HINDEXED_INTEGER)
         return c_hindexed_integer;
+    if (combiner == MPI_COMBINER_STRUCT_INTEGER)
+        return c_struct_integer;
+#endif
     if (combiner == MPI_COMBINER_INDEXED_BLOCK)
         return c_indexed_block;
     if (combiner == MPI_COMBINER_HINDEXED_BLOCK)
         return c_hindexed_block;
-    if (combiner == MPI_COMBINER_STRUCT_INTEGER)
-        return c_struct_integer;
     if (combiner == MPI_COMBINER_SUBARRAY)
         return c_subarray;
     if (combiner == MPI_COMBINER_DARRAY)

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_commit.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_commit.c
@@ -123,11 +123,13 @@ void MPIR_Typerep_commit(MPI_Datatype type)
                 goto clean_exit;
             }
             break;
+#ifndef BUILD_MPI_ABI
         case MPI_COMBINER_HVECTOR_INTEGER:
         case MPI_COMBINER_HINDEXED_INTEGER:
         case MPI_COMBINER_STRUCT_INTEGER:
             MPIR_Assert_error("wrong combiner");
             break;
+#endif
         default:
             break;
     }

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -350,21 +350,6 @@ int MPIR_Datatype_commit_pairtypes(void)
     return MPI_SUCCESS;
 }
 
-/* This will eventually be removed once ROMIO knows more about MPICH */
-void MPIR_Datatype_iscontig(MPI_Datatype datatype, int *flag)
-{
-    if (HANDLE_IS_BUILTIN(datatype))
-        *flag = 1;
-    else {
-        MPIR_Datatype *dt_ptr;
-        MPIR_Datatype_get_ptr(datatype, dt_ptr);
-        if (!dt_ptr->is_committed) {
-            MPIR_Type_commit_impl(&datatype);
-        }
-        MPIR_Datatype_is_contig(datatype, flag);
-    }
-}
-
 /* If an attribute is added to a predefined type, we free the attributes
    in Finalize */
 static int datatype_attr_finalize_cb(void *dummy ATTRIBUTE((unused)))

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -7,15 +7,6 @@
 
 #include "mpiimpl.h"
 
-/* stdarg is required to handle the variable argument lists for
-   MPIR_Err_create_code */
-#include <stdarg.h>
-/* Define USE_ERR_CODE_VALIST to get the prototype for the valist version
-   of MPIR_Err_create_code in mpir_err.h (without this definition,
-   the prototype is not included.  The "valist" version of the function
-   is used in only a few places, here and potentially in ROMIO) */
-#define USE_ERR_CODE_VALIST
-
 /* defmsg is generated automatically from the source files and contains
    all of the error messages, both the generic and specific.  Depending
    on the value of MPICH_ERROR_MSG_LEVEL, different amounts of message

--- a/src/mpi/romio/Makefile.am
+++ b/src/mpi/romio/Makefile.am
@@ -96,6 +96,23 @@ libromio_la_LDFLAGS = $(external_ldflags)
 libromio_la_LIBADD = $(external_libs)
 endif !BUILD_PROFILING_LIB
 
+if BUILD_ABI_LIB
+noinst_LTLIBRARIES += libromio_abi.la
+libromio_abi_la_SOURCES = $(romio_mpi_sources) $(romio_other_sources) $(glue_sources)
+libromio_abi_la_CPPFLAGS = $(AM_CPPFLAGS) -DBUILD_MPI_ABI
+
+if BUILD_PROFILING_LIB
+noinst_LTLIBRARIES += libpromio_abi.la
+libpromio_abi_la_SOURCES = $(romio_mpi_sources)
+libpromio_abi_la_CPPFLAGS = $(AM_CPPFLAGS) -DMPIO_BUILD_PROFILING -DBUILD_MPI_ABI
+libpromio_abi_la_LDFLAGS = $(external_ldflags)
+libpromio_abi_la_LIBADD = $(external_libs)
+endif BUILD_PROFILING_LIB
+libromio_abi_la_LDFLAGS = $(external_ldflags)
+libromio_abi_la_LIBADD = $(external_libs)
+endif BUILD_ABI_LIB
+
+# ---------------------------
 else !BUILD_ROMIO_EMBEDDED
 lib_LTLIBRARIES = libromio.la
 libromio_la_SOURCES = $(romio_mpi_sources) $(romio_other_sources) $(glue_sources)

--- a/src/mpi/romio/adio/common/ad_open.c
+++ b/src/mpi/romio/adio/common/ad_open.c
@@ -8,7 +8,6 @@
 #include "adio_cb_config_list.h"
 #include "hint_fns.h"
 
-#include "mpio.h"
 static int is_aggregator(int rank, ADIO_File fd);
 static int uses_generic_read(ADIO_File fd);
 static int uses_generic_write(ADIO_File fd);

--- a/src/mpi/romio/adio/common/cb_config_list.c
+++ b/src/mpi/romio/adio/common/cb_config_list.c
@@ -16,7 +16,6 @@
  */
 
 #include "adio.h"
-#include "mpi.h"
 #include "adio_cb_config_list.h"
 #include <stdio.h>
 #include <string.h>

--- a/src/mpi/romio/adio/common/iscontig.c
+++ b/src/mpi/romio/adio/common/iscontig.c
@@ -6,12 +6,10 @@
 #include "adio.h"
 
 #if defined(MPICH)
-/* MPICH also provides this routine */
-void MPIR_Datatype_iscontig(MPI_Datatype datatype, int *flag);
 
 void ADIOI_Datatype_iscontig(MPI_Datatype datatype, int *flag)
 {
-    MPIR_Datatype_iscontig(datatype, flag);
+    MPIR_Ext_datatype_iscontig(datatype, flag);
 
     /* if the datatype is reported as contiguous, check if the true_lb is
      * non-zero, and if so, mark the datatype as noncontiguous */

--- a/src/mpi/romio/adio/common/malloc.c
+++ b/src/mpi/romio/adio/common/malloc.c
@@ -13,7 +13,6 @@
    MPID_trmalloc. */
 
 #include "adio.h"
-#include "mpi.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include "mpipr.h"

--- a/src/mpi/romio/adio/common/status_setb.c
+++ b/src/mpi/romio/adio/common/status_setb.c
@@ -4,7 +4,6 @@
  */
 
 #include "adio.h"
-#include "mpi.h"
 
 #if defined(HAVE_MPI_STATUS_SET_ELEMENTS_X)
 /* Not quite correct, but much closer for MPI2 */

--- a/src/mpi/romio/adio/include/adio.h
+++ b/src/mpi/romio/adio/include/adio.h
@@ -62,8 +62,13 @@
 #define ROMIOCONF_H_INCLUDED
 #endif
 
+#ifdef BUILD_MPI_ABI
+#include "romio_abi_internal.h"
+#else
 #include "mpi.h"
 #include "mpio.h"
+#endif
+
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
@@ -259,6 +264,7 @@ typedef struct {
 
 
 /* access modes */
+#ifndef BUILD_MPI_ABI
 #define ADIO_CREATE              1
 #define ADIO_RDONLY              2
 #define ADIO_WRONLY              4
@@ -268,6 +274,19 @@ typedef struct {
 #define ADIO_EXCL                64
 #define ADIO_APPEND             128
 #define ADIO_SEQUENTIAL         256
+#else
+/* FIXME: maybe we should always do this rather than define two sets of macros */
+#define ADIO_CREATE              MPI_MODE_CREATE
+#define ADIO_RDONLY              MPI_MODE_RDONLY
+#define ADIO_WRONLY              MPI_MODE_WRONLY
+#define ADIO_RDWR                MPI_MODE_RDWR
+#define ADIO_DELETE_ON_CLOSE     MPI_MODE_DELETE_ON_CLOSE
+#define ADIO_UNIQUE_OPEN         MPI_MODE_UNIQUE_OPEN
+#define ADIO_EXCL                MPI_MODE_EXCL
+#define ADIO_APPEND              MPI_MODE_APPEND
+#define ADIO_SEQUENTIAL          MPI_MODE_SEQUENTIAL
+#endif
+
 
 #define ADIO_AMODE_NOMATCH  ~(ADIO_CREATE|ADIO_RDONLY|ADIO_WRONLY|ADIO_RDWR|ADIO_DELETE_ON_CLOSE|ADIO_UNIQUE_OPEN|ADIO_EXCL|ADIO_APPEND|ADIO_SEQUENTIAL)
 

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -210,6 +210,11 @@ known_filesystems="m4_join([ ],known_filesystems_m4)"
 
 #
 # Defaults
+AC_ARG_ENABLE(mpi-abi,
+        AS_HELP_STRING([--enable-mpi-abi], [Enable building libmpi_abi.so]),,
+        enable_mpi_abi=no)
+AM_CONDITIONAL([BUILD_ABI_LIB], [test "$enable_mpi_abi" = "yes"])
+
 AC_ARG_ENABLE(aio,[
 --enable-aio - Request use of asynchronous I/O routines (default)],
 [

--- a/src/mpi/romio/mpi-io/mpioimpl.h
+++ b/src/mpi/romio/mpi-io/mpioimpl.h
@@ -11,7 +11,6 @@
 #define MPIOIMPL_H_INCLUDED
 
 #include "adio.h"
-#include "mpio.h"
 
 #ifdef ROMIO_INSIDE_MPICH
 #include "mpir_ext.h"

--- a/src/mpi_t/pvar_impl.c
+++ b/src/mpi_t/pvar_impl.c
@@ -9,7 +9,17 @@
 /* Define storage for the ALL_HANDLES constant */
 MPIR_T_pvar_handle_t MPIR_T_pvar_all_handles_obj;
 
+#ifndef BUILD_MPI_ABI
 MPIR_T_pvar_handle_t *const MPI_T_PVAR_ALL_HANDLES = &MPIR_T_pvar_all_handles_obj;
+#define CHECK_PVAR_ALL_HANDLES(handle) do { } while (0)
+#else
+#define CHECK_PVAR_ALL_HANDLES(handle) \
+    do { \
+        if (handle == MPI_T_PVAR_ALL_HANDLES) { \
+            handle = &MPIR_T_pvar_all_handles_obj; \
+        } \
+    } while (0)
+#endif
 
 void MPIR_T_pvar_env_init(void)
 {
@@ -371,6 +381,8 @@ int MPIR_T_pvar_reset_impl(MPI_T_pvar_session session, MPI_T_pvar_handle handle)
     int mpi_errno = MPI_SUCCESS;
     MPIR_T_pvar_watermark_t *mark;
 
+    CHECK_PVAR_ALL_HANDLES(handle);
+
     if (MPIR_T_pvar_is_sum(handle)) {
         /* Use zero as starting value */
         memset(handle->accum, 0, handle->bytes * handle->count);
@@ -454,6 +466,8 @@ int MPIR_T_pvar_start_impl(MPI_T_pvar_session session, MPI_T_pvar_handle handle)
     int mpi_errno = MPI_SUCCESS;
     MPIR_T_pvar_watermark_t *mark;
 
+    CHECK_PVAR_ALL_HANDLES(handle);
+
     if (MPIR_T_pvar_is_sum(handle)) {
         /* To start SUM, we only need to cache its current value into offset.
          * If it has ever been started, accum holds correct value. Otherwise,
@@ -491,6 +505,8 @@ int MPIR_T_pvar_stop_impl(MPI_T_pvar_session session, MPI_T_pvar_handle handle)
 {
     int i, mpi_errno = MPI_SUCCESS;
     MPIR_T_pvar_watermark_t *mark;
+
+    CHECK_PVAR_ALL_HANDLES(handle);
 
     MPIR_T_pvar_unset_started(handle);
 

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -407,7 +407,7 @@ struct MPIDIG_win_lock {
     struct MPIDIG_win_lock *next;
     int rank;
     uint16_t mtype;             /* MPIDIG_WIN_LOCK or MPIDIG_WIN_LOCKALL */
-    uint16_t type;              /* MPI_LOCK_EXCLUSIVE or MPI_LOCK_SHARED */
+    int16_t type;               /* MPI_LOCK_EXCLUSIVE or MPI_LOCK_SHARED */
 };
 
 typedef struct MPIDIG_win_lock_recvd {

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -608,7 +608,7 @@ int MPID_InitCompleted(void)
     MPIR_FUNC_ENTER;
 
     if (MPIR_Process.has_parent) {
-        MPIR_Assert(MPID_MAX_PORT_NAME > MPI_MAX_PORT_NAME);
+        MPIR_Assert(MPID_MAX_PORT_NAME >= MPI_MAX_PORT_NAME);
         char parent_port[MPID_MAX_PORT_NAME];
         mpi_errno =
             MPIR_pmi_kvs_parent_get(MPIDI_PARENT_PORT_KVSKEY, parent_port, MPID_MAX_PORT_NAME);

--- a/src/mpid/common/shm/mpidu_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_shm_alloc.c
@@ -166,7 +166,7 @@ typedef struct {
 
 /* Compute maxloc for unsigned long long type.
  * If more than one max value exists, the loc with lower rank is returned. */
-static void ull_maxloc_op_func(void *invec, void *inoutvec, int *len, MPI_Datatype * datatype)
+static void ull_maxloc_op(void *invec, void *inoutvec, int *len)
 {
     ull_maxloc_t *inmaxloc = (ull_maxloc_t *) invec;
     ull_maxloc_t *outmaxloc = (ull_maxloc_t *) inoutvec;
@@ -179,6 +179,18 @@ static void ull_maxloc_op_func(void *invec, void *inoutvec, int *len, MPI_Dataty
             outmaxloc->loc = inmaxloc->loc;
     }
 }
+
+#ifndef BUILD_MPI_ABI
+static void ull_maxloc_op_func(void *invec, void *inoutvec, int *len, MPI_Datatype * datatype)
+{
+    ull_maxloc_op(invec, inoutvec, len);
+}
+#else
+static void ull_maxloc_op_func(void *invec, void *inoutvec, int *len, ABI_Datatype * datatype)
+{
+    ull_maxloc_op(invec, inoutvec, len);
+}
+#endif
 
 /* Allreduce MAXLOC for unsigned size type by using user defined operator
  * and derived datatype. We have to customize it because standard MAXLOC

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -270,6 +270,10 @@ AC_ARG_WITH(mpi,
                 [Use the selected MPI; compilation scripts for mpicc,
                 mpifort and mpicxx should be in dir/bin])],,)
 
+AC_ARG_ENABLE(mpi-abi,
+        [AC_HELP_STRING([--enable-mpi-abi],
+                [Compile the C tests using mpicc_abi])],,[enable_mpi_abi=no])
+
 AC_ARG_WITH(pm,
         AC_HELP_STRING([--with-pm=name],
                 [Specify the process manager for MPICH.  "no" or "none" are
@@ -349,8 +353,21 @@ if test "$with_config_args" != "no" ; then
     fi
 fi
 
+# only a subset of tests work with (experimental) MPI-5 ABI
+if test "$enable_mpi_abi" = "yes" ; then
+    enable_strictmpi="yes"
+    enable_f77="no"
+    enable_fc="no"
+    enable_f08="no"
+    enable_cxx="no"
+fi
+
 # Attach program prefix and suffix to executable names
-PAC_GET_EXENAME("mpicc", MPICC_NAME)
+if test "$enable_mpi_abi" = "yes" ; then
+    PAC_GET_EXENAME("mpicc_abi", MPICC_NAME)
+else
+    PAC_GET_EXENAME("mpicc", MPICC_NAME)
+fi
 PAC_GET_EXENAME("mpif77", MPIF77_NAME)
 PAC_GET_EXENAME("mpifort", MPIFORT_NAME)
 PAC_GET_EXENAME("mpicxx", MPICXX_NAME)

--- a/test/mpi/errors/group/gerr.c
+++ b/test/mpi/errors/group/gerr.c
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
 
     /* Create some valid input data except for the group handle */
     ranks[0] = 0;
-    rc = MPI_Group_incl(MPI_COMM_WORLD, 1, ranks, &ng);
+    rc = MPI_Group_incl((MPI_Group) MPI_COMM_WORLD, 1, ranks, &ng);
     if (rc == MPI_SUCCESS) {
         errs++;
         printf("Did not detect invalid handle (comm) in group_incl\n");

--- a/test/mpi/errors/rma/winerr.c
+++ b/test/mpi/errors/rma/winerr.c
@@ -26,7 +26,7 @@ void weh(MPI_Win * win, int *err, ...)
     }
     if (*win != mywin) {
         errs++;
-        printf("Unexpected window (got %x expected %x)\n", (int) *win, (int) mywin);
+        printf("Unexpected window\n");
     }
     calls++;
     return;

--- a/test/mpi/errors/rma/winerr2.c
+++ b/test/mpi/errors/rma/winerr2.c
@@ -31,7 +31,7 @@ void weh1(MPI_Win * win, int *err, ...)
     }
     if (*win != mywin) {
         errs++;
-        printf("Unexpected window (got %x expected %x)\n", (int) *win, (int) mywin);
+        printf("Unexpected window\n");
     }
     calls++;
     return;
@@ -49,7 +49,7 @@ void weh2(MPI_Win * win, int *err, ...)
     }
     if (*win != mywin) {
         errs++;
-        printf("Unexpected window (got %x expected %x)\n", (int) *win, (int) mywin);
+        printf("Unexpected window\n");
     }
     calls++;
     return;

--- a/test/mpi/rma/overlap_wins_rma.c
+++ b/test/mpi/rma/overlap_wins_rma.c
@@ -169,12 +169,14 @@ static int run_test(void)
     /* 1. Specify working window and displacement.
      *  - Target:  no RMA issued, always check results on wins[0].
      *  - Origins: issue RMA on different window and different memory location */
+    int win_idx;
     if (rank == target) {
-        win = wins[0];
+        win_idx = 0;
     } else {
-        win = wins[rank];
+        win_idx = rank;
         target_disp = rank;
     }
+    win = wins[win_idx];
     dst = target;
 
     /* 2. Every one resets local data */
@@ -188,8 +190,8 @@ static int run_test(void)
 
         /* 3. Origins issue RMA to target over its working window */
         MPI_Win_lock(MPI_LOCK_SHARED, dst, 0, win);
-        verbose_print("[%d] RMA start, test %s (dst=%d, target_disp=%d, win 0x%x) - flush\n",
-                      rank, rma_name, dst, target_disp, win);
+        verbose_print("[%d] RMA start, test %s (dst=%d, target_disp=%d, wins[%d]) - flush\n",
+                      rank, rma_name, dst, target_disp, win_idx);
 
         for (x = 0; x < ITER; x++) {
             /* update local buffers and expected value in every iteration */

--- a/test/mpi/threads/part/parrived_wait.c
+++ b/test/mpi/threads/part/parrived_wait.c
@@ -182,9 +182,9 @@ int main(int argc, char *argv[])
     scount = tot_count / spart;
     rcount = tot_count / rpart;
     if (spart * scount != rpart * rcount) {
-        fprintf(stderr, "Invalid partitions (%d, %d) or tot_count (%ld):\n"
+        fprintf(stderr, "Invalid partitions (%d, %d) or tot_count (%lld):\n"
                 "(tot_count / spart * spart) and (tot_count / rpart * rpart) "
-                "must be identical\n", spart, rpart, tot_count);
+                "must be identical\n", spart, rpart, (long long) tot_count);
         fflush(stderr);
         MPI_Abort(MPI_COMM_WORLD, 1);
     }

--- a/test/mpi/threads/perf/mt_rma_msgrate.c
+++ b/test/mpi/threads/perf/mt_rma_msgrate.c
@@ -62,7 +62,7 @@ enum SYNC_MODE {
 int rma_op = OP_INVALID;
 int sync_mode = SYNC_INVALID;
 int world_rank;
-MPI_Comm *thread_wins;
+MPI_Win *thread_wins;
 double *t_elapsed;
 int num_threads;
 

--- a/test/mpi/threads/pt2pt/mt_probe_impl.c
+++ b/test/mpi/threads/pt2pt/mt_probe_impl.c
@@ -108,7 +108,7 @@ int probetest_invoke_probe(int sender_rank, int tag, MPI_Comm comm, int *recv_co
             break;
         case Improbe:
             while (!flag) {
-                RECORD_ERROR(*message != MPI_REQUEST_NULL);
+                RECORD_ERROR(*message != MPI_MESSAGE_NULL);
                 MPI_Improbe(sender_rank, tag, comm, &flag, message, status);
             }
             break;


### PR DESCRIPTION
## Pull Request Description
Reference the current MPI ABI working group: https://github.com/mpiwg-abi

This pr enable mpich to build libmpi_abi.so, which conforms to the new (in-progress) MPI ABI standard

Use `--enable-mpi-abi` to enable it.

## To test
```
$ ./autogen.sh
$ ./configure --prefix=[path] --eanble-mpi-abi
$ make install
$ [set path]
$ mpicc_abi -o cpi examples/cpi.c

$ mpirun -n 2 ./cpi

$ ldd ./cpi

$ nm [path/to/]libmpi_abi.so | less
```
## Points
### For users
* `mpicc` builds mpich abi, `mpicc_abi` builds mpi5 abi
* `libmpi.so` uses mpich abi, `libmpi_abi.so` uses mpi5 abi
* `mpi.h` will effectively become `mpi_abi.h` when `mpicc_abi` is used. User code always `#include <mpi.h>`
### implementations
* `src/binding/abi/mpi_abi_util.c` provides the shim for ABI link-time constants
* `src/binding/abi/mpi_abi_util.h` provides conversion routines
* `src/binding/abi/c_binding_abi.c` provides all the `MPI_` and `PMPI_` functions
* generate `mpi_abi_internal.h` from `mpi_abi.h` for internal use (`mpi_abi_util.c` and `c_binding_abi.c`)

### Notes
* Let's push for `MPI_Aint/Offset/Count/Fint` to be compatible ABI
* MPICH will need to support both MPICH ABI and MPI-5 ABI for the foreseeable future
* Open MPI likely can use MPI-5 ABI directly for its future versions
* MPI handler constant objects need to use pointers in ABI; MPICH can dereference its handle

* Scalar constants
    * option 1: translate in and translate out -- shim overhead
    * option 2: re-compile all objects with ABI constants -- build everything twice  -- current choice                      

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
