### PR TITLE
ch4/shm: Tweaks to GPU communication settings

### DIFF
--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -16,6 +16,18 @@ cvars:
       description : >-
         By default, we will cache ipc handle. To manually disable ipc
         handle cache, user can set this variable to 0.
+
+    - name        : MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD
+      category    : CH4
+      type        : int
+      default     : 1048576
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        If a send message size is greater than or equal to MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD (in
+        bytes), then enable GPU-based single copy protocol for intranode communication. The
+        environment variable is valid only when then GPU IPC shmmod is enabled.
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
@@ -5,25 +5,6 @@
 #ifndef GPU_POST_H_INCLUDED
 #define GPU_POST_H_INCLUDED
 
-/*
-=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
-
-cvars:
-    - name        : MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD
-      category    : CH4
-      type        : int
-      default     : 32768
-      class       : none
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_ALL_EQ
-      description : >-
-        If a send message size is greater than or equal to MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD (in
-        bytes), then enable GPU-based single copy protocol for intranode communication. The
-        environment variable is valid only when then GPU IPC shmmod is enabled.
-
-=== END_MPI_T_CVAR_INFO_BLOCK ===
-*/
-
 #include "gpu_pre.h"
 
 int MPIDI_GPU_get_ipc_attr(const void *vaddr, int rank, MPIR_Comm * comm,

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -13,6 +13,42 @@
 #include "../gpu/gpu_post.h"
 #include "ipc_p2p.h"
 
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+cvars:
+    - name        : MPIR_CVAR_CH4_IPC_MAP_REPEAT_ADDR
+      category    : CH4
+      type        : boolean
+      default     : true
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        If an address is used more than once in the last ten send operations,
+        map it for IPC use even if it is below the IPC threshold.
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
+MPL_STATIC_INLINE_PREFIX bool MPIDI_IPCI_is_repeat_addr(void *addr)
+{
+    if (!MPIR_CVAR_CH4_IPC_MAP_REPEAT_ADDR) {
+        return false;
+    }
+
+    static void *repeat_addr[10] = { 0 };
+    static int addr_idx = 0;
+
+    for (int i = 0; i < 10; i++) {
+        if (addr == repeat_addr[i]) {
+            return true;
+        }
+    }
+
+    repeat_addr[addr_idx] = addr;
+    addr_idx = (addr_idx + 1) % 10;
+    return false;
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint count,
                                                       MPI_Datatype datatype, int rank, int tag,
                                                       MPIR_Comm * comm, int attr,
@@ -89,7 +125,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
     if (ipc_attr.ipc_type == MPIDI_IPCI_TYPE__NONE) {
         goto fn_exit;
     }
-    if (data_sz < ipc_attr.threshold.send_lmt_sz) {
+    if (data_sz < ipc_attr.threshold.send_lmt_sz && !MPIDI_IPCI_is_repeat_addr(mem_addr)) {
         goto fn_exit;
     }
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -31,10 +31,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
 
     MPIDI_POSIX_THREAD_CS_ENTER_VCI(vsi_src);
 
-    if (rank == comm->rank) {
-        goto fn_exit;
-    }
-
     MPIR_Datatype *dt_ptr;
     bool dt_contig;
     MPI_Aint true_lb;

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -57,7 +57,7 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
      * queuing. */
     MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell,
                                      MPIR_CVAR_GENQ_SHMEM_POOL_FREE_QUEUE_SENDER_SIDE ?
-                                     MPIR_Process.local_rank : grank);
+                                     MPIR_Process.local_rank : grank, buf);
 
     /* If a cell wasn't available, let the caller know that we weren't able to send the message
      * immediately. */

--- a/src/mpid/common/genq/mpidu_genq_shmem_pool.c
+++ b/src/mpid/common/genq/mpidu_genq_shmem_pool.c
@@ -119,6 +119,7 @@ int MPIDU_genq_shmem_pool_create(uintptr_t cell_size, uintptr_t cells_per_proc,
     pool_obj->cells_per_proc = cells_per_proc;
     pool_obj->num_proc = num_proc;
     pool_obj->rank = rank;
+    pool_obj->gpu_registered = false;
 
     /* the global_block_index is at the end of the slab to avoid extra need of alignment */
     int total_cells_size = num_proc * cells_per_proc * pool_obj->cell_alloc_size;
@@ -127,11 +128,6 @@ int MPIDU_genq_shmem_pool_create(uintptr_t cell_size, uintptr_t cells_per_proc,
 
     rc = MPIDU_Init_shm_alloc(slab_size, &pool_obj->slab);
     MPIR_ERR_CHECK(rc);
-
-    if (MPIR_CVAR_GENQ_SHMEM_POOL_GPU_REGISTER) {
-        rc = MPIR_gpu_register_host(pool_obj->slab, slab_size);
-        MPIR_ERR_CHECK(rc);
-    }
 
     pool_obj->cell_header_base = (MPIDU_genqi_shmem_cell_header_s *) pool_obj->slab;
     pool_obj->free_queues =
@@ -171,7 +167,7 @@ int MPIDU_genq_shmem_pool_destroy(MPIDU_genq_shmem_pool_t pool)
 
     MPL_free(pool_obj->cell_headers);
 
-    if (MPIR_CVAR_GENQ_SHMEM_POOL_GPU_REGISTER) {
+    if (pool_obj->gpu_registered) {
         MPIR_gpu_unregister_host(pool_obj->slab);
     }
     MPIDU_Init_shm_free(pool_obj->slab);
@@ -179,6 +175,28 @@ int MPIDU_genq_shmem_pool_destroy(MPIDU_genq_shmem_pool_t pool)
     /* free self */
     MPL_free(pool_obj);
 
+    MPIR_FUNC_EXIT;
+    return rc;
+}
+
+int MPIDU_genqi_shmem_pool_register(MPIDU_genqi_shmem_pool_s * pool_obj)
+{
+    int rc = MPI_SUCCESS;
+
+    MPIR_FUNC_ENTER;
+
+    if (MPIR_CVAR_GENQ_SHMEM_POOL_GPU_REGISTER) {
+        int total_cells_size =
+            pool_obj->num_proc * pool_obj->cells_per_proc * pool_obj->cell_alloc_size;
+        int free_queue_size = pool_obj->num_proc * sizeof(MPIDU_genq_shmem_queue_u);
+        uintptr_t slab_size = total_cells_size + free_queue_size;
+
+        rc = MPIR_gpu_register_host(pool_obj->slab, slab_size);
+        MPIR_ERR_CHECK(rc);
+        pool_obj->gpu_registered = true;
+    }
+
+  fn_fail:
     MPIR_FUNC_EXIT;
     return rc;
 }

--- a/src/mpid/common/genq/mpidu_genq_shmem_pool.c
+++ b/src/mpid/common/genq/mpidu_genq_shmem_pool.c
@@ -156,6 +156,7 @@ int MPIDU_genq_shmem_pool_destroy(MPIDU_genq_shmem_pool_t pool)
 
     MPL_free(pool_obj->cell_headers);
 
+    MPIR_gpu_unregister_host(pool_obj->slab);
     MPIDU_Init_shm_free(pool_obj->slab);
 
     /* free self */

--- a/src/mpid/common/genq/mpidu_genqi_shmem_types.h
+++ b/src/mpid/common/genq/mpidu_genqi_shmem_types.h
@@ -54,6 +54,7 @@ typedef struct MPIDU_genqi_shmem_pool {
     int rank;
 
     void *slab;
+    bool gpu_registered;
     MPIDU_genqi_shmem_cell_header_s *cell_header_base;
     MPIDU_genqi_shmem_cell_header_s **cell_headers;
     union MPIDU_genq_shmem_queue *free_queues;


### PR DESCRIPTION
## Pull Request Description

1. Improve checks and threshold setting for GPU IPC.
2. Do not register genq shmem pools with the GPU by default to avoid consuming GPU memory.

Fixes #6401 

* [x] Verify OSU latency that we should reach optimum latency for all message sizes
* [ ] Verify we do not take ~300MB per process by default when e.g. launching 16 processes on a single GPU

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
