### PR TITLE
test: cleanup testsuite for testing non-mpich ABI

### DIFF
--- a/test/mpi/attr/keyval_double_free_type.c
+++ b/test/mpi/attr/keyval_double_free_type.c
@@ -10,8 +10,8 @@
 
 /* tests multiple invocations of MPI_Type_free_keyval on the same keyval */
 
-int delete_fn(MPI_Comm comm, int keyval, void *attr, void *extra);
-int delete_fn(MPI_Comm comm, int keyval, void *attr, void *extra)
+int delete_fn(MPI_Datatype datatype, int keyval, void *attr, void *extra);
+int delete_fn(MPI_Datatype datatype, int keyval, void *attr, void *extra)
 {
     MPI_Type_free_keyval(&keyval);
     return MPI_SUCCESS;

--- a/test/mpi/attr/keyval_double_free_win.c
+++ b/test/mpi/attr/keyval_double_free_win.c
@@ -13,8 +13,8 @@
 
 /* tests multiple invocations of MPI_Win_free_keyval on the same keyval */
 
-int delete_fn(MPI_Comm comm, int keyval, void *attr, void *extra);
-int delete_fn(MPI_Comm comm, int keyval, void *attr, void *extra)
+int delete_fn(MPI_Win win, int keyval, void *attr, void *extra);
+int delete_fn(MPI_Win win, int keyval, void *attr, void *extra)
 {
     MPI_Win_free_keyval(&keyval);
     return MPI_SUCCESS;

--- a/test/mpi/coll/nonblocking2.c
+++ b/test/mpi/coll/nonblocking2.c
@@ -58,8 +58,8 @@ int *sendcounts = NULL;
 int *recvcounts = NULL;
 int *sdispls = NULL;
 int *rdispls = NULL;
-int *sendtypes = NULL;
-int *recvtypes = NULL;
+MPI_Datatype *sendtypes = NULL;
+MPI_Datatype *recvtypes = NULL;
 signed char *buf_alias = NULL;
 MPI_Request req;
 

--- a/test/mpi/coll/nonblocking3.c
+++ b/test/mpi/coll/nonblocking3.c
@@ -95,8 +95,8 @@ struct laundry {
     int *recvcounts;
     int *sdispls;
     int *rdispls;
-    int *sendtypes;
-    int *recvtypes;
+    MPI_Datatype *sendtypes;
+    MPI_Datatype *recvtypes;
 };
 
 static void cleanup_laundry(struct laundry *l)
@@ -136,8 +136,8 @@ static void start_random_nonblocking(MPI_Comm comm, unsigned int rndnum, MPI_Req
     int *recvcounts = NULL;
     int *sdispls = NULL;
     int *rdispls = NULL;
-    int *sendtypes = NULL;
-    int *recvtypes = NULL;
+    MPI_Datatype *sendtypes = NULL;
+    MPI_Datatype *recvtypes = NULL;
     signed char *buf_alias = NULL;
 
     MPI_Comm_rank(comm, &rank);

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -471,6 +471,8 @@ if test "$MPI_IS_MPICH" = "yes" ; then
     fi
 fi
 
+AM_CONDITIONAL([NOT_STRICTMPI], [test x$enable_strictmpi = xno])
+
 # First, determine whether we are/can support the language bindings
 #
 # Since F90/F90FLAGS are replaced by FC/FCFLAGS, rather than silently

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -472,6 +472,9 @@ if test "$MPI_IS_MPICH" = "yes" ; then
 fi
 
 AM_CONDITIONAL([NOT_STRICTMPI], [test x$enable_strictmpi = xno])
+if test "$enable_strictmpi" = "yes" ; then
+    AC_DEFINE([ENABLE_STRICTMPI], [1], [Define if configured with --enable-strictmpi])
+fi
 
 # First, determine whether we are/can support the language bindings
 #

--- a/test/mpi/datatype/Makefile.am
+++ b/test/mpi/datatype/Makefile.am
@@ -31,14 +31,12 @@ noinst_PROGRAMS =             \
     hindexed_block_contents   \
     hvecblklen                \
     indexed_misc              \
-    indexed_misc_oldapi       \
     large_count               \
     large_type                \
     large_type_sendrec        \
     large_vec                 \
     type_large	              \
     lbub                      \
-    lbub_oldapi               \
     localpack                 \
     longdouble                \
     lots_of_types             \
@@ -53,14 +51,12 @@ noinst_PROGRAMS =             \
     simple_pack_external2     \
     simple_resized            \
     simple_size_extent        \
-    simple_size_extent_oldapi \
     sizedtypes                \
     slice_pack                \
     slice_pack_external       \
     struct_derived_zeros      \
     struct_empty_el           \
     struct_ezhov              \
-    struct_no_real_types      \
     struct_pack               \
     structpack2               \
     struct_pack_mpi_bottom    \
@@ -72,7 +68,6 @@ noinst_PROGRAMS =             \
     tfree                     \
     tmatchsize                \
     transpose_pack            \
-    transpose_pack_oldapi     \
     tresized                  \
     tresized2                 \
     triangular_pack           \
@@ -80,12 +75,21 @@ noinst_PROGRAMS =             \
     typefree                  \
     typelb                    \
     typename                  \
-    typename_oldapi           \
     unpack                    \
     unusual_noncontigs        \
     vecblklen                 \
     zeroblks                  \
     zeroparms
+
+if NOT_STRICTMPI
+noinst_PROGRAMS += \
+    indexed_misc_oldapi       \
+    lbub_oldapi               \
+    simple_size_extent_oldapi \
+    struct_no_real_types      \
+    transpose_pack_oldapi     \
+    typename_oldapi
+endif
 
 # Some of the tests use a more comprehensive set of datatype tests.
 # These must specify a different LDADD that includes the object file

--- a/test/mpi/datatype/typename.c
+++ b/test/mpi/datatype/typename.c
@@ -156,8 +156,14 @@ int main(int argc, char **argv)
     isSynonymName = 0;
     for (i = 0; mpi_names[i].name != 0; i++) {
         /* Are we in the optional types? */
-        if (strcmp(mpi_names[i].name, "MPI_REAL4") == 0)
+        if (strcmp(mpi_names[i].name, "MPI_REAL4") == 0) {
             inOptional = 1;
+#ifdef ENABLE_STRICTMPI
+            /* strictly we can't use MPI_DATATYPE_NULL to test datatype availability,
+             * just skip the optional datatypes */
+            break;
+#endif
+        }
         /* If this optional type is not supported, skip it */
         if (inOptional && mpi_names[i].dtype == MPI_DATATYPE_NULL)
             continue;

--- a/test/mpi/errhan/Makefile.am
+++ b/test/mpi/errhan/Makefile.am
@@ -15,11 +15,15 @@ EXTRA_DIST = testlist
 noinst_PROGRAMS =   \
     adderr          \
     commcall        \
-    commcall_oldapi \
     errfatal        \
     predef_eh       \
     errstring2      \
     dynamic_errcode_predefined_errclass
+
+if NOT_STRICTMPI
+noinst_PROGRAMS += \
+    commcall_oldapi
+endif
 
 EXTRA_PROGRAMS = errcode errring errstring
 

--- a/test/mpi/errors/datatype/Makefile.am
+++ b/test/mpi/errors/datatype/Makefile.am
@@ -12,12 +12,16 @@ EXTRA_DIST = testlist
 ## correctly
 noinst_PROGRAMS = getcnterr \
                   type_contiguous_nullarg \
-                  type_extent_nullarg \
                   type_get_extent_nullarg \
                   type_get_true_extent_nullarg \
                   type_get_true_extent_x_nullarg \
-                  type_lb_nullarg \
-                  type_ub_nullarg \
                   type_size_x_nullarg \
                   type_vector_nullarg
+
+if NOT_STRICTMPI
+noinst_PROGRAMS += \
+                  type_extent_nullarg \
+                  type_lb_nullarg \
+                  type_ub_nullarg
+endif
 

--- a/test/mpi/mpi_t/Makefile.am
+++ b/test/mpi/mpi_t/Makefile.am
@@ -15,5 +15,9 @@ noinst_PROGRAMS =     \
     mpit_isendirecv \
     mpit_vars   \
     cvarwrite   \
-    getindex    \
+    getindex
+
+if NOT_STRICTMPI
+noinst_PROGRAMS += \
     qmpi_test
+endif

--- a/test/mpi/mpi_t/testlist
+++ b/test/mpi/mpi_t/testlist
@@ -6,4 +6,4 @@ mpit_isendirecv 2 arg=1 arg=1
 mpit_vars 1
 cvarwrite 1
 getindex 1
-qmpi_test 2 env=MPIR_CVAR_QMPI_TOOL_LIST=test_tool:test_tool
+qmpi_test 2 env=MPIR_CVAR_QMPI_TOOL_LIST=test_tool:test_tool strict=FALSE

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -1,5 +1,5 @@
-sendself 1 test/mpi/pt2pt/sendself arg=-type=MPI_C_DOUBLE_COMPLEX arg=-sendcnt=8192 arg=-recvcnt=8192 arg=-seed=47 arg=-testsize=100
-sendself 2 test/mpi/pt2pt/sendself arg=-type=MPI_C_DOUBLE_COMPLEX arg=-sendcnt=8192 arg=-recvcnt=8192 arg=-seed=47 arg=-testsize=100
+sendself 1 arg=-type=MPI_C_DOUBLE_COMPLEX arg=-sendcnt=8192 arg=-recvcnt=8192 arg=-seed=47 arg=-testsize=100
+sendself 2 arg=-type=MPI_C_DOUBLE_COMPLEX arg=-sendcnt=8192 arg=-recvcnt=8192 arg=-seed=47 arg=-testsize=100
 sendrecv2 2
 sendrecv2 2 env=MPIR_CVAR_ASYNC_PROGRESS=1 env=MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY=1,2 env=MPIR_CVAR_ODD_EVEN_CLIQUES=0 env=MPIR_CVAR_NUM_CLIQUES=1
 sendrecv2 2 env=MPIR_CVAR_ASYNC_PROGRESS=1 env=MPIR_CVAR_CH4_PROGRESS_THREAD_AFFINITY=auto env=MPIR_CVAR_ODD_EVEN_CLIQUES=0 env=MPIR_CVAR_NUM_CLIQUES=1
@@ -40,11 +40,11 @@ probenull 1
 probenull 1 env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=16384
 probenull 1 env=MPIR_CVAR_CH4_OFI_AM_LONG_FORCE_PIPELINE=true
 # For testing, scancel will run with 1 process as well
-scancel 2 xfail=ticket2266 xfail=ticket2270
-scancel2 2 xfail=ticket2266 xfail=ticket2270
-pscancel 2 xfail=ticket2266 xfail=ticket2270
+scancel 2 xfail=ticket2266
+scancel2 2 xfail=ticket2266
+pscancel 2 xfail=ticket2266
 rcancel 2
-cancelrecv 2 xfail=ticket2266 xfail=ticket2270
+cancelrecv 2 xfail=ticket2266
 scancel_unmatch 2 xfail=ticket2276
 cancelanysrc 2
 isendselfprobe 1

--- a/test/mpi/runtests
+++ b/test/mpi/runtests
@@ -479,13 +479,6 @@ sub LoadTests {
                 next;
             }
 
-            if ($g_opt{strict}) {
-                # Strict MPI testing was requested, so assume that a non-MPICH MPI
-                # implementation is being tested and the "xfail" implementation
-                # assumptions do not hold.
-                delete($test_opt->{xfail});
-            }
-
             if ($test_opt->{xfail} && !$g_opt{runxfail}) {
                 # Skip xfail tests if they are not configured. Strict MPI tests that are
                 # marked xfail will still run with --enable-strictmpi.


### PR DESCRIPTION
## Pull Request Description
Misc cleanups to prepare testsuite to be used to test a non-mpich abi. 

We assume --enable-strictmpi is turned on when testing non-mpich.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
