### PR TITLE
doc: fix man page rendering for stream functions

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -81,10 +81,8 @@ def dump_mpi_c(func, is_large=False):
         dump_function_internal(func, kind="normal")
     G.out.append("")
 
-    # NOTE: dump_manpage is now called inside dump_qmpi_wrappers
-
     # Create the MPI and QMPI wrapper functions that will call the above, "real" version of the
-    # function in the MPII prefix
+    # function in the internal prefix
     dump_qmpi_wrappers(func, func['_is_large'])
 
 def get_func_file_path(func, root_dir):
@@ -868,6 +866,9 @@ def dump_manpage(func, out):
         if l > 0:
             out.append('  ' + ' '.join(words[i0:]))
     # ----
+    if not func['desc']:
+        # place holder to make the man page render
+        func['desc'] = "[short description]"
     out.append("/*D")
     out.append("   %s - %s" % (get_function_name(func, False), func['desc']))
     out.append("")

--- a/src/binding/c/stream_api.txt
+++ b/src/binding/c/stream_api.txt
@@ -1,39 +1,48 @@
 # vim: set ft=c:
 
 MPIX_Stream_create:
+    .desc: Create a new stream object
     info: INFO, [info argument]
     stream: STREAM, direction=out, [stream object created]
 
 MPIX_Stream_free:
+    .desc: Free a stream object
     stream: STREAM, direction=inout, [stream object]
 
 MPIX_Stream_comm_create:
+    .desc: Create a new communicator with local stream attached
     comm: COMMUNICATOR, [communicator]
     stream: STREAM, [stream object]
     newcomm: COMMUNICATOR, direction=out, [new stream-associated communicator]
 
 MPIX_Stream_comm_create_multiplex:
+    .desc: Create a new communicator with multiple local streams attached
     comm: COMMUNICATOR, [communicator]
     count: ARRAY_LENGTH_NNI, [list length]
     array_of_streams: STREAM, length=count, [stream object array]
     newcomm: COMMUNICATOR, direction=out, [new stream-associated communicator]
 
 MPIX_Comm_get_stream:
+    .desc: Get the stream object that is attached to the communicator
     comm: COMMUNICATOR, [communicator]
     idx: INDEX
     stream: STREAM, direction=out, [stream object]
 
 MPIX_Stream_progress:
     stream: STREAM, [stream object]
+    .desc: Invoke progress on the given stream
     .impl: mpid
 
 MPIX_Start_progress_thread:
+    .desc: Start a progress thread that will poll progress on the given stream
     stream: STREAM, [stream object]
 
 MPIX_Stop_progress_thread:
+    .desc: Stop the progress thread that polls progress on the given stream
     stream: STREAM, [stream object]
 
 MPIX_Stream_send:
+    .desc: Send message from a specific local stream to a specific destination stream
     buf: BUFFER, constant=True, [initial address of send buffer]
     count: POLYXFER_NUM_ELEM_NNI, [number of elements in send buffer]
     datatype: DATATYPE, [datatype of each send buffer element]
@@ -67,6 +76,7 @@ MPIX_Stream_send:
 }
 
 MPIX_Stream_isend:
+    .desc: Start a nonblocking send from a specific local stream to a specific remote stream
     buf: BUFFER, asynchronous=True, constant=True, [initial address of send buffer]
     count: POLYXFER_NUM_ELEM_NNI, [number of elements in send buffer]
     datatype: DATATYPE, [datatype of each send buffer element]
@@ -98,6 +108,7 @@ MPIX_Stream_isend:
 }
 
 MPIX_Stream_recv:
+    .desc: Receive a message from a specific source stream to a specific local stream
     buf: BUFFER, direction=out, [initial address of receive buffer]
     count: POLYXFER_NUM_ELEM_NNI, [number of elements in receive buffer]
     datatype: DATATYPE, [datatype of each receive buffer element]
@@ -134,6 +145,7 @@ MPIX_Stream_recv:
 }
 
 MPIX_Stream_irecv:
+    .desc: Start a nonblocking receive from a specific source stream to a specific local stream
     buf: BUFFER, direction=out, asynchronous=True, suppress=f08_intent, [initial address of receive buffer]
     count: POLYXFER_NUM_ELEM_NNI, [number of elements in receive buffer]
     datatype: DATATYPE, [datatype of each receive buffer element]
@@ -159,6 +171,7 @@ MPIX_Stream_irecv:
 }
 
 MPIX_Send_enqueue:
+    .desc: Enqueue a send operation to a GPU stream that is associated with the local stream
     buf: BUFFER, constant=True, [initial address of send buffer]
     count: POLYXFER_NUM_ELEM_NNI, [number of elements in send buffer]
     datatype: DATATYPE, [datatype of each send buffer element]
@@ -169,6 +182,7 @@ MPIX_Send_enqueue:
     .decl: MPIR_Send_enqueue_impl
 
 MPIX_Recv_enqueue:
+    .desc: Enqueue a receive operation to a GPU stream that is associated with the local stream
     buf: BUFFER, direction=out, [initial address of receive buffer]
     count: POLYXFER_NUM_ELEM_NNI, [number of elements in receive buffer]
     datatype: DATATYPE, [datatype of each receive buffer element]
@@ -180,6 +194,7 @@ MPIX_Recv_enqueue:
     .decl: MPIR_Recv_enqueue_impl
 
 MPIX_Isend_enqueue:
+    .desc: Enqueue a nonblocking send operation to a GPU stream that is associated with the local stream
     buf: BUFFER, constant=True, [initial address of send buffer]
     count: POLYXFER_NUM_ELEM_NNI, [number of elements in send buffer]
     datatype: DATATYPE, [datatype of each send buffer element]
@@ -191,6 +206,7 @@ MPIX_Isend_enqueue:
     .decl: MPIR_Isend_enqueue_impl
 
 MPIX_Irecv_enqueue:
+    .desc: Enqueue a nonblocking receive operation to a GPU stream that is associated with the local stream
     buf: BUFFER, direction=out, [initial address of receive buffer]
     count: POLYXFER_NUM_ELEM_NNI, [number of elements in receive buffer]
     datatype: DATATYPE, [datatype of each receive buffer element]
@@ -202,12 +218,14 @@ MPIX_Irecv_enqueue:
     .decl: MPIR_Irecv_enqueue_impl
 
 MPIX_Wait_enqueue:
+    .desc: Enqueue a wait operation to a GPU stream that is associated with the local stream
     request: REQUEST, direction=inout, [request]
     status: STATUS, direction=out
     .impl: mpid
     .decl: MPIR_Wait_enqueue_impl
 
 MPIX_Waitall_enqueue:
+    .desc: Enqueue a waitall operation to a GPU stream that is associated with the local stream
     count: ARRAY_LENGTH_NNI, [lists length]
     array_of_requests: REQUEST, direction=inout, length=count, [array of requests]
     array_of_statuses: STATUS, direction=out, length=*, pointer=False, [array of status objects]
@@ -220,6 +238,7 @@ MPIX_Waitall_enqueue:
 }
 
 MPIX_Allreduce_enqueue:
+    .desc: Enqueue an allreduce operation to a GPU stream that is associated with the local stream
     sendbuf: BUFFER, constant=True, [starting address of send buffer]
     recvbuf: BUFFER, direction=out, [starting address of receive buffer]
     count: POLYXFER_NUM_ELEM_NNI, [number of elements in send buffer]

--- a/test/mpi/impls/mpich/comm/stream_comm_dup.c
+++ b/test/mpi/impls/mpich/comm/stream_comm_dup.c
@@ -73,7 +73,7 @@ static int test_stream_comm_dup_single(MPIX_Stream stream)
 
     MPIX_Comm_get_stream(dup_comm, 0, &stream_check);
     if (stream_check != stream) {
-        printf("MPIX_Comm_get_stream did not return expected stread\n");
+        printf("MPIX_Comm_get_stream did not return expected stream\n");
         errs++;
     }
 
@@ -108,7 +108,7 @@ static int test_stream_comm_idup_multiplex(MPIX_Stream stream)
     for (int i = 0; i < 2; i++) {
         MPIX_Comm_get_stream(dup_comm, i, &stream_check);
         if (stream_check != local_streams[i]) {
-            printf("MPIX_Comm_get_stream (idx=%d) did not return expected stread\n", i);
+            printf("MPIX_Comm_get_stream (idx=%d) did not return expected stream\n", i);
             errs++;
         }
     }


### PR DESCRIPTION
## Pull Request Description
Add short descriptions to the new MPIX Stream APIs. The man page cannot be properly rendered if the `.desc` is empty.

Fixes #6391 
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
