### PR TITLE
mpit: Add MPI_T_ERR_NOT_ACCESSIBLE

### DIFF
--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -920,10 +920,11 @@ typedef int (MPIX_Grequest_wait_function)(int, void **, double, MPI_Status *);
 #define MPI_ERR_VALUE_TOO_LARGE    77  /* Value is too large to store */
 
 #define MPI_T_ERR_NOT_SUPPORTED    78  /* Requested functionality not supported */
+#define MPI_T_ERR_NOT_ACCESSIBLE   79  /* Requested functionality not accessible */
 
 #define MPI_ERR_LASTCODE    0x3fffffff  /* Last valid error code for a 
 					   predefined error class */
-#define MPICH_ERR_LAST_CLASS 78     /* It is also helpful to know the
+#define MPICH_ERR_LAST_CLASS 79     /* It is also helpful to know the
 				       last valid class */
 
 #define MPICH_ERR_FIRST_MPIX 100 /* Define a gap here because sock is


### PR DESCRIPTION
## Pull Request Description

This was missed when implementing MPI-4.0. This is a backwards compatible ABI change. Fixes pmodels/mpich#6392.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
