### PR TITLE
binding/f77: do not adjust by 1 for MPI_UNDEFINED

### DIFF
--- a/maint/local_python/binding_f77.py
+++ b/maint/local_python/binding_f77.py
@@ -438,7 +438,11 @@ def dump_f77_c_func(func):
         c_arg_list_B.append("&%s_i" % v)
         code_list_common.append("int %s_i;" % v)
         end_list_common.append("if (*ierr == MPI_SUCCESS) {")
-        end_list_common.append("    *%s = %s_i + 1;" % (v, v))
+        end_list_common.append("    if (%s_i == MPI_UNDEFINED) {" % v)
+        end_list_common.append("        *%s = %s_i;" % (v, v))
+        end_list_common.append("    } else {")
+        end_list_common.append("        *%s = %s_i + 1;" % (v, v))
+        end_list_common.append("    }")
         end_list_common.append("}")
 
     def dump_string_len_inout(v):


### PR DESCRIPTION

## Pull Request Description
The fortran binding should adjust index by 1 unless it is MPI_UNDEFINED.

Fixes #6402 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
