### PR TITLE
ch4: always use vci 0 during init

### DIFF
--- a/src/mpid/ch4/src/ch4_vci.h
+++ b/src/mpid/ch4/src/ch4_vci.h
@@ -129,11 +129,9 @@ static bool is_vci_restricted_to_zero(MPIR_Comm * comm)
     if (!(comm->comm_kind == MPIR_COMM_KIND__INTRACOMM && !comm->tainted)) {
         vci_restricted |= true;
     }
-#ifdef  MPIDI_OFI_VNI_USE_DOMAIN
     if (!MPIDI_global.is_initialized) {
         vci_restricted |= true;
     }
-#endif /* ifdef  MPIDI_OFI_VNI_USE_DOMAIN */
 
     return vci_restricted;
 }


### PR DESCRIPTION
## Pull Request Description

In implicit mode, we need prevent using non-zero vci during init for ucx. Remove the ifdef guard since there is not much benefit for allowing non-zero vci usage during init for OFI SEP case either. It is much safer and simpler to always use vci 0 during init.

Fixes #6388 

[skip warning]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
