### PR TITLE
session: free errhandler on finalize

### DIFF
--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -365,6 +365,10 @@ int MPII_Finalize(MPIR_Session * session_ptr)
         MPID_Thread_mutex_destroy(&session_ptr->mutex, &thr_err);
         MPIR_Assert(thr_err == 0);
 
+        if (session_ptr->errhandler != NULL) {
+            MPIR_Errhandler_free_impl(session_ptr->errhandler);
+        }
+
         MPIR_Handle_obj_free(&MPIR_Session_mem, session_ptr);
     }
 


### PR DESCRIPTION
## Pull Request Description
We neglected to free attached errhandler at session finalize, causing a handle leak.


Fixes #6397 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
