### PR TITLE
coll/p_allgather: fix intra_sched_recursive_doubling algorithm

### DIFF
--- a/src/mpi/request/request_impl.c
+++ b/src/mpi/request/request_impl.c
@@ -22,7 +22,9 @@ cvars:
         MPIR_CVAR_REQUEST_ERR_FATAL is set to true, these routines will
         return the error code of the request immediately. The default
         MPI_ERRS_ARE_FATAL error handler will dump a error stack in this
-        case, which maybe more convenient for debugging.
+        case, which maybe more convenient for debugging. This cvar will also
+        make nonblocking shched return error right away as it issues
+        operations.
 
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -1177,10 +1177,10 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
             /* TODO refactor into a sched_complete routine? */
             switch (s->req->u.nbc.errflag) {
                 case MPIR_ERR_PROC_FAILED:
-                    MPIR_ERR_SET(s->req->status.MPI_ERROR, MPIX_ERR_PROC_FAILED, "**comm");
+                    MPIR_ERR_SET(s->req->status.MPI_ERROR, MPIX_ERR_PROC_FAILED, "**proc_failed");
                     break;
                 case MPIR_ERR_OTHER:
-                    MPIR_ERR_SET(s->req->status.MPI_ERROR, MPI_ERR_OTHER, "**comm");
+                    MPIR_ERR_SET(s->req->status.MPI_ERROR, MPI_ERR_OTHER, "**other");
                     break;
                 case MPIR_ERR_NONE:
                 default:

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -251,6 +251,9 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
                 e->status = MPIDU_SCHED_ENTRY_STATUS_FAILED;
                 MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "Sched SEND failed. Errflag: %d\n",
                               (int) r->u.nbc.errflag);
+                if (MPIR_CVAR_REQUEST_ERR_FATAL) {
+                    return ret_errno;
+                }
             } else {
                 e->status = MPIDU_SCHED_ENTRY_STATUS_STARTED;
             }
@@ -274,6 +277,9 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
                 e->status = MPIDU_SCHED_ENTRY_STATUS_STARTED;
                 MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "Sched RECV failed. Errflag: %d\n",
                               (int) r->u.nbc.errflag);
+                if (MPIR_CVAR_REQUEST_ERR_FATAL) {
+                    return ret_errno;
+                }
             } else {
                 e->status = MPIDU_SCHED_ENTRY_STATUS_STARTED;
             }
@@ -284,6 +290,9 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
                                    0, &e->u.send.sreq);
             if (unlikely(ret_errno)) {
                 e->status = MPIDU_SCHED_ENTRY_STATUS_FAILED;
+                if (MPIR_CVAR_REQUEST_ERR_FATAL) {
+                    return ret_errno;
+                }
             } else {
                 e->status = MPIDU_SCHED_ENTRY_STATUS_STARTED;
             }
@@ -294,6 +303,9 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
                                    0, &e->u.recv.rreq);
             if (unlikely(ret_errno)) {
                 e->status = MPIDU_SCHED_ENTRY_STATUS_FAILED;
+                if (MPIR_CVAR_REQUEST_ERR_FATAL) {
+                    return ret_errno;
+                }
             } else {
                 e->status = MPIDU_SCHED_ENTRY_STATUS_STARTED;
             }
@@ -336,6 +348,9 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
                         }
                     }
                     e->status = MPIDU_SCHED_ENTRY_STATUS_FAILED;
+                    if (MPIR_CVAR_REQUEST_ERR_FATAL) {
+                        return ret_errno;
+                    }
                 } else {
                     e->status = MPIDU_SCHED_ENTRY_STATUS_COMPLETE;
                 }
@@ -356,6 +371,9 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
                         }
                     }
                     e->status = MPIDU_SCHED_ENTRY_STATUS_FAILED;
+                    if (MPIR_CVAR_REQUEST_ERR_FATAL) {
+                        return ret_errno;
+                    }
                 } else {
                     e->status = MPIDU_SCHED_ENTRY_STATUS_COMPLETE;
                 }


### PR DESCRIPTION
## Pull Request Description
The intra_sched_recursive_doubling algorithm uses a state to track send counts during the steps. We need reset the state for the additional start of the operation to work correctly.

Fixes #6423

Thanks @jeffhammond for reporting the bug.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
