### PR TITLE
coll: fix ialltoallw inplace

### DIFF
--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_inplace.c
@@ -65,7 +65,7 @@ int MPIR_Ialltoallw_intra_sched_inplace(const void *sendbuf, const MPI_Aint send
                 else
                     dst = i;
 
-                MPIR_Datatype_get_size_macro(recvtypes[i], recvtype_sz);
+                MPIR_Datatype_get_size_macro(recvtypes[dst], recvtype_sz);
                 mpi_errno = MPIR_Sched_send(((char *) recvbuf + rdispls[dst]),
                                             recvcounts[dst], recvtypes[dst], dst, comm_ptr, s);
                 MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace.c
@@ -36,6 +36,10 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
     MPIR_ERR_CHECK(mpi_errno);
 
+    /* FIXME: Here we allocate tmp_buf using extent and send/recv with datatype directly,
+     *        which can be potentially very inefficient. Why don't we use bytes as in
+     *        ialltoallw_intra_sched_inplace.c ?
+     */
     MPI_Aint max_size;
     max_size = 0;
     for (i = 0; i < nranks; ++i) {

--- a/test/mpi/coll/alltoallw2.c
+++ b/test/mpi/coll/alltoallw2.c
@@ -23,125 +23,164 @@
   that use point-to-point operations
  */
 
+static int test_noinplace(MPI_Comm comm);
+static int test_inplace(MPI_Comm comm);
+
 int main(int argc, char **argv)
 {
-
+    int errs = 0;
     MPI_Comm comm;
-    int *sbuf, *rbuf;
-    int rank, size;
-    int *sendcounts, *recvcounts, *rdispls, *sdispls;
-    int i, j, *p, errs;
-    MPI_Datatype *sendtypes, *recvtypes;
 
     MTest_Init(&argc, &argv);
-    errs = 0;
-
     while (MTestGetIntracommGeneral(&comm, 2, 1)) {
         if (comm == MPI_COMM_NULL)
             continue;
 
-        /* Create the buffer */
-        MPI_Comm_size(comm, &size);
-        MPI_Comm_rank(comm, &rank);
-        sbuf = (int *) malloc(size * size * sizeof(int));
-        rbuf = (int *) malloc(size * size * sizeof(int));
-        if (!sbuf || !rbuf) {
-            fprintf(stderr, "Could not allocated buffers!\n");
-            MPI_Abort(comm, 1);
-        }
-
-        /* Load up the buffers */
-        for (i = 0; i < size * size; i++) {
-            sbuf[i] = i + 100 * rank;
-            rbuf[i] = -i;
-        }
-
-        /* Create and load the arguments to alltoallv */
-        sendcounts = (int *) malloc(size * sizeof(int));
-        recvcounts = (int *) malloc(size * sizeof(int));
-        rdispls = (int *) malloc(size * sizeof(int));
-        sdispls = (int *) malloc(size * sizeof(int));
-        sendtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
-        recvtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
-        if (!sendcounts || !recvcounts || !rdispls || !sdispls || !sendtypes || !recvtypes) {
-            fprintf(stderr, "Could not allocate arg items!\n");
-            MPI_Abort(comm, 1);
-        }
-        /* Note that process 0 sends no data (sendcounts[0] = 0) */
-        for (i = 0; i < size; i++) {
-            sendcounts[i] = i;
-            recvcounts[i] = rank;
-            rdispls[i] = i * rank * sizeof(int);
-            sdispls[i] = (((i + 1) * (i)) / 2) * sizeof(int);
-            sendtypes[i] = recvtypes[i] = MPI_INT;
-        }
-        MPI_Alltoallw(sbuf, sendcounts, sdispls, sendtypes,
-                      rbuf, recvcounts, rdispls, recvtypes, comm);
-
-        /* Check rbuf */
-        for (i = 0; i < size; i++) {
-            p = rbuf + rdispls[i] / sizeof(int);
-            for (j = 0; j < rank; j++) {
-                if (p[j] != i * 100 + (rank * (rank + 1)) / 2 + j) {
-                    fprintf(stderr, "[%d] got %d expected %d for %dth\n",
-                            rank, p[j], (i * (i + 1)) / 2 + j, j);
-                    errs++;
-                }
-            }
-        }
-
-        free(sendtypes);
-        free(sdispls);
-        free(sendcounts);
-        free(sbuf);
+        errs += test_noinplace(comm);
 
 #if MTEST_HAVE_MIN_MPI_VERSION(2,2)
-        /* check MPI_IN_PLACE, added in MPI-2.2 */
-        free(rbuf);
-        rbuf = (int *) malloc(size * (2 * size) * sizeof(int));
-        if (!rbuf) {
-            fprintf(stderr, "Could not reallocate rbuf!\n");
-            MPI_Abort(comm, 1);
-        }
-
-        /* Load up the buffers */
-        for (i = 0; i < size; i++) {
-            /* alltoallw displs are in bytes, not in type extents */
-            rdispls[i] = i * (2 * size) * sizeof(int);
-            recvtypes[i] = MPI_INT;
-            recvcounts[i] = i + rank;
-        }
-        memset(rbuf, -1, size * (2 * size) * sizeof(int));
-        for (i = 0; i < size; i++) {
-            p = rbuf + (rdispls[i] / sizeof(int));
-            for (j = 0; j < recvcounts[i]; ++j) {
-                p[j] = 100 * rank + 10 * i + j;
-            }
-        }
-
-        MPI_Alltoallw(MPI_IN_PLACE, NULL, NULL, NULL, rbuf, recvcounts, rdispls, recvtypes, comm);
-
-        /* Check rbuf */
-        for (i = 0; i < size; i++) {
-            p = rbuf + (rdispls[i] / sizeof(int));
-            for (j = 0; j < recvcounts[i]; j++) {
-                int expected = 100 * i + 10 * rank + j;
-                if (p[j] != expected) {
-                    fprintf(stderr, "[%d] got %d expected %d for block=%d, element=%dth\n",
-                            rank, p[j], expected, i, j);
-                    ++errs;
-                }
-            }
-        }
+        errs += test_inplace(comm);
 #endif
-
-        free(recvtypes);
-        free(rdispls);
-        free(recvcounts);
-        free(rbuf);
         MTestFreeComm(&comm);
     }
 
     MTest_Finalize(errs);
     return MTestReturnValue(errs);
 }
+
+static int test_noinplace(MPI_Comm comm)
+{
+    int errs = 0;
+    int *sbuf, *rbuf;
+    int *sendcounts, *recvcounts, *rdispls, *sdispls;
+    MPI_Datatype *sendtypes, *recvtypes;
+
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    /* Create the buffer */
+    sbuf = (int *) malloc(size * size * sizeof(int));
+    rbuf = (int *) malloc(size * size * sizeof(int));
+    if (!sbuf || !rbuf) {
+        fprintf(stderr, "Could not allocated buffers!\n");
+        MPI_Abort(comm, 1);
+    }
+
+    /* Load up the buffers */
+    for (int i = 0; i < size * size; i++) {
+        sbuf[i] = i + 100 * rank;
+        rbuf[i] = -i;
+    }
+
+    /* Create and load the arguments to alltoallv */
+    sendcounts = (int *) malloc(size * sizeof(int));
+    recvcounts = (int *) malloc(size * sizeof(int));
+    rdispls = (int *) malloc(size * sizeof(int));
+    sdispls = (int *) malloc(size * sizeof(int));
+    sendtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
+    recvtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
+    if (!sendcounts || !recvcounts || !rdispls || !sdispls || !sendtypes || !recvtypes) {
+        fprintf(stderr, "Could not allocate arg items!\n");
+        MPI_Abort(comm, 1);
+    }
+    /* Note that process 0 sends no data (sendcounts[0] = 0) */
+    for (int i = 0; i < size; i++) {
+        sendcounts[i] = i;
+        recvcounts[i] = rank;
+        rdispls[i] = i * rank * sizeof(int);
+        sdispls[i] = (((i + 1) * (i)) / 2) * sizeof(int);
+        sendtypes[i] = recvtypes[i] = MPI_INT;
+    }
+    MPI_Alltoallw(sbuf, sendcounts, sdispls, sendtypes, rbuf, recvcounts, rdispls, recvtypes, comm);
+
+    /* Check rbuf */
+    for (int i = 0; i < size; i++) {
+        int *p = rbuf + rdispls[i] / sizeof(int);
+        for (int j = 0; j < rank; j++) {
+            if (p[j] != i * 100 + (rank * (rank + 1)) / 2 + j) {
+                fprintf(stderr, "[%d] got %d expected %d for %dth\n",
+                        rank, p[j], (i * (i + 1)) / 2 + j, j);
+                errs++;
+            }
+        }
+    }
+
+    free(sendtypes);
+    free(sdispls);
+    free(sendcounts);
+    free(sbuf);
+    free(recvtypes);
+    free(rdispls);
+    free(recvcounts);
+    free(rbuf);
+
+    return errs;
+}
+
+#if MTEST_HAVE_MIN_MPI_VERSION(2,2)
+static int test_inplace(MPI_Comm comm)
+{
+    int errs = 0;
+    int *rbuf;
+    int *recvcounts, *rdispls;
+    MPI_Datatype *recvtypes;
+
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    /* Create the buffer */
+    rbuf = (int *) malloc(size * (2 * size) * sizeof(int));
+    if (!rbuf) {
+        fprintf(stderr, "Could not reallocate rbuf!\n");
+        MPI_Abort(comm, 1);
+    }
+
+    /* Load up the buffers */
+    memset(rbuf, -1, size * (2 * size) * sizeof(int));
+    for (int i = 0; i < size; i++) {
+        int *p = rbuf + i * (2 * size);
+        for (int j = 0; j < i + rank; ++j) {
+            p[j] = 100 * rank + 10 * i + j;
+        }
+    }
+
+    /* Create and load the arguments to alltoallv */
+    recvcounts = (int *) malloc(size * sizeof(int));
+    rdispls = (int *) malloc(size * sizeof(int));
+    recvtypes = (MPI_Datatype *) malloc(size * sizeof(MPI_Datatype));
+    if (!recvcounts || !rdispls || !recvtypes) {
+        fprintf(stderr, "Could not allocate arg items!\n");
+        MPI_Abort(comm, 1);
+    }
+    for (int i = 0; i < size; i++) {
+        /* alltoallw displs are in bytes, not in type extents */
+        rdispls[i] = i * (2 * size) * sizeof(int);
+        recvtypes[i] = MPI_INT;
+        recvcounts[i] = i + rank;
+    }
+
+    MPI_Alltoallw(MPI_IN_PLACE, NULL, NULL, NULL, rbuf, recvcounts, rdispls, recvtypes, comm);
+
+    /* Check rbuf */
+    for (int i = 0; i < size; i++) {
+        int *p = rbuf + (rdispls[i] / sizeof(int));
+        for (int j = 0; j < recvcounts[i]; j++) {
+            int expected = 100 * i + 10 * rank + j;
+            if (p[j] != expected) {
+                fprintf(stderr, "[%d] got %d expected %d for block=%d, element=%dth\n",
+                        rank, p[j], expected, i, j);
+                ++errs;
+            }
+        }
+    }
+
+    free(recvtypes);
+    free(rdispls);
+    free(recvcounts);
+    free(rbuf);
+
+    return errs;
+}
+#endif


### PR DESCRIPTION
## Pull Request Description
In MPIR_Ialltoallw_intra_sched_inplace, we neglected to use the correct index for getting recvtype_sz.

MPIR_TSP_Ialltoallw_sched_intra_inplace is not affected because it send/recv the original datatypes. That is inefficient if the datatype is large and non-contiguous. Wonder why it didn't do the same as MPIR_Ialltoallw_intra_sched_inplace.

Fixes #6404

[skip warnings]

## TODO
* [x] Enhance testsuite

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
