### PR TITLE
mpl/gpu: Upstreaming support for Intel GPUs

### DIFF
--- a/src/include/mpir_gpu.h
+++ b/src/include/mpir_gpu.h
@@ -99,10 +99,7 @@ MPL_STATIC_INLINE_PREFIX int MPIR_GPU_query_pointer_attr(const void *ptr, MPL_po
 MPL_STATIC_INLINE_PREFIX bool MPIR_GPU_query_pointer_is_dev(const void *ptr)
 {
     if (ENABLE_GPU && ptr != NULL) {
-        MPL_pointer_attr_t attr;
-        MPL_gpu_query_pointer_attr(ptr, &attr);
-
-        return attr.type == MPL_GPU_POINTER_DEV;
+        return MPL_gpu_query_pointer_is_dev(ptr, NULL);
     }
 
     return false;

--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -59,7 +59,7 @@ int MPIR_Localcopy_stream(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype 
 int MPIR_Localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                        MPL_pointer_attr_t * sendattr, void *recvbuf, MPI_Aint recvcount,
                        MPI_Datatype recvtype, MPL_pointer_attr_t * recvattr,
-                       MPL_gpu_engine_type_t enginetype, bool commit);
+                       MPL_gpu_copy_direction_t dir, MPL_gpu_engine_type_t enginetype, bool commit);
 
 /* Contiguous datatype calculates buffer address with `(char *) buf + dt_true_lb`.
  * However, dt_true_lb is treated as ptrdiff_t (signed), and when buf is MPI_BOTTOM

--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -56,6 +56,10 @@ int MPIR_Ilocalcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendty
                     MPIR_Typerep_req * typerep_req);
 int MPIR_Localcopy_stream(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                           void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, void *stream);
+int MPIR_Localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                       MPL_pointer_attr_t * sendattr, void *recvbuf, MPI_Aint recvcount,
+                       MPI_Datatype recvtype, MPL_pointer_attr_t * recvattr,
+                       MPL_gpu_engine_type_t enginetype, bool commit);
 
 /* Contiguous datatype calculates buffer address with `(char *) buf + dt_true_lb`.
  * However, dt_true_lb is treated as ptrdiff_t (signed), and when buf is MPI_BOTTOM

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -956,6 +956,9 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **mpl_ze_init_device_fds: mpl_ze_init_device_fds failed
 **mpl_ze_mmap_device_ptr:  MPL_ze_mmap_device_pointer failed
 **mpl_gpu_fast_memcpy:  MPL_gpu_fast_memcpy failed
+**mpl_gpu_get_dev_id_from_attr: MPL_gpu_get_dev_id_from_attr failed
+**mpl_gpu_imemcpy: MPL_gpu_imemcpy failed
+**mpl_gpu_test: MPL_gpu_test failed
 
 ## GAVL tree related error messages
 **mpl_gavl_search: mpl_gavl_search failed

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -954,6 +954,8 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **gpu_get_buffer_info: gpu_get_buffer_info failed
 **gpu_get_dev_count: gpu_get_dev_count failed
 **mpl_ze_init_device_fds: mpl_ze_init_device_fds failed
+**mpl_ze_mmap_device_ptr:  MPL_ze_mmap_device_pointer failed
+**mpl_gpu_fast_memcpy:  MPL_gpu_fast_memcpy failed
 
 ## GAVL tree related error messages
 **mpl_gavl_search: mpl_gavl_search failed

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -222,8 +222,8 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
         int mpl_errno = MPL_gpu_init(debug_summary);
         MPIR_ERR_CHKANDJUMP(mpl_errno != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_init");
 
-        int device_count, max_dev_id;
-        mpi_errno = MPL_gpu_get_dev_count(&device_count, &max_dev_id);
+        int device_count, max_dev_id, max_subdev_id;
+        mpi_errno = MPL_gpu_get_dev_count(&device_count, &max_dev_id, &max_subdev_id);
         MPIR_ERR_CHKANDJUMP(mpl_errno != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_init");
 
         if (device_count <= 0) {

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -45,6 +45,16 @@ cvars:
         in order to allow the process to continue (e.g., in gdb, "set
         hold=0").
 
+    - name        : MPIR_CVAR_GPU_USE_IMMEDIATE_COMMAND_LIST
+      category    : GPU
+      type        : boolean
+      default     : false
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        If true, mpl/ze will use immediate command list for copying
+
     - name        : MPIR_CVAR_NO_COLLECTIVE_FINALIZE
       category    : COLLECTIVE
       type        : boolean
@@ -224,6 +234,7 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
             (MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE == MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE_specialized);
 
         MPL_gpu_info.specialized_cache = specialized_cache;
+        MPL_gpu_info.use_immediate_cmdlist = MPIR_CVAR_GPU_USE_IMMEDIATE_COMMAND_LIST;
 
         int mpl_errno = MPL_gpu_init(debug_summary);
         MPIR_ERR_CHKANDJUMP(mpl_errno != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_init");

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -55,6 +55,17 @@ cvars:
       description : >-
         If true, mpl/ze will use immediate command list for copying
 
+    - name        : MPIR_CVAR_GPU_ROUND_ROBIN_COMMAND_QUEUES
+      category    : GPU
+      type        : boolean
+      default     : false
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        If true, mpl/ze will use command queues in a round-robin fashion.
+        If false, only command queues of index 0 will be used.
+
     - name        : MPIR_CVAR_NO_COLLECTIVE_FINALIZE
       category    : COLLECTIVE
       type        : boolean
@@ -235,6 +246,7 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
 
         MPL_gpu_info.specialized_cache = specialized_cache;
         MPL_gpu_info.use_immediate_cmdlist = MPIR_CVAR_GPU_USE_IMMEDIATE_COMMAND_LIST;
+        MPL_gpu_info.roundrobin_cmdq = MPIR_CVAR_GPU_ROUND_ROBIN_COMMAND_QUEUES;
 
         int mpl_errno = MPL_gpu_init(debug_summary);
         MPIR_ERR_CHKANDJUMP(mpl_errno != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_init");

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -180,6 +180,122 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
     goto fn_exit;
 }
 
+#ifdef MPL_HAVE_GPU
+static int do_localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                            MPL_pointer_attr_t * send_attr, void *recvbuf, MPI_Aint recvcount,
+                            MPI_Datatype recvtype, MPL_pointer_attr_t * recv_attr,
+                            MPL_gpu_engine_type_t enginetype, bool commit,
+                            MPIR_Typerep_req * typerep_req)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int mpl_errno = MPL_SUCCESS;
+    int sendtype_iscontig, recvtype_iscontig;
+    MPI_Aint sendsize, recvsize, sdata_sz, rdata_sz, copy_sz;
+    MPI_Aint true_extent, sendtype_true_lb, recvtype_true_lb;
+    MPL_gpu_request gpu_req;
+    int completed = 0;
+    int dev_id = -1;
+
+    MPIR_FUNC_ENTER;
+
+    if (typerep_req)
+        *typerep_req = MPIR_TYPEREP_REQ_NULL;
+
+    MPIR_Datatype_get_size_macro(sendtype, sendsize);
+    MPIR_Datatype_get_size_macro(recvtype, recvsize);
+
+    sdata_sz = sendsize * sendcount;
+    rdata_sz = recvsize * recvcount;
+
+    /* if there is no data to copy, bail out */
+    if (!sdata_sz || !rdata_sz)
+        goto fn_exit;
+
+#if defined(HAVE_ERROR_CHECKING)
+    if (sdata_sz > rdata_sz) {
+        MPIR_ERR_SET2(mpi_errno, MPI_ERR_TRUNCATE, "**truncate", "**truncate %d %d", sdata_sz,
+                      rdata_sz);
+        copy_sz = rdata_sz;
+    } else
+#endif /* HAVE_ERROR_CHECKING */
+        copy_sz = sdata_sz;
+
+    /* This case is specific for contig datatypes */
+    MPIR_Datatype_iscontig(sendtype, &sendtype_iscontig);
+    MPIR_Datatype_iscontig(recvtype, &recvtype_iscontig);
+
+    MPIR_Type_get_true_extent_impl(sendtype, &sendtype_true_lb, &true_extent);
+    MPIR_Type_get_true_extent_impl(recvtype, &recvtype_true_lb, &true_extent);
+
+    if (sendtype_iscontig && recvtype_iscontig) {
+        if (copy_sz <= MPIR_CVAR_CH4_IPC_GPU_FAST_COPY_MAX_SIZE) {
+            mpl_errno = MPL_gpu_fast_memcpy(MPIR_get_contig_ptr(sendbuf, sendtype_true_lb),
+                                            send_attr, MPIR_get_contig_ptr(recvbuf,
+                                                                           recvtype_true_lb),
+                                            recv_attr, copy_sz);
+            MPIR_ERR_CHKANDJUMP(mpl_errno != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                                "**mpl_gpu_fast_memcpy");
+        } else {
+            if (send_attr == NULL) {
+                MPL_pointer_attr_t sendattr;
+                MPIR_GPU_query_pointer_attr(sendbuf, &sendattr);
+                if (sendattr.type == MPL_GPU_POINTER_DEV) {
+                    dev_id = MPL_gpu_get_dev_id_from_attr(&sendattr);
+                }
+            } else if (send_attr->type == MPL_GPU_POINTER_DEV) {
+                dev_id = MPL_gpu_get_dev_id_from_attr(send_attr);
+            }
+
+            if (dev_id == -1) {
+                if (recv_attr == NULL) {
+                    MPL_pointer_attr_t recvattr;
+                    MPIR_GPU_query_pointer_attr(recvbuf, &recvattr);
+                    if (recvattr.type == MPL_GPU_POINTER_DEV) {
+                        dev_id = MPL_gpu_get_dev_id_from_attr(&recvattr);
+                    } else {
+                        goto fn_fallback;
+                    }
+                } else if (recv_attr->type == MPL_GPU_POINTER_DEV) {
+                    dev_id = MPL_gpu_get_dev_id_from_attr(recv_attr);
+                } else {
+                    /* fallback to do_localcopy */
+                    goto fn_fallback;
+                }
+            }
+            MPIR_ERR_CHKANDJUMP(dev_id == -1, mpi_errno, MPI_ERR_OTHER,
+                                "**mpl_gpu_get_dev_id_from_attr");
+
+            mpl_errno = MPL_gpu_imemcpy(MPIR_get_contig_ptr(recvbuf, recvtype_true_lb),
+                                        MPIR_get_contig_ptr(sendbuf, sendtype_true_lb), copy_sz,
+                                        dev_id, enginetype, &gpu_req, commit);
+            MPIR_ERR_CHKANDJUMP(mpl_errno != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                                "**mpl_gpu_imemcpy");
+
+            while (!completed) {
+                mpl_errno = MPL_gpu_test(&gpu_req, &completed);
+                MPIR_ERR_CHKANDJUMP(mpl_errno != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                                    "**mpl_gpu_test");
+            }
+        }
+    } else {
+        /* fallback to do_localcopy */
+        goto fn_fallback;
+    }
+
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+  fn_fallback:
+    mpi_errno =
+        do_localcopy(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
+                     LOCALCOPY_BLOCKING, NULL);
+    MPIR_ERR_CHECK(mpi_errno);
+    goto fn_exit;
+}
+#endif
+
 int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype)
 {
@@ -232,6 +348,33 @@ int MPIR_Localcopy_stream(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype 
     mpi_errno = do_localcopy(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
                              LOCALCOPY_STREAM, stream);
     MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_Localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                       MPL_pointer_attr_t * sendattr, void *recvbuf, MPI_Aint recvcount,
+                       MPI_Datatype recvtype, MPL_pointer_attr_t * recvattr,
+                       MPL_gpu_engine_type_t enginetype, bool commit)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_FUNC_ENTER;
+
+#ifdef MPL_HAVE_GPU
+    mpi_errno = do_localcopy_gpu(sendbuf, sendcount, sendtype, sendattr, recvbuf, recvcount,
+                                 recvtype, recvattr, enginetype, commit, NULL);
+    MPIR_ERR_CHECK(mpi_errno);
+#else
+    mpi_errno =
+        do_localcopy(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, LOCALCOPY_BLOCKING,
+                     NULL);
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
 
   fn_exit:
     MPIR_FUNC_EXIT;

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -184,8 +184,8 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
 static int do_localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                             MPL_pointer_attr_t * send_attr, void *recvbuf, MPI_Aint recvcount,
                             MPI_Datatype recvtype, MPL_pointer_attr_t * recv_attr,
-                            MPL_gpu_engine_type_t enginetype, bool commit,
-                            MPIR_Typerep_req * typerep_req)
+                            MPL_gpu_copy_direction_t dir, MPL_gpu_engine_type_t enginetype,
+                            bool commit, MPIR_Typerep_req * typerep_req)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpl_errno = MPL_SUCCESS;
@@ -267,7 +267,7 @@ static int do_localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
 
             mpl_errno = MPL_gpu_imemcpy(MPIR_get_contig_ptr(recvbuf, recvtype_true_lb),
                                         MPIR_get_contig_ptr(sendbuf, sendtype_true_lb), copy_sz,
-                                        dev_id, enginetype, &gpu_req, commit);
+                                        dev_id, dir, enginetype, &gpu_req, commit);
             MPIR_ERR_CHKANDJUMP(mpl_errno != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                                 "**mpl_gpu_imemcpy");
 
@@ -359,7 +359,7 @@ int MPIR_Localcopy_stream(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype 
 int MPIR_Localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                        MPL_pointer_attr_t * sendattr, void *recvbuf, MPI_Aint recvcount,
                        MPI_Datatype recvtype, MPL_pointer_attr_t * recvattr,
-                       MPL_gpu_engine_type_t enginetype, bool commit)
+                       MPL_gpu_copy_direction_t dir, MPL_gpu_engine_type_t enginetype, bool commit)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -367,7 +367,7 @@ int MPIR_Localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sen
 
 #ifdef MPL_HAVE_GPU
     mpi_errno = do_localcopy_gpu(sendbuf, sendcount, sendtype, sendattr, recvbuf, recvcount,
-                                 recvtype, recvattr, enginetype, commit, NULL);
+                                 recvtype, recvattr, dir, enginetype, commit, NULL);
     MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno =

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -346,6 +346,11 @@ typedef struct MPIDIG_win_shared_info {
     void *shm_base_addr;
     uint32_t disp_unit;
     int ipc_mapped_device;
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    MPIDI_IPCI_type_t ipc_type;
+    MPIDI_GPU_ipc_handle_t ipc_handle;
+#endif
+    int mapped_type;            /* 0: gpu ipc mapped 1: gpu host mmapped 2: xpmem */
 } MPIDIG_win_shared_info_t;
 
 #define MPIDIG_ACCU_ORDER_RAR (1)

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -42,7 +42,7 @@ static void ipc_handle_free_hook(void *dptr)
 
     MPIR_FUNC_ENTER;
 
-    if (MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE) {
+    if (MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE == MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE_generic) {
         mpl_err = MPL_gpu_get_buffer_bounds(dptr, &pbase, &len);
         MPIR_Assert(mpl_err == MPL_SUCCESS);
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -58,7 +58,7 @@ static void ipc_handle_free_hook(void *dptr)
                 MPIR_Assert(mpl_err == MPL_SUCCESS);
             }
 
-            mpl_err = MPL_gpu_ipc_handle_destroy(pbase);
+            mpl_err = MPL_gpu_ipc_handle_destroy(pbase, &gpu_attr);
             MPIR_Assert(mpl_err == MPL_SUCCESS);
         }
     }

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -76,10 +76,13 @@ int MPIDI_GPU_init_world(void)
 {
     int mpl_err, mpi_errno = MPI_SUCCESS;
     int device_count;
+    /* my_max_* represents the max value local to the process. node_max_* represents the max value
+     * between all node-local processes. */
     int my_max_dev_id, node_max_dev_id = -1;
+    int my_max_subdev_id, node_max_subdev_id = -1;
 
     MPIDI_GPUI_global.initialized = 0;
-    mpl_err = MPL_gpu_get_dev_count(&device_count, &my_max_dev_id);
+    mpl_err = MPL_gpu_get_dev_count(&device_count, &my_max_dev_id, &my_max_subdev_id);
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_get_dev_count");
     if (device_count < 0)
         goto fn_exit;
@@ -95,7 +98,27 @@ int MPIDI_GPU_init_world(void)
     }
     MPIDU_Init_shm_barrier();
 
-    MPIDI_GPUI_global.global_max_dev_id = node_max_dev_id;
+    MPIDU_Init_shm_put(&my_max_subdev_id, sizeof(int));
+    MPIDU_Init_shm_barrier();
+
+    /* get node max subdevice count */
+    for (int i = 0; i < MPIR_Process.local_size; ++i) {
+        MPIDU_Init_shm_get(i, sizeof(int), &my_max_subdev_id);
+        if (my_max_subdev_id > node_max_subdev_id)
+            node_max_subdev_id = my_max_subdev_id;
+    }
+    MPIDU_Init_shm_barrier();
+
+    /* Initialize the local and global device mappings */
+    MPL_gpu_init_device_mappings(node_max_dev_id, node_max_subdev_id);
+
+    if (node_max_subdev_id > 0) {
+        /* global_device_count = device_count * (subdevice_count + 1)
+         * global_max_dev_id = global_devices - 1 */
+        MPIDI_GPUI_global.global_max_dev_id = (node_max_dev_id + 1) * (node_max_subdev_id + 2) - 1;
+    } else {
+        MPIDI_GPUI_global.global_max_dev_id = node_max_dev_id;
+    }
 
     MPIDI_GPUI_global.local_procs = MPIR_Process.node_local_map;
     MPIDI_GPUI_global.local_ranks =

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -302,7 +302,7 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int map_dev_id, void
         if (do_mmap) {
 #ifdef MPL_HAVE_ZE
             mpl_err =
-                MPL_ze_ipc_handle_mmap_host(handle.ipc_handle, 1, map_dev_id, handle.len, &pbase);
+                MPL_ze_ipc_handle_mmap_host(&handle.ipc_handle, 1, map_dev_id, handle.len, &pbase);
             MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                                 "**gpu_ipc_handle_map");
             *vaddr = (void *) ((uintptr_t) pbase + handle.offset);
@@ -311,7 +311,7 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int map_dev_id, void
             goto fn_fail;
 #endif
         } else {
-            mpl_err = MPL_gpu_ipc_handle_map(handle.ipc_handle, map_dev_id, &pbase);
+            mpl_err = MPL_gpu_ipc_handle_map(&handle.ipc_handle, map_dev_id, &pbase);
             MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                                 "**gpu_ipc_handle_map");
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -201,7 +201,9 @@ int MPIDI_GPU_get_ipc_attr(const void *vaddr, int rank, MPIR_Comm * comm,
     MPIR_ERR_CHECK(mpi_errno);
 
     if (handle_obj == NULL) {
-        mpl_err = MPL_gpu_ipc_handle_create(pbase, &ipc_attr->ipc_handle.gpu.ipc_handle);
+        mpl_err =
+            MPL_gpu_ipc_handle_create(pbase, &ipc_attr->gpu_attr.device_attr,
+                                      &ipc_attr->ipc_handle.gpu.ipc_handle);
         MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                             "**gpu_ipc_handle_create");
         ipc_attr->ipc_handle.gpu.handle_status = MPIDI_GPU_IPC_HANDLE_REMAP_REQUIRED;

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
@@ -10,11 +10,15 @@
 int MPIDI_GPU_get_ipc_attr(const void *vaddr, int rank, MPIR_Comm * comm,
                            MPIDI_IPCI_ipc_attr_t * ipc_attr);
 int MPIDI_GPU_ipc_get_map_dev(int remote_global_dev_id, int local_dev_id, MPI_Datatype datatype);
-int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int map_dev_id, void **vaddr);
-int MPIDI_GPU_ipc_handle_unmap(void *vaddr, MPIDI_GPU_ipc_handle_t handle);
+int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int map_dev_id, void **vaddr,
+                             bool do_mmap);
+int MPIDI_GPU_ipc_handle_unmap(void *vaddr, MPIDI_GPU_ipc_handle_t handle, int do_mmap);
 int MPIDI_GPU_init_local(void);
 int MPIDI_GPU_init_world(void);
 int MPIDI_GPU_mpi_finalize_hook(void);
 int MPIDI_GPU_ipc_handle_cache_insert(int rank, MPIR_Comm * comm, MPIDI_GPU_ipc_handle_t handle);
+
+int MPIDI_GPU_ipc_fast_memcpy(MPIDI_IPCI_ipc_handle_t ipc_handle, void *dest_vaddr,
+                              MPI_Aint src_data_sz, MPI_Datatype datatype);
 
 #endif /* GPU_POST_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -159,6 +159,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPC_hdr * ipc_hdr,
     int mpi_errno = MPI_SUCCESS;
     void *src_buf = NULL;
     uintptr_t data_sz, recv_data_sz;
+    bool dt_contig;
 
     MPIR_FUNC_ENTER;
 
@@ -184,20 +185,34 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPC_hdr * ipc_hdr,
         MPIR_ERR_CHECK(mpi_errno);
         /* skip unmap */
     } else if (ipc_hdr->ipc_type == MPIDI_IPCI_TYPE__GPU) {
-        MPL_pointer_attr_t attr;
-        MPIR_GPU_query_pointer_attr(MPIDIG_REQUEST(rreq, buffer), &attr);
-        int dev_id = MPL_gpu_get_dev_id_from_attr(&attr);
-        int map_dev = MPIDI_GPU_ipc_get_map_dev(ipc_hdr->ipc_handle.gpu.global_dev_id, dev_id,
-                                                MPIDIG_REQUEST(rreq, datatype));
-        mpi_errno = MPIDI_GPU_ipc_handle_map(ipc_hdr->ipc_handle.gpu, map_dev, &src_buf);
-        MPIR_ERR_CHECK(mpi_errno);
-        /* copy */
-        /* TODO: get sender datatype and call MPIR_Typerep_op with mapped_device set to dev_id */
-        mpi_errno = MPIDI_IPCI_copy_data(ipc_hdr, rreq, src_buf, src_data_sz);
-        MPIR_ERR_CHECK(mpi_errno);
-        /* unmap */
-        mpi_errno = MPIDI_GPU_ipc_handle_unmap(src_buf, ipc_hdr->ipc_handle.gpu);
-        MPIR_ERR_CHECK(mpi_errno);
+        /* try fast memcpy first */
+        int fast_copy = 0;
+        if (src_data_sz <= MPIR_CVAR_CH4_IPC_GPU_FAST_COPY_MAX_SIZE) {
+            MPIDI_Datatype_check_contig(MPIDIG_REQUEST(rreq, datatype), dt_contig);
+            if (ipc_hdr->is_contig && dt_contig) {
+                mpi_errno =
+                    MPIDI_GPU_ipc_fast_memcpy(ipc_hdr->ipc_handle, MPIDIG_REQUEST(rreq, buffer),
+                                              src_data_sz, MPIDIG_REQUEST(rreq, datatype));
+                if (mpi_errno == MPI_SUCCESS)
+                    fast_copy = 1;
+            }
+        }
+        if (!fast_copy) {
+            MPL_pointer_attr_t attr;
+            MPIR_GPU_query_pointer_attr(MPIDIG_REQUEST(rreq, buffer), &attr);
+            int dev_id = MPL_gpu_get_dev_id_from_attr(&attr);
+            int map_dev = MPIDI_GPU_ipc_get_map_dev(ipc_hdr->ipc_handle.gpu.global_dev_id, dev_id,
+                                                    MPIDIG_REQUEST(rreq, datatype));
+            mpi_errno = MPIDI_GPU_ipc_handle_map(ipc_hdr->ipc_handle.gpu, map_dev, &src_buf, false);
+            MPIR_ERR_CHECK(mpi_errno);
+            /* copy */
+            /* TODO: get sender datatype and call MPIR_Typerep_op with mapped_device set to dev_id */
+            mpi_errno = MPIDI_IPCI_copy_data(ipc_hdr, rreq, src_buf, src_data_sz);
+            MPIR_ERR_CHECK(mpi_errno);
+            /* unmap */
+            mpi_errno = MPIDI_GPU_ipc_handle_unmap(src_buf, ipc_hdr->ipc_handle.gpu, 0);
+            MPIR_ERR_CHECK(mpi_errno);
+        }
     } else if (ipc_hdr->ipc_type == MPIDI_IPCI_TYPE__NONE) {
         /* no-op */
     } else {

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -151,6 +151,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_copy_data(MPIDI_IPC_hdr * ipc_hdr, MPIR_
     goto fn_exit;
 }
 
+MPL_STATIC_INLINE_PREFIX MPL_gpu_engine_type_t MPIDI_IPCI_choose_engine(int dev1, int dev2)
+{
+    MPL_gpu_engine_type_t engine = MPL_GPU_ENGINE_TYPE_COPY_LOW_LATENCY;
+    if (dev1 == -1 || dev2 == -1) {
+        return MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH;
+    }
+    assert(dev1 != -1 && dev2 != -1);
+    if (MPL_gpu_query_is_same_dev(dev1, dev2))
+        engine = MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH;
+    return engine;
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPC_hdr * ipc_hdr,
                                                         size_t src_data_sz,
                                                         MPIR_Request * sreq_ptr,
@@ -196,11 +208,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPC_hdr * ipc_hdr,
         MPIR_ERR_CHECK(mpi_errno);
         /* copy */
         if (ipc_hdr->is_contig && dt_contig) {
-            mpi_errno = MPIR_Localcopy_gpu(src_buf, src_data_sz, MPI_BYTE, NULL,
-                                           MPIDIG_REQUEST(rreq, buffer),
-                                           MPIDIG_REQUEST(rreq, count),
-                                           MPIDIG_REQUEST(rreq, datatype), &attr,
-                                           MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH, true);
+            MPL_gpu_engine_type_t engine =
+                MPIDI_IPCI_choose_engine(ipc_hdr->ipc_handle.gpu.global_dev_id, dev_id);
+            mpi_errno =
+                MPIR_Localcopy_gpu(src_buf, src_data_sz, MPI_BYTE, NULL,
+                                   MPIDIG_REQUEST(rreq, buffer), MPIDIG_REQUEST(rreq, count),
+                                   MPIDIG_REQUEST(rreq, datatype), &attr, engine, true);
             MPIR_ERR_CHECK(mpi_errno);
         } else {
             /* TODO: get sender datatype and call MPIR_Typerep_op with mapped_device set to dev_id */

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -185,34 +185,32 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPC_hdr * ipc_hdr,
         MPIR_ERR_CHECK(mpi_errno);
         /* skip unmap */
     } else if (ipc_hdr->ipc_type == MPIDI_IPCI_TYPE__GPU) {
-        /* try fast memcpy first */
-        int fast_copy = 0;
-        if (src_data_sz <= MPIR_CVAR_CH4_IPC_GPU_FAST_COPY_MAX_SIZE) {
-            MPIDI_Datatype_check_contig(MPIDIG_REQUEST(rreq, datatype), dt_contig);
-            if (ipc_hdr->is_contig && dt_contig) {
-                mpi_errno =
-                    MPIDI_GPU_ipc_fast_memcpy(ipc_hdr->ipc_handle, MPIDIG_REQUEST(rreq, buffer),
-                                              src_data_sz, MPIDIG_REQUEST(rreq, datatype));
-                if (mpi_errno == MPI_SUCCESS)
-                    fast_copy = 1;
-            }
-        }
-        if (!fast_copy) {
-            MPL_pointer_attr_t attr;
-            MPIR_GPU_query_pointer_attr(MPIDIG_REQUEST(rreq, buffer), &attr);
-            int dev_id = MPL_gpu_get_dev_id_from_attr(&attr);
-            int map_dev = MPIDI_GPU_ipc_get_map_dev(ipc_hdr->ipc_handle.gpu.global_dev_id, dev_id,
-                                                    MPIDIG_REQUEST(rreq, datatype));
-            mpi_errno = MPIDI_GPU_ipc_handle_map(ipc_hdr->ipc_handle.gpu, map_dev, &src_buf, false);
+        bool do_mmap = (src_data_sz <= MPIR_CVAR_CH4_IPC_GPU_FAST_COPY_MAX_SIZE);
+        MPL_pointer_attr_t attr;
+        MPIR_GPU_query_pointer_attr(MPIDIG_REQUEST(rreq, buffer), &attr);
+        MPIDI_Datatype_check_contig(MPIDIG_REQUEST(rreq, datatype), dt_contig);
+        int dev_id = MPL_gpu_get_dev_id_from_attr(&attr);
+        int map_dev = MPIDI_GPU_ipc_get_map_dev(ipc_hdr->ipc_handle.gpu.global_dev_id, dev_id,
+                                                MPIDIG_REQUEST(rreq, datatype));
+        mpi_errno = MPIDI_GPU_ipc_handle_map(ipc_hdr->ipc_handle.gpu, map_dev, &src_buf, do_mmap);
+        MPIR_ERR_CHECK(mpi_errno);
+        /* copy */
+        if (ipc_hdr->is_contig && dt_contig) {
+            mpi_errno = MPIR_Localcopy_gpu(src_buf, src_data_sz, MPI_BYTE, NULL,
+                                           MPIDIG_REQUEST(rreq, buffer),
+                                           MPIDIG_REQUEST(rreq, count),
+                                           MPIDIG_REQUEST(rreq, datatype), &attr,
+                                           MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH, true);
             MPIR_ERR_CHECK(mpi_errno);
-            /* copy */
+        } else {
             /* TODO: get sender datatype and call MPIR_Typerep_op with mapped_device set to dev_id */
             mpi_errno = MPIDI_IPCI_copy_data(ipc_hdr, rreq, src_buf, src_data_sz);
             MPIR_ERR_CHECK(mpi_errno);
-            /* unmap */
-            mpi_errno = MPIDI_GPU_ipc_handle_unmap(src_buf, ipc_hdr->ipc_handle.gpu, 0);
-            MPIR_ERR_CHECK(mpi_errno);
         }
+
+        /* unmap */
+        mpi_errno = MPIDI_GPU_ipc_handle_unmap(src_buf, ipc_hdr->ipc_handle.gpu, 0);
+        MPIR_ERR_CHECK(mpi_errno);
     } else if (ipc_hdr->ipc_type == MPIDI_IPCI_TYPE__NONE) {
         /* no-op */
     } else {

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -213,7 +213,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPC_hdr * ipc_hdr,
             mpi_errno =
                 MPIR_Localcopy_gpu(src_buf, src_data_sz, MPI_BYTE, NULL,
                                    MPIDIG_REQUEST(rreq, buffer), MPIDIG_REQUEST(rreq, count),
-                                   MPIDIG_REQUEST(rreq, datatype), &attr, engine, true);
+                                   MPIDIG_REQUEST(rreq, datatype), &attr,
+                                   MPL_GPU_COPY_DIRECTION_NONE, engine, true);
             MPIR_ERR_CHECK(mpi_errno);
         } else {
             /* TODO: get sender datatype and call MPIR_Typerep_op with mapped_device set to dev_id */

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -118,7 +118,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
     if (ipc_attr.gpu_attr.type == MPL_GPU_POINTER_DEV) {
         mpi_errno = MPIDI_GPU_get_ipc_attr(mem_addr, rank, comm, &ipc_attr);
         MPIR_ERR_CHECK(mpi_errno);
-    } else {
+    } else if (!MPL_gpu_query_pointer_is_dev(buf, &ipc_attr.gpu_attr)) {
         mpi_errno = MPIDI_XPMEM_get_ipc_attr(mem_addr, mem_size, &ipc_attr);
         MPIR_ERR_CHECK(mpi_errno);
     }

--- a/src/mpid/ch4/shm/ipc/src/ipc_win.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_win.c
@@ -173,7 +173,7 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
                                                                    MPI_BYTE);
                         mpi_errno = MPIDI_GPU_ipc_handle_map(ipc_shared_table[i].ipc_handle.gpu,
                                                              map_dev_id,
-                                                             &shared_table[i].shm_base_addr);
+                                                             &shared_table[i].shm_base_addr, false);
                         MPIR_ERR_CHECK(mpi_errno);
                         shared_table[i].ipc_mapped_device = map_dev_id;
                     }

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -158,6 +158,7 @@ AC_ARG_ENABLE(fast,
 # only alwaysinline option is valid but still need break down multiple options
 # transferred from MPICH separated by commas
 enable_fast_alwaysinline=no
+enable_fast_avx_instr=no
 save_IFS="$IFS"
 IFS=","
 for option in $enable_fast ; do
@@ -167,6 +168,9 @@ for option in $enable_fast ; do
         ;;
         all|yes)
         enable_fast_alwaysinline=yes
+        ;;
+        avx)
+        enable_fast_avx_instr=yes
         ;;
         *) # do not change default value (no) for other fast options
         ;;
@@ -602,6 +606,7 @@ AC_MSG_NOTICE([Timer type selected is $timer_type])
 AC_CHECK_HEADERS(sched.h)
 AC_CHECK_HEADERS(unistd.h)
 AC_CHECK_HEADERS(sys/select.h)
+AC_CHECK_HEADERS(x86intrin.h)
 AC_CHECK_FUNCS(sched_yield yield usleep sleep select)
 
 if test "$ac_cv_func_usleep" = "yes" ; then
@@ -1133,6 +1138,64 @@ if test "X${pac_have_ze}" = "Xyes" ; then
     AC_CHECK_LIB(dl, dlopen, [], AC_MSG_ERROR([dlopen not found.  MPL ZE support requires libdl.]))
 fi
 AM_CONDITIONAL([MPL_HAVE_ZE],[test "X${pac_have_ze}" = "Xyes"])
+
+if test "$enable_fast_avx_instr" = "yes" ; then
+    AC_CACHE_CHECK([whether -mavx512f is supported], pac_cv_found_avx512f,
+                   [PAC_C_CHECK_COMPILER_OPTION([-mavx512f],pac_cv_found_avx512f=yes,pac_cv_found_avx512f=no)],
+                   pac_cv_found_avx512f=no,pac_cv_found_avx512f=yes)
+    if test "$pac_cv_found_avx512f" = "yes" ; then
+        PAC_APPEND_FLAG([-mavx512f],[CFLAGS])
+
+        AC_CACHE_CHECK([whether _mm512_storeu_si512 is supported], pac_cv_found___mm512_storeu_si512,[
+                        AC_RUN_IFELSE([AC_LANG_SOURCE([[
+                                       #include <x86intrin.h>
+
+                                       int main(int argc, char **argv) {
+                                           char source[1024], dest[1024];
+                                           for (int i = 0; i < 1024; i++) source[i] = 'a';
+
+                                           _mm512_storeu_si512((__m512i *) dest, _mm512_loadu_si512((__m512i const *) source));
+
+                                           if (dest[0] == source[0]) return 0;
+                                           else return 1;
+                                       }
+                                       ]])], pac_cv_found___mm512_storeu_si512="yes",
+                                       pac_cv_found___mm512_storeu_si512="no",
+                                       pac_cv_found___mm512_storeu_si512="unknown")
+                        ])
+    fi
+    if test "$pac_cv_found___mm512_storeu_si512" = "yes" ; then
+        AC_DEFINE(HAVE_MM512_STOREU_SI512,1,[Define if avx512f is available])
+    fi
+
+    AC_CACHE_CHECK([whether -mavx is supported], pac_cv_found_avx,
+                   [PAC_C_CHECK_COMPILER_OPTION([-mavx],pac_cv_found_avx=yes,pac_cv_found_avx=no)],
+                   pac_cv_found_avx=no,pac_cv_found_avx=yes)
+    if test "$pac_cv_found_avx" = "yes" ; then
+        PAC_APPEND_FLAG([-mavx],[CFLAGS])
+
+        AC_CACHE_CHECK([whether _mm256_storeu_si256 is supported], pac_cv_found___mm256_storeu_si256,[
+                        AC_RUN_IFELSE([AC_LANG_SOURCE([[
+                                       #include <x86intrin.h>
+
+                                       int main(int argc, char **argv) {
+                                           char source[1024], dest[1024];
+                                           for (int i = 0; i < 1024; i++) source[i] = 'a';
+
+                                           _mm256_storeu_si256((__m256i *) dest, _mm256_loadu_si256((__m256i const *) source));
+
+                                           if (dest[0] == source[0]) return 0;
+                                           else return 1;
+                                       }
+                                       ]])], pac_cv_found___mm256_storeu_si256="yes",
+                                       pac_cv_found___mm256_storeu_si256="no",
+                                       pac_cv_found___mm256_storeu_si256="unknown")
+                        ])
+    fi
+    if test "$pac_cv_found___mm256_storeu_si256" = "yes" ; then
+        AC_DEFINE(HAVE_MM256_STOREU_SI256,1,[Define if avx is available])
+    fi
+fi
 
 
 # Check HIP availability

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -82,7 +82,8 @@ static inline int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t
 int MPL_gpu_query_support(MPL_gpu_type_t * type);
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr);
 
-int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle);
+int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
+                              MPL_gpu_ipc_mem_handle_t * ipc_handle);
 /* Used in ipc_handle_free_hook. Needed for fd-based ipc mechanism. */
 int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr);
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr);

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -70,6 +70,7 @@ typedef struct {
     /* Input */
     int debug_summary;
     bool use_immediate_cmdlist;
+    bool roundrobin_cmdq;
     /* Output */
     bool enable_ipc;
     MPL_gpu_ipc_handle_type_t ipc_handle_type;

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -94,6 +94,7 @@ int MPL_gpu_local_to_global_dev_id(int local_dev_id);
 
 int MPL_gpu_get_dev_id_from_attr(MPL_pointer_attr_t * attr);
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len);
+int MPL_gpu_get_root_device(int dev_id);
 
 int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr));
 int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id);

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -76,7 +76,7 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr);
 
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle);
 /* Used in ipc_handle_free_hook. Needed for fd-based ipc mechanism. */
-int MPL_gpu_ipc_handle_destroy(const void *ptr);
+int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr);
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr);
 int MPL_gpu_ipc_handle_unmap(void *ptr);
 

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -51,13 +51,25 @@ typedef enum {
     MPL_GPU_ENGINE_TYPE_COMPUTE = 0,
     MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH,
     MPL_GPU_ENGINE_TYPE_COPY_LOW_LATENCY,
+    MPL_GPU_ENGINE_TYPE_LAST,
 } MPL_gpu_engine_type_t;
 
 #define MPL_GPU_ENGINE_NUM_TYPES 3
 
+typedef enum {
+    MPL_GPU_COPY_D2H = 0,
+    MPL_GPU_COPY_H2D,
+    MPL_GPU_COPY_D2D_INCOMING,
+    MPL_GPU_COPY_D2D_OUTGOING,
+    MPL_GPU_COPY_DIRECTION_NONE,
+} MPL_gpu_copy_direction_t;
+
+#define MPL_GPU_COPY_DIRECTION_TYPES 4
+
 typedef struct {
     /* Input */
     int debug_summary;
+    bool use_immediate_cmdlist;
     /* Output */
     bool enable_ipc;
     MPL_gpu_ipc_handle_type_t ipc_handle_type;
@@ -129,7 +141,8 @@ int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
                         MPL_pointer_attr_t * dest_attr, size_t size);
 
 int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
-                    MPL_gpu_engine_type_t engine_type, MPL_gpu_request * req, bool commit);
+                    MPL_gpu_copy_direction_t dir, MPL_gpu_engine_type_t engine_type,
+                    MPL_gpu_request * req, bool commit);
 int MPL_gpu_test(MPL_gpu_request * req, int *completed);
 
 typedef void (*MPL_gpu_hostfn) (void *data);

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -101,6 +101,8 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id);
 int MPL_gpu_get_dev_list(int *dev_count, char ***dev_list, bool is_subdev);
 int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env);
 
+int MPL_gpu_init_device_mappings(int max_devid, int max_subdev_id);
+
 typedef void (*MPL_gpu_hostfn) (void *data);
 int MPL_gpu_launch_hostfn(MPL_gpu_stream_t stream, MPL_gpu_hostfn fn, void *data);
 bool MPL_gpu_stream_is_valid(MPL_gpu_stream_t stream);

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -97,7 +97,7 @@ int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len);
 int MPL_gpu_get_root_device(int dev_id);
 
 int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr));
-int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id);
+int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id, int *subdevice_id);
 int MPL_gpu_get_dev_list(int *dev_count, char ***dev_list, bool is_subdev);
 int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env);
 

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -53,6 +53,8 @@ typedef struct {
     /* Output */
     bool enable_ipc;
     MPL_gpu_ipc_handle_type_t ipc_handle_type;
+    /* Input/Output */
+    bool specialized_cache;
 } MPL_gpu_info_t;
 
 extern MPL_gpu_info_t MPL_gpu_info;

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -105,6 +105,9 @@ int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env);
 
 int MPL_gpu_init_device_mappings(int max_devid, int max_subdev_id);
 
+int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
+                        MPL_pointer_attr_t * dest_attr, size_t size);
+
 typedef void (*MPL_gpu_hostfn) (void *data);
 int MPL_gpu_launch_hostfn(MPL_gpu_stream_t stream, MPL_gpu_hostfn fn, void *data);
 bool MPL_gpu_stream_is_valid(MPL_gpu_stream_t stream);

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -47,6 +47,14 @@ typedef enum {
     MPL_GPU_TYPE_HIP,
 } MPL_gpu_type_t;
 
+typedef enum {
+    MPL_GPU_ENGINE_TYPE_COMPUTE = 0,
+    MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH,
+    MPL_GPU_ENGINE_TYPE_COPY_LOW_LATENCY,
+} MPL_gpu_engine_type_t;
+
+#define MPL_GPU_ENGINE_NUM_TYPES 3
+
 typedef struct {
     /* Input */
     int debug_summary;
@@ -107,6 +115,10 @@ int MPL_gpu_init_device_mappings(int max_devid, int max_subdev_id);
 
 int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
                         MPL_pointer_attr_t * dest_attr, size_t size);
+
+int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
+                    MPL_gpu_engine_type_t engine_type, MPL_gpu_request * req, bool commit);
+int MPL_gpu_test(MPL_gpu_request * req, int *completed);
 
 typedef void (*MPL_gpu_hostfn) (void *data);
 int MPL_gpu_launch_hostfn(MPL_gpu_stream_t stream, MPL_gpu_hostfn fn, void *data);

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -106,10 +106,10 @@ int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr_t * attr);
 int MPL_gpu_query_is_same_dev(int dev1, int dev2);
 
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
-                              MPL_gpu_ipc_mem_handle_t * ipc_handle);
+                              MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle);
 /* Used in ipc_handle_free_hook. Needed for fd-based ipc mechanism. */
 int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr);
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr);
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle, int dev_id, void **ptr);
 int MPL_gpu_ipc_handle_unmap(void *ptr);
 
 int MPL_gpu_malloc_host(void **ptr, size_t size);

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -81,11 +81,17 @@ static inline int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr
 {
     return 0;
 }
+
+static inline int MPL_gpu_query_is_same_dev(int dev1, int dev2)
+{
+    return dev1 == dev2;
+}
 #endif /* ! MPL_HAVE_GPU */
 
 int MPL_gpu_query_support(MPL_gpu_type_t * type);
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr);
 int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr_t * attr);
+int MPL_gpu_query_is_same_dev(int dev1, int dev2);
 
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
                               MPL_gpu_ipc_mem_handle_t * ipc_handle);

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -77,10 +77,15 @@ static inline int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t
     return MPL_SUCCESS;
 }
 
+static inline int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr_t * attr)
+{
+    return 0;
+}
 #endif /* ! MPL_HAVE_GPU */
 
 int MPL_gpu_query_support(MPL_gpu_type_t * type);
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr);
+int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr_t * attr);
 
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
                               MPL_gpu_ipc_mem_handle_t * ipc_handle);

--- a/src/mpl/include/mpl_gpu_cuda.h
+++ b/src/mpl/include/mpl_gpu_cuda.h
@@ -12,6 +12,7 @@
 typedef cudaIpcMemHandle_t MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
 typedef struct cudaPointerAttributes MPL_gpu_device_attr;
+typedef int MPL_gpu_request;
 typedef cudaStream_t MPL_gpu_stream_t;
 
 /* Note: event variable need be allocated on a gpu registered host buffer for it to work */

--- a/src/mpl/include/mpl_gpu_fallback.h
+++ b/src/mpl/include/mpl_gpu_fallback.h
@@ -9,6 +9,7 @@
 typedef int MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
 typedef int MPL_gpu_device_attr;        /* dummy type */
+typedef int MPL_gpu_request;
 typedef int MPL_gpu_stream_t;
 
 typedef volatile int MPL_gpu_event_t;

--- a/src/mpl/include/mpl_gpu_hip.h
+++ b/src/mpl/include/mpl_gpu_hip.h
@@ -16,6 +16,7 @@
 typedef hipIpcMemHandle_t MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
 typedef struct hipPointerAttribute_t MPL_gpu_device_attr;
+typedef int MPL_gpu_request;
 typedef hipStream_t MPL_gpu_stream_t;
 
 typedef volatile int MPL_gpu_event_t;

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -29,5 +29,6 @@ typedef volatile int MPL_gpu_event_t;
 /* ZE specific function */
 int MPL_ze_init_device_fds(int *num_fds, int *device_fds);
 void MPL_ze_set_fds(int num_fds, int *fds);
+void MPL_ze_ipc_remove_cache_handle(void *dptr);
 
 #endif /* ifndef MPL_GPU_ZE_H_INCLUDED */

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -16,6 +16,19 @@ typedef struct {
 typedef ze_ipc_mem_handle_t MPL_gpu_ipc_mem_handle_t;
 typedef ze_device_handle_t MPL_gpu_device_handle_t;
 typedef ze_alloc_attr_t MPL_gpu_device_attr;
+
+typedef struct MPL_cmdlist_pool {
+    ze_command_list_handle_t cmdList;
+    int dev;
+    int engine;
+    struct MPL_cmdlist_pool *next, *prev;
+} MPL_cmdlist_pool_t;
+
+typedef struct {
+    ze_event_handle_t event;
+    MPL_cmdlist_pool_t *cmdList;
+} MPL_gpu_request;
+
 /* FIXME: implement ze stream */
 typedef int MPL_gpu_stream_t;
 

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -57,8 +57,8 @@ typedef volatile int MPL_gpu_event_t;
 #define MPL_GPU_DEV_AFFINITY_ENV "ZE_AFFINITY_MASK"
 
 /* ZE specific function */
-int MPL_ze_init_device_fds(int *num_fds, int *device_fds);
-void MPL_ze_set_fds(int num_fds, int *fds);
+int MPL_ze_init_device_fds(int *num_fds, int *device_fds, int *bdfs);
+void MPL_ze_set_fds(int num_fds, int *fds, int *bdfs);
 void MPL_ze_ipc_remove_cache_handle(void *dptr);
 int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, int local_dev_id,
                              int use_shared_fd, MPL_gpu_ipc_mem_handle_t * ipc_handle);

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -30,5 +30,14 @@ typedef volatile int MPL_gpu_event_t;
 int MPL_ze_init_device_fds(int *num_fds, int *device_fds);
 void MPL_ze_set_fds(int num_fds, int *fds);
 void MPL_ze_ipc_remove_cache_handle(void *dptr);
+int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, int local_dev_id,
+                             int use_shared_fd, MPL_gpu_ipc_mem_handle_t * ipc_handle);
+int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_handle, int dev_id,
+                          int is_mmap, size_t size, void **ptr);
+int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int shared_handle, int dev_id,
+                                size_t size, void **ptr);
+int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,
+                               MPL_gpu_device_handle_t device, void **mmaped_ptr);
+int MPL_ze_mmap_handle_unmap(void *ptr, int dev_id);
 
 #endif /* ifndef MPL_GPU_ZE_H_INCLUDED */

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -24,8 +24,13 @@ typedef struct MPL_cmdlist_pool {
     struct MPL_cmdlist_pool *next, *prev;
 } MPL_cmdlist_pool_t;
 
-typedef struct {
+typedef struct MPL_ze_event {
     ze_event_handle_t event;
+    struct MPL_ze_event *next, *prev;
+} MPL_gpu_event;
+
+typedef struct {
+    MPL_gpu_event *gpu_event;
     MPL_cmdlist_pool_t *cmdList;
 } MPL_gpu_request;
 

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -13,7 +13,19 @@ typedef struct {
     ze_device_handle_t device;
 } ze_alloc_attr_t;
 
-typedef ze_ipc_mem_handle_t MPL_gpu_ipc_mem_handle_t;
+typedef struct {
+    int fds[2];
+    uint32_t nfds;
+    pid_t pid;
+    int dev_id;
+    uint64_t mem_id;
+} fd_pid_t;
+
+typedef struct _MPL_gpu_ipc_mem_handle_t {
+    ze_ipc_mem_handle_t ipc_handles[2];
+    fd_pid_t data;
+} MPL_gpu_ipc_mem_handle_t;
+
 typedef ze_device_handle_t MPL_gpu_device_handle_t;
 typedef ze_alloc_attr_t MPL_gpu_device_attr;
 
@@ -50,10 +62,10 @@ void MPL_ze_set_fds(int num_fds, int *fds);
 void MPL_ze_ipc_remove_cache_handle(void *dptr);
 int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, int local_dev_id,
                              int use_shared_fd, MPL_gpu_ipc_mem_handle_t * ipc_handle);
-int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_handle, int dev_id,
+int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * ipc_handle, int is_shared_handle, int dev_id,
                           int is_mmap, size_t size, void **ptr);
-int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int shared_handle, int dev_id,
-                                size_t size, void **ptr);
+int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t * ipc_handle, int shared_handle,
+                                int dev_id, size_t size, void **ptr);
 int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,
                                MPL_gpu_device_handle_t device, void **mmaped_ptr);
 int MPL_ze_mmap_handle_unmap(void *ptr, int dev_id);

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -517,7 +517,8 @@ int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
 }
 
 int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
-                    MPL_gpu_engine_type_t engine_type, MPL_gpu_request * req, bool commit)
+                    MPL_gpu_copy_direction_t dir, MPL_gpu_engine_type_t engine_type,
+                    MPL_gpu_request * req, bool commit)
 {
     return MPL_ERR_GPU_INTERNAL;
 }

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -146,7 +146,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     goto fn_exit;
 }
 
-int MPL_gpu_ipc_handle_destroy(const void *ptr)
+int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
 {
     return MPL_SUCCESS;
 }

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -87,6 +87,11 @@ int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env)
     return ret;
 }
 
+int MPL_gpu_init_device_mappings(int max_devid, int max_subdev_id)
+{
+    return MPL_SUCCESS;
+}
+
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -290,6 +290,7 @@ int MPL_gpu_init(int debug_summary)
     MPL_gpu_info.debug_summary = debug_summary;
     MPL_gpu_info.enable_ipc = true;
     MPL_gpu_info.ipc_handle_type = MPL_GPU_IPC_HANDLE_SHAREABLE;
+    MPL_gpu_info.specialized_cache = false;
 
     char *visible_devices = getenv("CUDA_VISIBLE_DEVICES");
     if (visible_devices) {

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -493,6 +493,12 @@ cudaError_t CUDARTAPI cudaFree(void *dptr)
     return result;
 }
 
+int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
+                        MPL_pointer_attr_t * dest_attr, size_t size)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
 int MPL_gpu_launch_hostfn(cudaStream_t stream, MPL_gpu_hostfn fn, void *data)
 {
     cudaError_t result;

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -131,7 +131,8 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     goto fn_exit;
 }
 
-int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
+int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
+                              MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     int mpl_err = MPL_SUCCESS;
     cudaError_t ret;

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -499,6 +499,17 @@ int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
     return MPL_ERR_GPU_INTERNAL;
 }
 
+int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
+                    MPL_gpu_engine_type_t engine_type, MPL_gpu_request * req, bool commit)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
+int MPL_gpu_test(MPL_gpu_request * req, int *completed)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
 int MPL_gpu_launch_hostfn(cudaStream_t stream, MPL_gpu_hostfn fn, void *data)
 {
     cudaError_t result;

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -383,6 +383,11 @@ int MPL_gpu_get_dev_id_from_attr(MPL_pointer_attr_t * attr)
     return attr->device;
 }
 
+int MPL_gpu_get_root_device(int dev_id)
+{
+    return dev_id;
+}
+
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -131,6 +131,17 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     goto fn_exit;
 }
 
+int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr_t * attr)
+{
+    MPL_pointer_attr_t a;
+
+    if (attr == NULL) {
+        MPL_gpu_query_pointer_attr(ptr, &a);
+        attr = &a;
+    }
+    return attr->type == MPL_GPU_POINTER_DEV;
+}
+
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
                               MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -33,7 +33,7 @@ static cudaError_t CUDARTAPI(*sys_cudaFree) (void *dptr);
 
 static int gpu_mem_hook_init();
 
-int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
+int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id, int *subdevice_id)
 {
     int ret = MPL_SUCCESS;
     if (!gpu_initialized) {
@@ -42,6 +42,7 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 
     *dev_cnt = device_count;
     *dev_id = max_dev_id;
+    *subdevice_id = 0;
     return ret;
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -142,6 +142,11 @@ int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr_t * attr)
     return attr->type == MPL_GPU_POINTER_DEV;
 }
 
+int MPL_gpu_query_is_same_dev(int dev1, int dev2)
+{
+    return dev1 == dev2;
+}
+
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
                               MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -168,7 +168,7 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
     return MPL_SUCCESS;
 }
 
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * ipc_handle, int dev_id, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;
     cudaError_t ret;
@@ -176,7 +176,7 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
 
     cudaGetDevice(&prev_devid);
     cudaSetDevice(dev_id);
-    ret = cudaIpcOpenMemHandle(ptr, ipc_handle, cudaIpcMemLazyEnablePeerAccess);
+    ret = cudaIpcOpenMemHandle(ptr, *ipc_handle, cudaIpcMemLazyEnablePeerAccess);
     CUDA_ERR_CHECK(ret);
 
   fn_exit:

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -44,7 +44,7 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * ipc_handle, int dev_id, void **ptr)
 {
     abort();
     return MPL_ERR_GPU_INTERNAL;

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -139,7 +139,8 @@ int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
 }
 
 int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
-                    MPL_gpu_engine_type_t engine_type, MPL_gpu_request * req, bool commit)
+                    MPL_gpu_copy_direction_t dir, MPL_gpu_engine_type_t engine_type,
+                    MPL_gpu_request * req, bool commit)
 {
     return MPL_ERR_GPU_INTERNAL;
 }

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -100,6 +100,11 @@ int MPL_gpu_get_dev_id_from_attr(MPL_pointer_attr_t * attr)
     return -1;
 }
 
+int MPL_gpu_get_root_device(int dev_id)
+{
+    return -1;
+}
+
 int MPL_gpu_global_to_local_dev_id(int global_dev_id)
 {
     return -1;

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -6,9 +6,9 @@
 #include "mpl.h"
 #include <assert.h>
 
-int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
+int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id, int *subdevice_id)
 {
-    *dev_cnt = *dev_id = -1;
+    *dev_cnt = *dev_id = *subdevice_id = -1;
     return MPL_SUCCESS;
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -93,6 +93,7 @@ int MPL_gpu_free(void *ptr)
 int MPL_gpu_init(int debug_summary)
 {
     MPL_gpu_info.enable_ipc = false;
+    MPL_gpu_info.specialized_cache = false;
     return MPL_SUCCESS;
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -138,6 +138,17 @@ int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
     return MPL_ERR_GPU_INTERNAL;
 }
 
+int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
+                    MPL_gpu_engine_type_t engine_type, MPL_gpu_request * req, bool commit)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
+int MPL_gpu_test(MPL_gpu_request * req, int *completed)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
 int MPL_gpu_launch_hostfn(int stream, MPL_gpu_hostfn fn, void *data)
 {
     return -1;

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -132,6 +132,12 @@ int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr))
     return MPL_SUCCESS;
 }
 
+int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
+                        MPL_pointer_attr_t * dest_attr, size_t size)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
 int MPL_gpu_launch_hostfn(int stream, MPL_gpu_hostfn fn, void *data)
 {
     return -1;

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -26,7 +26,13 @@ int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env)
     return ret;
 }
 
-int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
+int MPL_gpu_init_device_mappings(int max_devid, int max_subdev_id)
+{
+    return MPL_SUCCESS;
+}
+
+int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
+                              MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     abort();
     return MPL_ERR_GPU_INTERNAL;

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -38,7 +38,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_ipc_handle_destroy(const void *ptr)
+int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
 {
     abort();
     return MPL_ERR_GPU_INTERNAL;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -84,6 +84,11 @@ int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env)
     return ret;
 }
 
+int MPL_gpu_init_device_mappings(int max_devid, int max_subdev_id)
+{
+    return MPL_SUCCESS;
+}
+
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -32,7 +32,7 @@ static hipError_t(*sys_hipFree) (void *dptr);
 
 static int gpu_mem_hook_init();
 
-int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
+int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id, int *subdevice_id)
 {
     int ret = MPL_SUCCESS;
     if (!gpu_initialized) {
@@ -41,6 +41,7 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 
     *dev_cnt = device_count;
     *dev_id = max_dev_id;
+    *subdevice_id = 0;
     return ret;
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -123,6 +123,17 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     goto fn_exit;
 }
 
+int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr_t * attr)
+{
+    MPL_pointer_attr_t a;
+
+    if (attr == NULL) {
+        MPL_gpu_query_pointer_attr(ptr, &a);
+        attr = &a;
+    }
+    return attr->type == MPL_GPU_POINTER_DEV;
+}
+
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
                               MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -466,7 +466,8 @@ int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
 }
 
 int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
-                    MPL_gpu_engine_type_t engine_type, MPL_gpu_request * req, bool commit)
+                    MPL_gpu_copy_direction_t dir, MPL_gpu_engine_type_t engine_type,
+                    MPL_gpu_request * req, bool commit)
 {
     return MPL_ERR_GPU_INTERNAL;
 }

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -448,6 +448,17 @@ int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
     return MPL_ERR_GPU_INTERNAL;
 }
 
+int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
+                    MPL_gpu_engine_type_t engine_type, MPL_gpu_request * req, bool commit)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
+int MPL_gpu_test(MPL_gpu_request * req, int *completed)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
 /* ---- */
 struct stream_callback_wrapper {
     MPL_gpu_hostfn fn;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -123,7 +123,8 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     goto fn_exit;
 }
 
-int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
+int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
+                              MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     int mpl_err = MPL_SUCCESS;
     hipError_t ret;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -134,6 +134,11 @@ int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr_t * attr)
     return attr->type == MPL_GPU_POINTER_DEV;
 }
 
+int MPL_gpu_query_is_same_dev(int dev1, int dev2)
+{
+    return dev1 == dev2;
+}
+
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
                               MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -138,6 +138,11 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     goto fn_exit;
 }
 
+int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
+{
+    return MPL_SUCCESS;
+}
+
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -361,6 +361,11 @@ int MPL_gpu_get_dev_id_from_attr(MPL_pointer_attr_t * attr)
     return attr->device;
 }
 
+int MPL_gpu_get_root_device(int dev_id)
+{
+    return dev_id;
+}
+
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -160,7 +160,7 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
     return MPL_SUCCESS;
 }
 
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * ipc_handle, int dev_id, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;
     hipError_t ret;
@@ -168,7 +168,7 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
 
     hipGetDevice(&prev_devid);
     hipSetDevice(dev_id);
-    ret = hipIpcOpenMemHandle(ptr, ipc_handle, hipIpcMemLazyEnablePeerAccess);
+    ret = hipIpcOpenMemHandle(ptr, *ipc_handle, hipIpcMemLazyEnablePeerAccess);
     HIP_ERR_CHECK(ret);
 
   fn_exit:

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -437,6 +437,12 @@ hipError_t hipFree(void *dptr)
     return result;
 }
 
+int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
+                        MPL_pointer_attr_t * dest_attr, size_t size)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
 /* ---- */
 struct stream_callback_wrapper {
     MPL_gpu_hostfn fn;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -268,6 +268,7 @@ int MPL_gpu_init(int debug_summary)
     MPL_gpu_info.debug_summary = debug_summary;
     MPL_gpu_info.enable_ipc = true;
     MPL_gpu_info.ipc_handle_type = MPL_GPU_IPC_HANDLE_SHAREABLE;
+    MPL_gpu_info.specialized_cache = false;
 
     char *visible_devices = getenv("HIP_VISIBLE_DEVICES");
     if (visible_devices) {

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -62,8 +62,26 @@ typedef struct {
     UT_hash_handle hh;
 } MPL_ze_ipc_handle_entry_t;
 
+typedef struct {
+    void *ipc_buf;
+
+    /* Multiple keys */
+    uint64_t remote_mem_id;
+    int remote_dev_id;
+    pid_t remote_pid;
+    UT_hash_handle hh;
+} MPL_ze_mapped_buffer_entry_t;
+
+typedef struct {
+    uint64_t remote_mem_id;
+    int remote_dev_id;
+    pid_t remote_pid;
+} MPL_ze_mapped_buffer_lookup_t;
+
 static MPL_ze_gem_hash_entry_t *gem_hash = NULL;
 static MPL_ze_ipc_handle_entry_t **ipc_cache_tracked = NULL;
+static MPL_ze_mapped_buffer_entry_t **ipc_cache_mapped = NULL;
+static MPL_ze_mapped_buffer_entry_t **ipc_cache_removal = NULL;
 
 typedef struct {
     int fd;
@@ -474,8 +492,24 @@ int MPL_gpu_init(int debug_summary)
         goto fn_fail;
     }
 
+    ipc_cache_mapped =
+        MPL_malloc(local_ze_device_count * sizeof(MPL_ze_mapped_buffer_entry_t *), MPL_MEM_OTHER);
+    if (ipc_cache_mapped == NULL) {
+        mpl_err = MPL_ERR_GPU_NOMEM;
+        goto fn_fail;
+    }
+
+    ipc_cache_removal =
+        MPL_malloc(local_ze_device_count * sizeof(MPL_ze_mapped_buffer_entry_t *), MPL_MEM_OTHER);
+    if (ipc_cache_removal == NULL) {
+        mpl_err = MPL_ERR_GPU_NOMEM;
+        goto fn_fail;
+    }
+
     for (int i = 0; i < local_ze_device_count; ++i) {
         ipc_cache_tracked[i] = NULL;
+        ipc_cache_mapped[i] = NULL;
+        ipc_cache_removal[i] = NULL;
     }
 
     mypid = getpid();
@@ -717,6 +751,15 @@ int MPL_gpu_finalize(void)
     int i;
 
     for (i = 0; i < local_ze_device_count; ++i) {
+        MPL_ze_mapped_buffer_entry_t *entry = NULL, *tmp = NULL;
+        if (ipc_cache_removal[i]) {
+            HASH_ITER(hh, ipc_cache_removal[i], entry, tmp) {
+                MPL_gpu_ipc_handle_unmap(entry->ipc_buf);
+            }
+        }
+    }
+
+    for (i = 0; i < local_ze_device_count; ++i) {
         MPL_ze_ipc_handle_entry_t *entry = NULL, *tmp = NULL;
         HASH_ITER(hh, ipc_cache_tracked[i], entry, tmp) {
             HASH_DELETE(hh, ipc_cache_tracked[i], entry);
@@ -724,6 +767,9 @@ int MPL_gpu_finalize(void)
         }
     }
 
+    MPL_free(ipc_cache_tracked);
+    MPL_free(ipc_cache_removal);
+    MPL_free(ipc_cache_mapped);
     MPL_free(local_to_global_map);
     MPL_free(global_to_local_map);
     MPL_free(ze_devices_handle);
@@ -930,46 +976,93 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
     int fd, status;
     MPL_gpu_device_handle_t dev_handle;
     ze_ipc_mem_handle_t ze_ipc_handle;
+    MPL_ze_mapped_buffer_entry_t *cache_entry = NULL;
+    MPL_ze_mapped_buffer_entry_t *removal_entry = NULL;
+    MPL_ze_mapped_buffer_lookup_t lookup_entry;
+    unsigned keylen = 0;
 
     memset(&ze_ipc_handle, 0, sizeof(ze_ipc_mem_handle_t));
 
     fd_pid_t h;
     memcpy(&h, &ipc_handle, sizeof(fd_pid_t));
 
-    if (shared_device_fds != NULL) {
-        /* convert GEM handle to fd */
-        status = handle_to_fd(shared_device_fds[h.dev_id], h.fd, &fd);
-        if (status) {
-            goto fn_fail;
-        }
+    /* Check if ipc-mapped buffer is already cached */
+    memset(&lookup_entry, 0, sizeof(MPL_ze_mapped_buffer_lookup_t));
+    lookup_entry.remote_mem_id = h.mem_id;
+    lookup_entry.remote_dev_id = h.dev_id;
+    lookup_entry.remote_pid = h.pid;
+
+    keylen = offsetof(MPL_ze_mapped_buffer_entry_t, remote_pid) + sizeof(pid_t) -
+        offsetof(MPL_ze_mapped_buffer_entry_t, remote_mem_id);
+
+    HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry.remote_mem_id, keylen, cache_entry);
+
+    if (cache_entry) {
+        *ptr = cache_entry->ipc_buf;
     } else {
-        /* pidfd_getfd */
-        if (h.pid != mypid) {
-            int pid_fd = syscall(__NR_pidfd_open, h.pid, 0);
-            if (pid_fd == -1) {
-                printf("pidfd_open error: %s (%d %d %d)\n", strerror(errno), h.pid, h.fd, h.dev_id);
-            }
-            assert(pid_fd != -1);
-            fd = syscall(__NR_pidfd_getfd, pid_fd, h.fd, 0);
-            if (fd == -1) {
-                printf("Error> pidfd_getfd is not implemented!");
-                mpl_err = MPL_ERR_GPU_INTERNAL;
+        if (shared_device_fds != NULL) {
+            /* convert GEM handle to fd */
+            status = handle_to_fd(shared_device_fds[h.dev_id], h.fd, &fd);
+            if (status) {
                 goto fn_fail;
             }
-            close(pid_fd);
         } else {
-            fd = h.fd;
+            /* pidfd_getfd */
+            if (h.pid != mypid) {
+                int pid_fd = syscall(__NR_pidfd_open, h.pid, 0);
+                if (pid_fd == -1) {
+                    printf("pidfd_open error: %s (%d %d %d)\n", strerror(errno), h.pid, h.fd,
+                           h.dev_id);
+                }
+                assert(pid_fd != -1);
+                fd = syscall(__NR_pidfd_getfd, pid_fd, h.fd, 0);
+                if (fd == -1) {
+                    printf("Error> pidfd_getfd is not implemented!");
+                    mpl_err = MPL_ERR_GPU_INTERNAL;
+                    goto fn_fail;
+                }
+                close(pid_fd);
+            } else {
+                fd = h.fd;
+            }
         }
-    }
 
-    mpl_err = dev_id_to_device(dev_id, &dev_handle);
-    if (mpl_err != MPL_SUCCESS) {
-        goto fn_fail;
-    }
-    memcpy(&ze_ipc_handle, &fd, sizeof(fd));
+        mpl_err = dev_id_to_device(dev_id, &dev_handle);
+        if (mpl_err != MPL_SUCCESS) {
+            goto fn_fail;
+        }
+        memcpy(&ze_ipc_handle, &fd, sizeof(fd));
 
-    ret = zeMemOpenIpcHandle(ze_context, dev_handle, ze_ipc_handle, 0, ptr);
-    ZE_ERR_CHECK(ret);
+        ret = zeMemOpenIpcHandle(ze_context, dev_handle, ze_ipc_handle, 0, ptr);
+        ZE_ERR_CHECK(ret);
+
+        /* Insert into the cache */
+        cache_entry =
+            (MPL_ze_mapped_buffer_entry_t *) MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t),
+                                                        MPL_MEM_OTHER);
+        if (cache_entry == NULL) {
+            mpl_err = MPL_ERR_GPU_NOMEM;
+            goto fn_fail;
+        }
+
+        removal_entry =
+            (MPL_ze_mapped_buffer_entry_t *) MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t),
+                                                        MPL_MEM_OTHER);
+        if (removal_entry == NULL) {
+            mpl_err = MPL_ERR_GPU_NOMEM;
+            goto fn_fail;
+        }
+
+        cache_entry->remote_mem_id = lookup_entry.remote_mem_id;
+        cache_entry->remote_dev_id = lookup_entry.remote_dev_id;
+        cache_entry->remote_pid = lookup_entry.remote_pid;
+        cache_entry->ipc_buf = *ptr;
+        memcpy(removal_entry, cache_entry, sizeof(MPL_ze_mapped_buffer_entry_t));
+
+        HASH_ADD(hh, ipc_cache_mapped[dev_id], remote_mem_id, keylen, cache_entry, MPL_MEM_OTHER);
+        HASH_ADD(hh, ipc_cache_removal[dev_id], ipc_buf, sizeof(void *), removal_entry,
+                 MPL_MEM_OTHER);
+    }
 
   fn_exit:
     return mpl_err;
@@ -980,8 +1073,55 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
 int MPL_gpu_ipc_handle_unmap(void *ptr)
 {
     int mpl_err = MPL_SUCCESS;
-
+    int dev_id;
+    unsigned keylen;
     ze_result_t ret;
+    ze_device_handle_t device = NULL;
+    MPL_ze_mapped_buffer_entry_t *cache_entry = NULL;
+    MPL_ze_mapped_buffer_lookup_t lookup_entry;
+
+    ze_memory_allocation_properties_t ptr_attr = {
+        .stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES,
+        .pNext = NULL,
+        .type = 0,
+        .id = 0,
+        .pageSize = 0,
+    };
+
+    ret = zeMemGetAllocProperties(ze_context, ptr, &ptr_attr, &device);
+    ZE_ERR_CHECK(ret);
+
+    dev_id = device_to_dev_id(device);
+    if (dev_id == -1) {
+        goto fn_fail;
+    }
+
+    /* Remove from the caches */
+    HASH_FIND(hh, ipc_cache_removal[dev_id], &ptr, sizeof(void *), cache_entry);
+
+    if (cache_entry != NULL) {
+        memset(&lookup_entry, 0, sizeof(MPL_ze_mapped_buffer_lookup_t));
+        lookup_entry.remote_mem_id = cache_entry->remote_mem_id;
+        lookup_entry.remote_dev_id = cache_entry->remote_dev_id;
+        lookup_entry.remote_pid = cache_entry->remote_pid;
+
+        keylen = offsetof(MPL_ze_mapped_buffer_entry_t, remote_pid) + sizeof(pid_t) -
+            offsetof(MPL_ze_mapped_buffer_entry_t, remote_mem_id);
+
+        HASH_DEL(ipc_cache_removal[dev_id], cache_entry);
+        MPL_free(cache_entry);
+        cache_entry = NULL;
+
+        HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry.remote_mem_id, keylen, cache_entry);
+
+        if (cache_entry != NULL) {
+            HASH_DEL(ipc_cache_mapped[dev_id], cache_entry);
+            MPL_free(cache_entry);
+            cache_entry = NULL;
+        }
+    }
+
+    /* Unmap the buffer */
     ret = zeMemCloseIpcHandle(ze_context, ptr);
     ZE_ERR_CHECK(ret);
 

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -474,6 +474,13 @@ int MPL_gpu_init(int debug_summary)
         goto fn_exit;
     }
 
+    MPL_gpu_info.debug_summary = debug_summary;
+    MPL_gpu_info.enable_ipc = true;
+
+    if (MPL_gpu_info.debug_summary) {
+        printf("==== GPU Init (ZE) ====\n");
+    }
+
     mpl_err = gpu_ze_init_driver();
     if (mpl_err != MPL_SUCCESS)
         goto fn_fail;
@@ -597,7 +604,6 @@ int MPL_gpu_init(int debug_summary)
     gpu_initialized = 1;
 
     if (MPL_gpu_info.debug_summary) {
-        printf("==== GPU Init (ZE) ====\n");
         printf("device_count: %d\n", device_count);
         printf("subdevice_count: %d\n", local_ze_device_count - device_count);
         printf("=========================\n");
@@ -857,6 +863,9 @@ static int gpu_ze_init_driver(void)
     ret = zeDriverGet(&driver_count, NULL);
     ZE_ERR_CHECK(ret);
     if (driver_count == 0) {
+        if (MPL_gpu_info.debug_summary) {
+            printf("No Intel GPU library driver found.\n");
+        }
         goto fn_fail;
     }
 
@@ -951,6 +960,10 @@ static int gpu_ze_init_driver(void)
 
             dev_id += subdevice_count[d];
         }
+    } else {
+        if (MPL_gpu_info.debug_summary) {
+            printf("No Intel GPU device found.\n");
+        }
     }
 
     ze_context_desc_t contextDesc = {
@@ -1042,6 +1055,47 @@ static int gpu_ze_init_driver(void)
                                             (void **) &zexMemOpenIpcHandles);
     if (ZE_RESULT_SUCCESS != ret)
         zexMemOpenIpcHandles = NULL;
+
+    if (MPL_gpu_info.debug_summary) {
+        for (d = 0; d < local_ze_device_count; ++d) {
+            MPL_ze_device_entry_t *device_state = device_states + d;
+            ze_device_properties_t device_properties;
+            memset(&device_properties, 0, sizeof(ze_device_properties_t));
+            device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
+            device_properties.pNext = NULL;
+            ret = zeDeviceGetProperties(ze_devices_handle[d], &device_properties);
+            fprintf(stderr, "==== Device %d ====\n", d);
+            if (d < device_count) {
+                fprintf(stderr, "\troot device: %d tiles\n", subdevice_count[d]);
+            }
+            fprintf(stderr, "  device name: %s\n", device_properties.name);
+            fprintf(stderr, "  deviceId: %d\n", device_properties.deviceId);
+            fprintf(stderr, "  subdeviceId: %d\n", device_properties.subdeviceId);
+            fprintf(stderr, "  coreClockRate: %d\n", device_properties.coreClockRate);
+            fprintf(stderr, "  maxMemAllocSize: %ld\n", device_properties.maxMemAllocSize);
+            fprintf(stderr, "  maxHardwareContexts: %d\n", device_properties.maxHardwareContexts);
+            fprintf(stderr, "  numThreadsPerEU: %d\n", device_properties.numThreadsPerEU);
+            char uuid_str[1024];
+            strcpy(uuid_str, "uuid: ");
+            for (int j = 0; j < ZE_MAX_DRIVER_UUID_SIZE; j++) {
+                char s[128];
+                sprintf(s, "%x ", device_properties.uuid.id[j]);
+                strcat(uuid_str, s);
+            }
+            fprintf(stderr, "  %s\n", uuid_str);
+#ifdef ZE_PCI_PROPERTIES_EXT_NAME
+            if (device_state->pci_avail)
+                fprintf(stderr, "  BDF: domain:%x B:%x D:%x F:%x\n", device_state->pci.domain,
+                        device_state->pci.bus, device_state->pci.device,
+                        device_state->pci.function);
+#endif
+            fprintf(stderr, "  Command Queue (engine) types: %d \n", device_state->numQueueGroups);
+            for (i = 0; i < device_state->numQueueGroups; i++) {
+                fprintf(stderr, "    Engine: %d  numQueues: %d \n", i,
+                        device_state->engines[i].numQueues);
+            }
+        }
+    }
 
   fn_exit:
     MPL_free(all_drivers);

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -3,6 +3,11 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "mplconfig.h"
+#ifdef MPL_HAVE_X86INTRIN_H
+/* must come before mpl_trmem.h */
+#include <x86intrin.h>
+#endif
 #include "mpl.h"
 #include <assert.h>
 #include <dlfcn.h>
@@ -59,11 +64,16 @@ typedef struct {
 typedef struct {
     uint64_t mem_id;
     MPL_gpu_ipc_mem_handle_t ipc_handle;
+    void *mapped_ptr;
+    size_t mapped_size;
+    bool handle_cached;
     UT_hash_handle hh;
 } MPL_ze_ipc_handle_entry_t;
 
 typedef struct {
     void *ipc_buf;
+    void *mapped_ptr;
+    size_t mapped_size;
 
     /* Multiple keys */
     uint64_t remote_mem_id;
@@ -82,6 +92,7 @@ static MPL_ze_gem_hash_entry_t *gem_hash = NULL;
 static MPL_ze_ipc_handle_entry_t **ipc_cache_tracked = NULL;
 static MPL_ze_mapped_buffer_entry_t **ipc_cache_mapped = NULL;
 static MPL_ze_mapped_buffer_entry_t **ipc_cache_removal = NULL;
+static MPL_ze_mapped_buffer_entry_t **mmap_cache_removal = NULL;
 
 typedef struct {
     int fd;
@@ -509,10 +520,19 @@ int MPL_gpu_init(int debug_summary)
             goto fn_fail;
         }
 
+        mmap_cache_removal =
+            MPL_malloc(local_ze_device_count * sizeof(MPL_ze_mapped_buffer_entry_t *),
+                       MPL_MEM_OTHER);
+        if (mmap_cache_removal == NULL) {
+            mpl_err = MPL_ERR_GPU_NOMEM;
+            goto fn_fail;
+        }
+
         for (int i = 0; i < local_ze_device_count; ++i) {
             ipc_cache_tracked[i] = NULL;
             ipc_cache_mapped[i] = NULL;
             ipc_cache_removal[i] = NULL;
+            mmap_cache_removal[i] = NULL;
         }
 
         MPL_gpu_free_hook_register(MPL_ze_ipc_remove_cache_handle);
@@ -598,6 +618,8 @@ static int handle_to_fd(int dev_fd, int handle, int *fd)
     open_fd.handle = handle;
 
     int ret = ioctl(dev_fd, DRM_IOCTL_PRIME_HANDLE_TO_FD, &open_fd);
+    if (ret == -1)
+        perror("handle_to_fd");
     assert(ret != -1);
     *fd = open_fd.fd;
     return ret;
@@ -762,11 +784,21 @@ int MPL_gpu_finalize(void)
                     MPL_gpu_ipc_handle_unmap(entry->ipc_buf);
                 }
             }
+
+            if (mmap_cache_removal[i]) {
+                MPL_ze_mapped_buffer_entry_t *entry = NULL, *tmp = NULL;
+                HASH_ITER(hh, mmap_cache_removal[i], entry, tmp) {
+                    MPL_ze_mmap_handle_unmap(entry->mapped_ptr, i);
+                }
+            }
         }
 
         for (i = 0; i < local_ze_device_count; ++i) {
             MPL_ze_ipc_handle_entry_t *entry = NULL, *tmp = NULL;
             HASH_ITER(hh, ipc_cache_tracked[i], entry, tmp) {
+                if (entry->mapped_ptr != NULL) {
+                    munmap(entry->mapped_ptr, entry->mapped_size);
+                }
                 HASH_DELETE(hh, ipc_cache_tracked[i], entry);
                 MPL_free(entry);
             }
@@ -774,6 +806,7 @@ int MPL_gpu_finalize(void)
 
         MPL_free(ipc_cache_tracked);
         MPL_free(ipc_cache_removal);
+        MPL_free(mmap_cache_removal);
         MPL_free(ipc_cache_mapped);
     }
 
@@ -821,97 +854,60 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
 {
     int mpl_err = MPL_SUCCESS;
     ze_result_t ret;
-    int fd, handle, status, local_dev_id = -1;
-    ze_device_handle_t device;
-    ze_ipc_mem_handle_t ze_ipc_handle;
-    fd_pid_t h;
+    int local_dev_id = -1;
     MPL_ze_ipc_handle_entry_t *cache_entry = NULL;
     uint64_t mem_id = 0;
 
-    ze_memory_allocation_properties_t ptr_attr = {
-        .stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES,
-        .pNext = NULL,
-        .type = 0,
-        .id = 0,
-        .pageSize = 0,
-    };
+    MPL_gpu_device_attr ptr_attr;
+    memset(&ptr_attr, 0, sizeof(MPL_gpu_device_attr));
+    memset(ipc_handle, 0, sizeof(MPL_gpu_ipc_mem_handle_t));
 
-    ret = zeMemGetAllocProperties(ze_context, ptr, &ptr_attr, &device);
+    ret = zeMemGetAllocProperties(ze_context, ptr, &ptr_attr.prop, &ptr_attr.device);
     ZE_ERR_CHECK(ret);
 
-    local_dev_id = device_to_dev_id(device);
+    local_dev_id = device_to_dev_id(ptr_attr.device);
     if (local_dev_id == -1) {
         goto fn_fail;
     }
 
     /* Check if ipc_handle is already cached */
     if (likely(MPL_gpu_info.specialized_cache)) {
-        mem_id = ptr_attr.id;
+        mem_id = ptr_attr.prop.id;
         HASH_FIND(hh, ipc_cache_tracked[local_dev_id], &mem_id, sizeof(uint64_t), cache_entry);
     }
 
-    if (cache_entry) {
+    if (cache_entry && cache_entry->handle_cached) {
         memcpy(ipc_handle, &cache_entry->ipc_handle, sizeof(MPL_gpu_ipc_mem_handle_t));
     } else {
-        ret = zeMemGetIpcHandle(ze_context, ptr, &ze_ipc_handle);
-        ZE_ERR_CHECK(ret);
+        mpl_err = MPL_ze_ipc_handle_create(ptr, &ptr_attr, local_dev_id, true, ipc_handle);
+        if (mpl_err != MPL_SUCCESS) {
+            goto fn_fail;
+        }
 
-        if (shared_device_fds != NULL) {
-            int shared_dev_id = MPL_gpu_get_root_device(local_dev_id);
-            /* convert dma_buf fd to GEM handle */
-            memcpy(&fd, &ze_ipc_handle, sizeof(fd));
-            status = fd_to_handle(shared_device_fds[shared_dev_id], fd, &handle);
-            if (status) {
-                goto fn_fail;
-            }
+        if (likely(MPL_gpu_info.specialized_cache)) {
+            if (cache_entry) {
+                /* In the case where there was an entry, but no ipc handle yet */
+                cache_entry->handle_cached = true;
+                memcpy(&cache_entry->ipc_handle, ipc_handle, sizeof(MPL_gpu_ipc_mem_handle_t));
+            } else {
+                /* Insert into the cache */
+                cache_entry =
+                    (MPL_ze_ipc_handle_entry_t *) MPL_malloc(sizeof(MPL_ze_ipc_handle_entry_t),
+                                                             MPL_MEM_OTHER);
 
-            /* Hash (ptr, dev_id, handle) to close later */
-            MPL_ze_gem_hash_entry_t *entry = NULL;
-            HASH_FIND_PTR(gem_hash, &ptr, entry);
-
-            if (entry == NULL) {
-                entry =
-                    (MPL_ze_gem_hash_entry_t *) MPL_malloc(sizeof(MPL_ze_gem_hash_entry_t),
-                                                           MPL_MEM_OTHER);
-                if (entry == NULL) {
+                if (cache_entry == NULL) {
+                    mpl_err = MPL_ERR_GPU_NOMEM;
                     goto fn_fail;
                 }
 
-                entry->ptr = ptr;
-                entry->dev_id = shared_dev_id;
-                entry->handle = handle;
-                HASH_ADD_PTR(gem_hash, ptr, entry, MPL_MEM_OTHER);
+                memset(cache_entry, 0, sizeof(MPL_ze_ipc_handle_entry_t));
+
+                cache_entry->mem_id = mem_id;
+                cache_entry->handle_cached = true;
+                memcpy(&cache_entry->ipc_handle, ipc_handle, sizeof(MPL_gpu_ipc_mem_handle_t));
+                HASH_ADD(hh, ipc_cache_tracked[local_dev_id], mem_id, sizeof(uint64_t), cache_entry,
+                         MPL_MEM_OTHER);
             }
-
-            memcpy(&h.fd, &handle, sizeof(int));
-            h.dev_id = shared_dev_id;
-        } else {
-            memcpy(&h.fd, &ze_ipc_handle, sizeof(fd));
-            h.dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
-            assert(h.dev_id != -1);
-        }
-
-        h.pid = mypid;
-        h.mem_id = mem_id;
-        memcpy(ipc_handle, &h, sizeof(fd_pid_t));
-
-        if (likely(MPL_gpu_info.specialized_cache)) {
-            /* Insert into the cache */
-            cache_entry =
-                (MPL_ze_ipc_handle_entry_t *) MPL_malloc(sizeof(MPL_ze_ipc_handle_entry_t),
-                                                         MPL_MEM_OTHER);
-
-            if (cache_entry == NULL) {
-                mpl_err = MPL_ERR_GPU_NOMEM;
-                goto fn_fail;
-            }
-
-            memset(cache_entry, 0, sizeof(MPL_ze_ipc_handle_entry_t));
-
-            cache_entry->mem_id = mem_id;
-            memcpy(&cache_entry->ipc_handle, ipc_handle, sizeof(MPL_gpu_ipc_mem_handle_t));
-            HASH_ADD(hh, ipc_cache_tracked[local_dev_id], mem_id, sizeof(uint64_t), cache_entry,
-                     MPL_MEM_OTHER);
         }
     }
 
@@ -985,9 +981,6 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr)
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;
-    ze_result_t ret;
-    int fd, status;
-    MPL_gpu_device_handle_t dev_handle;
     ze_ipc_mem_handle_t ze_ipc_handle;
     MPL_ze_mapped_buffer_entry_t *cache_entry = NULL;
     MPL_ze_mapped_buffer_entry_t *removal_entry = NULL;
@@ -1012,79 +1005,118 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
         HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry.remote_mem_id, keylen, cache_entry);
     }
 
-    if (cache_entry) {
+    if (cache_entry && cache_entry->ipc_buf) {
         *ptr = cache_entry->ipc_buf;
     } else {
-        if (shared_device_fds != NULL) {
-            /* convert GEM handle to fd */
-            status = handle_to_fd(shared_device_fds[h.dev_id], h.fd, &fd);
-            if (status) {
-                goto fn_fail;
-            }
-        } else {
-            /* pidfd_getfd */
-            if (h.pid != mypid) {
-                int pid_fd = syscall(__NR_pidfd_open, h.pid, 0);
-                if (pid_fd == -1) {
-                    printf("pidfd_open error: %s (%d %d %d)\n", strerror(errno), h.pid, h.fd,
-                           h.dev_id);
-                }
-                assert(pid_fd != -1);
-                fd = syscall(__NR_pidfd_getfd, pid_fd, h.fd, 0);
-                if (fd == -1) {
-                    printf("Error> pidfd_getfd is not implemented!");
-                    mpl_err = MPL_ERR_GPU_INTERNAL;
-                    goto fn_fail;
-                }
-                close(pid_fd);
-            } else {
-                fd = h.fd;
-            }
-        }
-
-        mpl_err = dev_id_to_device(dev_id, &dev_handle);
+        mpl_err = MPL_ze_ipc_handle_map(ipc_handle, true, dev_id, false, 0, ptr);
         if (mpl_err != MPL_SUCCESS) {
             goto fn_fail;
         }
-        memcpy(&ze_ipc_handle, &fd, sizeof(fd));
-
-        ret = zeMemOpenIpcHandle(ze_context, dev_handle, ze_ipc_handle, 0, ptr);
-        ZE_ERR_CHECK(ret);
 
         if (likely(MPL_gpu_info.specialized_cache)) {
-            /* Insert into the cache */
-            cache_entry =
-                (MPL_ze_mapped_buffer_entry_t *) MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t),
-                                                            MPL_MEM_OTHER);
-            if (cache_entry == NULL) {
-                mpl_err = MPL_ERR_GPU_NOMEM;
-                goto fn_fail;
+            if (cache_entry) {
+                cache_entry->ipc_buf = *ptr;
+
+                removal_entry = (MPL_ze_mapped_buffer_entry_t *)
+                    MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t), MPL_MEM_OTHER);
+                if (removal_entry == NULL) {
+                    mpl_err = MPL_ERR_GPU_NOMEM;
+                    goto fn_fail;
+                }
+
+                memset(removal_entry, 0, sizeof(MPL_ze_mapped_buffer_entry_t));
+                memcpy(removal_entry, cache_entry, sizeof(MPL_ze_mapped_buffer_entry_t));
+                removal_entry->mapped_ptr = NULL;
+
+                HASH_ADD(hh, ipc_cache_removal[dev_id], ipc_buf, sizeof(void *), removal_entry,
+                         MPL_MEM_OTHER);
+            } else {
+                /* Insert into the cache */
+                cache_entry = (MPL_ze_mapped_buffer_entry_t *)
+                    MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t), MPL_MEM_OTHER);
+                if (cache_entry == NULL) {
+                    mpl_err = MPL_ERR_GPU_NOMEM;
+                    goto fn_fail;
+                }
+
+                removal_entry = (MPL_ze_mapped_buffer_entry_t *)
+                    MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t), MPL_MEM_OTHER);
+                if (removal_entry == NULL) {
+                    mpl_err = MPL_ERR_GPU_NOMEM;
+                    goto fn_fail;
+                }
+
+                memset(removal_entry, 0, sizeof(MPL_ze_mapped_buffer_entry_t));
+                memset(cache_entry, 0, sizeof(MPL_ze_mapped_buffer_entry_t));
+
+                cache_entry->remote_mem_id = lookup_entry.remote_mem_id;
+                cache_entry->remote_dev_id = lookup_entry.remote_dev_id;
+                cache_entry->remote_pid = lookup_entry.remote_pid;
+                cache_entry->ipc_buf = *ptr;
+                memcpy(removal_entry, cache_entry, sizeof(MPL_ze_mapped_buffer_entry_t));
+
+                HASH_ADD(hh, ipc_cache_mapped[dev_id], remote_mem_id, keylen, cache_entry,
+                         MPL_MEM_OTHER);
+                HASH_ADD(hh, ipc_cache_removal[dev_id], ipc_buf, sizeof(void *), removal_entry,
+                         MPL_MEM_OTHER);
             }
-
-            removal_entry =
-                (MPL_ze_mapped_buffer_entry_t *) MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t),
-                                                            MPL_MEM_OTHER);
-            if (removal_entry == NULL) {
-                mpl_err = MPL_ERR_GPU_NOMEM;
-                goto fn_fail;
-            }
-
-            cache_entry->remote_mem_id = lookup_entry.remote_mem_id;
-            cache_entry->remote_dev_id = lookup_entry.remote_dev_id;
-            cache_entry->remote_pid = lookup_entry.remote_pid;
-            cache_entry->ipc_buf = *ptr;
-            memcpy(removal_entry, cache_entry, sizeof(MPL_ze_mapped_buffer_entry_t));
-
-            HASH_ADD(hh, ipc_cache_mapped[dev_id], remote_mem_id, keylen, cache_entry,
-                     MPL_MEM_OTHER);
-            HASH_ADD(hh, ipc_cache_removal[dev_id], ipc_buf, sizeof(void *), removal_entry,
-                     MPL_MEM_OTHER);
         }
     }
 
   fn_exit:
     return mpl_err;
   fn_fail:
+    goto fn_exit;
+}
+
+int MPL_ze_mmap_handle_unmap(void *ptr, int dev_id)
+{
+    int ret_err, mpl_err = MPL_SUCCESS;
+    unsigned keylen;
+    size_t size = 0;
+    MPL_ze_mapped_buffer_entry_t *cache_entry = NULL;
+    MPL_ze_mapped_buffer_lookup_t lookup_entry;
+
+    if (likely(MPL_gpu_info.specialized_cache)) {
+        HASH_FIND(hh, mmap_cache_removal[dev_id], &ptr, sizeof(void *), cache_entry);
+
+        if (cache_entry != NULL) {
+            size = cache_entry->mapped_size;
+        }
+
+        if (cache_entry != NULL) {
+            memset(&lookup_entry, 0, sizeof(MPL_ze_mapped_buffer_lookup_t));
+            lookup_entry.remote_mem_id = cache_entry->remote_mem_id;
+            lookup_entry.remote_dev_id = cache_entry->remote_dev_id;
+            lookup_entry.remote_pid = cache_entry->remote_pid;
+
+            keylen = offsetof(MPL_ze_mapped_buffer_entry_t, remote_pid) + sizeof(pid_t) -
+                offsetof(MPL_ze_mapped_buffer_entry_t, remote_mem_id);
+
+            HASH_DEL(mmap_cache_removal[dev_id], cache_entry);
+            MPL_free(cache_entry);
+            cache_entry = NULL;
+
+            HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry.remote_mem_id, keylen,
+                      cache_entry);
+
+            if (cache_entry != NULL) {
+                HASH_DEL(ipc_cache_mapped[dev_id], cache_entry);
+                MPL_free(cache_entry);
+                cache_entry = NULL;
+            }
+        }
+    }
+
+    ret_err = munmap(ptr, size);
+    if (ret_err == -1) {
+        goto fn_fail;
+    }
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    mpl_err = MPL_ERR_GPU_INTERNAL;
     goto fn_exit;
 }
 
@@ -1484,6 +1516,377 @@ void MPL_ze_ipc_remove_cache_handle(void *dptr)
   fn_fail:
     fprintf(stderr, "Error > failed to complete MPL_ze_ipc_remove_cache_handle\n");
     goto fn_exit;
+}
+
+int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, int local_dev_id,
+                             int use_shared_fd, MPL_gpu_ipc_mem_handle_t * ipc_handle)
+{
+    int mpl_err = MPL_SUCCESS;
+    ze_result_t ret;
+    int fd, handle, status;
+    ze_ipc_mem_handle_t ze_ipc_handle;
+    fd_pid_t h;
+    uint64_t mem_id = 0;
+
+    mem_id = ptr_attr->prop.id;
+
+    ret = zeMemGetIpcHandle(ze_context, ptr, &ze_ipc_handle);
+    ZE_ERR_CHECK(ret);
+
+    if (shared_device_fds != NULL) {
+        if (use_shared_fd) {
+            int shared_dev_id = MPL_gpu_get_root_device(local_dev_id);
+            /* convert dma_buf fd to GEM handle */
+            memcpy(&fd, &ze_ipc_handle, sizeof(fd));
+            status = fd_to_handle(shared_device_fds[shared_dev_id], fd, &handle);
+            if (status) {
+                goto fn_fail;
+            }
+
+            /* Hash (ptr, dev_id, handle) to close later */
+            MPL_ze_gem_hash_entry_t *entry = NULL;
+            HASH_FIND_PTR(gem_hash, &ptr, entry);
+
+            if (entry == NULL) {
+                entry =
+                    (MPL_ze_gem_hash_entry_t *) MPL_malloc(sizeof(MPL_ze_gem_hash_entry_t),
+                                                           MPL_MEM_OTHER);
+                if (entry == NULL) {
+                    goto fn_fail;
+                }
+
+                entry->ptr = ptr;
+                entry->dev_id = shared_dev_id;
+                entry->handle = handle;
+                HASH_ADD_PTR(gem_hash, ptr, entry, MPL_MEM_OTHER);
+            }
+
+            memcpy(&h.fd, &handle, sizeof(int));
+            h.dev_id = shared_dev_id;
+        } else {
+            memcpy(&h.fd, &ze_ipc_handle, sizeof(int));
+            h.dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
+        }
+    } else {
+        memcpy(&h.fd, &ze_ipc_handle, sizeof(fd));
+        h.dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
+        assert(h.dev_id != -1);
+    }
+
+    h.pid = mypid;
+    h.mem_id = mem_id;
+    memcpy(ipc_handle, &h, sizeof(fd_pid_t));
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
+}
+
+int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_handle, int dev_id,
+                          int is_mmap, size_t size, void **ptr)
+{
+    int mpl_err = MPL_SUCCESS;
+    ze_result_t ret;
+    int fd, status;
+    MPL_gpu_device_handle_t dev_handle;
+    ze_ipc_mem_handle_t ze_ipc_handle;
+
+    memset(&ze_ipc_handle, 0, sizeof(ze_ipc_mem_handle_t));
+
+    fd_pid_t h;
+    memcpy(&h, &ipc_handle, sizeof(fd_pid_t));
+
+    if (shared_device_fds != NULL) {
+        /* convert GEM handle to fd */
+        status = handle_to_fd(shared_device_fds[h.dev_id], h.fd, &fd);
+        if (status) {
+            goto fn_fail;
+        }
+    } else {
+        /* pidfd_getfd */
+        if (h.pid != mypid) {
+            int pid_fd = syscall(__NR_pidfd_open, h.pid, 0);
+            if (pid_fd == -1) {
+                printf("pidfd_open error: %s (%d %d %d)\n", strerror(errno), h.pid, h.fd, h.dev_id);
+            }
+            assert(pid_fd != -1);
+            fd = syscall(__NR_pidfd_getfd, pid_fd, h.fd, 0);
+            if (fd == -1) {
+                printf("Error> pidfd_getfd is not implemented!");
+                mpl_err = MPL_ERR_GPU_INTERNAL;
+                goto fn_fail;
+            }
+            close(pid_fd);
+        } else {
+            fd = h.fd;
+        }
+    }
+
+    if (is_mmap) {
+        void *buf;
+        buf = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        if (buf == (void *) -1) {
+            mpl_err = MPL_ERR_GPU_INTERNAL;
+            perror("mmap device to host");
+            printf("gdr_handle_open failed\n");
+            goto fn_fail;
+        }
+        *ptr = buf;
+    } else {
+        mpl_err = dev_id_to_device(dev_id, &dev_handle);
+        if (mpl_err != MPL_SUCCESS) {
+            goto fn_fail;
+        }
+        memcpy(&ze_ipc_handle, &fd, sizeof(fd));
+
+        ret = zeMemOpenIpcHandle(ze_context, dev_handle, ze_ipc_handle, 0, ptr);
+        ZE_ERR_CHECK(ret);
+    }
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_handle,
+                                int dev_id, size_t size, void **ptr)
+{
+    int mpl_err = MPL_SUCCESS;
+    unsigned keylen;
+    MPL_ze_mapped_buffer_entry_t *cache_entry = NULL;
+    MPL_ze_mapped_buffer_entry_t *removal_entry = NULL;
+    MPL_ze_mapped_buffer_lookup_t lookup_entry;
+
+    fd_pid_t h;
+    memcpy(&h, &ipc_handle, sizeof(fd_pid_t));
+
+    if (likely(MPL_gpu_info.specialized_cache)) {
+        /* Check if ipc-mapped buffer is already cached */
+        memset(&lookup_entry, 0, sizeof(MPL_ze_mapped_buffer_lookup_t));
+        lookup_entry.remote_mem_id = h.mem_id;
+        lookup_entry.remote_dev_id = h.dev_id;
+        lookup_entry.remote_pid = h.pid;
+
+        keylen = offsetof(MPL_ze_mapped_buffer_entry_t, remote_pid) + sizeof(pid_t) -
+            offsetof(MPL_ze_mapped_buffer_entry_t, remote_mem_id);
+
+        HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry.remote_mem_id, keylen, cache_entry);
+    }
+
+    if (cache_entry) {
+        *ptr = cache_entry->mapped_ptr;
+    } else {
+        mpl_err = MPL_ze_ipc_handle_map(ipc_handle, is_shared_handle, dev_id, true, size, ptr);
+        if (mpl_err != MPL_SUCCESS) {
+            goto fn_fail;
+        }
+
+        if (likely(MPL_gpu_info.specialized_cache)) {
+            /* Insert into the cache */
+            cache_entry =
+                (MPL_ze_mapped_buffer_entry_t *) MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t),
+                                                            MPL_MEM_OTHER);
+            if (cache_entry == NULL) {
+                mpl_err = MPL_ERR_GPU_NOMEM;
+                goto fn_fail;
+            }
+
+            removal_entry =
+                (MPL_ze_mapped_buffer_entry_t *) MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t),
+                                                            MPL_MEM_OTHER);
+            if (removal_entry == NULL) {
+                mpl_err = MPL_ERR_GPU_NOMEM;
+                goto fn_fail;
+            }
+
+            memset(removal_entry, 0, sizeof(MPL_ze_mapped_buffer_entry_t));
+            memset(cache_entry, 0, sizeof(MPL_ze_mapped_buffer_entry_t));
+
+            cache_entry->remote_mem_id = lookup_entry.remote_mem_id;
+            cache_entry->remote_dev_id = lookup_entry.remote_dev_id;
+            cache_entry->remote_pid = lookup_entry.remote_pid;
+            cache_entry->mapped_ptr = *ptr;
+            cache_entry->mapped_size = size;
+            memcpy(removal_entry, cache_entry, sizeof(MPL_ze_mapped_buffer_entry_t));
+
+            HASH_ADD(hh, ipc_cache_mapped[dev_id], remote_mem_id, keylen, cache_entry,
+                     MPL_MEM_OTHER);
+            HASH_ADD(hh, mmap_cache_removal[dev_id], mapped_ptr, sizeof(void *), removal_entry,
+                     MPL_MEM_OTHER);
+        }
+    }
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,
+                               MPL_gpu_device_handle_t device, void **mmaped_ptr)
+{
+    ze_result_t ret;
+    ze_ipc_mem_handle_t ze_ipc_handle;
+    int fd, mpl_err = MPL_SUCCESS, local_dev_id = -1;
+    uint64_t mem_id, offset, len;
+    void *pbase, *base;
+    MPL_ze_ipc_handle_entry_t *cache_entry = NULL;
+
+    ret = zeMemGetAddressRange(ze_context, dptr, &pbase, &len);
+    ZE_ERR_CHECK(ret);
+
+    offset = (char *) dptr - (char *) pbase;
+
+    mem_id = attr->prop.id;
+    local_dev_id = device_to_dev_id(device);
+    if (local_dev_id == -1) {
+        goto fn_fail;
+    }
+
+    /* Search cache for mapped base address */
+    if (likely(MPL_gpu_info.specialized_cache)) {
+        HASH_FIND(hh, ipc_cache_tracked[local_dev_id], &mem_id, sizeof(uint64_t), cache_entry);
+    }
+
+    if (cache_entry && cache_entry->mapped_ptr) {
+        base = cache_entry->mapped_ptr;
+    } else {
+        ret = zeMemGetIpcHandle(ze_context, pbase, &ze_ipc_handle);
+        ZE_ERR_CHECK(ret);
+
+        memcpy(&fd, &ze_ipc_handle, sizeof(int));
+
+        base = mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        if (base == (void *) -1) {
+            mpl_err = MPL_ERR_GPU_INTERNAL;
+            perror("mmap_device_pointer:");
+            printf("gdr_handle_open failed\n");
+            goto fn_fail;
+        }
+
+        if (likely(MPL_gpu_info.specialized_cache)) {
+            if (cache_entry) {
+                /* This could have been cached already, but via the ipc path */
+                cache_entry->mapped_ptr = base;
+                cache_entry->mapped_size = len;
+            } else {
+                /* Insert into the cache */
+                cache_entry =
+                    (MPL_ze_ipc_handle_entry_t *) MPL_malloc(sizeof(MPL_ze_ipc_handle_entry_t),
+                                                             MPL_MEM_OTHER);
+
+                if (cache_entry == NULL) {
+                    mpl_err = MPL_ERR_GPU_NOMEM;
+                    goto fn_fail;
+                }
+
+                memset(cache_entry, 0, sizeof(MPL_ze_ipc_handle_entry_t));
+
+                cache_entry->mem_id = mem_id;
+                cache_entry->mapped_ptr = base;
+                cache_entry->mapped_size = len;
+                cache_entry->handle_cached = false;
+                HASH_ADD(hh, ipc_cache_tracked[local_dev_id], mem_id, sizeof(uint64_t), cache_entry,
+                         MPL_MEM_OTHER);
+            }
+        }
+    }
+
+    *mmaped_ptr = (char *) base + offset;
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
+                        MPL_pointer_attr_t * dest_attr, size_t size)
+{
+    int mpl_err = MPL_SUCCESS;
+    char *d = (char *) dest;
+    const char *s = (const char *) src;
+    size_t n = size;
+
+    if (src_attr && src_attr->type == MPL_GPU_POINTER_DEV) {
+        mpl_err =
+            MPL_ze_mmap_device_pointer(src, &src_attr->device_attr, src_attr->device, (void **) &s);
+        if (mpl_err != MPL_SUCCESS)
+            goto fn_fail;
+    }
+
+    if (dest_attr && dest_attr->type == MPL_GPU_POINTER_DEV) {
+        mpl_err =
+            MPL_ze_mmap_device_pointer(dest, &dest_attr->device_attr, dest_attr->device,
+                                       (void **) &d);
+        if (mpl_err != MPL_SUCCESS)
+            goto fn_fail;
+    }
+#if defined(MPL_HAVE_MM512_STOREU_SI512)
+    while (n >= 64) {
+        _mm512_storeu_si512((__m512i *) d, _mm512_loadu_si512((__m512i const *) s));
+        d += 64;
+        s += 64;
+        n -= 64;
+    }
+    if (n & 32) {
+        _mm256_storeu_si256((__m256i *) d, _mm256_loadu_si256((__m256i const *) s));
+        d += 32;
+        s += 32;
+        n -= 32;
+    }
+#elif defined(MPL_HAVE_MM256_STOREU_SI256)
+    while (n >= 32) {
+        _mm256_storeu_si256((__m256i *) d, _mm256_loadu_si256((__m256i const *) s));
+        d += 32;
+        s += 32;
+        n -= 32;
+    }
+#else
+    goto fallback;
+#endif
+    if (n & 16) {
+        _mm_storeu_si128((__m128i *) d, _mm_loadu_si128((__m128i const *) s));
+        d += 16;
+        s += 16;
+        n -= 16;
+    }
+    if (n & 8) {
+        *(int64_t *) d = *(int64_t *) s;
+        d += 8;
+        s += 8;
+        n -= 8;
+    }
+    if (n & 4) {
+        *(int *) d = *(int *) s;
+        d += 4;
+        s += 4;
+        n -= 4;
+    }
+    if (n & 2) {
+        *(int16_t *) d = *(int16_t *) s;
+        d += 2;
+        s += 2;
+        n -= 2;
+    }
+    if (n == 1) {
+        *(char *) d = *(char *) s;
+    }
+#if defined(MPL_HAVE_MM256_STOREU_SI256)
+    _mm_sfence();
+#endif
+    goto fn_exit;
+
+  fallback:
+    memcpy(d, s, n);
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    return MPL_ERR_GPU_INTERNAL;
 }
 
 #endif /* MPL_HAVE_ZE */

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -148,8 +148,9 @@ typedef struct {
 } MPL_ze_engine_entry_t;
 
 typedef struct {
-    MPL_ze_engine_entry_t *engines;
+    int dev_id;
     unsigned int numQueueGroups;
+    MPL_ze_engine_entry_t *engines;
     ze_event_handle_t prev_event;       /* for imemcopy */
     MPL_cmdlist_pool_t *last_cmdList_entry;     /* for imemcopy */
 #ifdef ZE_PCI_PROPERTIES_EXT_NAME
@@ -867,7 +868,7 @@ static int gpu_ze_init_driver(void)
     ret = zeDriverGet(&driver_count, all_drivers);
     ZE_ERR_CHECK(ret);
 
-    int i, j, d;
+    int i, d;
     /* Find a driver instance with a GPU device */
     for (i = 0; i < driver_count; ++i) {
         device_count = 0;
@@ -964,20 +965,10 @@ static int gpu_ze_init_driver(void)
         (MPL_ze_device_entry_t *) MPL_malloc(sizeof(MPL_ze_device_entry_t) * local_ze_device_count,
                                              MPL_MEM_OTHER);
 
-    /* create command queues */
     for (d = 0; d < local_ze_device_count; d++) {
         unsigned int numQueueGroups = 0;
-        ze_command_queue_desc_t cmdQueueDesc = {
-            .stype = ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC,
-            .pNext = NULL,
-            .index = 0,
-            .flags = 0,
-            .ordinal = 0,
-            .mode = ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS,
-            .priority = ZE_COMMAND_QUEUE_PRIORITY_NORMAL,
-        };
-
         MPL_ze_device_entry_t *device_state = device_states + d;
+        device_state->dev_id = d;
         device_state->prev_event = NULL;
         device_state->last_cmdList_entry = NULL;
         ret = zeDeviceGetCommandQueueGroupProperties(ze_devices_handle[d], &numQueueGroups, NULL);
@@ -994,33 +985,25 @@ static int gpu_ze_init_driver(void)
         device_state->numQueueGroups = numQueueGroups;
 
         for (i = 0; i < numQueueGroups; i++) {
-            cmdQueueDesc.ordinal = -1;
+            int ordinal = -1;
             if (queueProperties[i].flags & ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COMPUTE) {
-                cmdQueueDesc.ordinal = i;
+                ordinal = i;
             } else if (queueProperties[i].flags & ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COPY &&
                        queueProperties[i].numQueues >= 1 &&
                        !(queueProperties[i].flags & ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COMPUTE)) {
-                cmdQueueDesc.ordinal = i;
+                ordinal = i;
             }
             device_state->engines[i].cmdList_pool = NULL;
-            if (cmdQueueDesc.ordinal == -1) {
-                device_state->engines[i].curQueue = 0;
-                device_state->engines[i].numQueues = 0;
-                device_state->engines[i].cmdQueues = NULL;
-            } else {
-                device_state->engines[i].numQueues = queueProperties[i].numQueues;
-                device_state->engines[i].curQueue = 0;
+            device_state->engines[i].curQueue = 0;
+            device_state->engines[i].numQueues = ordinal == -1 ? 0 : queueProperties[i].numQueues;
+            device_state->engines[i].cmdQueues = NULL;
+            if (device_state->engines[i].numQueues) {
                 device_state->engines[i].cmdQueues =
                     (ze_command_queue_handle_t *) MPL_malloc(sizeof(ze_command_queue_handle_t) *
-                                                             queueProperties[i].numQueues,
+                                                             device_state->engines[i].numQueues,
                                                              MPL_MEM_OTHER);
-                for (j = 0; j < queueProperties[i].numQueues; j++) {
-                    cmdQueueDesc.index = j;
-                    ret =
-                        zeCommandQueueCreate(ze_context, ze_devices_handle[d], &cmdQueueDesc,
-                                             &device_state->engines[i].cmdQueues[j]);
-                    ZE_ERR_CHECK(ret);
-                }
+                memset(device_state->engines[i].cmdQueues, 0,
+                       sizeof(ze_command_queue_handle_t) * device_state->engines[i].numQueues);
             }
         }
 #ifdef ZE_PCI_PROPERTIES_EXT_NAME
@@ -1145,15 +1128,16 @@ int MPL_gpu_finalize(void)
         for (j = 0; j < device_state->numQueueGroups; j++) {
             MPL_ze_engine_entry_t *engine = device_state->engines + j;
             for (k = 0; k < engine->numQueues; k++) {
-                zeCommandQueueDestroy(engine->cmdQueues[k]);
+                if (engine->cmdQueues[k])
+                    zeCommandQueueDestroy(engine->cmdQueues[k]);
             }
+            MPL_free(engine->cmdQueues);
             MPL_cmdlist_pool_t *cmdlist, *t, *pool = engine->cmdList_pool;
             DL_FOREACH_SAFE(pool, cmdlist, t) {
                 zeCommandListDestroy(cmdlist->cmdList);
                 DL_DELETE(pool, cmdlist);
                 MPL_free(cmdlist);
             }
-            MPL_free(engine->cmdQueues);
         }
         MPL_free(device_state->engines);
     }
@@ -1707,6 +1691,42 @@ int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)
 
 /*                         MPL_gpu_imemcpy                          */
 
+/* create complete set of command queues for an engine type */
+static int create_cmdqueue(int dev, int engine)
+{
+    int mpl_err = MPL_SUCCESS;
+    int ret;
+
+    ze_command_queue_desc_t cmdQueueDesc = {
+        .stype = ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC,
+        .pNext = NULL,
+        .index = 0,
+        .flags = 0,
+        .ordinal = engine,
+        .mode = ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS,
+        .priority = ZE_COMMAND_QUEUE_PRIORITY_NORMAL,
+    };
+
+    MPL_ze_device_entry_t *device_state = device_states + dev;
+    assert(engine < device_state->numQueueGroups);
+    MPL_ze_engine_entry_t *engine_state = device_state->engines + engine;
+    assert(engine_state->numQueues);
+
+    for (int i = 0; i < engine_state->numQueues; i++) {
+        cmdQueueDesc.index = i;
+        ret =
+            zeCommandQueueCreate(ze_context, ze_devices_handle[dev], &cmdQueueDesc,
+                                 &engine_state->cmdQueues[i]);
+        ZE_ERR_CHECK(ret);
+    }
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
+}
+
 /* command list utility functions */
 static int get_cmdlist(int dev, int engine, MPL_cmdlist_pool_t ** cl_entry)
 {
@@ -1805,18 +1825,16 @@ int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
     if (dest_ptr && src_ptr) {
         ret = get_next_event(&event);
         ZE_ERR_CHECK(ret);
-        if (device_states[dev].last_cmdList_entry == NULL) {
+        if (device_states[orig_dev].last_cmdList_entry == NULL) {
             MPL_cmdlist_pool_t *cmdList_entry;
-            ret = get_cmdlist(dev, engine, &cmdList_entry);
+            ret = get_cmdlist(orig_dev, engine, &cmdList_entry);
             ZE_ERR_CHECK(ret);
-            cmdList = cmdList_entry->cmdList;
-            device_states[dev].last_cmdList_entry = cmdList_entry;
+            device_states[orig_dev].last_cmdList_entry = cmdList_entry;
             dev = cmdList_entry->dev;
-        } else {
-            cmdList = device_states[dev].last_cmdList_entry->cmdList;
-            if (device_states[dev].last_cmdList_entry->dev != dev)
-                goto fn_fail;
         }
+        cmdList = device_states[orig_dev].last_cmdList_entry->cmdList;
+        if (device_states[orig_dev].last_cmdList_entry->dev != dev)
+            goto fn_fail;
         assert(dev < local_ze_device_count);
         device_state = device_states + dev;
         ret =
@@ -1837,12 +1855,19 @@ int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
     if (commit && cmdList) {
         ret = zeCommandListClose(cmdList);
         ZE_ERR_CHECK(ret);
-        ret =
-            zeCommandQueueExecuteCommandLists(device_state->
-                                              engines[engine].cmdQueues[device_state->
-                                                                        engines[engine].curQueue],
-                                              1, &cmdList, NULL);
+        int q_index = device_state->engines[engine].curQueue;
+        assert(device_state->engines[engine].cmdQueues);
+        ze_command_queue_handle_t cmdq = device_state->engines[engine].cmdQueues[q_index];
+        if (cmdq == NULL) {
+            mpl_err = create_cmdqueue(device_state->dev_id, engine);
+            if (mpl_err != MPL_SUCCESS)
+                goto fn_fail;
+            cmdq = device_state->engines[engine].cmdQueues[q_index];
+            assert(cmdq);
+        }
+        ret = zeCommandQueueExecuteCommandLists(cmdq, 1, &cmdList, NULL);
         ZE_ERR_CHECK(ret);
+        /* move to next queue */
         device_state->engines[engine].curQueue++;
         if (device_state->engines[engine].curQueue == device_state->engines[engine].numQueues)
             device_state->engines[engine].curQueue = 0;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -139,11 +139,12 @@ ze_context_handle_t ze_context;
 uint32_t local_ze_device_count; /* This counts both devices and subdevices */
 uint32_t global_ze_device_count;        /* This counts both devices and subdevices */
 
-#define MPL_ZE_EVENT_POOL_SIZE    16384
+#define MPL_ZE_EVENT_POOL_SIZE    (131072)
 
 typedef struct {
     ze_command_queue_handle_t *cmdQueues;
     MPL_cmdlist_pool_t *cmdList_pool;
+    ze_command_list_handle_t *cmdlists; /* immediate command lists */
     unsigned int numQueues, curQueue;
 } MPL_ze_engine_entry_t;
 
@@ -151,8 +152,8 @@ typedef struct {
     int dev_id;
     unsigned int numQueueGroups;
     MPL_ze_engine_entry_t *engines;
-    ze_event_handle_t prev_event;       /* for imemcopy */
-    MPL_cmdlist_pool_t *last_cmdList_entry;     /* for imemcopy */
+    ze_event_handle_t prev_event[MPL_GPU_COPY_DIRECTION_TYPES]; /* for imemcopy */
+    MPL_cmdlist_pool_t *last_cmdList_entry[MPL_GPU_COPY_DIRECTION_TYPES];       /* for imemcopy */
 #ifdef ZE_PCI_PROPERTIES_EXT_NAME
     ze_pci_address_ext_t pci;
     int pci_avail;
@@ -982,8 +983,10 @@ static int gpu_ze_init_driver(void)
         unsigned int numQueueGroups = 0;
         MPL_ze_device_entry_t *device_state = device_states + d;
         device_state->dev_id = d;
-        device_state->prev_event = NULL;
-        device_state->last_cmdList_entry = NULL;
+        memset(device_state->prev_event, 0,
+               MPL_GPU_COPY_DIRECTION_TYPES * sizeof(ze_event_handle_t));
+        memset(device_state->last_cmdList_entry, 0,
+               MPL_GPU_COPY_DIRECTION_TYPES * sizeof(MPL_cmdlist_pool_t *));
         ret = zeDeviceGetCommandQueueGroupProperties(ze_devices_handle[d], &numQueueGroups, NULL);
         ZE_ERR_CHECK(ret);
         ze_command_queue_group_properties_t *queueProperties =
@@ -1017,6 +1020,12 @@ static int gpu_ze_init_driver(void)
                                                              MPL_MEM_OTHER);
                 memset(device_state->engines[i].cmdQueues, 0,
                        sizeof(ze_command_queue_handle_t) * device_state->engines[i].numQueues);
+                device_state->engines[i].cmdlists =
+                    (ze_command_list_handle_t *) MPL_malloc(sizeof(ze_command_list_handle_t) *
+                                                            device_state->engines[i].numQueues,
+                                                            MPL_MEM_OTHER);
+                memset(device_state->engines[i].cmdlists, 0,
+                       device_state->engines[i].numQueues * sizeof(ze_command_list_handle_t));
             }
         }
 #ifdef ZE_PCI_PROPERTIES_EXT_NAME
@@ -1184,8 +1193,11 @@ int MPL_gpu_finalize(void)
             for (k = 0; k < engine->numQueues; k++) {
                 if (engine->cmdQueues[k])
                     zeCommandQueueDestroy(engine->cmdQueues[k]);
+                if (engine->cmdlists[k])
+                    zeCommandListDestroy(engine->cmdlists[k]);
             }
             MPL_free(engine->cmdQueues);
+            MPL_free(engine->cmdlists);
             MPL_cmdlist_pool_t *cmdlist, *t, *pool = engine->cmdList_pool;
             DL_FOREACH_SAFE(pool, cmdlist, t) {
                 zeCommandListDestroy(cmdlist->cmdList);
@@ -1751,23 +1763,21 @@ static int create_cmdqueue(int dev, int engine)
     int mpl_err = MPL_SUCCESS;
     int ret;
 
-    ze_command_queue_desc_t cmdQueueDesc = {
-        .stype = ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC,
-        .pNext = NULL,
-        .index = 0,
-        .flags = 0,
-        .ordinal = engine,
-        .mode = ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS,
-        .priority = ZE_COMMAND_QUEUE_PRIORITY_NORMAL,
-    };
-
     MPL_ze_device_entry_t *device_state = device_states + dev;
     assert(engine < device_state->numQueueGroups);
     MPL_ze_engine_entry_t *engine_state = device_state->engines + engine;
     assert(engine_state->numQueues);
 
     for (int i = 0; i < engine_state->numQueues; i++) {
-        cmdQueueDesc.index = i;
+        ze_command_queue_desc_t cmdQueueDesc = {
+            .stype = ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC,
+            .pNext = NULL,
+            .index = i,
+            .flags = 0,
+            .ordinal = engine,
+            .mode = ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS,
+            .priority = ZE_COMMAND_QUEUE_PRIORITY_NORMAL,
+        };
         ret =
             zeCommandQueueCreate(ze_context, ze_devices_handle[dev], &cmdQueueDesc,
                                  &engine_state->cmdQueues[i]);
@@ -1794,9 +1804,10 @@ static int get_cmdlist(int dev, int engine, MPL_cmdlist_pool_t ** cl_entry)
     if (engine > device_states[dev].numQueueGroups - 1 ||
         device_states[dev].engines[engine].numQueues == 0) {
         /* certain type of engine may not be available on the subdevices */
-        dev = MPL_gpu_get_root_device(dev);
-        if (device_states[dev].engines[engine].numQueues == 0)
+        int parent_dev = MPL_gpu_get_root_device(dev);
+        if (parent_dev == dev || device_states[dev].engines[engine].numQueues == 0)
             goto fn_fail;
+        dev = parent_dev;
     }
     assert(dev < local_ze_device_count);
     device_state = device_states + dev;
@@ -1825,6 +1836,65 @@ static int get_cmdlist(int dev, int engine, MPL_cmdlist_pool_t ** cl_entry)
         cmdList_entry->engine = engine;
     }
     *cl_entry = cmdList_entry;
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
+}
+
+/* immediate command list utility functions */
+static inline int get_immediate_cmdlist(int *dev, MPL_gpu_copy_direction_t dir, int engine,
+                                        ze_command_list_handle_t * cl)
+{
+    int mpl_err = MPL_SUCCESS;
+    int ret, index;
+    MPL_ze_device_entry_t *device_state;
+
+    if (engine > device_states[*dev].numQueueGroups - 1 ||
+        device_states[*dev].engines[engine].numQueues == 0) {
+        /* certain type of engine may not be available on the subdevices */
+        *dev = MPL_gpu_get_root_device(*dev);
+        if (device_states[*dev].engines[engine].numQueues == 0)
+            goto fn_fail;
+    }
+    assert(*dev < local_ze_device_count);
+    device_state = device_states + *dev;
+    assert(engine < device_state->numQueueGroups);
+    MPL_ze_engine_entry_t *engine_state = device_state->engines + engine;
+
+    if (dir == MPL_GPU_COPY_DIRECTION_NONE) {
+        index = engine_state->curQueue;
+        /* move to next queue */
+        engine_state->curQueue++;
+        if (engine_state->curQueue == engine_state->numQueues)
+            engine_state->curQueue = 0;
+    } else {
+        index = dir % engine_state->numQueues;
+    }
+
+    if (!engine_state->cmdlists[index]) {
+        assert(engine_state->numQueues);
+
+        for (int i = 0; i < engine_state->numQueues; i++) {
+            ze_command_queue_desc_t cmdQueueDesc = {
+                .stype = ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC,
+                .pNext = NULL,
+                .index = i,
+                .flags = 0,
+                .ordinal = engine,
+                .mode = ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS,
+                .priority = ZE_COMMAND_QUEUE_PRIORITY_NORMAL,
+            };
+            ret = zeCommandListCreateImmediate(ze_context, ze_devices_handle[*dev], &cmdQueueDesc,
+                                               &engine_state->cmdlists[i]);
+            ZE_ERR_CHECK(ret);
+        }
+    }
+    assert(engine_state->cmdlists[index]);
+
+    *cl = engine_state->cmdlists[index];
 
   fn_exit:
     return mpl_err;
@@ -1862,14 +1932,19 @@ static inline int get_next_event(ze_event_handle_t * event)
 /* no safety check in this function, call this function with safety protection.
    commit = false: append to command list only
    commit = true:  close the command list and submit to command queue
+   direction can be 0, 1:  for device to host   d2h h2d
+                    2, 3:  for device to device    local to remote, remote to local
+                    4:     no direction, can use random command list and queue
 */
-int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
-                    MPL_gpu_engine_type_t engine_type, MPL_gpu_request * req, bool commit)
+static int MPL_gpu_imemcpy_normal(void *dest_ptr, void *src_ptr, size_t size, int dev,
+                                  MPL_gpu_copy_direction_t dir, MPL_gpu_engine_type_t engine_type,
+                                  MPL_gpu_request * req, bool commit)
 {
+    int mpl_err = MPL_SUCCESS;
     MPL_ze_device_entry_t *device_state = NULL;
     ze_event_handle_t event;
     ze_command_list_handle_t cmdList = NULL;
-    int mpl_err = MPL_SUCCESS;
+    MPL_cmdlist_pool_t *cmdList_entry;
     int ret;
     int orig_dev = dev;
     int engine = engine_conversion[engine_type];
@@ -1877,60 +1952,137 @@ int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
     assert(dev >= 0 && dev < local_ze_device_count);
 
     if (dest_ptr && src_ptr) {
+        ze_event_handle_t pre_event = NULL;
+        int nevent = 0;
         ret = get_next_event(&event);
         ZE_ERR_CHECK(ret);
-        if (device_states[orig_dev].last_cmdList_entry == NULL) {
-            MPL_cmdlist_pool_t *cmdList_entry;
+        device_state = device_states + dev;
+        if (dir == MPL_GPU_COPY_DIRECTION_NONE) {
             ret = get_cmdlist(orig_dev, engine, &cmdList_entry);
             ZE_ERR_CHECK(ret);
-            device_states[orig_dev].last_cmdList_entry = cmdList_entry;
-            dev = cmdList_entry->dev;
+            cmdList = cmdList_entry->cmdList;
+        } else {
+            if (!device_states[orig_dev].last_cmdList_entry[dir]) {
+                ret = get_cmdlist(orig_dev, engine, &cmdList_entry);
+                ZE_ERR_CHECK(ret);
+                device_states[orig_dev].last_cmdList_entry[dir] = cmdList_entry;
+                dev = cmdList_entry->dev;
+                device_state = device_states + dev;
+            }
+            cmdList_entry = device_states[orig_dev].last_cmdList_entry[dir];
+            cmdList = cmdList_entry->cmdList;
+            if (device_state->prev_event[dir]) {
+                pre_event = device_state->prev_event[dir];
+                nevent = 1;
+            }
+            if (device_states[orig_dev].last_cmdList_entry[dir]->dev != dev)
+                goto fn_fail;
+            device_state->prev_event[dir] = event;
         }
-        cmdList = device_states[orig_dev].last_cmdList_entry->cmdList;
-        if (device_states[orig_dev].last_cmdList_entry->dev != dev)
-            goto fn_fail;
         assert(dev < local_ze_device_count);
-        device_state = device_states + dev;
         ret =
-            zeCommandListAppendMemoryCopy(cmdList, dest_ptr, src_ptr, size, event,
-                                          device_state->prev_event ? 1 : 0,
-                                          device_state->
-                                          prev_event ? &device_state->prev_event : NULL);
+            zeCommandListAppendMemoryCopy(cmdList, dest_ptr, src_ptr, size, event, nevent,
+                                          pre_event ? &pre_event : NULL);
         ZE_ERR_CHECK(ret);
         req->event = event;
-        device_state->prev_event = event;
     } else {
+        /* unlikely */
         device_state = device_states + dev;
-        assert(device_state->prev_event);
-        req->event = device_state->prev_event;
-        if (device_state->last_cmdList_entry)
-            cmdList = device_state->last_cmdList_entry->cmdList;
+        assert(device_state->prev_event[dir]);
+        req->event = device_state->prev_event[dir];
+        assert(dir < MPL_GPU_COPY_DIRECTION_TYPES);
+        cmdList_entry = device_states[orig_dev].last_cmdList_entry[dir];
+        assert(cmdList_entry);
+        cmdList = cmdList_entry->cmdList;
     }
     if (commit && cmdList) {
+        MPL_ze_engine_entry_t *engine_state = device_state->engines + engine;
         ret = zeCommandListClose(cmdList);
         ZE_ERR_CHECK(ret);
-        int q_index = device_state->engines[engine].curQueue;
-        assert(device_state->engines[engine].cmdQueues);
-        ze_command_queue_handle_t cmdq = device_state->engines[engine].cmdQueues[q_index];
+        int q_index;
+        if (dir == MPL_GPU_COPY_DIRECTION_NONE) {
+            q_index = engine_state->curQueue;
+            /* move to next queue */
+            engine_state->curQueue++;
+            if (engine_state->curQueue == engine_state->numQueues)
+                engine_state->curQueue = 0;
+        } else {
+            q_index = dir % engine_state->numQueues;
+        }
+        assert(engine_state->cmdQueues);
+        ze_command_queue_handle_t cmdq = engine_state->cmdQueues[q_index];
         if (cmdq == NULL) {
             mpl_err = create_cmdqueue(device_state->dev_id, engine);
             if (mpl_err != MPL_SUCCESS)
                 goto fn_fail;
-            cmdq = device_state->engines[engine].cmdQueues[q_index];
+            cmdq = engine_state->cmdQueues[q_index];
             assert(cmdq);
         }
         ret = zeCommandQueueExecuteCommandLists(cmdq, 1, &cmdList, NULL);
         ZE_ERR_CHECK(ret);
-        /* move to next queue */
-        device_state->engines[engine].curQueue++;
-        if (device_state->engines[engine].curQueue == device_state->engines[engine].numQueues)
-            device_state->engines[engine].curQueue = 0;
-        req->cmdList = device_states[orig_dev].last_cmdList_entry;
-        device_states[orig_dev].last_cmdList_entry = NULL;
+        req->cmdList = cmdList_entry;
+        if (dir != MPL_GPU_COPY_DIRECTION_NONE)
+            device_states[orig_dev].last_cmdList_entry[dir] = NULL;
     } else {
         /* continue building the command list till done */
         req->cmdList = NULL;
     }
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
+}
+
+/* use immediate command list, commit is ignored */
+int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
+                    MPL_gpu_copy_direction_t dir, MPL_gpu_engine_type_t engine_type,
+                    MPL_gpu_request * req, bool commit)
+{
+    int mpl_err = MPL_SUCCESS;
+    int ret;
+    MPL_ze_device_entry_t *device_state = NULL;
+    ze_event_handle_t event, pre_event = NULL;
+    ze_command_list_handle_t cmdl;
+    int nevent = 0;
+    int engine = -1;
+
+    assert(dev >= 0 && dev < local_ze_device_count);
+    /* if engine type does not exist, e.g. link copy does not exist on ATS
+     * use the highest engine number */
+    assert(engine_type >= 0 && engine_type < MPL_GPU_ENGINE_TYPE_LAST);
+    engine = engine_conversion[engine_type];
+    if (engine >= device_states[dev].numQueueGroups) {
+        engine_type = device_states[dev].numQueueGroups - 1;
+        engine = engine_conversion[engine_type];
+    }
+
+    if (!MPL_gpu_info.use_immediate_cmdlist) {
+        return MPL_gpu_imemcpy_normal(dest_ptr, src_ptr, size, dev, dir, engine_type, req, commit);
+    }
+
+    assert(dest_ptr && src_ptr);
+
+    ret = get_next_event(&event);
+    ZE_ERR_CHECK(ret);
+    ret = get_immediate_cmdlist(&dev, dir, engine, &cmdl);
+    ZE_ERR_CHECK(ret);
+    assert(cmdl);
+    device_state = device_states + dev;
+    if (dir != MPL_GPU_COPY_DIRECTION_NONE) {
+        if (device_state->prev_event[dir]) {
+            nevent = 1;
+            pre_event = device_state->prev_event[dir];
+        }
+        device_state->prev_event[dir] = event;
+    }
+    ret =
+        zeCommandListAppendMemoryCopy(cmdl, dest_ptr, src_ptr, size, event, nevent,
+                                      nevent ? &pre_event : NULL);
+    ZE_ERR_CHECK(ret);
+    req->cmdList = NULL;
+    req->event = event;
 
   fn_exit:
     return mpl_err;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -751,7 +751,7 @@ static int mmapFunction(int nfds, int *fds, size_t size, void **ptr)
         if (*ptr == (void *) -1) {
             mpl_err = MPL_ERR_GPU_INTERNAL;
             perror("mmap device to host");
-            printf("gdr_handle_open failed fd: %d\n", fds[0]);
+            printf("mmap failed fd: %d size: %ld\n", fds[0], size);
             goto fn_fail;
         }
     } else {
@@ -2017,13 +2017,20 @@ static inline int get_immediate_cmdlist(int *dev, MPL_gpu_copy_direction_t dir, 
     MPL_ze_engine_entry_t *engine_state = device_state->engines + engine;
 
     if (dir == MPL_GPU_COPY_DIRECTION_NONE) {
-        index = engine_state->curQueue;
-        /* move to next queue */
-        engine_state->curQueue++;
-        if (engine_state->curQueue == engine_state->numQueues)
-            engine_state->curQueue = 0;
+        if (MPL_gpu_info.roundrobin_cmdq) {
+            index = engine_state->curQueue;
+            /* move to next queue */
+            engine_state->curQueue++;
+            if (engine_state->curQueue == engine_state->numQueues)
+                engine_state->curQueue = 0;
+        } else {
+            index = 0;
+        }
     } else {
-        index = dir % engine_state->numQueues;
+        if (MPL_gpu_info.roundrobin_cmdq)
+            index = dir % engine_state->numQueues;
+        else
+            index = 0;
     }
 
     if (!engine_state->cmdlists[index]) {
@@ -2127,13 +2134,20 @@ static int MPL_gpu_imemcpy_normal(void *dest_ptr, void *src_ptr, size_t size, in
         ZE_ERR_CHECK(ret);
         int q_index;
         if (dir == MPL_GPU_COPY_DIRECTION_NONE) {
-            q_index = engine_state->curQueue;
-            /* move to next queue */
-            engine_state->curQueue++;
-            if (engine_state->curQueue == engine_state->numQueues)
-                engine_state->curQueue = 0;
+            if (MPL_gpu_info.roundrobin_cmdq) {
+                q_index = engine_state->curQueue;
+                /* move to next queue */
+                engine_state->curQueue++;
+                if (engine_state->curQueue == engine_state->numQueues)
+                    engine_state->curQueue = 0;
+            } else {
+                q_index = 0;
+            }
         } else {
-            q_index = dir % engine_state->numQueues;
+            if (MPL_gpu_info.roundrobin_cmdq)
+                q_index = dir % engine_state->numQueues;
+            else
+                q_index = 0;
         }
         assert(engine_state->cmdQueues);
         ze_command_queue_handle_t cmdq = engine_state->cmdQueues[q_index];

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -26,6 +26,7 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 #include <sys/ioctl.h>
 #include <sys/syscall.h>        /* Definition of SYS_* constants */
 #include "uthash.h"
+#include "utlist.h"
 
 static int gpu_initialized = 0;
 static uint32_t device_count;
@@ -45,6 +46,8 @@ static uint32_t *subdevice_count = NULL;
 
 static int shared_device_fd_count = 0;
 static int *shared_device_fds = NULL;
+
+static int *engine_conversion = NULL;
 
 /* pidfd */
 #ifndef __NR_pidfd_open
@@ -131,6 +134,25 @@ ze_device_handle_t *ze_devices_handle = NULL;
 ze_context_handle_t ze_context;
 uint32_t local_ze_device_count; /* This counts both devices and subdevices */
 uint32_t global_ze_device_count;        /* This counts both devices and subdevices */
+
+#define MPL_ZE_EVENT_POOL_SIZE    16384
+
+typedef struct {
+    ze_command_queue_handle_t *cmdQueues;
+    MPL_cmdlist_pool_t *cmdList_pool;
+    unsigned int numQueues, curQueue;
+} MPL_ze_engine_entry_t;
+
+typedef struct {
+    MPL_ze_engine_entry_t *engines;
+    unsigned int numQueueGroups;
+    ze_event_handle_t prev_event;       /* for imemcopy */
+    MPL_cmdlist_pool_t *last_cmdList_entry;     /* for imemcopy */
+} MPL_ze_device_entry_t;
+
+static MPL_ze_device_entry_t *device_states;
+static ze_event_pool_handle_t eventPool;
+
 static int gpu_ze_init_driver(void);
 static int fd_to_handle(int dev_fd, int fd, int *handle);
 static int handle_to_fd(int dev_fd, int handle, int *fd);
@@ -547,6 +569,12 @@ int MPL_gpu_init(int debug_summary)
         MPL_gpu_free_hook_register(MPL_ze_ipc_remove_cache_handle);
     }
 
+    /* Initialize gpu engine mapping */
+    engine_conversion = (int *) MPL_malloc(sizeof(int) * MPL_GPU_ENGINE_NUM_TYPES, MPL_MEM_OTHER);
+    engine_conversion[MPL_GPU_ENGINE_TYPE_COMPUTE] = 0; // Compute engine
+    engine_conversion[MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH] = 1;     // Main copy engine
+    engine_conversion[MPL_GPU_ENGINE_TYPE_COPY_LOW_LATENCY] = 2;        // Link copy engine
+
     mypid = getpid();
 
     gpu_mem_hook_init();
@@ -677,7 +705,7 @@ static int gpu_ze_init_driver(void)
     ret = zeDriverGet(&driver_count, all_drivers);
     ZE_ERR_CHECK(ret);
 
-    int i, d;
+    int i, j, d;
     /* Find a driver instance with a GPU device */
     for (i = 0; i < driver_count; ++i) {
         device_count = 0;
@@ -770,6 +798,80 @@ static int gpu_ze_init_driver(void)
     ret = zeContextCreate(ze_driver_handle, &contextDesc, &ze_context);
     ZE_ERR_CHECK(ret);
 
+    device_states =
+        (MPL_ze_device_entry_t *) MPL_malloc(sizeof(MPL_ze_device_entry_t) * local_ze_device_count,
+                                             MPL_MEM_OTHER);
+
+    /* create command queues */
+    for (d = 0; d < local_ze_device_count; d++) {
+        unsigned int numQueueGroups = 0;
+        ze_command_queue_desc_t cmdQueueDesc = {
+            .stype = ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC,
+            .pNext = NULL,
+            .index = 0,
+            .flags = 0,
+            .ordinal = 0,
+            .mode = ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS,
+            .priority = ZE_COMMAND_QUEUE_PRIORITY_NORMAL,
+        };
+
+        MPL_ze_device_entry_t *device_state = device_states + d;
+        device_state->prev_event = NULL;
+        device_state->last_cmdList_entry = NULL;
+        ret = zeDeviceGetCommandQueueGroupProperties(ze_devices_handle[d], &numQueueGroups, NULL);
+        ZE_ERR_CHECK(ret);
+        ze_command_queue_group_properties_t *queueProperties =
+            (ze_command_queue_group_properties_t *)
+            MPL_malloc(sizeof(ze_command_queue_group_properties_t) * numQueueGroups, MPL_MEM_OTHER);
+        ret =
+            zeDeviceGetCommandQueueGroupProperties(ze_devices_handle[d], &numQueueGroups,
+                                                   queueProperties);
+        device_state->engines =
+            (MPL_ze_engine_entry_t *) MPL_malloc(sizeof(MPL_ze_engine_entry_t) * numQueueGroups,
+                                                 MPL_MEM_OTHER);
+        device_state->numQueueGroups = numQueueGroups;
+
+        for (i = 0; i < numQueueGroups; i++) {
+            cmdQueueDesc.ordinal = -1;
+            if (queueProperties[i].flags & ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COMPUTE) {
+                cmdQueueDesc.ordinal = i;
+            } else if (queueProperties[i].flags & ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COPY &&
+                       queueProperties[i].numQueues >= 1 &&
+                       !(queueProperties[i].flags & ZE_COMMAND_QUEUE_GROUP_PROPERTY_FLAG_COMPUTE)) {
+                cmdQueueDesc.ordinal = i;
+            }
+            device_state->engines[i].cmdList_pool = NULL;
+            if (cmdQueueDesc.ordinal == -1) {
+                device_state->engines[i].curQueue = 0;
+                device_state->engines[i].numQueues = 0;
+                device_state->engines[i].cmdQueues = NULL;
+            } else {
+                device_state->engines[i].numQueues = queueProperties[i].numQueues;
+                device_state->engines[i].curQueue = 0;
+                device_state->engines[i].cmdQueues =
+                    (ze_command_queue_handle_t *) MPL_malloc(sizeof(ze_command_queue_handle_t) *
+                                                             queueProperties[i].numQueues,
+                                                             MPL_MEM_OTHER);
+                for (j = 0; j < queueProperties[i].numQueues; j++) {
+                    cmdQueueDesc.index = j;
+                    ret =
+                        zeCommandQueueCreate(ze_context, ze_devices_handle[d], &cmdQueueDesc,
+                                             &device_state->engines[i].cmdQueues[j]);
+                    ZE_ERR_CHECK(ret);
+                }
+            }
+        }
+        MPL_free(queueProperties);
+    }
+
+    ze_event_pool_desc_t pool_desc;
+    pool_desc.stype = ZE_STRUCTURE_TYPE_EVENT_POOL_DESC;
+    pool_desc.pNext = NULL;
+    pool_desc.flags = 0;
+    pool_desc.count = MPL_ZE_EVENT_POOL_SIZE;
+    ret = zeEventPoolCreate(ze_context, &pool_desc, 0, NULL, &eventPool);
+    ZE_ERR_CHECK(ret);
+
   fn_exit:
     MPL_free(all_drivers);
     return ret_error;
@@ -783,7 +885,7 @@ static int gpu_ze_init_driver(void)
 
 int MPL_gpu_finalize(void)
 {
-    int i;
+    int i, j, k;
 
     if (likely(MPL_gpu_info.specialized_cache)) {
         for (i = 0; i < local_ze_device_count; ++i) {
@@ -852,6 +954,28 @@ int MPL_gpu_finalize(void)
         free_hook_chain = free_hook_chain->next;
         MPL_free(prev);
     }
+
+    for (i = 0; i < local_ze_device_count; i++) {
+        MPL_ze_device_entry_t *device_state = device_states + i;
+        for (j = 0; j < device_state->numQueueGroups; j++) {
+            MPL_ze_engine_entry_t *engine = device_state->engines + j;
+            for (k = 0; k < engine->numQueues; k++) {
+                zeCommandQueueDestroy(engine->cmdQueues[k]);
+            }
+            MPL_cmdlist_pool_t *cmdlist, *t, *pool = engine->cmdList_pool;
+            DL_FOREACH_SAFE(pool, cmdlist, t) {
+                zeCommandListDestroy(cmdlist->cmdList);
+                DL_DELETE(pool, cmdlist);
+                MPL_free(cmdlist);
+            }
+            MPL_free(engine->cmdQueues);
+        }
+        MPL_free(device_state->engines);
+    }
+    MPL_free(device_states);
+    MPL_free(engine_conversion);
+
+    zeEventPoolDestroy(eventPool);
 
     return MPL_SUCCESS;
 }
@@ -1369,6 +1493,186 @@ int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)
     int ret;
     ret = zeMemGetAddressRange(ze_context, ptr, pbase, len);
     ZE_ERR_CHECK(ret);
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
+}
+
+/*                         MPL_gpu_imemcpy                          */
+
+/* command list utility functions */
+static int get_cmdlist(int dev, int engine, MPL_cmdlist_pool_t ** cl_entry)
+{
+    int mpl_err = MPL_SUCCESS;
+    int ret;
+    MPL_cmdlist_pool_t *cmdList_entry = NULL;
+    ze_command_list_handle_t cmdList = NULL;
+    MPL_ze_device_entry_t *device_state;
+
+    *cl_entry = NULL;
+    if (engine > device_states[dev].numQueueGroups - 1 ||
+        device_states[dev].engines[engine].numQueues == 0) {
+        /* certain type of engine may not be available on the subdevices */
+        dev = MPL_gpu_get_root_device(dev);
+        if (device_states[dev].engines[engine].numQueues == 0)
+            goto fn_fail;
+    }
+    assert(dev < local_ze_device_count);
+    device_state = device_states + dev;
+    if (device_state->engines[engine].cmdList_pool) {
+        cmdList_entry = device_state->engines[engine].cmdList_pool;
+        DL_DELETE(device_state->engines[engine].cmdList_pool, cmdList_entry);
+        cmdList = cmdList_entry->cmdList;
+        ret = zeCommandListReset(cmdList);
+        ZE_ERR_CHECK(ret);
+    } else {
+        ze_command_list_desc_t cmdListDesc = {
+            .stype = ZE_STRUCTURE_TYPE_COMMAND_LIST_DESC,
+            .pNext = NULL,
+            .commandQueueGroupOrdinal = engine,
+            .flags = 0,
+        };
+        ret = zeCommandListCreate(ze_context, ze_devices_handle[dev], &cmdListDesc, &cmdList);
+        ZE_ERR_CHECK(ret);
+        cmdList_entry =
+            (MPL_cmdlist_pool_t *) MPL_malloc(sizeof(MPL_cmdlist_pool_t), MPL_MEM_OTHER);
+        if (cmdList_entry == NULL) {
+            goto fn_fail;
+        }
+        cmdList_entry->cmdList = cmdList;
+        cmdList_entry->dev = dev;
+        cmdList_entry->engine = engine;
+    }
+    *cl_entry = cmdList_entry;
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
+}
+
+static inline int get_next_event(ze_event_handle_t * event)
+{
+    static int pool_idx = 0;
+    int mpl_err = MPL_SUCCESS;
+    int ret;
+
+    *event = NULL;
+    ze_event_desc_t event_desc = {
+        .stype = ZE_STRUCTURE_TYPE_EVENT_DESC,
+        .pNext = NULL,
+        .signal = ZE_EVENT_SCOPE_FLAG_HOST,
+        .wait = ZE_EVENT_SCOPE_FLAG_HOST
+    };
+    event_desc.index = pool_idx++;
+    if (pool_idx >= MPL_ZE_EVENT_POOL_SIZE)
+        pool_idx = 0;
+    ret = zeEventCreate(eventPool, &event_desc, event);
+    ZE_ERR_CHECK(ret);
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
+}
+
+/* no safety check in this function, call this function with safety protection.
+   commit = false: append to command list only
+   commit = true:  close the command list and submit to command queue
+*/
+int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
+                    MPL_gpu_engine_type_t engine_type, MPL_gpu_request * req, bool commit)
+{
+    MPL_ze_device_entry_t *device_state = NULL;
+    ze_event_handle_t event;
+    ze_command_list_handle_t cmdList = NULL;
+    int mpl_err = MPL_SUCCESS;
+    int ret;
+    int orig_dev = dev;
+    int engine = engine_conversion[engine_type];
+
+    if (dest_ptr && src_ptr) {
+        ret = get_next_event(&event);
+        ZE_ERR_CHECK(ret);
+        if (device_states[dev].last_cmdList_entry == NULL) {
+            MPL_cmdlist_pool_t *cmdList_entry;
+            ret = get_cmdlist(dev, engine, &cmdList_entry);
+            ZE_ERR_CHECK(ret);
+            cmdList = cmdList_entry->cmdList;
+            device_states[dev].last_cmdList_entry = cmdList_entry;
+            dev = cmdList_entry->dev;
+        } else {
+            cmdList = device_states[dev].last_cmdList_entry->cmdList;
+            if (device_states[dev].last_cmdList_entry->dev != dev)
+                goto fn_fail;
+        }
+        assert(dev < local_ze_device_count);
+        device_state = device_states + dev;
+        ret =
+            zeCommandListAppendMemoryCopy(cmdList, dest_ptr, src_ptr, size, event,
+                                          device_state->prev_event ? 1 : 0,
+                                          device_state->
+                                          prev_event ? &device_state->prev_event : NULL);
+        ZE_ERR_CHECK(ret);
+        req->event = event;
+        device_state->prev_event = event;
+    } else {
+        device_state = device_states + dev;
+        assert(device_state->prev_event);
+        req->event = device_state->prev_event;
+        if (device_state->last_cmdList_entry)
+            cmdList = device_state->last_cmdList_entry->cmdList;
+    }
+    if (commit && cmdList) {
+        ret = zeCommandListClose(cmdList);
+        ZE_ERR_CHECK(ret);
+        ret =
+            zeCommandQueueExecuteCommandLists(device_state->
+                                              engines[engine].cmdQueues[device_state->
+                                                                        engines[engine].curQueue],
+                                              1, &cmdList, NULL);
+        ZE_ERR_CHECK(ret);
+        device_state->engines[engine].curQueue++;
+        if (device_state->engines[engine].curQueue == device_state->engines[engine].numQueues)
+            device_state->engines[engine].curQueue = 0;
+        req->cmdList = device_states[orig_dev].last_cmdList_entry;
+        device_states[orig_dev].last_cmdList_entry = NULL;
+    } else {
+        /* continue building the command list till done */
+        req->cmdList = NULL;
+    }
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
+}
+
+int MPL_gpu_test(MPL_gpu_request * req, int *completed)
+{
+    int mpl_err = MPL_SUCCESS;
+    ze_result_t ret;
+
+    assert(req->event);
+    ret = zeEventQueryStatus(req->event);
+    if (ret == ZE_RESULT_SUCCESS) {
+        *completed = 1;
+        if (req->cmdList) {
+            DL_APPEND(device_states[req->cmdList->dev].engines[req->cmdList->engine].cmdList_pool,
+                      req->cmdList);
+        }
+    } else if (ret != ZE_RESULT_NOT_READY) {
+        assert(0);
+        goto fn_fail;
+    } else {
+        *completed = 0;
+    }
 
   fn_exit:
     return mpl_err;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -60,37 +60,40 @@ static int *engine_conversion = NULL;
 typedef struct {
     const void *ptr;
     int dev_id;
-    int handle;
+    int handles[2];
+    uint32_t nhandles;
     UT_hash_handle hh;
 } MPL_ze_gem_hash_entry_t;
 
+/*
+this cache entry may cache two device pointers:
+   1. from remote device which is obtained by zeOpenIpcHandle
+   2. from a local device pointer which is obtained by zeGetIpchandle and mmap
+*/
 typedef struct {
-    uint64_t mem_id;
+    uint64_t mem_id;            /* key */
     MPL_gpu_ipc_mem_handle_t ipc_handle;
-    int fd;
+    int fds[2];
+    uint32_t nfds;
     void *mapped_ptr;
-    size_t mapped_size;
+    size_t mapped_size;         /* total size */
     bool handle_cached;
     UT_hash_handle hh;
 } MPL_ze_ipc_handle_entry_t;
-
-typedef struct {
-    void *ipc_buf;
-    void *mapped_ptr;
-    size_t mapped_size;
-
-    /* Multiple keys */
-    uint64_t remote_mem_id;
-    int remote_dev_id;
-    pid_t remote_pid;
-    UT_hash_handle hh;
-} MPL_ze_mapped_buffer_entry_t;
 
 typedef struct {
     uint64_t remote_mem_id;
     int remote_dev_id;
     pid_t remote_pid;
 } MPL_ze_mapped_buffer_lookup_t;
+
+typedef struct {
+    MPL_ze_mapped_buffer_lookup_t key;
+    void *ipc_buf;
+    void *mapped_ptr;
+    size_t mapped_size;
+    UT_hash_handle hh;
+} MPL_ze_mapped_buffer_entry_t;
 
 static MPL_ze_gem_hash_entry_t *gem_hash = NULL;
 static MPL_ze_ipc_handle_entry_t **ipc_cache_tracked = NULL;
@@ -107,7 +110,8 @@ typedef struct {
 static MPL_ze_mem_id_entry_t *mem_id_cache = NULL;
 
 typedef struct {
-    int fd;
+    int fds[2];
+    uint32_t nfds;
     pid_t pid;
     int dev_id;
     uint64_t mem_id;
@@ -152,6 +156,13 @@ typedef struct {
 
 static MPL_ze_device_entry_t *device_states;
 static ze_event_pool_handle_t eventPool;
+
+/* *INDENT-OFF* */
+typedef ze_result_t (*pFnzexMemGetIpcHandles)(ze_context_handle_t, const void *, uint32_t *, ze_ipc_mem_handle_t *);
+typedef ze_result_t (*pFnzexMemOpenIpcHandles)(ze_context_handle_t, ze_device_handle_t, uint32_t, ze_ipc_mem_handle_t *, ze_ipc_memory_flags_t, void **);
+static pFnzexMemGetIpcHandles zexMemGetIpcHandles = NULL;
+static pFnzexMemOpenIpcHandles zexMemOpenIpcHandles = NULL;
+/* *INDENT-ON* */
 
 static int gpu_ze_init_driver(void);
 static int fd_to_handle(int dev_fd, int fd, int *handle);
@@ -679,6 +690,153 @@ static int close_handle(int dev_fd, int handle)
 #endif
 }
 
+/* implicit scaling */
+static inline void split_size(size_t size, size_t sizes[2])
+{
+    /* calculate sizes */
+    const size_t alignment = 64 * 1024;;
+    size_t mask = alignment - 1;
+    size = (size + mask) & ~mask;
+    size_t n = size >> 16;
+    if (size < alignment) {
+        sizes[0] = size;
+        sizes[1] = 0;
+    } else if (n % 2) {
+        sizes[0] = (n + 1) / 2 * alignment;
+        sizes[1] = size - sizes[0];
+    } else {
+        sizes[0] = n / 2 * alignment;
+        sizes[1] = size - sizes[0];
+    }
+    assert(sizes[0]);
+}
+
+/* map two allocations into one contiguous buffer */
+static int mmapFunction(int nfds, int *fds, size_t size, void **ptr)
+{
+    int mpl_err = MPL_SUCCESS;
+    size_t split_sizes[2];
+
+    if (nfds == 1) {
+        *ptr = mmap(0, size, PROT_READ | PROT_WRITE, MAP_SHARED, fds[0], 0);
+        if (*ptr == (void *) -1) {
+            mpl_err = MPL_ERR_GPU_INTERNAL;
+            perror("mmap device to host");
+            printf("gdr_handle_open failed fd: %d\n", fds[0]);
+            goto fn_fail;
+        }
+    } else {
+        split_size(size, split_sizes);
+        void *buf = mmap(0, size, PROT_NONE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        if (buf == (void *) -1) {
+            mpl_err = MPL_ERR_GPU_INTERNAL;
+            perror("mmap");
+            printf("mmapFunction failed when reserving whole size\n");
+            goto fn_fail;
+        }
+        void *p =
+            mmap(buf, split_sizes[0], PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, fds[0], 0);
+        if (p != buf) {
+            mpl_err = MPL_ERR_GPU_INTERNAL;
+            perror("mmap 1st tile");
+            printf("mmapFunction failed when mapping first tile \n");
+            goto fn_fail;
+        }
+        if (split_sizes[1]) {
+            char *p2 = (char *) buf + split_sizes[0];
+            p = mmap(p2, split_sizes[1], PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, fds[1], 0);
+            if (p != (void *) p2) {
+                mpl_err = MPL_ERR_GPU_INTERNAL;
+                perror("mmap 2nd tile");
+                printf("mmapFunction failed when mapping second tile \n");
+                goto fn_fail;
+            }
+        }
+        *ptr = buf;
+    }
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    *ptr = NULL;
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
+}
+
+/* munmap an implicit scaling buffer */
+static int munmapFunction(int nfds, int *fds, void *ptr, size_t size)
+{
+    int mpl_err = MPL_SUCCESS;
+    size_t split_sizes[2];
+    int ret;
+
+    if (nfds == 1) {
+        ret = munmap(ptr, size);
+        if (ret != 0) {
+            goto fn_fail;
+        }
+        close(fds[0]);
+    } else {
+        split_size(size, split_sizes);
+        void *ptr1 = ptr;
+        ret = munmap(ptr1, split_sizes[0]);
+        if (ret != 0) {
+            goto fn_fail;
+        }
+        close(fds[0]);
+        void *ptr2 = (char *) ptr + split_sizes[0];
+        ret = munmap(ptr2, split_sizes[1]);
+        if (ret != 0) {
+            goto fn_fail;
+        }
+        close(fds[1]);
+    }
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
+}
+
+/*
+    cache utility functions for MPL_ze_ipc_handle_entry_t:
+    used to cache local device pointer's ipc handle and mmap'ed pointer.
+    mapped pointers can be from a remote IPC handle
+*/
+
+static inline void free_ipc_handle_cache(MPL_ze_ipc_handle_entry_t * cache_entry)
+{
+    if (cache_entry->mapped_ptr) {
+        munmapFunction(cache_entry->nfds, cache_entry->fds, cache_entry->mapped_ptr,
+                       cache_entry->mapped_size);
+    }
+}
+
+static inline int new_ipc_handle_cache(MPL_ze_ipc_handle_entry_t ** entry, int mem_id)
+{
+    int mpl_err = MPL_SUCCESS;
+    MPL_ze_ipc_handle_entry_t *cache_entry;
+
+    cache_entry =
+        (MPL_ze_ipc_handle_entry_t *) MPL_malloc(sizeof(MPL_ze_ipc_handle_entry_t), MPL_MEM_OTHER);
+    if (cache_entry == NULL) {
+        mpl_err = MPL_ERR_GPU_NOMEM;
+        goto fn_fail;
+    }
+
+    memset(cache_entry, 0, sizeof(MPL_ze_ipc_handle_entry_t));
+    cache_entry->mem_id = mem_id;
+    cache_entry->handle_cached = false;
+    *entry = cache_entry;
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    *entry = NULL;
+    goto fn_exit;
+}
+
 /* Loads a global ze driver */
 static int gpu_ze_init_driver(void)
 {
@@ -872,6 +1030,19 @@ static int gpu_ze_init_driver(void)
     ret = zeEventPoolCreate(ze_context, &pool_desc, 0, NULL, &eventPool);
     ZE_ERR_CHECK(ret);
 
+    /* driver extension */
+    ret =
+        zeDriverGetExtensionFunctionAddress(ze_driver_handle, "zexMemGetIpcHandles",
+                                            (void **) &zexMemGetIpcHandles);
+    if (ZE_RESULT_SUCCESS != ret)
+        zexMemGetIpcHandles = NULL;
+
+    ret =
+        zeDriverGetExtensionFunctionAddress(ze_driver_handle, "zexMemOpenIpcHandles",
+                                            (void **) &zexMemOpenIpcHandles);
+    if (ZE_RESULT_SUCCESS != ret)
+        zexMemOpenIpcHandles = NULL;
+
   fn_exit:
     MPL_free(all_drivers);
     return ret_error;
@@ -907,10 +1078,7 @@ int MPL_gpu_finalize(void)
         for (i = 0; i < local_ze_device_count; ++i) {
             MPL_ze_ipc_handle_entry_t *entry = NULL, *tmp = NULL;
             HASH_ITER(hh, ipc_cache_tracked[i], entry, tmp) {
-                if (entry->mapped_ptr != NULL) {
-                    munmap(entry->mapped_ptr, entry->mapped_size);
-                    close(entry->fd);
-                }
+                free_ipc_handle_cache(entry);
                 HASH_DELETE(hh, ipc_cache_tracked[i], entry);
                 MPL_free(entry);
             }
@@ -992,6 +1160,7 @@ int MPL_gpu_local_to_global_dev_id(int local_dev_id)
     return local_to_global_map[local_dev_id];
 }
 
+/* given a local device pointer, create an IPC handle */
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     int mpl_err = MPL_SUCCESS;
@@ -999,14 +1168,14 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     int local_dev_id = -1;
     MPL_ze_ipc_handle_entry_t *cache_entry = NULL;
     MPL_ze_mem_id_entry_t *memid_entry = NULL;
+    MPL_gpu_device_attr ptr_attr;
     uint64_t mem_id = 0;
     void *pbase = NULL;
     uintptr_t len;
 
-    MPL_gpu_device_attr ptr_attr;
-    memset(&ptr_attr, 0, sizeof(MPL_gpu_device_attr));
     memset(ipc_handle, 0, sizeof(MPL_gpu_ipc_mem_handle_t));
 
+    memset(&ptr_attr, 0, sizeof(MPL_gpu_device_attr));
     ret = zeMemGetAllocProperties(ze_context, ptr, &ptr_attr.prop, &ptr_attr.device);
     ZE_ERR_CHECK(ret);
 
@@ -1029,9 +1198,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
             HASH_FIND(hh, ipc_cache_tracked[local_dev_id], &memid_entry->mem_id, sizeof(uint64_t),
                       cache_entry);
             if (cache_entry) {
-                if (cache_entry->mapped_ptr != NULL) {
-                    munmap(cache_entry->mapped_ptr, cache_entry->mapped_size);
-                }
+                free_ipc_handle_cache(cache_entry);
                 HASH_DELETE(hh, ipc_cache_tracked[local_dev_id], cache_entry);
                 MPL_free(cache_entry);
                 cache_entry = NULL;
@@ -1061,32 +1228,24 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
                 memcpy(&cache_entry->ipc_handle, ipc_handle, sizeof(MPL_gpu_ipc_mem_handle_t));
             } else {
                 /* Insert into the cache */
-                cache_entry =
-                    (MPL_ze_ipc_handle_entry_t *) MPL_malloc(sizeof(MPL_ze_ipc_handle_entry_t),
-                                                             MPL_MEM_OTHER);
-
-                if (cache_entry == NULL) {
+                mpl_err = new_ipc_handle_cache(&cache_entry, mem_id);
+                if (mpl_err != MPL_SUCCESS) {
                     mpl_err = MPL_ERR_GPU_NOMEM;
                     goto fn_fail;
                 }
 
-                memid_entry = (MPL_ze_mem_id_entry_t *) MPL_malloc(sizeof(MPL_ze_mem_id_entry_t),
-                                                                   MPL_MEM_OTHER);
-
-                if (memid_entry == NULL) {
-                    mpl_err = MPL_ERR_GPU_NOMEM;
-                    goto fn_fail;
-                }
-
-                memset(cache_entry, 0, sizeof(MPL_ze_ipc_handle_entry_t));
-                memset(memid_entry, 0, sizeof(MPL_ze_mem_id_entry_t));
-
-                cache_entry->mem_id = mem_id;
                 cache_entry->handle_cached = true;
                 memcpy(&cache_entry->ipc_handle, ipc_handle, sizeof(MPL_gpu_ipc_mem_handle_t));
                 HASH_ADD(hh, ipc_cache_tracked[local_dev_id], mem_id, sizeof(uint64_t), cache_entry,
                          MPL_MEM_OTHER);
 
+                memid_entry = (MPL_ze_mem_id_entry_t *) MPL_malloc(sizeof(MPL_ze_mem_id_entry_t),
+                                                                   MPL_MEM_OTHER);
+                if (memid_entry == NULL) {
+                    mpl_err = MPL_ERR_GPU_NOMEM;
+                    goto fn_fail;
+                }
+                memset(memid_entry, 0, sizeof(MPL_ze_mem_id_entry_t));
                 memid_entry->ptr = pbase;
                 memid_entry->mem_id = mem_id;
                 HASH_ADD(hh, mem_id_cache, ptr, sizeof(void *), memid_entry, MPL_MEM_OTHER);
@@ -1120,9 +1279,11 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
         MPL_free(entry);
 
         /* close GEM handle */
-        status = close_handle(shared_device_fds[entry->dev_id], entry->handle);
-        if (status) {
-            goto fn_fail;
+        for (int i = 0; i < entry->nhandles; i++) {
+            status = close_handle(shared_device_fds[entry->dev_id], entry->handles[i]);
+            if (status) {
+                goto fn_fail;
+            }
         }
     }
 
@@ -1136,10 +1297,7 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
         HASH_FIND(hh, ipc_cache_tracked[dev_id], &mem_id, sizeof(uint64_t), cache_entry);
 
         if (cache_entry != NULL) {
-            if (cache_entry->mapped_ptr) {
-                munmap(cache_entry->mapped_ptr, cache_entry->mapped_size);
-                close(cache_entry->fd);
-            }
+            free_ipc_handle_cache(cache_entry);
             HASH_DELETE(hh, ipc_cache_tracked[dev_id], cache_entry);
             MPL_free(cache_entry);
         }
@@ -1155,26 +1313,21 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;
-    ze_ipc_mem_handle_t ze_ipc_handle;
     MPL_ze_mapped_buffer_entry_t *cache_entry = NULL;
     MPL_ze_mapped_buffer_entry_t *removal_entry = NULL;
     MPL_ze_mapped_buffer_lookup_t lookup_entry;
     unsigned keylen = 0;
-
-    memset(&ze_ipc_handle, 0, sizeof(ze_ipc_mem_handle_t));
 
     fd_pid_t h;
     memcpy(&h, &ipc_handle, sizeof(fd_pid_t));
 
     if (likely(MPL_gpu_info.specialized_cache)) {
         /* Check if ipc-mapped buffer is already cached */
-        memset(&lookup_entry, 0, sizeof(MPL_ze_mapped_buffer_lookup_t));
         lookup_entry.remote_mem_id = h.mem_id;
         lookup_entry.remote_dev_id = h.dev_id;
         lookup_entry.remote_pid = h.pid;
 
-        keylen = offsetof(MPL_ze_mapped_buffer_entry_t, remote_pid) + sizeof(pid_t) -
-            offsetof(MPL_ze_mapped_buffer_entry_t, remote_mem_id);
+        keylen = sizeof(MPL_ze_mapped_buffer_lookup_t);
 
         HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry.remote_mem_id, keylen, cache_entry);
     }
@@ -1197,8 +1350,6 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
                     mpl_err = MPL_ERR_GPU_NOMEM;
                     goto fn_fail;
                 }
-
-                memset(removal_entry, 0, sizeof(MPL_ze_mapped_buffer_entry_t));
                 memcpy(removal_entry, cache_entry, sizeof(MPL_ze_mapped_buffer_entry_t));
                 removal_entry->mapped_ptr = NULL;
 
@@ -1212,6 +1363,9 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
                     mpl_err = MPL_ERR_GPU_NOMEM;
                     goto fn_fail;
                 }
+                memset(cache_entry, 0, sizeof(MPL_ze_mapped_buffer_entry_t));
+                cache_entry->key = lookup_entry;
+                cache_entry->ipc_buf = *ptr;
 
                 removal_entry = (MPL_ze_mapped_buffer_entry_t *)
                     MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t), MPL_MEM_OTHER);
@@ -1219,18 +1373,9 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
                     mpl_err = MPL_ERR_GPU_NOMEM;
                     goto fn_fail;
                 }
-
-                memset(removal_entry, 0, sizeof(MPL_ze_mapped_buffer_entry_t));
-                memset(cache_entry, 0, sizeof(MPL_ze_mapped_buffer_entry_t));
-
-                cache_entry->remote_mem_id = lookup_entry.remote_mem_id;
-                cache_entry->remote_dev_id = lookup_entry.remote_dev_id;
-                cache_entry->remote_pid = lookup_entry.remote_pid;
-                cache_entry->ipc_buf = *ptr;
                 memcpy(removal_entry, cache_entry, sizeof(MPL_ze_mapped_buffer_entry_t));
 
-                HASH_ADD(hh, ipc_cache_mapped[dev_id], remote_mem_id, keylen, cache_entry,
-                         MPL_MEM_OTHER);
+                HASH_ADD(hh, ipc_cache_mapped[dev_id], key, keylen, cache_entry, MPL_MEM_OTHER);
                 HASH_ADD(hh, ipc_cache_removal[dev_id], ipc_buf, sizeof(void *), removal_entry,
                          MPL_MEM_OTHER);
             }
@@ -1259,27 +1404,24 @@ int MPL_ze_mmap_handle_unmap(void *ptr, int dev_id)
         }
 
         if (cache_entry != NULL) {
-            memset(&lookup_entry, 0, sizeof(MPL_ze_mapped_buffer_lookup_t));
-            lookup_entry.remote_mem_id = cache_entry->remote_mem_id;
-            lookup_entry.remote_dev_id = cache_entry->remote_dev_id;
-            lookup_entry.remote_pid = cache_entry->remote_pid;
-
-            keylen = offsetof(MPL_ze_mapped_buffer_entry_t, remote_pid) + sizeof(pid_t) -
-                offsetof(MPL_ze_mapped_buffer_entry_t, remote_mem_id);
+            lookup_entry = cache_entry->key;
+            keylen = sizeof(MPL_ze_mapped_buffer_lookup_t);
 
             HASH_DEL(mmap_cache_removal[dev_id], cache_entry);
             MPL_free(cache_entry);
             cache_entry = NULL;
 
-            HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry.remote_mem_id, keylen,
-                      cache_entry);
+            HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry, keylen, cache_entry);
 
             if (cache_entry != NULL) {
+                // FIXME: need to close IPC handle?
                 HASH_DEL(ipc_cache_mapped[dev_id], cache_entry);
                 MPL_free(cache_entry);
                 cache_entry = NULL;
             }
         }
+    } else {
+        goto fn_fail;
     }
 
     ret_err = munmap(ptr, size);
@@ -1325,13 +1467,8 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
         HASH_FIND(hh, ipc_cache_removal[dev_id], &ptr, sizeof(void *), cache_entry);
 
         if (cache_entry != NULL) {
-            memset(&lookup_entry, 0, sizeof(MPL_ze_mapped_buffer_lookup_t));
-            lookup_entry.remote_mem_id = cache_entry->remote_mem_id;
-            lookup_entry.remote_dev_id = cache_entry->remote_dev_id;
-            lookup_entry.remote_pid = cache_entry->remote_pid;
-
-            keylen = offsetof(MPL_ze_mapped_buffer_entry_t, remote_pid) + sizeof(pid_t) -
-                offsetof(MPL_ze_mapped_buffer_entry_t, remote_mem_id);
+            lookup_entry = cache_entry->key;
+            keylen = sizeof(MPL_ze_mapped_buffer_lookup_t);
 
             HASH_DEL(ipc_cache_removal[dev_id], cache_entry);
             MPL_free(cache_entry);
@@ -1341,6 +1478,7 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
                       cache_entry);
 
             if (cache_entry != NULL) {
+                // FIXME: need to unmap?
                 HASH_DEL(ipc_cache_mapped[dev_id], cache_entry);
                 MPL_free(cache_entry);
                 cache_entry = NULL;
@@ -1877,24 +2015,37 @@ int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, in
 {
     int mpl_err = MPL_SUCCESS;
     ze_result_t ret;
-    int fd, handle, status;
-    ze_ipc_mem_handle_t ze_ipc_handle;
+    int fds[2], handles[2], status;
+    uint32_t nfds;
+    ze_ipc_mem_handle_t ze_ipc_handle[2];
     fd_pid_t h;
     uint64_t mem_id = 0;
 
     mem_id = ptr_attr->prop.id;
 
-    ret = zeMemGetIpcHandle(ze_context, ptr, &ze_ipc_handle);
+    if (zexMemGetIpcHandles) {
+        nfds = 0;       /* must initialized to 0 */
+        ret = zexMemGetIpcHandles(ze_context, ptr, &nfds, NULL);
+        ZE_ERR_CHECK(ret);
+        assert(nfds <= 2);
+        ret = zexMemGetIpcHandles(ze_context, ptr, &nfds, ze_ipc_handle);
+    } else {
+        ret = zeMemGetIpcHandle(ze_context, ptr, &ze_ipc_handle[0]);
+        nfds = 1;
+    }
     ZE_ERR_CHECK(ret);
 
+    h.nfds = nfds;
     if (shared_device_fds != NULL) {
         if (use_shared_fd) {
             int shared_dev_id = MPL_gpu_get_root_device(local_dev_id);
-            /* convert dma_buf fd to GEM handle */
-            memcpy(&fd, &ze_ipc_handle, sizeof(fd));
-            status = fd_to_handle(shared_device_fds[shared_dev_id], fd, &handle);
-            if (status) {
-                goto fn_fail;
+            for (int i = 0; i < nfds; i++) {
+                /* convert dma_buf fd to GEM handle */
+                memcpy(&fds[i], &ze_ipc_handle[i], sizeof(int));
+                status = fd_to_handle(shared_device_fds[shared_dev_id], fds[i], &handles[i]);
+                if (status) {
+                    goto fn_fail;
+                }
             }
 
             /* Hash (ptr, dev_id, handle) to close later */
@@ -1911,18 +2062,25 @@ int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, in
 
                 entry->ptr = ptr;
                 entry->dev_id = shared_dev_id;
-                entry->handle = handle;
+                for (int i = 0; i < nfds; i++)
+                    entry->handles[i] = handles[i];
+                entry->nhandles = nfds;
                 HASH_ADD_PTR(gem_hash, ptr, entry, MPL_MEM_OTHER);
             }
 
-            memcpy(&h.fd, &handle, sizeof(int));
+            for (int i = 0; i < nfds; i++)
+                h.fds[i] = handles[i];
             h.dev_id = shared_dev_id;
         } else {
-            memcpy(&h.fd, &ze_ipc_handle, sizeof(int));
+            for (int i = 0; i < nfds; i++) {
+                memcpy(&h.fds[i], &ze_ipc_handle[i], sizeof(int));
+            }
             h.dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
         }
     } else {
-        memcpy(&h.fd, &ze_ipc_handle, sizeof(fd));
+        for (int i = 0; i < nfds; i++) {
+            memcpy(&h.fds[i], &ze_ipc_handle[i], sizeof(int));
+        }
         h.dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
         assert(h.dev_id != -1);
     }
@@ -1943,59 +2101,68 @@ int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_han
 {
     int mpl_err = MPL_SUCCESS;
     ze_result_t ret;
-    int fd, status;
+    int fds[2], status;
+    uint32_t nfds;
     MPL_gpu_device_handle_t dev_handle;
-    ze_ipc_mem_handle_t ze_ipc_handle;
-
-    memset(&ze_ipc_handle, 0, sizeof(ze_ipc_mem_handle_t));
 
     fd_pid_t h;
     memcpy(&h, &ipc_handle, sizeof(fd_pid_t));
+    nfds = h.nfds;
 
     if (shared_device_fds != NULL) {
         /* convert GEM handle to fd */
-        status = handle_to_fd(shared_device_fds[h.dev_id], h.fd, &fd);
-        if (status) {
-            goto fn_fail;
+        for (int i = 0; i < nfds; i++) {
+            status = handle_to_fd(shared_device_fds[h.dev_id], h.fds[i], &fds[i]);
+            if (status) {
+                goto fn_fail;
+            }
         }
     } else {
         /* pidfd_getfd */
         if (h.pid != mypid) {
             int pid_fd = syscall(__NR_pidfd_open, h.pid, 0);
             if (pid_fd == -1) {
-                printf("pidfd_open error: %s (%d %d %d)\n", strerror(errno), h.pid, h.fd, h.dev_id);
+                printf("pidfd_open error: %s (%d %d %d)\n", strerror(errno), h.pid, h.fds[0],
+                       h.dev_id);
             }
             assert(pid_fd != -1);
-            fd = syscall(__NR_pidfd_getfd, pid_fd, h.fd, 0);
-            if (fd == -1) {
-                printf("Error> pidfd_getfd is not implemented!");
-                mpl_err = MPL_ERR_GPU_INTERNAL;
-                goto fn_fail;
+            for (int i = 0; i < nfds; i++) {
+                fds[i] = syscall(__NR_pidfd_getfd, pid_fd, h.fds[i], 0);
+                if (fds[i] == -1) {
+                    printf("Error> pidfd_getfd is not implemented!");
+                    mpl_err = MPL_ERR_GPU_INTERNAL;
+                    goto fn_fail;
+                }
             }
             close(pid_fd);
         } else {
-            fd = h.fd;
+            fds[0] = h.fds[0];
+            fds[1] = h.fds[1];
         }
     }
 
     if (is_mmap) {
-        void *buf;
-        buf = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-        if (buf == (void *) -1) {
-            mpl_err = MPL_ERR_GPU_INTERNAL;
-            perror("mmap device to host");
-            printf("gdr_handle_open failed\n");
+        mpl_err = mmapFunction(nfds, fds, size, ptr);
+        if (mpl_err != MPL_SUCCESS) {
             goto fn_fail;
         }
-        *ptr = buf;
     } else {
+        ze_ipc_mem_handle_t ze_ipc_handle[2];
+
         mpl_err = dev_id_to_device(dev_id, &dev_handle);
         if (mpl_err != MPL_SUCCESS) {
             goto fn_fail;
         }
-        memcpy(&ze_ipc_handle, &fd, sizeof(fd));
+        for (int i = 0; i < nfds; i++) {
+            memset(&ze_ipc_handle[i], 0, sizeof(ze_ipc_mem_handle_t));
+            memcpy(&ze_ipc_handle[i], &fds[i], sizeof(int));
+        }
 
-        ret = zeMemOpenIpcHandle(ze_context, dev_handle, ze_ipc_handle, 0, ptr);
+        if (zexMemOpenIpcHandles) {
+            ret = zexMemOpenIpcHandles(ze_context, dev_handle, nfds, ze_ipc_handle, 0, ptr);
+        } else {
+            ret = zeMemOpenIpcHandle(ze_context, dev_handle, ze_ipc_handle[0], 0, ptr);
+        }
         ZE_ERR_CHECK(ret);
     }
 
@@ -2005,6 +2172,7 @@ int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_han
     goto fn_exit;
 }
 
+/* given an remote IPC handle, mmap it to host */
 int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_handle,
                                 int dev_id, size_t size, void **ptr)
 {
@@ -2024,8 +2192,7 @@ int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shar
         lookup_entry.remote_dev_id = h.dev_id;
         lookup_entry.remote_pid = h.pid;
 
-        keylen = offsetof(MPL_ze_mapped_buffer_entry_t, remote_pid) + sizeof(pid_t) -
-            offsetof(MPL_ze_mapped_buffer_entry_t, remote_mem_id);
+        keylen = sizeof(MPL_ze_mapped_buffer_lookup_t);
 
         HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry.remote_mem_id, keylen, cache_entry);
     }
@@ -2047,6 +2214,10 @@ int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shar
                 mpl_err = MPL_ERR_GPU_NOMEM;
                 goto fn_fail;
             }
+            memset(cache_entry, 0, sizeof(MPL_ze_mapped_buffer_entry_t));
+            cache_entry->key = lookup_entry;
+            cache_entry->mapped_ptr = *ptr;
+            cache_entry->mapped_size = size;
 
             removal_entry =
                 (MPL_ze_mapped_buffer_entry_t *) MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t),
@@ -2055,19 +2226,9 @@ int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shar
                 mpl_err = MPL_ERR_GPU_NOMEM;
                 goto fn_fail;
             }
-
-            memset(removal_entry, 0, sizeof(MPL_ze_mapped_buffer_entry_t));
-            memset(cache_entry, 0, sizeof(MPL_ze_mapped_buffer_entry_t));
-
-            cache_entry->remote_mem_id = lookup_entry.remote_mem_id;
-            cache_entry->remote_dev_id = lookup_entry.remote_dev_id;
-            cache_entry->remote_pid = lookup_entry.remote_pid;
-            cache_entry->mapped_ptr = *ptr;
-            cache_entry->mapped_size = size;
             memcpy(removal_entry, cache_entry, sizeof(MPL_ze_mapped_buffer_entry_t));
 
-            HASH_ADD(hh, ipc_cache_mapped[dev_id], remote_mem_id, keylen, cache_entry,
-                     MPL_MEM_OTHER);
+            HASH_ADD(hh, ipc_cache_mapped[dev_id], key, keylen, cache_entry, MPL_MEM_OTHER);
             HASH_ADD(hh, mmap_cache_removal[dev_id], mapped_ptr, sizeof(void *), removal_entry,
                      MPL_MEM_OTHER);
         }
@@ -2079,12 +2240,15 @@ int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shar
     goto fn_exit;
 }
 
+/* this function takes a local device pointer and mmap to host */
 int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,
                                MPL_gpu_device_handle_t device, void **mmaped_ptr)
 {
     ze_result_t ret;
-    ze_ipc_mem_handle_t ze_ipc_handle;
-    int fd, mpl_err = MPL_SUCCESS, local_dev_id = -1;
+    int mpl_err = MPL_SUCCESS;
+    ze_ipc_mem_handle_t ze_ipc_handle[2];
+    int fds[2], local_dev_id = -1;
+    uint32_t nfds;
     uint64_t mem_id, offset, len;
     void *pbase, *base;
     MPL_ze_ipc_handle_entry_t *cache_entry = NULL;
@@ -2109,10 +2273,7 @@ int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,
             HASH_FIND(hh, ipc_cache_tracked[local_dev_id], &memid_entry->mem_id, sizeof(uint64_t),
                       cache_entry);
             if (cache_entry) {
-                if (cache_entry->mapped_ptr != NULL) {
-                    munmap(cache_entry->mapped_ptr, cache_entry->mapped_size);
-                    close(cache_entry->fd);
-                }
+                free_ipc_handle_cache(cache_entry);
                 HASH_DELETE(hh, ipc_cache_tracked[local_dev_id], cache_entry);
                 MPL_free(cache_entry);
                 cache_entry = NULL;
@@ -2130,16 +2291,22 @@ int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,
     if (cache_entry && cache_entry->mapped_ptr) {
         base = cache_entry->mapped_ptr;
     } else {
-        ret = zeMemGetIpcHandle(ze_context, pbase, &ze_ipc_handle);
+        if (zexMemGetIpcHandles) {
+            nfds = 0;   /* must be initialized to 0 */
+            ret = zexMemGetIpcHandles(ze_context, pbase, &nfds, NULL);
+            ZE_ERR_CHECK(ret);
+            assert(nfds <= 2);
+            ret = zexMemGetIpcHandles(ze_context, pbase, &nfds, ze_ipc_handle);
+        } else {
+            ret = zeMemGetIpcHandle(ze_context, pbase, &ze_ipc_handle[0]);
+            nfds = 1;
+        }
         ZE_ERR_CHECK(ret);
 
-        memcpy(&fd, &ze_ipc_handle, sizeof(int));
-
-        base = mmap(NULL, len, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-        if (base == (void *) -1) {
-            mpl_err = MPL_ERR_GPU_INTERNAL;
-            perror("mmap_device_pointer:");
-            printf("gdr_handle_open failed\n");
+        for (int i = 0; i < nfds; i++)
+            memcpy(&fds[i], &ze_ipc_handle[i], sizeof(int));
+        mpl_err = mmapFunction(nfds, fds, len, &base);
+        if (mpl_err != MPL_SUCCESS) {
             goto fn_fail;
         }
 
@@ -2148,36 +2315,30 @@ int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,
                 /* This could have been cached already, but via the ipc path */
                 cache_entry->mapped_ptr = base;
                 cache_entry->mapped_size = len;
+                cache_entry->nfds = nfds;
+                for (int i = 0; i < nfds; i++)
+                    cache_entry->fds[i] = fds[i];
             } else {
                 /* Insert into the cache */
-                cache_entry =
-                    (MPL_ze_ipc_handle_entry_t *) MPL_malloc(sizeof(MPL_ze_ipc_handle_entry_t),
-                                                             MPL_MEM_OTHER);
-
-                if (cache_entry == NULL) {
-                    mpl_err = MPL_ERR_GPU_NOMEM;
+                mpl_err = new_ipc_handle_cache(&cache_entry, mem_id);
+                if (mpl_err != MPL_SUCCESS) {
                     goto fn_fail;
                 }
+                cache_entry->mapped_ptr = base;
+                cache_entry->mapped_size = len;
+                cache_entry->nfds = nfds;
+                for (int i = 0; i < nfds; i++)
+                    cache_entry->fds[i] = fds[i];
+                HASH_ADD(hh, ipc_cache_tracked[local_dev_id], mem_id, sizeof(uint64_t), cache_entry,
+                         MPL_MEM_OTHER);
 
                 memid_entry = (MPL_ze_mem_id_entry_t *) MPL_malloc(sizeof(MPL_ze_mem_id_entry_t),
                                                                    MPL_MEM_OTHER);
-
                 if (memid_entry == NULL) {
                     mpl_err = MPL_ERR_GPU_NOMEM;
                     goto fn_fail;
                 }
-
-                memset(cache_entry, 0, sizeof(MPL_ze_ipc_handle_entry_t));
                 memset(memid_entry, 0, sizeof(MPL_ze_mem_id_entry_t));
-
-                cache_entry->mem_id = mem_id;
-                cache_entry->mapped_ptr = base;
-                cache_entry->mapped_size = len;
-                cache_entry->handle_cached = false;
-                cache_entry->fd = fd;
-                HASH_ADD(hh, ipc_cache_tracked[local_dev_id], mem_id, sizeof(uint64_t), cache_entry,
-                         MPL_MEM_OTHER);
-
                 memid_entry->ptr = pbase;
                 memid_entry->mem_id = mem_id;
                 HASH_ADD(hh, mem_id_cache, ptr, sizeof(void *), memid_entry, MPL_MEM_OTHER);

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -485,31 +485,37 @@ int MPL_gpu_init(int debug_summary)
         }
     }
 
-    ipc_cache_tracked =
-        MPL_malloc(local_ze_device_count * sizeof(MPL_ze_ipc_handle_entry_t *), MPL_MEM_OTHER);
-    if (ipc_cache_tracked == NULL) {
-        mpl_err = MPL_ERR_GPU_NOMEM;
-        goto fn_fail;
-    }
+    if (likely(MPL_gpu_info.specialized_cache)) {
+        ipc_cache_tracked =
+            MPL_malloc(local_ze_device_count * sizeof(MPL_ze_ipc_handle_entry_t *), MPL_MEM_OTHER);
+        if (ipc_cache_tracked == NULL) {
+            mpl_err = MPL_ERR_GPU_NOMEM;
+            goto fn_fail;
+        }
 
-    ipc_cache_mapped =
-        MPL_malloc(local_ze_device_count * sizeof(MPL_ze_mapped_buffer_entry_t *), MPL_MEM_OTHER);
-    if (ipc_cache_mapped == NULL) {
-        mpl_err = MPL_ERR_GPU_NOMEM;
-        goto fn_fail;
-    }
+        ipc_cache_mapped =
+            MPL_malloc(local_ze_device_count * sizeof(MPL_ze_mapped_buffer_entry_t *),
+                       MPL_MEM_OTHER);
+        if (ipc_cache_mapped == NULL) {
+            mpl_err = MPL_ERR_GPU_NOMEM;
+            goto fn_fail;
+        }
 
-    ipc_cache_removal =
-        MPL_malloc(local_ze_device_count * sizeof(MPL_ze_mapped_buffer_entry_t *), MPL_MEM_OTHER);
-    if (ipc_cache_removal == NULL) {
-        mpl_err = MPL_ERR_GPU_NOMEM;
-        goto fn_fail;
-    }
+        ipc_cache_removal =
+            MPL_malloc(local_ze_device_count * sizeof(MPL_ze_mapped_buffer_entry_t *),
+                       MPL_MEM_OTHER);
+        if (ipc_cache_removal == NULL) {
+            mpl_err = MPL_ERR_GPU_NOMEM;
+            goto fn_fail;
+        }
 
-    for (int i = 0; i < local_ze_device_count; ++i) {
-        ipc_cache_tracked[i] = NULL;
-        ipc_cache_mapped[i] = NULL;
-        ipc_cache_removal[i] = NULL;
+        for (int i = 0; i < local_ze_device_count; ++i) {
+            ipc_cache_tracked[i] = NULL;
+            ipc_cache_mapped[i] = NULL;
+            ipc_cache_removal[i] = NULL;
+        }
+
+        MPL_gpu_free_hook_register(MPL_ze_ipc_remove_cache_handle);
     }
 
     mypid = getpid();
@@ -523,8 +529,6 @@ int MPL_gpu_init(int debug_summary)
         printf("subdevice_count: %d\n", local_ze_device_count - device_count);
         printf("=========================\n");
     }
-
-    MPL_gpu_free_hook_register(MPL_ze_ipc_remove_cache_handle);
 
   fn_exit:
     return mpl_err;
@@ -750,26 +754,29 @@ int MPL_gpu_finalize(void)
 {
     int i;
 
-    for (i = 0; i < local_ze_device_count; ++i) {
-        MPL_ze_mapped_buffer_entry_t *entry = NULL, *tmp = NULL;
-        if (ipc_cache_removal[i]) {
-            HASH_ITER(hh, ipc_cache_removal[i], entry, tmp) {
-                MPL_gpu_ipc_handle_unmap(entry->ipc_buf);
+    if (likely(MPL_gpu_info.specialized_cache)) {
+        for (i = 0; i < local_ze_device_count; ++i) {
+            if (ipc_cache_removal[i]) {
+                MPL_ze_mapped_buffer_entry_t *entry = NULL, *tmp = NULL;
+                HASH_ITER(hh, ipc_cache_removal[i], entry, tmp) {
+                    MPL_gpu_ipc_handle_unmap(entry->ipc_buf);
+                }
             }
         }
-    }
 
-    for (i = 0; i < local_ze_device_count; ++i) {
-        MPL_ze_ipc_handle_entry_t *entry = NULL, *tmp = NULL;
-        HASH_ITER(hh, ipc_cache_tracked[i], entry, tmp) {
-            HASH_DELETE(hh, ipc_cache_tracked[i], entry);
-            MPL_free(entry);
+        for (i = 0; i < local_ze_device_count; ++i) {
+            MPL_ze_ipc_handle_entry_t *entry = NULL, *tmp = NULL;
+            HASH_ITER(hh, ipc_cache_tracked[i], entry, tmp) {
+                HASH_DELETE(hh, ipc_cache_tracked[i], entry);
+                MPL_free(entry);
+            }
         }
+
+        MPL_free(ipc_cache_tracked);
+        MPL_free(ipc_cache_removal);
+        MPL_free(ipc_cache_mapped);
     }
 
-    MPL_free(ipc_cache_tracked);
-    MPL_free(ipc_cache_removal);
-    MPL_free(ipc_cache_mapped);
     MPL_free(local_to_global_map);
     MPL_free(global_to_local_map);
     MPL_free(ze_devices_handle);
@@ -838,8 +845,10 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     }
 
     /* Check if ipc_handle is already cached */
-    mem_id = ptr_attr.id;
-    HASH_FIND(hh, ipc_cache_tracked[local_dev_id], &mem_id, sizeof(uint64_t), cache_entry);
+    if (likely(MPL_gpu_info.specialized_cache)) {
+        mem_id = ptr_attr.id;
+        HASH_FIND(hh, ipc_cache_tracked[local_dev_id], &mem_id, sizeof(uint64_t), cache_entry);
+    }
 
     if (cache_entry) {
         memcpy(ipc_handle, &cache_entry->ipc_handle, sizeof(MPL_gpu_ipc_mem_handle_t));
@@ -886,22 +895,24 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
         h.mem_id = mem_id;
         memcpy(ipc_handle, &h, sizeof(fd_pid_t));
 
-        /* Insert into the cache */
-        cache_entry =
-            (MPL_ze_ipc_handle_entry_t *) MPL_malloc(sizeof(MPL_ze_ipc_handle_entry_t),
-                                                     MPL_MEM_OTHER);
+        if (likely(MPL_gpu_info.specialized_cache)) {
+            /* Insert into the cache */
+            cache_entry =
+                (MPL_ze_ipc_handle_entry_t *) MPL_malloc(sizeof(MPL_ze_ipc_handle_entry_t),
+                                                         MPL_MEM_OTHER);
 
-        if (cache_entry == NULL) {
-            mpl_err = MPL_ERR_GPU_NOMEM;
-            goto fn_fail;
+            if (cache_entry == NULL) {
+                mpl_err = MPL_ERR_GPU_NOMEM;
+                goto fn_fail;
+            }
+
+            memset(cache_entry, 0, sizeof(MPL_ze_ipc_handle_entry_t));
+
+            cache_entry->mem_id = mem_id;
+            memcpy(&cache_entry->ipc_handle, ipc_handle, sizeof(MPL_gpu_ipc_mem_handle_t));
+            HASH_ADD(hh, ipc_cache_tracked[local_dev_id], mem_id, sizeof(uint64_t), cache_entry,
+                     MPL_MEM_OTHER);
         }
-
-        memset(cache_entry, 0, sizeof(MPL_ze_ipc_handle_entry_t *));
-
-        cache_entry->mem_id = mem_id;
-        memcpy(&cache_entry->ipc_handle, ipc_handle, sizeof(MPL_gpu_ipc_mem_handle_t));
-        HASH_ADD(hh, ipc_cache_tracked[local_dev_id], mem_id, sizeof(uint64_t), cache_entry,
-                 MPL_MEM_OTHER);
     }
 
   fn_exit:
@@ -938,28 +949,30 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr)
         }
     }
 
-    ze_memory_allocation_properties_t ptr_attr = {
-        .stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES,
-        .pNext = NULL,
-        .type = 0,
-        .id = 0,
-        .pageSize = 0,
-    };
+    if (likely(MPL_gpu_info.specialized_cache)) {
+        ze_memory_allocation_properties_t ptr_attr = {
+            .stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES,
+            .pNext = NULL,
+            .type = 0,
+            .id = 0,
+            .pageSize = 0,
+        };
 
-    ret = zeMemGetAllocProperties(ze_context, ptr, &ptr_attr, &device);
-    ZE_ERR_CHECK(ret);
+        ret = zeMemGetAllocProperties(ze_context, ptr, &ptr_attr, &device);
+        ZE_ERR_CHECK(ret);
 
-    dev_id = device_to_dev_id(device);
-    if (dev_id == -1) {
-        goto fn_fail;
-    }
+        dev_id = device_to_dev_id(device);
+        if (dev_id == -1) {
+            goto fn_fail;
+        }
 
-    mem_id = ptr_attr.id;
-    HASH_FIND(hh, ipc_cache_tracked[dev_id], &mem_id, sizeof(uint64_t), cache_entry);
+        mem_id = ptr_attr.id;
+        HASH_FIND(hh, ipc_cache_tracked[dev_id], &mem_id, sizeof(uint64_t), cache_entry);
 
-    if (cache_entry != NULL) {
-        HASH_DELETE(hh, ipc_cache_tracked[dev_id], cache_entry);
-        MPL_free(cache_entry);
+        if (cache_entry != NULL) {
+            HASH_DELETE(hh, ipc_cache_tracked[dev_id], cache_entry);
+            MPL_free(cache_entry);
+        }
     }
 
   fn_exit:
@@ -986,16 +999,18 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
     fd_pid_t h;
     memcpy(&h, &ipc_handle, sizeof(fd_pid_t));
 
-    /* Check if ipc-mapped buffer is already cached */
-    memset(&lookup_entry, 0, sizeof(MPL_ze_mapped_buffer_lookup_t));
-    lookup_entry.remote_mem_id = h.mem_id;
-    lookup_entry.remote_dev_id = h.dev_id;
-    lookup_entry.remote_pid = h.pid;
+    if (likely(MPL_gpu_info.specialized_cache)) {
+        /* Check if ipc-mapped buffer is already cached */
+        memset(&lookup_entry, 0, sizeof(MPL_ze_mapped_buffer_lookup_t));
+        lookup_entry.remote_mem_id = h.mem_id;
+        lookup_entry.remote_dev_id = h.dev_id;
+        lookup_entry.remote_pid = h.pid;
 
-    keylen = offsetof(MPL_ze_mapped_buffer_entry_t, remote_pid) + sizeof(pid_t) -
-        offsetof(MPL_ze_mapped_buffer_entry_t, remote_mem_id);
+        keylen = offsetof(MPL_ze_mapped_buffer_entry_t, remote_pid) + sizeof(pid_t) -
+            offsetof(MPL_ze_mapped_buffer_entry_t, remote_mem_id);
 
-    HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry.remote_mem_id, keylen, cache_entry);
+        HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry.remote_mem_id, keylen, cache_entry);
+    }
 
     if (cache_entry) {
         *ptr = cache_entry->ipc_buf;
@@ -1036,32 +1051,35 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
         ret = zeMemOpenIpcHandle(ze_context, dev_handle, ze_ipc_handle, 0, ptr);
         ZE_ERR_CHECK(ret);
 
-        /* Insert into the cache */
-        cache_entry =
-            (MPL_ze_mapped_buffer_entry_t *) MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t),
-                                                        MPL_MEM_OTHER);
-        if (cache_entry == NULL) {
-            mpl_err = MPL_ERR_GPU_NOMEM;
-            goto fn_fail;
+        if (likely(MPL_gpu_info.specialized_cache)) {
+            /* Insert into the cache */
+            cache_entry =
+                (MPL_ze_mapped_buffer_entry_t *) MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t),
+                                                            MPL_MEM_OTHER);
+            if (cache_entry == NULL) {
+                mpl_err = MPL_ERR_GPU_NOMEM;
+                goto fn_fail;
+            }
+
+            removal_entry =
+                (MPL_ze_mapped_buffer_entry_t *) MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t),
+                                                            MPL_MEM_OTHER);
+            if (removal_entry == NULL) {
+                mpl_err = MPL_ERR_GPU_NOMEM;
+                goto fn_fail;
+            }
+
+            cache_entry->remote_mem_id = lookup_entry.remote_mem_id;
+            cache_entry->remote_dev_id = lookup_entry.remote_dev_id;
+            cache_entry->remote_pid = lookup_entry.remote_pid;
+            cache_entry->ipc_buf = *ptr;
+            memcpy(removal_entry, cache_entry, sizeof(MPL_ze_mapped_buffer_entry_t));
+
+            HASH_ADD(hh, ipc_cache_mapped[dev_id], remote_mem_id, keylen, cache_entry,
+                     MPL_MEM_OTHER);
+            HASH_ADD(hh, ipc_cache_removal[dev_id], ipc_buf, sizeof(void *), removal_entry,
+                     MPL_MEM_OTHER);
         }
-
-        removal_entry =
-            (MPL_ze_mapped_buffer_entry_t *) MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t),
-                                                        MPL_MEM_OTHER);
-        if (removal_entry == NULL) {
-            mpl_err = MPL_ERR_GPU_NOMEM;
-            goto fn_fail;
-        }
-
-        cache_entry->remote_mem_id = lookup_entry.remote_mem_id;
-        cache_entry->remote_dev_id = lookup_entry.remote_dev_id;
-        cache_entry->remote_pid = lookup_entry.remote_pid;
-        cache_entry->ipc_buf = *ptr;
-        memcpy(removal_entry, cache_entry, sizeof(MPL_ze_mapped_buffer_entry_t));
-
-        HASH_ADD(hh, ipc_cache_mapped[dev_id], remote_mem_id, keylen, cache_entry, MPL_MEM_OTHER);
-        HASH_ADD(hh, ipc_cache_removal[dev_id], ipc_buf, sizeof(void *), removal_entry,
-                 MPL_MEM_OTHER);
     }
 
   fn_exit:
@@ -1096,28 +1114,31 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
         goto fn_fail;
     }
 
-    /* Remove from the caches */
-    HASH_FIND(hh, ipc_cache_removal[dev_id], &ptr, sizeof(void *), cache_entry);
-
-    if (cache_entry != NULL) {
-        memset(&lookup_entry, 0, sizeof(MPL_ze_mapped_buffer_lookup_t));
-        lookup_entry.remote_mem_id = cache_entry->remote_mem_id;
-        lookup_entry.remote_dev_id = cache_entry->remote_dev_id;
-        lookup_entry.remote_pid = cache_entry->remote_pid;
-
-        keylen = offsetof(MPL_ze_mapped_buffer_entry_t, remote_pid) + sizeof(pid_t) -
-            offsetof(MPL_ze_mapped_buffer_entry_t, remote_mem_id);
-
-        HASH_DEL(ipc_cache_removal[dev_id], cache_entry);
-        MPL_free(cache_entry);
-        cache_entry = NULL;
-
-        HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry.remote_mem_id, keylen, cache_entry);
+    if (likely(MPL_gpu_info.specialized_cache)) {
+        /* Remove from the caches */
+        HASH_FIND(hh, ipc_cache_removal[dev_id], &ptr, sizeof(void *), cache_entry);
 
         if (cache_entry != NULL) {
-            HASH_DEL(ipc_cache_mapped[dev_id], cache_entry);
+            memset(&lookup_entry, 0, sizeof(MPL_ze_mapped_buffer_lookup_t));
+            lookup_entry.remote_mem_id = cache_entry->remote_mem_id;
+            lookup_entry.remote_dev_id = cache_entry->remote_dev_id;
+            lookup_entry.remote_pid = cache_entry->remote_pid;
+
+            keylen = offsetof(MPL_ze_mapped_buffer_entry_t, remote_pid) + sizeof(pid_t) -
+                offsetof(MPL_ze_mapped_buffer_entry_t, remote_mem_id);
+
+            HASH_DEL(ipc_cache_removal[dev_id], cache_entry);
             MPL_free(cache_entry);
             cache_entry = NULL;
+
+            HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry.remote_mem_id, keylen,
+                      cache_entry);
+
+            if (cache_entry != NULL) {
+                HASH_DEL(ipc_cache_mapped[dev_id], cache_entry);
+                MPL_free(cache_entry);
+                cache_entry = NULL;
+            }
         }
     }
 

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -24,14 +24,14 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 
 static int gpu_initialized = 0;
 static uint32_t device_count;
-static uint32_t max_dev_id;
+static uint32_t max_dev_id;     /* Does not include subdevices */
 static uint32_t max_subdev_id;
 static char **device_list = NULL;
 #define MAX_GPU_STR_LEN 256
 static char affinity_env[MAX_GPU_STR_LEN] = { 0 };
 
 static int *local_to_global_map;        /* [local_ze_device_count] */
-static int *global_to_local_map;        /* [max_dev_id + 1]   */
+static int *global_to_local_map;        /* [global_ze_device_count] */
 
 /* Maps a subdevice id to the upper device id, specifically for indexing into shared_device_fds */
 static int *subdevice_map = NULL;
@@ -84,6 +84,7 @@ ze_driver_handle_t ze_driver_handle;
 ze_device_handle_t *ze_devices_handle = NULL;
 ze_context_handle_t ze_context;
 uint32_t local_ze_device_count; /* This counts both devices and subdevices */
+uint32_t global_ze_device_count;        /* This counts both devices and subdevices */
 static int gpu_ze_init_driver(void);
 static int fd_to_handle(int dev_fd, int fd, int *handle);
 static int handle_to_fd(int dev_fd, int handle, int *fd);
@@ -224,6 +225,163 @@ int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env)
     return ret;
 }
 
+int MPL_gpu_init_device_mappings(int max_devid, int max_subdevid)
+{
+    int mpl_err = MPL_SUCCESS;
+    int global_dev_count = max_devid + 1;
+    int global_subdev_count = 0;
+
+    /* If max_subdevid is 0, then all procs use tile 0 as root devices, so subdevices aren't
+     * needed. */
+    if (max_subdevid == 0) {
+        global_ze_device_count = global_dev_count;
+    } else {
+        /* We can still have the situation where all procs use non-zero tile as root devices, but
+         * this can't be detected unless we also reduce subdevice count. Thus, consider them as
+         * subdevices in the global_to_local_map even if they are all root devices. */
+        global_subdev_count = max_subdevid + 1;
+        global_ze_device_count = global_dev_count * (global_subdev_count + 1);
+    }
+
+    /* Initialize local_to_global_map */
+    local_to_global_map = MPL_malloc(local_ze_device_count * sizeof(int), MPL_MEM_OTHER);
+    if (local_to_global_map == NULL) {
+        mpl_err = MPL_ERR_GPU_NOMEM;
+        goto fn_fail;
+    }
+
+    for (int i = 0; i < local_ze_device_count; ++i) {
+        local_to_global_map[i] = -1;
+    }
+
+    /* Initialize global_to_local_map */
+    global_to_local_map = MPL_malloc(global_ze_device_count * sizeof(int), MPL_MEM_OTHER);
+    if (global_to_local_map == NULL) {
+        mpl_err = MPL_ERR_GPU_NOMEM;
+        goto fn_fail;
+    }
+
+    for (int i = 0; i < global_ze_device_count; ++i) {
+        global_to_local_map[i] = -1;
+    }
+
+    /* Parse ZE_AFFINITY_MASK to find device and subdevice visibility based on global device id. */
+    char *visible_devices = getenv("ZE_AFFINITY_MASK");
+    if (visible_devices) {
+        size_t len = strlen(visible_devices);
+
+        char *devices = MPL_malloc(len + 1, MPL_MEM_OTHER);
+        if (devices == NULL) {
+            mpl_err = MPL_ERR_GPU_NOMEM;
+            goto fn_fail;
+        }
+        char *free_ptr, *dev;
+
+        memcpy(devices, visible_devices, len + 1);
+        free_ptr = devices;
+        char *tmp = strtok_r(devices, ",", &dev);
+
+        while (tmp != NULL) {
+            char *subdev;
+            char *subdevices = strtok_r(tmp, ".", &subdev);
+            int device = atoi(subdevices);
+            tmp = NULL;
+
+            /* Temporarily mark the device as visible. It might only be a subdevice that is
+             * visible. */
+            global_to_local_map[device] = 1;
+
+            /* Mark the subdevice(s) as visible. */
+            subdevices = strtok_r(tmp, ".", &subdev);
+            if (subdevices != NULL) {
+                /* Handle special case where there are no subdevices among any device. */
+                if (global_subdev_count > 0) {
+                    int subdevice = atoi(subdevices);
+                    int idx = global_dev_count + device * global_subdev_count + subdevice;
+                    global_to_local_map[idx] = 1;
+                }
+            } else {
+                int idx = global_dev_count + device * global_subdev_count;
+                for (int i = 0; i < global_subdev_count; ++i) {
+                    global_to_local_map[idx + i] = 1;
+                }
+            }
+
+            devices = NULL;
+            tmp = strtok_r(devices, ",", &dev);
+        }
+
+        MPL_free(free_ptr);
+    } else {
+        for (int i = 0; i < global_dev_count; ++i) {
+            /* Set device as visible */
+            global_to_local_map[i] = 1;
+
+            /* Set subdevices as visible */
+            int idx = global_dev_count + i * global_subdev_count;
+            for (int j = 0; j < subdevice_count[i]; ++j) {
+                global_to_local_map[idx + j] = 1;
+            }
+        }
+    }
+
+    /* Setup global_to_local_map */
+    int local_dev_id = 0;
+
+    /* The root devices first */
+    for (int i = 0; i < global_dev_count; ++i) {
+        if (global_to_local_map[i] == 1) {
+            /* Check if the device has subdevices before setting its index. If it does not, then
+             * only the subdevice is visible. However, need to check for the special case that
+             * there are no subdevices among any device. */
+            if (subdevice_count[local_dev_id] || global_subdev_count == 0) {
+                global_to_local_map[i] = local_dev_id;
+            } else {
+                /* Find which subdevice is visible and give it the local device id since it is the
+                 * root device. */
+                int idx = global_dev_count + i * global_subdev_count;
+                for (int j = 0; j < global_subdev_count; ++j) {
+                    if (global_to_local_map[idx + j] == 1) {
+                        global_to_local_map[idx + j] = local_dev_id;
+                    }
+                }
+                /* Unset the device as the root device, since its subdevice is the root. */
+                global_to_local_map[i] = -1;
+            }
+            ++local_dev_id;
+        }
+    }
+
+    /* The subdevices next */
+    for (int i = 0; i < global_dev_count; ++i) {
+        if (global_to_local_map[i] != -1) {
+            int idx = global_dev_count + i * global_subdev_count;
+            for (int j = 0; j < global_subdev_count; ++j) {
+                if (global_to_local_map[idx + j] == 1) {
+                    global_to_local_map[idx + j] = local_dev_id;
+                    ++local_dev_id;
+                }
+            }
+        }
+    }
+
+    assert(local_dev_id == local_ze_device_count);
+
+    /* Setup local_to_global_map */
+    local_dev_id = 0;
+    for (int i = 0; i < global_ze_device_count; ++i) {
+        int local_id = global_to_local_map[i];
+        if (local_id != -1) {
+            local_to_global_map[local_id] = i;
+        }
+    }
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    goto fn_exit;
+}
+
 int MPL_gpu_init(int debug_summary)
 {
     int mpl_err = MPL_SUCCESS;
@@ -300,23 +458,6 @@ int MPL_gpu_init(int debug_summary)
         }
     }
 
-    local_to_global_map = MPL_malloc(local_ze_device_count * sizeof(int), MPL_MEM_OTHER);
-    if (local_to_global_map == NULL) {
-        mpl_err = MPL_ERR_GPU_NOMEM;
-        goto fn_fail;
-    }
-
-    global_to_local_map = MPL_malloc(local_ze_device_count * sizeof(int), MPL_MEM_OTHER);
-    if (global_to_local_map == NULL) {
-        mpl_err = MPL_ERR_GPU_NOMEM;
-        goto fn_fail;
-    }
-
-    for (int i = 0; i < local_ze_device_count; i++) {
-        local_to_global_map[i] = i;
-        global_to_local_map[i] = i;
-    }
-
     mypid = getpid();
 
     gpu_mem_hook_init();
@@ -360,7 +501,7 @@ MPL_STATIC_INLINE_PREFIX int dev_id_to_device(int dev_id, MPL_gpu_device_handle_
 {
     int mpl_err = MPL_SUCCESS;
 
-    if (dev_id > max_dev_id) {
+    if (dev_id > local_ze_device_count) {
         goto fn_fail;
     }
 
@@ -583,7 +724,7 @@ int MPL_gpu_finalize(void)
 
 int MPL_gpu_global_to_local_dev_id(int global_dev_id)
 {
-    assert(global_dev_id <= max_dev_id);
+    assert(global_dev_id < global_ze_device_count);
     return global_to_local_map[global_dev_id];
 }
 
@@ -655,7 +796,9 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
         fd_pid_t h;
         memcpy(&h.fd, &ze_ipc_handle, sizeof(fd));
         h.pid = mypid;
-        h.dev_id = dev_id;
+        int global_dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
+        assert(global_dev_id != -1);
+        h.dev_id = global_dev_id;
         memcpy(ipc_handle, &h, sizeof(fd_pid_t));
     }
 

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -62,6 +62,7 @@ typedef struct {
     int fd;
     pid_t pid;
     int dev_id;
+    uint64_t mem_id;
 } fd_pid_t;
 
 typedef struct gpu_free_hook {
@@ -739,10 +740,10 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
 {
     int mpl_err = MPL_SUCCESS;
     ze_result_t ret;
-    unsigned long shared_handle;
     int fd, handle, status, local_dev_id = -1;
     ze_device_handle_t device;
     ze_ipc_mem_handle_t ze_ipc_handle;
+    fd_pid_t h;
 
     ze_memory_allocation_properties_t ptr_attr = {
         .stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES,
@@ -772,10 +773,6 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
             goto fn_fail;
         }
 
-        shared_handle = shared_dev_id;
-        shared_handle = shared_handle << 32 | handle;
-        memcpy(ipc_handle, &shared_handle, sizeof(shared_handle));
-
         /* Hash (ptr, dev_id, handle) to close later */
         MPL_ze_gem_hash_entry_t *entry = NULL;
         HASH_FIND_PTR(gem_hash, &ptr, entry);
@@ -793,15 +790,18 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
             entry->handle = handle;
             HASH_ADD_PTR(gem_hash, ptr, entry, MPL_MEM_OTHER);
         }
+
+        memcpy(&h.fd, &handle, sizeof(int));
+        h.dev_id = shared_dev_id;
     } else {
-        fd_pid_t h;
         memcpy(&h.fd, &ze_ipc_handle, sizeof(fd));
-        h.pid = mypid;
-        int global_dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
-        assert(global_dev_id != -1);
-        h.dev_id = global_dev_id;
-        memcpy(ipc_handle, &h, sizeof(fd_pid_t));
+        h.dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
+        assert(h.dev_id != -1);
     }
+
+    h.pid = mypid;
+    h.mem_id = ptr_attr.id;
+    memcpy(ipc_handle, &h, sizeof(fd_pid_t));
 
   fn_exit:
     return mpl_err;
@@ -843,27 +843,23 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
 {
     int mpl_err = MPL_SUCCESS;
     ze_result_t ret;
-    unsigned long shared_handle;
-    int fd, handle = 0, status;
+    int fd, status;
     MPL_gpu_device_handle_t dev_handle;
     ze_ipc_mem_handle_t ze_ipc_handle;
 
     memset(&ze_ipc_handle, 0, sizeof(ze_ipc_mem_handle_t));
 
+    fd_pid_t h;
+    memcpy(&h, &ipc_handle, sizeof(fd_pid_t));
+
     if (shared_device_fds != NULL) {
         /* convert GEM handle to fd */
-        memcpy(&shared_handle, &ipc_handle, sizeof(shared_handle));
-        int shared_dev_id = shared_handle >> 32;
-        handle = shared_handle << 32 >> 32;
-
-        status = handle_to_fd(shared_device_fds[shared_dev_id], handle, &fd);
+        status = handle_to_fd(shared_device_fds[h.dev_id], h.fd, &fd);
         if (status) {
             goto fn_fail;
         }
     } else {
         /* pidfd_getfd */
-        fd_pid_t h;
-        memcpy(&h, &ipc_handle, sizeof(fd_pid_t));
         if (h.pid != mypid) {
             int pid_fd = syscall(__NR_pidfd_open, h.pid, 0);
             if (pid_fd == -1) {

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -64,6 +64,7 @@ typedef struct {
 typedef struct {
     uint64_t mem_id;
     MPL_gpu_ipc_mem_handle_t ipc_handle;
+    int fd;
     void *mapped_ptr;
     size_t mapped_size;
     bool handle_cached;
@@ -93,6 +94,14 @@ static MPL_ze_ipc_handle_entry_t **ipc_cache_tracked = NULL;
 static MPL_ze_mapped_buffer_entry_t **ipc_cache_mapped = NULL;
 static MPL_ze_mapped_buffer_entry_t **ipc_cache_removal = NULL;
 static MPL_ze_mapped_buffer_entry_t **mmap_cache_removal = NULL;
+
+typedef struct {
+    void *ptr;
+    uint64_t mem_id;
+    UT_hash_handle hh;
+} MPL_ze_mem_id_entry_t;
+
+static MPL_ze_mem_id_entry_t *mem_id_cache = NULL;
 
 typedef struct {
     int fd;
@@ -798,8 +807,17 @@ int MPL_gpu_finalize(void)
             HASH_ITER(hh, ipc_cache_tracked[i], entry, tmp) {
                 if (entry->mapped_ptr != NULL) {
                     munmap(entry->mapped_ptr, entry->mapped_size);
+                    close(entry->fd);
                 }
                 HASH_DELETE(hh, ipc_cache_tracked[i], entry);
+                MPL_free(entry);
+            }
+        }
+
+        {
+            MPL_ze_mem_id_entry_t *entry = NULL, *tmp = NULL;
+            HASH_ITER(hh, mem_id_cache, entry, tmp) {
+                HASH_DELETE(hh, mem_id_cache, entry);
                 MPL_free(entry);
             }
         }
@@ -856,7 +874,10 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     ze_result_t ret;
     int local_dev_id = -1;
     MPL_ze_ipc_handle_entry_t *cache_entry = NULL;
+    MPL_ze_mem_id_entry_t *memid_entry = NULL;
     uint64_t mem_id = 0;
+    void *pbase = NULL;
+    uintptr_t len;
 
     MPL_gpu_device_attr ptr_attr;
     memset(&ptr_attr, 0, sizeof(MPL_gpu_device_attr));
@@ -870,9 +891,34 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
         goto fn_fail;
     }
 
-    /* Check if ipc_handle is already cached */
+    mpl_err = MPL_gpu_get_buffer_bounds(ptr, &pbase, &len);
+    if (mpl_err != MPL_SUCCESS) {
+        goto fn_fail;
+    }
+
+    /* First check if a removal from the cache is needed */
     if (likely(MPL_gpu_info.specialized_cache)) {
         mem_id = ptr_attr.prop.id;
+        HASH_FIND(hh, mem_id_cache, &pbase, sizeof(void *), memid_entry);
+
+        if (memid_entry && memid_entry->mem_id != mem_id) {
+            HASH_FIND(hh, ipc_cache_tracked[local_dev_id], &memid_entry->mem_id, sizeof(uint64_t),
+                      cache_entry);
+            if (cache_entry) {
+                if (cache_entry->mapped_ptr != NULL) {
+                    munmap(cache_entry->mapped_ptr, cache_entry->mapped_size);
+                }
+                HASH_DELETE(hh, ipc_cache_tracked[local_dev_id], cache_entry);
+                MPL_free(cache_entry);
+                cache_entry = NULL;
+            }
+
+            HASH_DELETE(hh, mem_id_cache, memid_entry);
+            MPL_free(memid_entry);
+            memid_entry = NULL;
+        }
+
+        /* Check if ipc_handle is already cached */
         HASH_FIND(hh, ipc_cache_tracked[local_dev_id], &mem_id, sizeof(uint64_t), cache_entry);
     }
 
@@ -900,13 +946,26 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
                     goto fn_fail;
                 }
 
+                memid_entry = (MPL_ze_mem_id_entry_t *) MPL_malloc(sizeof(MPL_ze_mem_id_entry_t),
+                                                                   MPL_MEM_OTHER);
+
+                if (memid_entry == NULL) {
+                    mpl_err = MPL_ERR_GPU_NOMEM;
+                    goto fn_fail;
+                }
+
                 memset(cache_entry, 0, sizeof(MPL_ze_ipc_handle_entry_t));
+                memset(memid_entry, 0, sizeof(MPL_ze_mem_id_entry_t));
 
                 cache_entry->mem_id = mem_id;
                 cache_entry->handle_cached = true;
                 memcpy(&cache_entry->ipc_handle, ipc_handle, sizeof(MPL_gpu_ipc_mem_handle_t));
                 HASH_ADD(hh, ipc_cache_tracked[local_dev_id], mem_id, sizeof(uint64_t), cache_entry,
                          MPL_MEM_OTHER);
+
+                memid_entry->ptr = pbase;
+                memid_entry->mem_id = mem_id;
+                HASH_ADD(hh, mem_id_cache, ptr, sizeof(void *), memid_entry, MPL_MEM_OTHER);
             }
         }
     }
@@ -953,6 +1012,10 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
         HASH_FIND(hh, ipc_cache_tracked[dev_id], &mem_id, sizeof(uint64_t), cache_entry);
 
         if (cache_entry != NULL) {
+            if (cache_entry->mapped_ptr) {
+                munmap(cache_entry->mapped_ptr, cache_entry->mapped_size);
+                close(cache_entry->fd);
+            }
             HASH_DELETE(hh, ipc_cache_tracked[dev_id], cache_entry);
             MPL_free(cache_entry);
         }
@@ -1466,7 +1529,7 @@ void MPL_ze_set_fds(int num_fds, int *fds)
 void MPL_ze_ipc_remove_cache_handle(void *dptr)
 {
     ze_result_t ret;
-    ze_device_handle_t device;
+    ze_device_handle_t device = NULL;
     int local_dev_id = -1;
     uint64_t mem_id = 0;
     MPL_ze_ipc_handle_entry_t *cache_entry = NULL;
@@ -1721,6 +1784,7 @@ int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,
     uint64_t mem_id, offset, len;
     void *pbase, *base;
     MPL_ze_ipc_handle_entry_t *cache_entry = NULL;
+    MPL_ze_mem_id_entry_t *memid_entry = NULL;
 
     ret = zeMemGetAddressRange(ze_context, dptr, &pbase, &len);
     ZE_ERR_CHECK(ret);
@@ -1733,8 +1797,29 @@ int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,
         goto fn_fail;
     }
 
-    /* Search cache for mapped base address */
+    /* First check if a removal from the cache is needed */
     if (likely(MPL_gpu_info.specialized_cache)) {
+        HASH_FIND(hh, mem_id_cache, &pbase, sizeof(void *), memid_entry);
+
+        if (memid_entry && memid_entry->mem_id != mem_id) {
+            HASH_FIND(hh, ipc_cache_tracked[local_dev_id], &memid_entry->mem_id, sizeof(uint64_t),
+                      cache_entry);
+            if (cache_entry) {
+                if (cache_entry->mapped_ptr != NULL) {
+                    munmap(cache_entry->mapped_ptr, cache_entry->mapped_size);
+                    close(cache_entry->fd);
+                }
+                HASH_DELETE(hh, ipc_cache_tracked[local_dev_id], cache_entry);
+                MPL_free(cache_entry);
+                cache_entry = NULL;
+            }
+
+            HASH_DELETE(hh, mem_id_cache, memid_entry);
+            MPL_free(memid_entry);
+            memid_entry = NULL;
+        }
+
+        /* Search cache for mapped base address */
         HASH_FIND(hh, ipc_cache_tracked[local_dev_id], &mem_id, sizeof(uint64_t), cache_entry);
     }
 
@@ -1770,14 +1855,28 @@ int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,
                     goto fn_fail;
                 }
 
+                memid_entry = (MPL_ze_mem_id_entry_t *) MPL_malloc(sizeof(MPL_ze_mem_id_entry_t),
+                                                                   MPL_MEM_OTHER);
+
+                if (memid_entry == NULL) {
+                    mpl_err = MPL_ERR_GPU_NOMEM;
+                    goto fn_fail;
+                }
+
                 memset(cache_entry, 0, sizeof(MPL_ze_ipc_handle_entry_t));
+                memset(memid_entry, 0, sizeof(MPL_ze_mem_id_entry_t));
 
                 cache_entry->mem_id = mem_id;
                 cache_entry->mapped_ptr = base;
                 cache_entry->mapped_size = len;
                 cache_entry->handle_cached = false;
+                cache_entry->fd = fd;
                 HASH_ADD(hh, ipc_cache_tracked[local_dev_id], mem_id, sizeof(uint64_t), cache_entry,
                          MPL_MEM_OTHER);
+
+                memid_entry->ptr = pbase;
+                memid_entry->mem_id = mem_id;
+                HASH_ADD(hh, mem_id_cache, ptr, sizeof(void *), memid_entry, MPL_MEM_OTHER);
             }
         }
     }

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -1524,6 +1524,30 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     goto fn_exit;
 }
 
+int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr_t * attr)
+{
+    ze_result_t ret ATTRIBUTE((unused));
+    ze_memory_type_t type;
+
+    if (attr == NULL) {
+        ze_memory_allocation_properties_t prop = {
+            .stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES,
+            .pNext = NULL,
+            .type = 0,
+            .id = 0,
+            .pageSize = 0,
+        };
+        ze_device_handle_t device = NULL;
+
+        ret = zeMemGetAllocProperties(ze_context, ptr, &prop, &device);
+        assert(ret == ZE_RESULT_SUCCESS);
+        type = prop.type;
+    } else {
+        type = attr->device_attr.prop.type;
+    }
+    return type != ZE_MEMORY_TYPE_UNKNOWN;
+}
+
 int MPL_gpu_malloc(void **ptr, size_t size, MPL_gpu_device_handle_t h_device)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -109,14 +109,6 @@ typedef struct {
 
 static MPL_ze_mem_id_entry_t *mem_id_cache = NULL;
 
-typedef struct {
-    int fds[2];
-    uint32_t nfds;
-    pid_t pid;
-    int dev_id;
-    uint64_t mem_id;
-} fd_pid_t;
-
 typedef struct gpu_free_hook {
     void (*free_hook) (void *dptr);
     struct gpu_free_hook *next;
@@ -1468,7 +1460,7 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
     goto fn_exit;
 }
 
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle, int dev_id, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;
     MPL_ze_mapped_buffer_entry_t *cache_entry = NULL;
@@ -1477,7 +1469,7 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
     unsigned keylen = 0;
 
     fd_pid_t h;
-    memcpy(&h, &ipc_handle, sizeof(fd_pid_t));
+    h = mpl_ipc_handle->data;
 
     if (likely(MPL_gpu_info.specialized_cache)) {
         /* Check if ipc-mapped buffer is already cached */
@@ -1493,7 +1485,7 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
     if (cache_entry && cache_entry->ipc_buf) {
         *ptr = cache_entry->ipc_buf;
     } else {
-        mpl_err = MPL_ze_ipc_handle_map(ipc_handle, true, dev_id, false, 0, ptr);
+        mpl_err = MPL_ze_ipc_handle_map(mpl_ipc_handle, true, dev_id, false, 0, ptr);
         if (mpl_err != MPL_SUCCESS) {
             goto fn_fail;
         }
@@ -2383,7 +2375,7 @@ void MPL_ze_ipc_remove_cache_handle(void *dptr)
 }
 
 int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, int local_dev_id,
-                             int use_shared_fd, MPL_gpu_ipc_mem_handle_t * ipc_handle)
+                             int use_shared_fd, MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle)
 {
     int mpl_err = MPL_SUCCESS;
     ze_result_t ret;
@@ -2460,8 +2452,10 @@ int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, in
     h.pid = mypid;
     h.mem_id = mem_id;
 
-    memset(ipc_handle, 0, sizeof(MPL_gpu_ipc_mem_handle_t));
-    memcpy(ipc_handle, &h, sizeof(fd_pid_t));
+    for (int i = 0; i < nfds; i++) {
+        memcpy(&mpl_ipc_handle->ipc_handles[i], &ze_ipc_handle[i], sizeof(ze_ipc_mem_handle_t));
+    }
+    mpl_ipc_handle->data = h;
 
   fn_exit:
     return mpl_err;
@@ -2470,8 +2464,8 @@ int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, in
     goto fn_exit;
 }
 
-int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_handle, int dev_id,
-                          int is_mmap, size_t size, void **ptr)
+int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle, int is_shared_handle,
+                          int dev_id, int is_mmap, size_t size, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;
     ze_result_t ret;
@@ -2480,7 +2474,7 @@ int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_han
     MPL_gpu_device_handle_t dev_handle;
 
     fd_pid_t h;
-    memcpy(&h, &ipc_handle, sizeof(fd_pid_t));
+    h = mpl_ipc_handle->data;
     nfds = h.nfds;
 
     if (shared_device_fds != NULL) {
@@ -2528,7 +2522,7 @@ int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_han
             goto fn_fail;
         }
         for (int i = 0; i < nfds; i++) {
-            memset(&ze_ipc_handle[i], 0, sizeof(ze_ipc_mem_handle_t));
+            memcpy(&ze_ipc_handle[i], &mpl_ipc_handle->ipc_handles[i], sizeof(ze_ipc_mem_handle_t));
             memcpy(&ze_ipc_handle[i], &fds[i], sizeof(int));
         }
 
@@ -2547,7 +2541,7 @@ int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_han
 }
 
 /* given an remote IPC handle, mmap it to host */
-int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_handle,
+int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle, int is_shared_handle,
                                 int dev_id, size_t size, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;
@@ -2557,7 +2551,7 @@ int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shar
     MPL_ze_mapped_buffer_lookup_t lookup_entry;
 
     fd_pid_t h;
-    memcpy(&h, &ipc_handle, sizeof(fd_pid_t));
+    h = mpl_ipc_handle->data;
 
     if (likely(MPL_gpu_info.specialized_cache)) {
         /* Check if ipc-mapped buffer is already cached */
@@ -2593,7 +2587,7 @@ int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shar
     }
 
     if (*ptr == NULL) {
-        mpl_err = MPL_ze_ipc_handle_map(ipc_handle, is_shared_handle, dev_id, true, size, ptr);
+        mpl_err = MPL_ze_ipc_handle_map(mpl_ipc_handle, is_shared_handle, dev_id, true, size, ptr);
         if (mpl_err != MPL_SUCCESS) {
             goto fn_fail;
         }

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -1161,25 +1161,18 @@ int MPL_gpu_local_to_global_dev_id(int local_dev_id)
 }
 
 /* given a local device pointer, create an IPC handle */
-int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
+int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
+                              MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     int mpl_err = MPL_SUCCESS;
-    ze_result_t ret;
     int local_dev_id = -1;
     MPL_ze_ipc_handle_entry_t *cache_entry = NULL;
     MPL_ze_mem_id_entry_t *memid_entry = NULL;
-    MPL_gpu_device_attr ptr_attr;
     uint64_t mem_id = 0;
     void *pbase = NULL;
     uintptr_t len;
 
-    memset(ipc_handle, 0, sizeof(MPL_gpu_ipc_mem_handle_t));
-
-    memset(&ptr_attr, 0, sizeof(MPL_gpu_device_attr));
-    ret = zeMemGetAllocProperties(ze_context, ptr, &ptr_attr.prop, &ptr_attr.device);
-    ZE_ERR_CHECK(ret);
-
-    local_dev_id = device_to_dev_id(ptr_attr.device);
+    local_dev_id = device_to_dev_id(ptr_attr->device);
     if (local_dev_id == -1) {
         goto fn_fail;
     }
@@ -1191,7 +1184,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
 
     /* First check if a removal from the cache is needed */
     if (likely(MPL_gpu_info.specialized_cache)) {
-        mem_id = ptr_attr.prop.id;
+        mem_id = ptr_attr->prop.id;
         HASH_FIND(hh, mem_id_cache, &pbase, sizeof(void *), memid_entry);
 
         if (memid_entry && memid_entry->mem_id != mem_id) {
@@ -1216,7 +1209,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     if (cache_entry && cache_entry->handle_cached) {
         memcpy(ipc_handle, &cache_entry->ipc_handle, sizeof(MPL_gpu_ipc_mem_handle_t));
     } else {
-        mpl_err = MPL_ze_ipc_handle_create(ptr, &ptr_attr, local_dev_id, true, ipc_handle);
+        mpl_err = MPL_ze_ipc_handle_create(ptr, ptr_attr, local_dev_id, true, ipc_handle);
         if (mpl_err != MPL_SUCCESS) {
             goto fn_fail;
         }
@@ -2087,6 +2080,8 @@ int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, in
 
     h.pid = mypid;
     h.mem_id = mem_id;
+
+    memset(ipc_handle, 0, sizeof(MPL_gpu_ipc_mem_handle_t));
     memcpy(ipc_handle, &h, sizeof(fd_pid_t));
 
   fn_exit:

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -139,7 +139,12 @@ ze_context_handle_t ze_context;
 uint32_t local_ze_device_count; /* This counts both devices and subdevices */
 uint32_t global_ze_device_count;        /* This counts both devices and subdevices */
 
-#define MPL_ZE_EVENT_POOL_SIZE    (131072)
+#define MPL_ZE_EVENT_POOL_SIZE    (4096)
+
+typedef struct MPL_ze_event_pool {
+    ze_event_pool_handle_t pool;
+    struct MPL_ze_event_pool *next, *prev;
+} MPL_ze_event_pool;
 
 typedef struct {
     ze_command_queue_handle_t *cmdQueues;
@@ -152,7 +157,7 @@ typedef struct {
     int dev_id;
     unsigned int numQueueGroups;
     MPL_ze_engine_entry_t *engines;
-    ze_event_handle_t prev_event[MPL_GPU_COPY_DIRECTION_TYPES]; /* for imemcopy */
+    MPL_gpu_event *prev_event[MPL_GPU_COPY_DIRECTION_TYPES];    /* for imemcpy */
     MPL_cmdlist_pool_t *last_cmdList_entry[MPL_GPU_COPY_DIRECTION_TYPES];       /* for imemcopy */
 #ifdef ZE_PCI_PROPERTIES_EXT_NAME
     ze_pci_address_ext_t pci;
@@ -161,7 +166,9 @@ typedef struct {
 } MPL_ze_device_entry_t;
 
 static MPL_ze_device_entry_t *device_states;
-static ze_event_pool_handle_t eventPool;
+
+static MPL_ze_event_pool *ze_event_pools = NULL;
+static MPL_gpu_event *ze_events = NULL;
 
 /* *INDENT-OFF* */
 typedef ze_result_t (*pFnzexMemGetIpcHandles)(ze_context_handle_t, const void *, uint32_t *, ze_ipc_mem_handle_t *);
@@ -849,6 +856,9 @@ static inline int new_ipc_handle_cache(MPL_ze_ipc_handle_entry_t ** entry, int m
     goto fn_exit;
 }
 
+static int MPL_event_pool_add_new_pool(void);
+static void MPL_event_pool_destroy(void);
+
 /* Loads a global ze driver */
 static int gpu_ze_init_driver(void)
 {
@@ -1044,13 +1054,7 @@ static int gpu_ze_init_driver(void)
         MPL_free(queueProperties);
     }
 
-    ze_event_pool_desc_t pool_desc;
-    pool_desc.stype = ZE_STRUCTURE_TYPE_EVENT_POOL_DESC;
-    pool_desc.pNext = NULL;
-    pool_desc.flags = 0;
-    pool_desc.count = MPL_ZE_EVENT_POOL_SIZE;
-    ret = zeEventPoolCreate(ze_context, &pool_desc, 0, NULL, &eventPool);
-    ZE_ERR_CHECK(ret);
+    MPL_event_pool_add_new_pool();
 
     /* driver extension */
     ret =
@@ -1210,7 +1214,7 @@ int MPL_gpu_finalize(void)
     MPL_free(device_states);
     MPL_free(engine_conversion);
 
-    zeEventPoolDestroy(eventPool);
+    MPL_event_pool_destroy();
 
     return MPL_SUCCESS;
 }
@@ -1225,6 +1229,100 @@ int MPL_gpu_local_to_global_dev_id(int local_dev_id)
 {
     assert(local_dev_id < local_ze_device_count);
     return local_to_global_map[local_dev_id];
+}
+
+static int MPL_event_pool_add_new_pool(void)
+{
+    int mpl_err = MPL_SUCCESS;
+    int ret;
+    ze_event_pool_handle_t event_pool;
+
+    ze_event_pool_desc_t pool_desc;
+    pool_desc.stype = ZE_STRUCTURE_TYPE_EVENT_POOL_DESC;
+    pool_desc.pNext = NULL;
+    pool_desc.flags = 0;
+    pool_desc.count = MPL_ZE_EVENT_POOL_SIZE;
+    ret = zeEventPoolCreate(ze_context, &pool_desc, 0, NULL, &event_pool);
+    ZE_ERR_CHECK(ret);
+
+    MPL_ze_event_pool *ep =
+        (MPL_ze_event_pool *) MPL_calloc(1, sizeof(MPL_ze_event_pool), MPL_MEM_OTHER);
+    if (ep == NULL) {
+        mpl_err = MPL_ERR_GPU_NOMEM;
+        goto fn_exit;
+    }
+    ep->pool = event_pool;
+    DL_APPEND(ze_event_pools, ep);
+
+    for (int i = 0; i < MPL_ZE_EVENT_POOL_SIZE; i++) {
+        ze_event_handle_t event = NULL;
+        ze_event_desc_t event_desc = {
+            .stype = ZE_STRUCTURE_TYPE_EVENT_DESC,
+            .pNext = NULL,
+            .index = i,
+            .signal = ZE_EVENT_SCOPE_FLAG_HOST,
+            .wait = ZE_EVENT_SCOPE_FLAG_HOST
+        };
+        ret = zeEventCreate(event_pool, &event_desc, &event);
+        ZE_ERR_CHECK(ret);
+        MPL_gpu_event *e = (MPL_gpu_event *) MPL_calloc(1, sizeof(MPL_gpu_event), MPL_MEM_OTHER);
+        if (e == NULL) {
+            mpl_err = MPL_ERR_GPU_NOMEM;
+            goto fn_exit;
+        }
+        e->event = event;
+        DL_APPEND(ze_events, e);
+    }
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
+}
+
+static inline int MPL_event_pool_get_event(MPL_gpu_event ** event)
+{
+    int mpl_err = MPL_SUCCESS;
+    MPL_gpu_event *e = NULL;
+
+    if (ze_events == NULL) {
+        mpl_err = MPL_event_pool_add_new_pool();
+        if (mpl_err != MPL_SUCCESS) {
+            goto fn_fail;
+        }
+    }
+    assert(ze_events);
+    e = ze_events;
+    DL_DELETE(ze_events, e);
+    zeEventHostReset(e->event);
+    *event = e;
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
+}
+
+static inline void MPL_event_pool_push_event(MPL_gpu_event * gpu_event)
+{
+    DL_APPEND(ze_events, gpu_event);
+}
+
+static void MPL_event_pool_destroy(void)
+{
+    MPL_gpu_event *e, *e_tmp;
+    MPL_ze_event_pool *ep, *ep_tmp;
+
+    DL_FOREACH_SAFE(ze_events, e, e_tmp) {
+        zeEventDestroy(e->event);
+        MPL_free(e);
+    }
+    DL_FOREACH_SAFE(ze_event_pools, ep, ep_tmp) {
+        zeEventPoolDestroy(ep->pool);
+        MPL_free(ep);
+    }
 }
 
 /* given a local device pointer, create an IPC handle */
@@ -1903,32 +2001,6 @@ static inline int get_immediate_cmdlist(int *dev, MPL_gpu_copy_direction_t dir, 
     goto fn_exit;
 }
 
-static inline int get_next_event(ze_event_handle_t * event)
-{
-    static int pool_idx = 0;
-    int mpl_err = MPL_SUCCESS;
-    int ret;
-
-    *event = NULL;
-    ze_event_desc_t event_desc = {
-        .stype = ZE_STRUCTURE_TYPE_EVENT_DESC,
-        .pNext = NULL,
-        .signal = ZE_EVENT_SCOPE_FLAG_HOST,
-        .wait = ZE_EVENT_SCOPE_FLAG_HOST
-    };
-    event_desc.index = pool_idx++;
-    if (pool_idx >= MPL_ZE_EVENT_POOL_SIZE)
-        pool_idx = 0;
-    ret = zeEventCreate(eventPool, &event_desc, event);
-    ZE_ERR_CHECK(ret);
-
-  fn_exit:
-    return mpl_err;
-  fn_fail:
-    mpl_err = MPL_ERR_GPU_INTERNAL;
-    goto fn_exit;
-}
-
 /* no safety check in this function, call this function with safety protection.
    commit = false: append to command list only
    commit = true:  close the command list and submit to command queue
@@ -1942,7 +2014,7 @@ static int MPL_gpu_imemcpy_normal(void *dest_ptr, void *src_ptr, size_t size, in
 {
     int mpl_err = MPL_SUCCESS;
     MPL_ze_device_entry_t *device_state = NULL;
-    ze_event_handle_t event;
+    MPL_gpu_event *mpl_event;
     ze_command_list_handle_t cmdList = NULL;
     MPL_cmdlist_pool_t *cmdList_entry;
     int ret;
@@ -1952,9 +2024,9 @@ static int MPL_gpu_imemcpy_normal(void *dest_ptr, void *src_ptr, size_t size, in
     assert(dev >= 0 && dev < local_ze_device_count);
 
     if (dest_ptr && src_ptr) {
-        ze_event_handle_t pre_event = NULL;
+        MPL_gpu_event *pre_event = NULL;
         int nevent = 0;
-        ret = get_next_event(&event);
+        ret = MPL_event_pool_get_event(&mpl_event);
         ZE_ERR_CHECK(ret);
         device_state = device_states + dev;
         if (dir == MPL_GPU_COPY_DIRECTION_NONE) {
@@ -1977,19 +2049,19 @@ static int MPL_gpu_imemcpy_normal(void *dest_ptr, void *src_ptr, size_t size, in
             }
             if (device_states[orig_dev].last_cmdList_entry[dir]->dev != dev)
                 goto fn_fail;
-            device_state->prev_event[dir] = event;
+            device_state->prev_event[dir] = mpl_event;
         }
         assert(dev < local_ze_device_count);
         ret =
-            zeCommandListAppendMemoryCopy(cmdList, dest_ptr, src_ptr, size, event, nevent,
-                                          pre_event ? &pre_event : NULL);
+            zeCommandListAppendMemoryCopy(cmdList, dest_ptr, src_ptr, size, mpl_event->event,
+                                          nevent, pre_event ? &pre_event->event : NULL);
         ZE_ERR_CHECK(ret);
-        req->event = event;
+        req->gpu_event = mpl_event;
     } else {
         /* unlikely */
         device_state = device_states + dev;
         assert(device_state->prev_event[dir]);
-        req->event = device_state->prev_event[dir];
+        req->gpu_event = device_state->prev_event[dir];
         assert(dir < MPL_GPU_COPY_DIRECTION_TYPES);
         cmdList_entry = device_states[orig_dev].last_cmdList_entry[dir];
         assert(cmdList_entry);
@@ -2043,7 +2115,7 @@ int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
     int mpl_err = MPL_SUCCESS;
     int ret;
     MPL_ze_device_entry_t *device_state = NULL;
-    ze_event_handle_t event, pre_event = NULL;
+    MPL_gpu_event *mpl_event, *pre_event = NULL;
     ze_command_list_handle_t cmdl;
     int nevent = 0;
     int engine = -1;
@@ -2064,7 +2136,7 @@ int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
 
     assert(dest_ptr && src_ptr);
 
-    ret = get_next_event(&event);
+    ret = MPL_event_pool_get_event(&mpl_event);
     ZE_ERR_CHECK(ret);
     ret = get_immediate_cmdlist(&dev, dir, engine, &cmdl);
     ZE_ERR_CHECK(ret);
@@ -2075,14 +2147,14 @@ int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
             nevent = 1;
             pre_event = device_state->prev_event[dir];
         }
-        device_state->prev_event[dir] = event;
+        device_state->prev_event[dir] = mpl_event;
     }
     ret =
-        zeCommandListAppendMemoryCopy(cmdl, dest_ptr, src_ptr, size, event, nevent,
-                                      nevent ? &pre_event : NULL);
+        zeCommandListAppendMemoryCopy(cmdl, dest_ptr, src_ptr, size, mpl_event->event, nevent,
+                                      nevent ? &pre_event->event : NULL);
     ZE_ERR_CHECK(ret);
     req->cmdList = NULL;
-    req->event = event;
+    req->gpu_event = mpl_event;
 
   fn_exit:
     return mpl_err;
@@ -2096,14 +2168,15 @@ int MPL_gpu_test(MPL_gpu_request * req, int *completed)
     int mpl_err = MPL_SUCCESS;
     ze_result_t ret;
 
-    assert(req->event);
-    ret = zeEventQueryStatus(req->event);
+    assert(req->gpu_event->event);
+    ret = zeEventQueryStatus(req->gpu_event->event);
     if (ret == ZE_RESULT_SUCCESS) {
         *completed = 1;
         if (req->cmdList) {
             DL_APPEND(device_states[req->cmdList->dev].engines[req->cmdList->engine].cmdList_pool,
                       req->cmdList);
         }
+        MPL_event_pool_push_event(req->gpu_event);
     } else if (ret != ZE_RESULT_NOT_READY) {
         assert(0);
         goto fn_fail;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -29,7 +29,7 @@ static char **device_list = NULL;
 #define MAX_GPU_STR_LEN 256
 static char affinity_env[MAX_GPU_STR_LEN] = { 0 };
 
-static int *local_to_global_map;        /* [global_ze_device_count] */
+static int *local_to_global_map;        /* [local_ze_device_count] */
 static int *global_to_local_map;        /* [max_dev_id + 1]   */
 
 /* Maps a subdevice id to the upper device id, specifically for indexing into shared_device_fds */
@@ -73,16 +73,16 @@ pid_t mypid;
 /* Level-zero API v1.0:
  * http://spec.oneapi.com/level-zero/latest/index.html
  */
-ze_driver_handle_t global_ze_driver_handle;
-/* global_ze_devices_handle contains all devices and subdevices. Indices [0, device_count) are
+ze_driver_handle_t ze_driver_handle;
+/* ze_devices_handle contains all devices and subdevices. Indices [0, device_count) are
  * devices while the rest are subdevices. Keeping them all in the same array allows for easy
  * comparison of device handle when a device id is passed from the upper layer. The only time it
  * matters if we have a subdevice vs a device is when with creating or mapping an ipc handle. In
  * situations, we use the subdevice_map to find the upper device id for indexing into
  * shared_device_fds, since these are only opened on the upper devices. */
-ze_device_handle_t *global_ze_devices_handle = NULL;
-ze_context_handle_t global_ze_context;
-uint32_t global_ze_device_count;        /* This counts both devices and subdevices */
+ze_device_handle_t *ze_devices_handle = NULL;
+ze_context_handle_t ze_context;
+uint32_t local_ze_device_count; /* This counts both devices and subdevices */
 static int gpu_ze_init_driver(void);
 static int fd_to_handle(int dev_fd, int fd, int *handle);
 static int handle_to_fd(int dev_fd, int handle, int *fd);
@@ -107,7 +107,7 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
         ret = MPL_gpu_init(0);
     }
 
-    *dev_cnt = global_ze_device_count;
+    *dev_cnt = local_ze_device_count;
     *dev_id = max_dev_id;
     return ret;
 }
@@ -148,26 +148,26 @@ int MPL_gpu_get_dev_list(int *dev_count, char ***dev_list, bool is_subdev)
 
         /* Find a driver instance with a GPU device */
         for (int i = 0; i < driver_count; ++i) {
-            global_ze_device_count = 0;
-            ret = zeDeviceGet(all_drivers[i], &global_ze_device_count, NULL);
-            global_ze_devices_handle =
-                MPL_malloc(global_ze_device_count * sizeof(ze_device_handle_t), MPL_MEM_OTHER);
-            assert(global_ze_devices_handle);
-            subdev_counts = MPL_malloc(global_ze_device_count * sizeof(int), MPL_MEM_OTHER);
-            memset(subdev_counts, 0, global_ze_device_count * sizeof(int));
+            local_ze_device_count = 0;
+            ret = zeDeviceGet(all_drivers[i], &local_ze_device_count, NULL);
+            ze_devices_handle =
+                MPL_malloc(local_ze_device_count * sizeof(ze_device_handle_t), MPL_MEM_OTHER);
+            assert(ze_devices_handle);
+            subdev_counts = MPL_malloc(local_ze_device_count * sizeof(int), MPL_MEM_OTHER);
+            memset(subdev_counts, 0, local_ze_device_count * sizeof(int));
             assert(subdev_counts);
 
-            ret = zeDeviceGet(all_drivers[i], &global_ze_device_count, global_ze_devices_handle);
+            ret = zeDeviceGet(all_drivers[i], &local_ze_device_count, ze_devices_handle);
             assert(ret == ZE_RESULT_SUCCESS);
 
             /* Check if the driver supports a gpu */
-            for (int d = 0; d < global_ze_device_count; ++d) {
+            for (int d = 0; d < local_ze_device_count; ++d) {
                 ze_device_properties_t device_properties;
-                ret = zeDeviceGetProperties(global_ze_devices_handle[d], &device_properties);
+                ret = zeDeviceGetProperties(ze_devices_handle[d], &device_properties);
                 assert(ret == ZE_RESULT_SUCCESS);
 
                 if (!(device_properties.flags & ZE_DEVICE_PROPERTY_FLAG_SUBDEVICE)) {
-                    zeDeviceGetSubDevices(global_ze_devices_handle[d], &subdev_counts[d], NULL);
+                    zeDeviceGetSubDevices(ze_devices_handle[d], &subdev_counts[d], NULL);
                     if (subdev_counts[d] == 0) {
                         /* ZE reports no subdevice when there is only one subdevice */
                         subdev_counts[d] = 1;
@@ -176,7 +176,7 @@ int MPL_gpu_get_dev_list(int *dev_count, char ***dev_list, bool is_subdev)
 
                 }
             }
-            MPL_free(global_ze_devices_handle);
+            MPL_free(ze_devices_handle);
         }
 
         device_list = (char **) MPL_malloc(total_subdev_count * sizeof(char *), MPL_MEM_OTHER);
@@ -238,26 +238,26 @@ int MPL_gpu_init(int debug_summary)
     MPL_gpu_info.enable_ipc = true;
     MPL_gpu_info.ipc_handle_type = MPL_GPU_IPC_HANDLE_SHAREABLE_FD;
 
-    max_dev_id = global_ze_device_count - 1;
+    max_dev_id = local_ze_device_count - 1;
 
-    if (global_ze_device_count <= 0) {
+    if (local_ze_device_count <= 0) {
         gpu_initialized = 1;
         goto fn_exit;
     }
 
-    local_to_global_map = MPL_malloc(global_ze_device_count * sizeof(int), MPL_MEM_OTHER);
+    local_to_global_map = MPL_malloc(local_ze_device_count * sizeof(int), MPL_MEM_OTHER);
     if (local_to_global_map == NULL) {
         mpl_err = MPL_ERR_GPU_NOMEM;
         goto fn_fail;
     }
 
-    global_to_local_map = MPL_malloc(global_ze_device_count * sizeof(int), MPL_MEM_OTHER);
+    global_to_local_map = MPL_malloc(local_ze_device_count * sizeof(int), MPL_MEM_OTHER);
     if (global_to_local_map == NULL) {
         mpl_err = MPL_ERR_GPU_NOMEM;
         goto fn_fail;
     }
 
-    for (int i = 0; i < global_ze_device_count; i++) {
+    for (int i = 0; i < local_ze_device_count; i++) {
         local_to_global_map[i] = i;
         global_to_local_map[i] = i;
     }
@@ -270,7 +270,7 @@ int MPL_gpu_init(int debug_summary)
     if (MPL_gpu_info.debug_summary) {
         printf("==== GPU Init (ZE) ====\n");
         printf("device_count: %d\n", device_count);
-        printf("subdevice_count: %d\n", global_ze_device_count - device_count);
+        printf("subdevice_count: %d\n", local_ze_device_count - device_count);
         printf("=========================\n");
     }
 
@@ -290,8 +290,8 @@ int MPL_gpu_get_root_device(int dev_id)
 MPL_STATIC_INLINE_PREFIX int device_to_dev_id(ze_device_handle_t device)
 {
     int dev_id = -1;
-    for (int d = 0; d < global_ze_device_count; d++) {
-        if (global_ze_devices_handle[d] == device) {
+    for (int d = 0; d < local_ze_device_count; d++) {
+        if (ze_devices_handle[d] == device) {
             dev_id = d;
             break;
         }
@@ -309,7 +309,7 @@ MPL_STATIC_INLINE_PREFIX int dev_id_to_device(int dev_id, MPL_gpu_device_handle_
         goto fn_fail;
     }
 
-    *device = global_ze_devices_handle[dev_id];
+    *device = ze_devices_handle[dev_id];
 
   fn_exit:
     return mpl_err;
@@ -396,39 +396,38 @@ static int gpu_ze_init_driver(void)
         device_count = 0;
         ret = zeDeviceGet(all_drivers[i], &device_count, NULL);
         ZE_ERR_CHECK(ret);
-        global_ze_devices_handle =
-            MPL_malloc(device_count * sizeof(ze_device_handle_t), MPL_MEM_OTHER);
-        if (global_ze_devices_handle == NULL) {
+        ze_devices_handle = MPL_malloc(device_count * sizeof(ze_device_handle_t), MPL_MEM_OTHER);
+        if (ze_devices_handle == NULL) {
             ret_error = MPL_ERR_GPU_NOMEM;
             goto fn_fail;
         }
-        ret = zeDeviceGet(all_drivers[i], &device_count, global_ze_devices_handle);
+        ret = zeDeviceGet(all_drivers[i], &device_count, ze_devices_handle);
         ZE_ERR_CHECK(ret);
         /* Check if the driver supports a gpu */
         for (d = 0; d < device_count; ++d) {
             ze_device_properties_t device_properties;
             device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
             device_properties.pNext = NULL;
-            ret = zeDeviceGetProperties(global_ze_devices_handle[d], &device_properties);
+            ret = zeDeviceGetProperties(ze_devices_handle[d], &device_properties);
             ZE_ERR_CHECK(ret);
 
             if (ZE_DEVICE_TYPE_GPU == device_properties.type) {
-                global_ze_driver_handle = all_drivers[i];
+                ze_driver_handle = all_drivers[i];
                 break;
             }
         }
 
-        if (NULL != global_ze_driver_handle) {
+        if (NULL != ze_driver_handle) {
             break;
         } else {
-            MPL_free(global_ze_devices_handle);
-            global_ze_devices_handle = NULL;
+            MPL_free(ze_devices_handle);
+            ze_devices_handle = NULL;
         }
     }
 
     /* Setup subdevices */
-    global_ze_device_count = device_count;
-    if (global_ze_devices_handle != NULL) {
+    local_ze_device_count = device_count;
+    if (ze_devices_handle != NULL) {
         /* Count the subdevices */
         subdevice_count = MPL_malloc(device_count * sizeof(uint32_t), MPL_MEM_OTHER);
         if (subdevice_count == NULL) {
@@ -438,23 +437,23 @@ static int gpu_ze_init_driver(void)
 
         for (d = 0; d < device_count; ++d) {
             subdevice_count[d] = 0;
-            ret = zeDeviceGetSubDevices(global_ze_devices_handle[d], &subdevice_count[d], NULL);
+            ret = zeDeviceGetSubDevices(ze_devices_handle[d], &subdevice_count[d], NULL);
             ZE_ERR_CHECK(ret);
 
-            global_ze_device_count += subdevice_count[d];
+            local_ze_device_count += subdevice_count[d];
         }
 
-        subdevice_map = MPL_malloc(global_ze_device_count * sizeof(int), MPL_MEM_OTHER);
+        subdevice_map = MPL_malloc(local_ze_device_count * sizeof(int), MPL_MEM_OTHER);
         if (subdevice_map == NULL) {
             ret_error = MPL_ERR_GPU_NOMEM;
             goto fn_fail;
         }
 
         /* Add the subdevices to the device array */
-        global_ze_devices_handle =
-            MPL_realloc(global_ze_devices_handle,
-                        global_ze_device_count * sizeof(ze_device_handle_t), MPL_MEM_OTHER);
-        if (global_ze_devices_handle == NULL) {
+        ze_devices_handle =
+            MPL_realloc(ze_devices_handle,
+                        local_ze_device_count * sizeof(ze_device_handle_t), MPL_MEM_OTHER);
+        if (ze_devices_handle == NULL) {
             ret_error = MPL_ERR_GPU_NOMEM;
             goto fn_fail;
         }
@@ -462,8 +461,8 @@ static int gpu_ze_init_driver(void)
         int dev_id = device_count;
         for (d = 0; d < device_count; ++d) {
             ret =
-                zeDeviceGetSubDevices(global_ze_devices_handle[d], &subdevice_count[d],
-                                      &global_ze_devices_handle[dev_id]);
+                zeDeviceGetSubDevices(ze_devices_handle[d], &subdevice_count[d],
+                                      &ze_devices_handle[dev_id]);
             ZE_ERR_CHECK(ret);
 
             /* Setup the subdevice map for shared_device_fds */
@@ -481,14 +480,14 @@ static int gpu_ze_init_driver(void)
         .pNext = NULL,
         .flags = 0,
     };
-    ret = zeContextCreate(global_ze_driver_handle, &contextDesc, &global_ze_context);
+    ret = zeContextCreate(ze_driver_handle, &contextDesc, &ze_context);
     ZE_ERR_CHECK(ret);
 
   fn_exit:
     MPL_free(all_drivers);
     return ret_error;
   fn_fail:
-    MPL_free(global_ze_devices_handle);
+    MPL_free(ze_devices_handle);
     /* If error code is already set, preserve it */
     if (ret_error == MPL_SUCCESS)
         ret_error = MPL_ERR_GPU_INTERNAL;
@@ -501,7 +500,7 @@ int MPL_gpu_finalize(void)
 
     MPL_free(local_to_global_map);
     MPL_free(global_to_local_map);
-    MPL_free(global_ze_devices_handle);
+    MPL_free(ze_devices_handle);
     MPL_free(subdevice_map);
     MPL_free(subdevice_count);
 
@@ -535,7 +534,7 @@ int MPL_gpu_global_to_local_dev_id(int global_dev_id)
 
 int MPL_gpu_local_to_global_dev_id(int local_dev_id)
 {
-    assert(local_dev_id < global_ze_device_count);
+    assert(local_dev_id < local_ze_device_count);
     return local_to_global_map[local_dev_id];
 }
 
@@ -544,7 +543,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     int mpl_err = MPL_SUCCESS;
     ze_result_t ret;
     unsigned long shared_handle;
-    int fd, handle, status, dev_id = -1;
+    int fd, handle, status, local_dev_id = -1;
     ze_device_handle_t device;
     ze_ipc_mem_handle_t ze_ipc_handle;
 
@@ -556,19 +555,19 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
         .pageSize = 0,
     };
 
-    ret = zeMemGetIpcHandle(global_ze_context, ptr, &ze_ipc_handle);
+    ret = zeMemGetIpcHandle(ze_context, ptr, &ze_ipc_handle);
     ZE_ERR_CHECK(ret);
 
-    ret = zeMemGetAllocProperties(global_ze_context, ptr, &ptr_attr, &device);
+    ret = zeMemGetAllocProperties(ze_context, ptr, &ptr_attr, &device);
     ZE_ERR_CHECK(ret);
 
-    dev_id = device_to_dev_id(device);
-    if (dev_id == -1) {
+    local_dev_id = device_to_dev_id(device);
+    if (local_dev_id == -1) {
         goto fn_fail;
     }
 
     if (shared_device_fds != NULL) {
-        int shared_dev_id = MPL_gpu_get_root_device(dev_id);
+        int shared_dev_id = MPL_gpu_get_root_device(local_dev_id);
         /* convert dma_buf fd to GEM handle */
         memcpy(&fd, &ze_ipc_handle, sizeof(fd));
         status = fd_to_handle(shared_device_fds[shared_dev_id], fd, &handle);
@@ -690,7 +689,7 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
     }
     memcpy(&ze_ipc_handle, &fd, sizeof(fd));
 
-    ret = zeMemOpenIpcHandle(global_ze_context, dev_handle, ze_ipc_handle, 0, ptr);
+    ret = zeMemOpenIpcHandle(ze_context, dev_handle, ze_ipc_handle, 0, ptr);
     ZE_ERR_CHECK(ret);
 
   fn_exit:
@@ -704,7 +703,7 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
     int mpl_err = MPL_SUCCESS;
 
     ze_result_t ret;
-    ret = zeMemCloseIpcHandle(global_ze_context, ptr);
+    ret = zeMemCloseIpcHandle(ze_context, ptr);
     ZE_ERR_CHECK(ret);
 
   fn_exit:
@@ -720,7 +719,7 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 
     ze_result_t ret;
     memset(&attr->device_attr.prop, 0, sizeof(ze_memory_allocation_properties_t));
-    ret = zeMemGetAllocProperties(global_ze_context, ptr,
+    ret = zeMemGetAllocProperties(ze_context, ptr,
                                   &attr->device_attr.prop, &attr->device_attr.device);
     ZE_ERR_CHECK(ret);
     attr->device = attr->device_attr.device;
@@ -762,7 +761,7 @@ int MPL_gpu_malloc(void **ptr, size_t size, MPL_gpu_device_handle_t h_device)
     /* Currently ZE ignores this argument and uses an internal alignment
      * value. However, this behavior can change in the future. */
     mem_alignment = 1;
-    ret = zeMemAllocDevice(global_ze_context, &device_desc, size, mem_alignment, h_device, ptr);
+    ret = zeMemAllocDevice(ze_context, &device_desc, size, mem_alignment, h_device, ptr);
 
     ZE_ERR_CHECK(ret);
 
@@ -787,7 +786,7 @@ int MPL_gpu_malloc_host(void **ptr, size_t size)
     /* Currently ZE ignores this argument and uses an internal alignment
      * value. However, this behavior can change in the future. */
     mem_alignment = 1;
-    ret = zeMemAllocHost(global_ze_context, &host_desc, size, mem_alignment, ptr);
+    ret = zeMemAllocHost(ze_context, &host_desc, size, mem_alignment, ptr);
     ZE_ERR_CHECK(ret);
 
   fn_exit:
@@ -800,7 +799,7 @@ int MPL_gpu_malloc_host(void **ptr, size_t size)
 int MPL_gpu_free(void *ptr)
 {
     int mpl_err = MPL_SUCCESS;
-    mpl_err = zeMemFree(global_ze_context, ptr);
+    mpl_err = zeMemFree(ze_context, ptr);
     ZE_ERR_CHECK(mpl_err);
 
   fn_exit:
@@ -813,7 +812,7 @@ int MPL_gpu_free(void *ptr)
 int MPL_gpu_free_host(void *ptr)
 {
     int mpl_err;
-    mpl_err = zeMemFree(global_ze_context, ptr);
+    mpl_err = zeMemFree(ze_context, ptr);
     ZE_ERR_CHECK(mpl_err);
 
   fn_exit:
@@ -846,7 +845,7 @@ int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)
 {
     int mpl_err = MPL_SUCCESS;
     int ret;
-    ret = zeMemGetAddressRange(global_ze_context, ptr, pbase, len);
+    ret = zeMemGetAddressRange(ze_context, ptr, pbase, len);
     ZE_ERR_CHECK(ret);
 
   fn_exit:

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -2571,14 +2571,12 @@ int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shar
         HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry.remote_mem_id, keylen, cache_entry);
     }
 
+    *ptr = NULL;
     if (cache_entry) {
-        *ptr = cache_entry->mapped_ptr;
-    } else {
-        mpl_err = MPL_ze_ipc_handle_map(ipc_handle, is_shared_handle, dev_id, true, size, ptr);
-        if (mpl_err != MPL_SUCCESS) {
-            goto fn_fail;
+        if (cache_entry->mapped_ptr) {
+            *ptr = cache_entry->mapped_ptr;
         }
-
+    } else {
         if (likely(MPL_gpu_info.specialized_cache)) {
             /* Insert into the cache */
             cache_entry =
@@ -2590,6 +2588,17 @@ int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shar
             }
             memset(cache_entry, 0, sizeof(MPL_ze_mapped_buffer_entry_t));
             cache_entry->key = lookup_entry;
+            HASH_ADD(hh, ipc_cache_mapped[dev_id], key, keylen, cache_entry, MPL_MEM_OTHER);
+        }
+    }
+
+    if (*ptr == NULL) {
+        mpl_err = MPL_ze_ipc_handle_map(ipc_handle, is_shared_handle, dev_id, true, size, ptr);
+        if (mpl_err != MPL_SUCCESS) {
+            goto fn_fail;
+        }
+
+        if (likely(MPL_gpu_info.specialized_cache)) {
             cache_entry->mapped_ptr = *ptr;
             cache_entry->mapped_size = size;
 
@@ -2602,7 +2611,6 @@ int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shar
             }
             memcpy(removal_entry, cache_entry, sizeof(MPL_ze_mapped_buffer_entry_t));
 
-            HASH_ADD(hh, ipc_cache_mapped[dev_id], key, keylen, cache_entry, MPL_MEM_OTHER);
             HASH_ADD(hh, mmap_cache_removal[dev_id], mapped_ptr, sizeof(void *), removal_entry,
                      MPL_MEM_OTHER);
         }

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -152,6 +152,10 @@ typedef struct {
     unsigned int numQueueGroups;
     ze_event_handle_t prev_event;       /* for imemcopy */
     MPL_cmdlist_pool_t *last_cmdList_entry;     /* for imemcopy */
+#ifdef ZE_PCI_PROPERTIES_EXT_NAME
+    ze_pci_address_ext_t pci;
+    int pci_avail;
+#endif
 } MPL_ze_device_entry_t;
 
 static MPL_ze_device_entry_t *device_states;
@@ -1019,6 +1023,19 @@ static int gpu_ze_init_driver(void)
                 }
             }
         }
+#ifdef ZE_PCI_PROPERTIES_EXT_NAME
+        ze_pci_ext_properties_t pci_property = {
+            .stype = ZE_STRUCTURE_TYPE_PCI_EXT_PROPERTIES,
+            .pNext = NULL,
+        };
+        ret = zeDevicePciGetPropertiesExt(ze_devices_handle[d], &pci_property);
+        if (ret == ZE_RESULT_SUCCESS) {
+            device_state->pci_avail = 1;
+            device_state->pci = pci_property.address;
+        } else {
+            device_state->pci_avail = 0;
+        }
+#endif
         MPL_free(queueProperties);
     }
 
@@ -1548,6 +1565,38 @@ int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr_t * attr)
     return type != ZE_MEMORY_TYPE_UNKNOWN;
 }
 
+int MPL_gpu_query_is_same_dev(int global_dev1, int global_dev2)
+{
+    MPL_ze_device_entry_t *device_state1, *device_state2;
+    int local_dev1, local_dev2;
+
+    assert(global_dev1 >= 0 && global_dev1 < global_ze_device_count);
+    assert(global_dev2 >= 0 && global_dev2 < global_ze_device_count);
+
+    local_dev1 = MPL_gpu_global_to_local_dev_id(global_dev1);
+    local_dev2 = MPL_gpu_global_to_local_dev_id(global_dev2);
+    /* check if invisible devices */
+    if (local_dev1 == -1 || local_dev2 == -1)
+        return 0;
+
+#ifdef ZE_PCI_PROPERTIES_EXT_NAME
+    if (MPL_gpu_get_root_device(local_dev1) == MPL_gpu_get_root_device(local_dev2))
+        return 1;
+
+    device_state1 = device_states + local_dev1;
+    device_state2 = device_states + local_dev2;
+    if (device_state1->pci_avail && device_state2->pci_avail)
+        return device_state1->pci.domain == device_state2->pci.domain &&
+            device_state1->pci.bus == device_state2->pci.bus &&
+            device_state1->pci.device == device_state2->pci.device &&
+            device_state1->pci.function == device_state2->pci.function;
+    else
+        return 0;
+#else
+    return MPL_gpu_get_root_device(local_dev1) == MPL_gpu_get_root_device(local_dev2);
+#endif
+}
+
 int MPL_gpu_malloc(void **ptr, size_t size, MPL_gpu_device_handle_t h_device)
 {
     int mpl_err = MPL_SUCCESS;
@@ -1750,6 +1799,8 @@ int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
     int ret;
     int orig_dev = dev;
     int engine = engine_conversion[engine_type];
+
+    assert(dev >= 0 && dev < local_ze_device_count);
 
     if (dest_ptr && src_ptr) {
         ret = get_next_event(&event);

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -1133,6 +1133,8 @@ static int gpu_ze_init_driver(void)
     goto fn_exit;
 }
 
+static void remove_ipc_handle_entry(MPL_ze_mapped_buffer_entry_t * cache_entry, int dev_id);
+
 int MPL_gpu_finalize(void)
 {
     int i, j, k;
@@ -1142,7 +1144,7 @@ int MPL_gpu_finalize(void)
             if (ipc_cache_removal[i]) {
                 MPL_ze_mapped_buffer_entry_t *entry = NULL, *tmp = NULL;
                 HASH_ITER(hh, ipc_cache_removal[i], entry, tmp) {
-                    MPL_gpu_ipc_handle_unmap(entry->ipc_buf);
+                    remove_ipc_handle_entry(entry, i);
                 }
             }
 
@@ -1666,6 +1668,29 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
   fn_fail:
     mpl_err = MPL_ERR_GPU_INTERNAL;
     goto fn_exit;
+}
+
+/* at finalize, to free a cache entry in ipc_cache_removal cache */
+static void remove_ipc_handle_entry(MPL_ze_mapped_buffer_entry_t * cache_entry, int dev_id)
+{
+    unsigned keylen;
+    MPL_ze_mapped_buffer_lookup_t lookup_entry;
+
+    lookup_entry = cache_entry->key;
+    keylen = sizeof(MPL_ze_mapped_buffer_lookup_t);
+
+    HASH_DEL(ipc_cache_removal[dev_id], cache_entry);
+    MPL_free(cache_entry);
+    cache_entry = NULL;
+
+    HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry.remote_mem_id, keylen, cache_entry);
+
+    if (cache_entry != NULL) {
+        // FIXME: need to unmap?
+        HASH_DEL(ipc_cache_mapped[dev_id], cache_entry);
+        MPL_free(cache_entry);
+        cache_entry = NULL;
+    }
 }
 
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -918,11 +918,9 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     goto fn_exit;
 }
 
-int MPL_gpu_ipc_handle_destroy(const void *ptr)
+int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
 {
-    ze_result_t ret;
     int status, mpl_err = MPL_SUCCESS;
-    ze_device_handle_t device;
     MPL_ze_ipc_handle_entry_t *cache_entry = NULL;
     int dev_id;
     uint64_t mem_id;
@@ -946,23 +944,12 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr)
     }
 
     if (likely(MPL_gpu_info.specialized_cache)) {
-        ze_memory_allocation_properties_t ptr_attr = {
-            .stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES,
-            .pNext = NULL,
-            .type = 0,
-            .id = 0,
-            .pageSize = 0,
-        };
-
-        ret = zeMemGetAllocProperties(ze_context, ptr, &ptr_attr, &device);
-        ZE_ERR_CHECK(ret);
-
-        dev_id = device_to_dev_id(device);
+        dev_id = device_to_dev_id(gpu_attr->device);
         if (dev_id == -1) {
             goto fn_fail;
         }
 
-        mem_id = ptr_attr.id;
+        mem_id = gpu_attr->device_attr.prop.id;
         HASH_FIND(hh, ipc_cache_tracked[dev_id], &mem_id, sizeof(uint64_t), cache_entry);
 
         if (cache_entry != NULL) {

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -102,7 +102,7 @@ static int gpu_mem_hook_init(void);
             goto fn_fail; \
     } while (0)
 
-int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
+int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id, int *subdev_id)
 {
     int ret = MPL_SUCCESS;
     if (!gpu_initialized) {
@@ -111,6 +111,7 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
 
     *dev_cnt = local_ze_device_count;
     *dev_id = max_dev_id;
+    *subdev_id = max_subdev_id;
     return ret;
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -23,14 +23,19 @@ MPL_SUPPRESS_OSX_HAS_NO_SYMBOLS_WARNING;
 #include "uthash.h"
 
 static int gpu_initialized = 0;
-static int device_count;
-static int max_dev_id;
+static uint32_t device_count;
+static uint32_t max_dev_id;
 static char **device_list = NULL;
 #define MAX_GPU_STR_LEN 256
 static char affinity_env[MAX_GPU_STR_LEN] = { 0 };
 
-static int *local_to_global_map;        /* [device_count] */
+static int *local_to_global_map;        /* [global_ze_device_count] */
 static int *global_to_local_map;        /* [max_dev_id + 1]   */
+
+/* Maps a subdevice id to the upper device id, specifically for indexing into shared_device_fds */
+static int *subdevice_map = NULL;
+/* Keeps the subdevice count for all locally visible devices */
+static uint32_t *subdevice_count = NULL;
 
 static int shared_device_fd_count = 0;
 static int *shared_device_fds = NULL;
@@ -69,9 +74,15 @@ pid_t mypid;
  * http://spec.oneapi.com/level-zero/latest/index.html
  */
 ze_driver_handle_t global_ze_driver_handle;
+/* global_ze_devices_handle contains all devices and subdevices. Indices [0, device_count) are
+ * devices while the rest are subdevices. Keeping them all in the same array allows for easy
+ * comparison of device handle when a device id is passed from the upper layer. The only time it
+ * matters if we have a subdevice vs a device is when with creating or mapping an ipc handle. In
+ * situations, we use the subdevice_map to find the upper device id for indexing into
+ * shared_device_fds, since these are only opened on the upper devices. */
 ze_device_handle_t *global_ze_devices_handle = NULL;
 ze_context_handle_t global_ze_context;
-uint32_t global_ze_device_count;
+uint32_t global_ze_device_count;        /* This counts both devices and subdevices */
 static int gpu_ze_init_driver(void);
 static int fd_to_handle(int dev_fd, int fd, int *handle);
 static int handle_to_fd(int dev_fd, int handle, int *fd);
@@ -96,7 +107,7 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id)
         ret = MPL_gpu_init(0);
     }
 
-    *dev_cnt = device_count;
+    *dev_cnt = global_ze_device_count;
     *dev_id = max_dev_id;
     return ret;
 }
@@ -227,17 +238,26 @@ int MPL_gpu_init(int debug_summary)
     MPL_gpu_info.enable_ipc = true;
     MPL_gpu_info.ipc_handle_type = MPL_GPU_IPC_HANDLE_SHAREABLE_FD;
 
-    device_count = global_ze_device_count;
-    max_dev_id = device_count - 1;
+    max_dev_id = global_ze_device_count - 1;
 
-    if (device_count <= 0) {
+    if (global_ze_device_count <= 0) {
         gpu_initialized = 1;
         goto fn_exit;
     }
 
-    local_to_global_map = MPL_malloc(device_count * sizeof(int), MPL_MEM_OTHER);
-    global_to_local_map = MPL_malloc(device_count * sizeof(int), MPL_MEM_OTHER);
-    for (int i = 0; i < device_count; i++) {
+    local_to_global_map = MPL_malloc(global_ze_device_count * sizeof(int), MPL_MEM_OTHER);
+    if (local_to_global_map == NULL) {
+        mpl_err = MPL_ERR_GPU_NOMEM;
+        goto fn_fail;
+    }
+
+    global_to_local_map = MPL_malloc(global_ze_device_count * sizeof(int), MPL_MEM_OTHER);
+    if (global_to_local_map == NULL) {
+        mpl_err = MPL_ERR_GPU_NOMEM;
+        goto fn_fail;
+    }
+
+    for (int i = 0; i < global_ze_device_count; i++) {
         local_to_global_map[i] = i;
         global_to_local_map[i] = i;
     }
@@ -250,12 +270,51 @@ int MPL_gpu_init(int debug_summary)
     if (MPL_gpu_info.debug_summary) {
         printf("==== GPU Init (ZE) ====\n");
         printf("device_count: %d\n", device_count);
+        printf("subdevice_count: %d\n", global_ze_device_count - device_count);
         printf("=========================\n");
     }
 
   fn_exit:
     return mpl_err;
   fn_fail:
+    goto fn_exit;
+}
+
+/* Get dev_id for shared_device_fds from regular dev_id */
+int MPL_gpu_get_root_device(int dev_id)
+{
+    return subdevice_map[dev_id];
+}
+
+/* Get dev_id from device */
+MPL_STATIC_INLINE_PREFIX int device_to_dev_id(ze_device_handle_t device)
+{
+    int dev_id = -1;
+    for (int d = 0; d < global_ze_device_count; d++) {
+        if (global_ze_devices_handle[d] == device) {
+            dev_id = d;
+            break;
+        }
+    }
+
+    return dev_id;
+}
+
+/* Get device from dev_id */
+MPL_STATIC_INLINE_PREFIX int dev_id_to_device(int dev_id, MPL_gpu_device_handle_t * device)
+{
+    int mpl_err = MPL_SUCCESS;
+
+    if (dev_id > max_dev_id) {
+        goto fn_fail;
+    }
+
+    *device = global_ze_devices_handle[dev_id];
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    mpl_err = MPL_ERR_GPU_INTERNAL;
     goto fn_exit;
 }
 
@@ -334,19 +393,19 @@ static int gpu_ze_init_driver(void)
     int i, d;
     /* Find a driver instance with a GPU device */
     for (i = 0; i < driver_count; ++i) {
-        global_ze_device_count = 0;
-        ret = zeDeviceGet(all_drivers[i], &global_ze_device_count, NULL);
+        device_count = 0;
+        ret = zeDeviceGet(all_drivers[i], &device_count, NULL);
         ZE_ERR_CHECK(ret);
         global_ze_devices_handle =
-            MPL_malloc(global_ze_device_count * sizeof(ze_device_handle_t), MPL_MEM_OTHER);
+            MPL_malloc(device_count * sizeof(ze_device_handle_t), MPL_MEM_OTHER);
         if (global_ze_devices_handle == NULL) {
             ret_error = MPL_ERR_GPU_NOMEM;
             goto fn_fail;
         }
-        ret = zeDeviceGet(all_drivers[i], &global_ze_device_count, global_ze_devices_handle);
+        ret = zeDeviceGet(all_drivers[i], &device_count, global_ze_devices_handle);
         ZE_ERR_CHECK(ret);
         /* Check if the driver supports a gpu */
-        for (d = 0; d < global_ze_device_count; ++d) {
+        for (d = 0; d < device_count; ++d) {
             ze_device_properties_t device_properties;
             device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
             device_properties.pNext = NULL;
@@ -364,6 +423,56 @@ static int gpu_ze_init_driver(void)
         } else {
             MPL_free(global_ze_devices_handle);
             global_ze_devices_handle = NULL;
+        }
+    }
+
+    /* Setup subdevices */
+    global_ze_device_count = device_count;
+    if (global_ze_devices_handle != NULL) {
+        /* Count the subdevices */
+        subdevice_count = MPL_malloc(device_count * sizeof(uint32_t), MPL_MEM_OTHER);
+        if (subdevice_count == NULL) {
+            ret_error = MPL_ERR_GPU_NOMEM;
+            goto fn_fail;
+        }
+
+        for (d = 0; d < device_count; ++d) {
+            subdevice_count[d] = 0;
+            ret = zeDeviceGetSubDevices(global_ze_devices_handle[d], &subdevice_count[d], NULL);
+            ZE_ERR_CHECK(ret);
+
+            global_ze_device_count += subdevice_count[d];
+        }
+
+        subdevice_map = MPL_malloc(global_ze_device_count * sizeof(int), MPL_MEM_OTHER);
+        if (subdevice_map == NULL) {
+            ret_error = MPL_ERR_GPU_NOMEM;
+            goto fn_fail;
+        }
+
+        /* Add the subdevices to the device array */
+        global_ze_devices_handle =
+            MPL_realloc(global_ze_devices_handle,
+                        global_ze_device_count * sizeof(ze_device_handle_t), MPL_MEM_OTHER);
+        if (global_ze_devices_handle == NULL) {
+            ret_error = MPL_ERR_GPU_NOMEM;
+            goto fn_fail;
+        }
+
+        int dev_id = device_count;
+        for (d = 0; d < device_count; ++d) {
+            ret =
+                zeDeviceGetSubDevices(global_ze_devices_handle[d], &subdevice_count[d],
+                                      &global_ze_devices_handle[dev_id]);
+            ZE_ERR_CHECK(ret);
+
+            /* Setup the subdevice map for shared_device_fds */
+            subdevice_map[d] = d;
+            for (i = 0; i < subdevice_count[d]; ++i) {
+                subdevice_map[dev_id + i] = d;
+            }
+
+            dev_id += subdevice_count[d];
         }
     }
 
@@ -393,6 +502,8 @@ int MPL_gpu_finalize(void)
     MPL_free(local_to_global_map);
     MPL_free(global_to_local_map);
     MPL_free(global_ze_devices_handle);
+    MPL_free(subdevice_map);
+    MPL_free(subdevice_count);
 
     MPL_ze_gem_hash_entry_t *entry = NULL, *tmp = NULL;
     HASH_ITER(hh, gem_hash, entry, tmp) {
@@ -424,7 +535,7 @@ int MPL_gpu_global_to_local_dev_id(int global_dev_id)
 
 int MPL_gpu_local_to_global_dev_id(int local_dev_id)
 {
-    assert(local_dev_id < device_count);
+    assert(local_dev_id < global_ze_device_count);
     return local_to_global_map[local_dev_id];
 }
 
@@ -433,7 +544,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     int mpl_err = MPL_SUCCESS;
     ze_result_t ret;
     unsigned long shared_handle;
-    int i, fd, handle, status, dev_id = -1;
+    int fd, handle, status, dev_id = -1;
     ze_device_handle_t device;
     ze_ipc_mem_handle_t ze_ipc_handle;
 
@@ -451,26 +562,21 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     ret = zeMemGetAllocProperties(global_ze_context, ptr, &ptr_attr, &device);
     ZE_ERR_CHECK(ret);
 
-    for (i = 0; i < device_count; i++) {
-        if (device == global_ze_devices_handle[i]) {
-            dev_id = i;
-            break;
-        }
-    }
-
+    dev_id = device_to_dev_id(device);
     if (dev_id == -1) {
         goto fn_fail;
     }
 
     if (shared_device_fds != NULL) {
+        int shared_dev_id = MPL_gpu_get_root_device(dev_id);
         /* convert dma_buf fd to GEM handle */
         memcpy(&fd, &ze_ipc_handle, sizeof(fd));
-        status = fd_to_handle(shared_device_fds[dev_id], fd, &handle);
+        status = fd_to_handle(shared_device_fds[shared_dev_id], fd, &handle);
         if (status) {
             goto fn_fail;
         }
 
-        shared_handle = dev_id;
+        shared_handle = shared_dev_id;
         shared_handle = shared_handle << 32 | handle;
         memcpy(ipc_handle, &shared_handle, sizeof(shared_handle));
 
@@ -487,7 +593,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
             }
 
             entry->ptr = ptr;
-            entry->dev_id = dev_id;
+            entry->dev_id = shared_dev_id;
             entry->handle = handle;
             HASH_ADD_PTR(gem_hash, ptr, entry, MPL_MEM_OTHER);
         }
@@ -549,10 +655,10 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
     if (shared_device_fds != NULL) {
         /* convert GEM handle to fd */
         memcpy(&shared_handle, &ipc_handle, sizeof(shared_handle));
-        src_dev_id = shared_handle >> 32;
+        int shared_dev_id = shared_handle >> 32;
         handle = shared_handle << 32 >> 32;
 
-        status = handle_to_fd(shared_device_fds[src_dev_id], handle, &fd);
+        status = handle_to_fd(shared_device_fds[shared_dev_id], handle, &fd);
         if (status) {
             goto fn_fail;
         }
@@ -578,7 +684,10 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
         }
     }
 
-    dev_handle = global_ze_devices_handle[dev_id];
+    mpl_err = dev_id_to_device(dev_id, &dev_handle);
+    if (mpl_err != MPL_SUCCESS) {
+        goto fn_fail;
+    }
     memcpy(&ze_ipc_handle, &fd, sizeof(fd));
 
     ret = zeMemOpenIpcHandle(global_ze_context, dev_handle, ze_ipc_handle, 0, ptr);
@@ -727,12 +836,9 @@ int MPL_gpu_unregister_host(const void *ptr)
 int MPL_gpu_get_dev_id_from_attr(MPL_pointer_attr_t * attr)
 {
     int dev_id = -1;
-    for (int i = 0; i < global_ze_device_count; i++) {
-        if (global_ze_devices_handle[i] == attr->device) {
-            dev_id = i;
-            break;
-        }
-    }
+
+    dev_id = device_to_dev_id(attr->device);
+
     return dev_id;
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -97,6 +97,8 @@ typedef struct {
     void *ipc_buf;
     void *mapped_ptr;
     size_t mapped_size;
+    int fds[2];
+    int nfds;                   /* used when doing mmap */
     UT_hash_handle hh;
 } MPL_ze_mapped_buffer_entry_t;
 
@@ -1133,7 +1135,7 @@ static int gpu_ze_init_driver(void)
     goto fn_exit;
 }
 
-static void remove_ipc_handle_entry(MPL_ze_mapped_buffer_entry_t * cache_entry, int dev_id);
+static int remove_ipc_handle_entry(MPL_ze_mapped_buffer_entry_t * cache_entry, int dev_id);
 
 int MPL_gpu_finalize(void)
 {
@@ -1561,21 +1563,16 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle, int dev_id
     goto fn_exit;
 }
 
+/* free a cache entry in mmap_cache_removal */
 int MPL_ze_mmap_handle_unmap(void *ptr, int dev_id)
 {
-    int ret_err, mpl_err = MPL_SUCCESS;
+    int mpl_err = MPL_SUCCESS;
     unsigned keylen;
-    size_t size = 0;
     MPL_ze_mapped_buffer_entry_t *cache_entry = NULL;
     MPL_ze_mapped_buffer_lookup_t lookup_entry;
 
     if (likely(MPL_gpu_info.specialized_cache)) {
         HASH_FIND(hh, mmap_cache_removal[dev_id], &ptr, sizeof(void *), cache_entry);
-
-        if (cache_entry != NULL) {
-            size = cache_entry->mapped_size;
-        }
-
         if (cache_entry != NULL) {
             lookup_entry = cache_entry->key;
             keylen = sizeof(MPL_ze_mapped_buffer_lookup_t);
@@ -1586,19 +1583,19 @@ int MPL_ze_mmap_handle_unmap(void *ptr, int dev_id)
 
             HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry, keylen, cache_entry);
 
+            /* since ipc_cache_removal is removed first, only mapped_ptr
+             * need to be considered */
             if (cache_entry != NULL) {
-                // FIXME: need to close IPC handle?
+                if (cache_entry->mapped_ptr) {
+                    munmapFunction(cache_entry->nfds, cache_entry->fds, cache_entry->mapped_ptr,
+                                   cache_entry->mapped_size);
+                }
                 HASH_DEL(ipc_cache_mapped[dev_id], cache_entry);
                 MPL_free(cache_entry);
                 cache_entry = NULL;
             }
         }
     } else {
-        goto fn_fail;
-    }
-
-    ret_err = munmap(ptr, size);
-    if (ret_err == -1) {
         goto fn_fail;
     }
 
@@ -1651,7 +1648,10 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
                       cache_entry);
 
             if (cache_entry != NULL) {
-                // FIXME: need to unmap?
+                if (cache_entry->mapped_ptr) {
+                    munmapFunction(cache_entry->nfds, cache_entry->fds, cache_entry->mapped_ptr,
+                                   cache_entry->mapped_size);
+                }
                 HASH_DEL(ipc_cache_mapped[dev_id], cache_entry);
                 MPL_free(cache_entry);
                 cache_entry = NULL;
@@ -1671,8 +1671,10 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
 }
 
 /* at finalize, to free a cache entry in ipc_cache_removal cache */
-static void remove_ipc_handle_entry(MPL_ze_mapped_buffer_entry_t * cache_entry, int dev_id)
+static int remove_ipc_handle_entry(MPL_ze_mapped_buffer_entry_t * cache_entry, int dev_id)
 {
+    int mpl_err = MPL_SUCCESS;
+    ze_result_t ret;
     unsigned keylen;
     MPL_ze_mapped_buffer_lookup_t lookup_entry;
 
@@ -1686,11 +1688,24 @@ static void remove_ipc_handle_entry(MPL_ze_mapped_buffer_entry_t * cache_entry, 
     HASH_FIND(hh, ipc_cache_mapped[dev_id], &lookup_entry.remote_mem_id, keylen, cache_entry);
 
     if (cache_entry != NULL) {
-        // FIXME: need to unmap?
+        if (cache_entry->ipc_buf) {
+            ret = zeMemCloseIpcHandle(ze_context, cache_entry->ipc_buf);
+            ZE_ERR_CHECK(ret);
+        }
+        if (cache_entry->mapped_ptr) {
+            munmapFunction(cache_entry->nfds, cache_entry->fds, cache_entry->mapped_ptr,
+                           cache_entry->mapped_size);
+        }
         HASH_DEL(ipc_cache_mapped[dev_id], cache_entry);
         MPL_free(cache_entry);
         cache_entry = NULL;
     }
+
+  fn_exit:
+    return mpl_err;
+  fn_fail:
+    mpl_err = MPL_ERR_GPU_INTERNAL;
+    goto fn_exit;
 }
 
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
@@ -2789,6 +2804,10 @@ int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle, int i
         if (likely(MPL_gpu_info.specialized_cache)) {
             cache_entry->mapped_ptr = *ptr;
             cache_entry->mapped_size = size;
+            cache_entry->nfds = h.nfds;
+            for (int i = 0; i < h.nfds; i++) {
+                cache_entry->fds[i] = h.fds[1];
+            }
 
             removal_entry =
                 (MPL_ze_mapped_buffer_entry_t *) MPL_malloc(sizeof(MPL_ze_mapped_buffer_entry_t),

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -44,8 +44,13 @@ static int *subdevice_map = NULL;
 /* Keeps the subdevice count for all locally visible devices */
 static uint32_t *subdevice_count = NULL;
 
-static int shared_device_fd_count = 0;
-static int *shared_device_fds = NULL;
+typedef struct _physical_device_state {
+    int fd;
+    int domain, bus, device, function;
+} physical_device_state;
+
+static int physical_device_count = 0;
+static physical_device_state *physical_device_states = NULL;
 
 static int *engine_conversion = NULL;
 
@@ -154,6 +159,7 @@ typedef struct {
 #ifdef ZE_PCI_PROPERTIES_EXT_NAME
     ze_pci_address_ext_t pci;
     int pci_avail;
+    int sys_device_index;
 #endif
 } MPL_ze_device_entry_t;
 
@@ -621,6 +627,16 @@ int MPL_gpu_get_root_device(int dev_id)
     return subdevice_map[dev_id];
 }
 
+/* Get dev_id for shared_device_fds from regular dev_id */
+static int get_physical_device(int dev_id)
+{
+#ifdef ZE_PCI_PROPERTIES_EXT_NAME
+    if (device_states[dev_id].sys_device_index != -1)
+        return device_states[dev_id].sys_device_index;
+#endif
+    return subdevice_map[dev_id];
+}
+
 /* Get dev_id from device */
 MPL_STATIC_INLINE_PREFIX int device_to_dev_id(ze_device_handle_t device)
 {
@@ -850,6 +866,9 @@ static inline int new_ipc_handle_cache(MPL_ze_ipc_handle_entry_t ** entry, int m
 
 static int MPL_event_pool_add_new_pool(void);
 static void MPL_event_pool_destroy(void);
+#ifdef ZE_PCI_PROPERTIES_EXT_NAME
+static int search_physical_devices(ze_pci_address_ext_t pci);
+#endif
 
 /* Loads a global ze driver */
 static int gpu_ze_init_driver(void)
@@ -1031,6 +1050,7 @@ static int gpu_ze_init_driver(void)
             }
         }
 #ifdef ZE_PCI_PROPERTIES_EXT_NAME
+        device_state->sys_device_index = -1;
         ze_pci_ext_properties_t pci_property = {
             .stype = ZE_STRUCTURE_TYPE_PCI_EXT_PROPERTIES,
             .pNext = NULL,
@@ -1169,11 +1189,11 @@ int MPL_gpu_finalize(void)
         MPL_free(entry);
     }
 
-    for (i = 0; i < shared_device_fd_count; ++i) {
-        close(shared_device_fds[i]);
+    for (i = 0; i < physical_device_count; ++i) {
+        close(physical_device_states[i].fd);
     }
 
-    MPL_free(shared_device_fds);
+    MPL_free(physical_device_states);
 
     gpu_free_hook_s *prev;
     while (free_hook_chain) {
@@ -1417,7 +1437,7 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
     int dev_id;
     uint64_t mem_id;
 
-    if (shared_device_fds != NULL) {
+    if (physical_device_states != NULL) {
         MPL_ze_gem_hash_entry_t *entry = NULL;
         HASH_FIND_PTR(gem_hash, &ptr, entry);
         if (entry == NULL) {
@@ -1426,15 +1446,16 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
         }
 
         HASH_DEL(gem_hash, entry);
-        MPL_free(entry);
 
         /* close GEM handle */
         for (int i = 0; i < entry->nhandles; i++) {
-            status = close_handle(shared_device_fds[entry->dev_id], entry->handles[i]);
+            status = close_handle(physical_device_states[entry->dev_id].fd, entry->handles[i]);
             if (status) {
                 goto fn_fail;
             }
         }
+
+        MPL_free(entry);
     }
 
     if (likely(MPL_gpu_info.specialized_cache)) {
@@ -1720,7 +1741,8 @@ int MPL_gpu_query_is_same_dev(int global_dev1, int global_dev2)
         return 0;
 
 #ifdef ZE_PCI_PROPERTIES_EXT_NAME
-    if (MPL_gpu_get_root_device(local_dev1) == MPL_gpu_get_root_device(local_dev2))
+    if (get_physical_device(local_dev1) != -1 && get_physical_device(local_dev2) != -1 &&
+        get_physical_device(local_dev1) == get_physical_device(local_dev2))
         return 1;
 
     device_state1 = device_states + local_dev1;
@@ -2276,7 +2298,27 @@ ze_result_t ZE_APICALL zeMemFree(ze_context_handle_t hContext, void *dptr)
 
 /* ZE-Specific Functions */
 
-int MPL_ze_init_device_fds(int *num_fds, int *device_fds)
+#ifdef ZE_PCI_PROPERTIES_EXT_NAME
+static void queryBDF(char *pcipath, int *domain, int *b, int *d, int *f)
+{
+    char *endptr = NULL;
+    const char *device_suffix = "-render";
+
+    char *rdsPos = strstr(pcipath, device_suffix);
+    assert(rdsPos);
+
+    char *bdfstr = rdsPos - 12;
+
+    *domain = strtol(bdfstr, &endptr, 16);
+    bdfstr = endptr + 1;
+    *b = strtol(bdfstr, &endptr, 16);
+    bdfstr = endptr + 1;
+    *d = strtol(bdfstr, &endptr, 16);
+    bdfstr = endptr + 1;
+    *f = strtol(bdfstr, &endptr, 16);
+}
+
+static int get_bdfs(int nfds, int *bdfs)
 {
     const char *device_directory = "/dev/dri/by-path";
     const char *device_suffix = "-render";
@@ -2310,15 +2352,13 @@ int MPL_ze_init_device_fds(int *num_fds, int *device_fds)
         strcat(dev_name, "/");
         strcat(dev_name, ent->d_name);
 
-        /* Open the device */
-        if (device_fds) {
-            device_fds[n] = open(dev_name, O_RDWR);
-        }
-
-        n++;
+        int domain, b, d, f;
+        queryBDF(dev_name, &domain, &b, &d, &f);
+        bdfs[n++] = domain;
+        bdfs[n++] = b;
+        bdfs[n++] = d;
+        bdfs[n++] = f;
     }
-
-    *num_fds = n;
 
   fn_exit:
     return MPL_SUCCESS;
@@ -2326,10 +2366,138 @@ int MPL_ze_init_device_fds(int *num_fds, int *device_fds)
     return MPL_ERR_GPU_INTERNAL;
 }
 
-void MPL_ze_set_fds(int num_fds, int *fds)
+static int search_physical_devices(ze_pci_address_ext_t pci)
 {
-    shared_device_fds = fds;
-    shared_device_fd_count = num_fds;
+    for (int i = 0; i < physical_device_count; i++) {
+        if (physical_device_states[i].domain == pci.domain &&
+            physical_device_states[i].bus == pci.bus &&
+            physical_device_states[i].device == pci.device &&
+            physical_device_states[i].function == pci.function)
+            return i;
+    }
+    return -1;
+}
+#endif
+
+static int compareBDFFn(const void *_a, const void *_b)
+{
+    int *a = (int *) _a;
+    int *b = (int *) _b;
+
+    if (a[0] != b[0])
+        return a[0] - b[0];
+
+    if (a[1] != b[1])
+        return a[1] - b[1];
+
+    if (a[2] != b[2])
+        return a[2] - b[2];
+
+    return a[3] - b[3];
+}
+
+static void sort_bdfs(int n, int *bdfs)
+{
+    qsort(bdfs, n, sizeof(int) * 4, compareBDFFn);
+}
+
+int MPL_ze_init_device_fds(int *num_fds, int *device_fds, int *bdfs)
+{
+    const char *device_directory = "/dev/dri/by-path";
+    const char *device_suffix = "-render";
+    struct dirent *ent = NULL;
+    int n = 0;
+
+#ifndef MPL_ENABLE_DRMFD
+    printf("Error> drmfd is not supported!");
+    goto fn_fail;
+#endif
+
+#ifdef ZE_PCI_PROPERTIES_EXT_NAME
+    if (device_fds) {
+        get_bdfs(*num_fds, bdfs);
+        /* sort bdf */
+        sort_bdfs(*num_fds, bdfs);
+    }
+#endif
+
+    DIR *dir = opendir(device_directory);
+    if (dir == NULL) {
+        goto fn_fail;
+    }
+
+    /* Search for all devices in the device directory */
+    while ((ent = readdir(dir)) != NULL) {
+        char dev_name[128];
+
+        if (ent->d_name[0] == '.') {
+            continue;
+        }
+
+        /* They must contain the device suffix */
+        if (strstr(ent->d_name, device_suffix) == NULL) {
+            continue;
+        }
+
+        strcpy(dev_name, device_directory);
+        strcat(dev_name, "/");
+        strcat(dev_name, ent->d_name);
+
+        /* Open the device */
+        if (device_fds) {
+#ifdef ZE_PCI_PROPERTIES_EXT_NAME
+            int domain, b, d, f;
+            queryBDF(dev_name, &domain, &b, &d, &f);
+            /* find in bdfs */
+            n = -1;
+            for (int i = 0; i < *num_fds; i++) {
+                if (domain == bdfs[i * 4] && b == bdfs[i * 4 + 1] && d == bdfs[i * 4 + 2] &&
+                    f == bdfs[i * 4 + 3])
+                    n = i;
+            }
+            assert(n != -1);
+#endif
+            device_fds[n] = open(dev_name, O_RDWR);
+        }
+
+        n++;
+    }
+
+    if (device_fds == NULL)
+        *num_fds = n;
+
+  fn_exit:
+    return MPL_SUCCESS;
+  fn_fail:
+    return MPL_ERR_GPU_INTERNAL;
+}
+
+void MPL_ze_set_fds(int num_fds, int *fds, int *bdfs)
+{
+    physical_device_count = num_fds;
+    physical_device_states =
+        (physical_device_state *) MPL_malloc(num_fds * sizeof(physical_device_state),
+                                             MPL_MEM_OTHER);
+    for (int i = 0; i < num_fds; i++) {
+        physical_device_states[i].fd = fds[i];
+#ifdef ZE_PCI_PROPERTIES_EXT_NAME
+        physical_device_states[i].domain = bdfs[4 * i];
+        physical_device_states[i].bus = bdfs[4 * i + 1];
+        physical_device_states[i].device = bdfs[4 * i + 2];
+        physical_device_states[i].function = bdfs[4 * i + 3];
+#endif
+    }
+    MPL_free(fds);
+    MPL_free(bdfs);
+
+#ifdef ZE_PCI_PROPERTIES_EXT_NAME
+    /* update sys_device_index for each logical device */
+    for (int d = 0; d < local_ze_device_count; d++) {
+        MPL_ze_device_entry_t *device_state = device_states + d;
+        device_state->sys_device_index = search_physical_devices(device_state->pci);
+        assert(device_state->sys_device_index != -1);
+    }
+#endif
 }
 
 void MPL_ze_ipc_remove_cache_handle(void *dptr)
@@ -2400,13 +2568,14 @@ int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, in
     ZE_ERR_CHECK(ret);
 
     h.nfds = nfds;
-    if (shared_device_fds != NULL) {
+    if (physical_device_states != NULL) {
         if (use_shared_fd) {
-            int shared_dev_id = MPL_gpu_get_root_device(local_dev_id);
+            int shared_dev_id = get_physical_device(local_dev_id);
             for (int i = 0; i < nfds; i++) {
                 /* convert dma_buf fd to GEM handle */
                 memcpy(&fds[i], &ze_ipc_handle[i], sizeof(int));
-                status = fd_to_handle(shared_device_fds[shared_dev_id], fds[i], &handles[i]);
+                status =
+                    fd_to_handle(physical_device_states[shared_dev_id].fd, fds[i], &handles[i]);
                 if (status) {
                     goto fn_fail;
                 }
@@ -2477,10 +2646,10 @@ int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle, int is_shar
     h = mpl_ipc_handle->data;
     nfds = h.nfds;
 
-    if (shared_device_fds != NULL) {
+    if (physical_device_states != NULL) {
         /* convert GEM handle to fd */
         for (int i = 0; i < nfds; i++) {
-            status = handle_to_fd(shared_device_fds[h.dev_id], h.fds[i], &fds[i]);
+            status = handle_to_fd(physical_device_states[h.dev_id].fd, h.fds[i], &fds[i]);
             if (status) {
                 goto fn_fail;
             }

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -905,12 +905,13 @@ static HYD_status launch_procs(struct pmip_pg *pg)
                 int dev_count = 0;
                 int n_dev_ids = 0;
                 int max_dev_id = 0;
+                int max_subdev_id = 0;
                 char **all_dev_ids = NULL;
                 char **child_dev_ids = NULL;
                 char *affinity_env_str = NULL;
                 int n_gpu_assgined = 0;
 
-                MPL_gpu_get_dev_count(&dev_count, &max_dev_id);
+                MPL_gpu_get_dev_count(&dev_count, &max_dev_id, &max_subdev_id);
                 MPL_gpu_get_dev_list(&n_dev_ids, &all_dev_ids, allocate_subdev);
                 child_dev_ids = (char **) MPL_malloc(n_local_gpus * sizeof(char *), MPL_MEM_OTHER);
                 HYDU_ASSERT(child_dev_ids, status);

--- a/test/mpi/coll/testlist.gpu
+++ b/test/mpi/coll/testlist.gpu
@@ -3,9 +3,16 @@
 allred 4 arg=-counts=10,100 arg=-memtype=all
 allred 7 arg=-counts=10 arg=-memtype=all
 allred2 4 arg=-memtype=all
+allred2 12 arg=-memtype=all
 reduce 5 arg=-memtype=all
 reduce 7 arg=-memtype=all
 op_coll 4 arg=-memtype=all
+
+# ZE_AFFINITY_MASK tests
+allred2 12 arg=-memtype=all env=MTEST_GPU_VISIBILITY_AFFINITY=CONTIGUOUS_DEVICE
+allred2 12 arg=-memtype=all env=MTEST_GPU_VISIBILITY_AFFINITY=CONTIGUOUS_SUBDEVICE
+allred2 12 arg=-memtype=all env=MTEST_GPU_VISIBILITY_AFFINITY=CONTIGUOUS_SINGLE_SUBDEVICE
+allred2 12 arg=-memtype=all env=MTEST_GPU_VISIBILITY_AFFINITY=CONTIGUOUS_MULTI_SUBDEVICE
 
 # The dtp test will iterate over all typelist and counts, each time will repeat [repeat] times and select seed, testsize, memtypes accordingly
 # set MPITEST_VERBOSE=1 to the list of tests being run.

--- a/test/mpi/include/mtest_common.h
+++ b/test/mpi/include/mtest_common.h
@@ -66,4 +66,5 @@ void MTestAlloc(size_t size, mtest_mem_type_e type, void **hostbuf, void **devic
 void MTestFree(mtest_mem_type_e type, void *hostbuf, void *devicebuf);
 void MTestCopyContent(const void *sbuf, void *dbuf, size_t size, mtest_mem_type_e type);
 void MTest_finalize_gpu(void);
+void MTest_init_visibility_gpu(void);
 #endif

--- a/test/mpi/util/mtest.c
+++ b/test/mpi/util/mtest.c
@@ -140,6 +140,9 @@ void MTest_Init_thread(int *argc, char ***argv, int required, int *provided)
 void MTest_Init(int *argc, char ***argv)
 {
     int provided;
+
+    MTest_init_visibility_gpu();
+
 #if MPI_VERSION >= 2 || defined(HAVE_MPI_INIT_THREAD)
     const char *str = 0;
     int threadLevel;


### PR DESCRIPTION
## Pull Request Description

This PR is a work in progress and will contain a culmination of infrastructure, implementation, and optimizations for supporting Intel GPUs.

* General IPC support
  * Level Zero implements IPC handles via file descriptors (fd). As such, the handles cannot be transmitted directly between processes in a generic manner. This PR adds two approaches to implement the transmission of IPC handles from Level Zero.
    1. Duplicate the underlying fd via `pidfd_open` and `pidfd_getfd` (available from Linux Kernel 5.6.0) inside the IPC protocol. This implementation does not require transmission via UNIX sockets, and thus can be transmitted generally via these APIs.
    2. Open each device as an fd and share them via UNIX sockets. When transmitting IPC handles, convert them from dma-buf objects to device GEM objects, transmit them through the device fds, then convert them back in order to map the handle.
* Optimized IPC cache
  * Cache implemented within `mpl_gpu_ze` backend. Cache maps unique mem_id to relevant cached information.
* Subdevice support
  * Adds recognition for subdevices when present.
* GPU fast memcpy
  * Uses file descriptor represented by an IPC handle to map device memory into the host and perform a host vector copy. This is good for very small messages (i.e. < 1 KB).
* Implicit Scaling support
  * Implicit scaling is where a single device allocation is split across the tiles on a device. Since there are two physical memory addresses associated with the allocation, IPC with implicit scaling requires managing two IPC handles.
* Bypass Yaksa when copying contiguous GPU buffers
  * Eliminates the overheads of Yaksa by implementing copy operations for contiguous buffers in MPL. There is no need to go through yaksa when packing/unpacking is not necessary.



## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
