### PR TITLE
ch4/ofi: fix multiple nic with "multi_nic_pref_nic" hint

### DIFF
--- a/src/include/mpir_process.h
+++ b/src/include/mpir_process.h
@@ -43,6 +43,9 @@ typedef struct MPIR_Process_t {
     int *node_local_map;        /* int[local_size], maps local_id to rank of local proc */
     int *node_root_map;         /* int[num_nodes], maps node_id to the rank of node root */
 
+    unsigned world_id;          /* this is a hash of pmi_kvs_name. One use is for
+                                 * ofi netmod active message to synchronize seq number. */
+
     /* -------------- */
     int do_error_checks;        /* runtime error check control */
     struct MPIR_Comm *comm_world;       /* Easy access to comm_world for

--- a/src/mpid/ch4/netmod/ofi/init_addrxchg.c
+++ b/src/mpid/ch4/netmod/ofi/init_addrxchg.c
@@ -222,7 +222,7 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
         for (int vci = 0; vci < num_vcis; vci++) {
             size_t actual_name_len = name_len;
             char *vci_addrname = my_names + (vci * num_nics + nic) * name_len;
-            int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+            int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
             MPIDI_OFI_CALL(fi_getname((fid_t) MPIDI_OFI_global.ctx[ctx_idx].ep, vci_addrname,
                                       &actual_name_len), getname);
             MPIR_Assert(actual_name_len == name_len);
@@ -234,7 +234,7 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
                                         all_names, my_len, MPI_BYTE, comm, MPIR_ERR_NONE);
 
     /* Step 2: insert and store non-root nic/vci on the root context */
-    int root_ctx_idx = MPIDI_OFI_get_ctx_index(NULL, 0, 0);
+    int root_ctx_idx = MPIDI_OFI_get_ctx_index(0, 0);
     for (int r = 0; r < size; r++) {
         GET_AV_AND_ADDRNAMES(r);
         for (int nic = 0; nic < num_nics; nic++) {
@@ -250,7 +250,7 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
     for (int nic_local = 0; nic_local < num_nics; nic_local++) {
         for (int vci_local = 0; vci_local < num_vcis; vci_local++) {
             SKIP_ROOT(nic_local, vci_local);
-            int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci_local, nic_local);
+            int ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, nic_local);
 
             /* -- same order as step 1 -- */
             if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -114,7 +114,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_rdma_read(void *dst,
 
         /* am uses nic 0 */
         int nic = 0;
-        MPIDI_OFI_cntr_incr(comm, vci_local, nic);
+        MPIDI_OFI_cntr_incr(vci_local, nic);
 
         struct iovec iov = {
             .iov_base = (char *) dst + done,
@@ -136,7 +136,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_rdma_read(void *dst,
             .data = 0
         };
 
-        int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_local, nic);
+        int ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, nic);
         MPIDI_OFI_CALL_RETRY_AM(fi_readmsg(MPIDI_OFI_global.ctx[ctx_idx].tx, &msg, FI_COMPLETION),
                                 rdma_readfrom);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -39,9 +39,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_pipeline(MPIDI_OFI_am_header_t * m
     MPIR_FUNC_ENTER;
 
     int vni = msg_hdr->vni_dst;
-    cache_rreq =
-        MPIDIG_req_cache_lookup(MPIDI_OFI_global.per_vni[vni].req_map,
-                                (uint64_t) msg_hdr->fi_src_addr);
+    void *req_map = MPIDI_OFI_global.per_vni[vni].req_map;
+    uint64_t remote_id = msg_hdr->src_id;
+
+    cache_rreq = MPIDIG_req_cache_lookup(req_map, remote_id);
     MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                     (MPL_DBG_FDEST, "cached req %p handle=0x%x", cache_rreq,
                      cache_rreq ? cache_rreq->handle : 0));
@@ -54,15 +55,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_pipeline(MPIDI_OFI_am_header_t * m
         MPIDIG_global.target_msg_cbs[msg_hdr->handler_id] (am_hdr, p_data, msg_hdr->payload_sz,
                                                            attr, &rreq);
         MPIDIG_recv_setup(rreq);
-        MPIDIG_req_cache_add(MPIDI_OFI_global.per_vni[vni].req_map, (uint64_t) msg_hdr->fi_src_addr,
-                             rreq);
+        MPIDIG_req_cache_add(req_map, remote_id, rreq);
     }
 
     is_done = MPIDIG_recv_copy_seg(p_data, msg_hdr->payload_sz, rreq);
     if (is_done) {
         MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
-        MPIDIG_req_cache_remove(MPIDI_OFI_global.per_vni[vni].req_map,
-                                (uint64_t) msg_hdr->fi_src_addr);
+        MPIDIG_req_cache_remove(req_map, remote_id);
     }
 
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -38,8 +38,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_pipeline(MPIDI_OFI_am_header_t * m
 
     MPIR_FUNC_ENTER;
 
-    int vni = msg_hdr->vni_dst;
-    void *req_map = MPIDI_OFI_global.per_vni[vni].req_map;
+    int vci = msg_hdr->vci_dst;
+    void *req_map = MPIDI_OFI_global.per_vci[vci].req_map;
     uint64_t remote_id = msg_hdr->src_id;
 
     cache_rreq = MPIDIG_req_cache_lookup(req_map, remote_id);
@@ -133,7 +133,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_rdma_read(void *dst,
             .msg_iov = &iov,
             .desc = NULL,
             .iov_count = 1,
-            .addr = MPIDI_OFI_comm_to_phys(comm, src_rank, nic, vci_local, vci_remote),
+            .addr = MPIDI_OFI_comm_to_phys(comm, src_rank, nic, vci_remote),
             .rma_iov = &rma_iov,
             .rma_iov_count = 1,
             .context = &am_req->context,

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -235,7 +235,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm,
     MPIDI_OFI_am_header_t *msg_hdr;
     MPIDI_OFI_lmt_msg_payload_t *lmt_info;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_src, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci_src, nic);
     fi_addr_t dst_addr = MPIDI_OFI_comm_to_phys(comm, rank, nic, vci_src, vci_dst);
 
     MPIR_FUNC_ENTER;
@@ -312,7 +312,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_short(int rank, MPIR_Comm * comm
 {
     int mpi_errno = MPI_SUCCESS;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_src, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci_src, nic);
     fi_addr_t dst_addr = MPIDI_OFI_comm_to_phys(comm, rank, nic, vci_src, vci_dst);
 
     MPIR_FUNC_ENTER;
@@ -380,7 +380,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_pipeline(int rank, MPIR_Comm * c
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t *msg_hdr;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_src, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci_src, nic);
     fi_addr_t dst_addr = MPIDI_OFI_comm_to_phys(comm, rank, nic, vci_src, vci_dst);
 
     MPIR_FUNC_ENTER;
@@ -544,7 +544,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(MPIR_Comm * comm, fi_a
     char *ibuf;
     size_t len;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_src, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci_src, nic);
 
     MPIDI_CH4_REQUEST_CREATE(sreq, MPIR_REQUEST_KIND__SEND, vci_src, 1);
     MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
@@ -577,7 +577,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_inject(int rank,
     char *buff;
     size_t buff_len;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_src, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci_src, nic);
     fi_addr_t dst_addr = MPIDI_OFI_comm_to_phys(comm, rank, nic, vci_src, vci_dst);
     MPIR_CHKLMEM_DECL(1);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -39,7 +39,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_progress_do_queue(int vci_idx);
     ((uint64_t) MPIR_Process.rank << 16) + ((nic) << 8) + (vci))
 
 #define MPIDI_OFI_REMOTE_ID(comm, rank, nic, vci) \
-    MPIDI_OFI_comm_to_phys(comm, rank, nic, vci, vci)
+    MPIDI_OFI_comm_to_phys(comm, rank, nic, vci)
 
 #define MPIDI_OFI_SET_AM_HDR_COMMON(msg_hdr, comm, rank, nic_src, vci_src, nic_dst, vci_dst) \
     do { \
@@ -258,7 +258,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm,
     MPIDI_OFI_lmt_msg_payload_t *lmt_info;
     int nic = 0;
     int ctx_idx = MPIDI_OFI_get_ctx_index(vci_src, nic);
-    fi_addr_t dst_addr = MPIDI_OFI_comm_to_phys(comm, rank, nic, vci_src, vci_dst);
+    fi_addr_t dst_addr = MPIDI_OFI_comm_to_phys(comm, rank, nic, vci_dst);
 
     MPIR_FUNC_ENTER;
 
@@ -332,7 +332,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_short(int rank, MPIR_Comm * comm
     int mpi_errno = MPI_SUCCESS;
     int nic = 0;
     int ctx_idx = MPIDI_OFI_get_ctx_index(vci_src, nic);
-    fi_addr_t dst_addr = MPIDI_OFI_comm_to_phys(comm, rank, nic, vci_src, vci_dst);
+    fi_addr_t dst_addr = MPIDI_OFI_comm_to_phys(comm, rank, nic, vci_dst);
 
     MPIR_FUNC_ENTER;
 
@@ -397,7 +397,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_pipeline(int rank, MPIR_Comm * c
     MPIDI_OFI_am_header_t *msg_hdr;
     int nic = 0;
     int ctx_idx = MPIDI_OFI_get_ctx_index(vci_src, nic);
-    fi_addr_t dst_addr = MPIDI_OFI_comm_to_phys(comm, rank, nic, vci_src, vci_dst);
+    fi_addr_t dst_addr = MPIDI_OFI_comm_to_phys(comm, rank, nic, vci_dst);
 
     MPIR_FUNC_ENTER;
 
@@ -591,7 +591,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_inject(int rank,
     size_t buff_len;
     int nic = 0;
     int ctx_idx = MPIDI_OFI_get_ctx_index(vci_src, nic);
-    fi_addr_t dst_addr = MPIDI_OFI_comm_to_phys(comm, rank, nic, vci_src, vci_dst);
+    fi_addr_t dst_addr = MPIDI_OFI_comm_to_phys(comm, rank, nic, vci_dst);
     MPIR_CHKLMEM_DECL(1);
 
     MPIR_FUNC_ENTER;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -551,7 +551,7 @@ int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret)
     ssize_t ret_cqerr;
     MPIR_FUNC_ENTER;
 
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
     switch (ret) {
         case -FI_EAVAIL:
             /* Provide separate error buffer for each thread. This makes the

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -265,7 +265,6 @@ static int am_recv_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * 
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t *am_hdr;
     MPIDI_OFI_am_unordered_msg_t *uo_msg = NULL;
-    fi_addr_t fi_src_addr;
     uint16_t expected_seqno, next_seqno;
     MPIR_FUNC_ENTER;
 
@@ -294,23 +293,24 @@ static int am_recv_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * 
     }
 #endif
 
-    expected_seqno = MPIDI_OFI_am_get_next_recv_seqno(vci, am_hdr->fi_src_addr);
+    expected_seqno = MPIDI_OFI_am_get_next_recv_seqno(vci, am_hdr->src_id);
     if (am_hdr->seqno != expected_seqno) {
         /* This message came earlier than the one that we were expecting.
          * Put it in the queue to process it later. */
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, TERSE,
                         (MPL_DBG_FDEST,
-                         "Expected seqno=%d but got %d (am_type=%d addr=%" PRIx64 "). "
+                         "Expected seqno=%d but got %d (am_type=%d src_rank=%d). "
                          "Enqueueing it to the queue.\n",
-                         expected_seqno, am_hdr->seqno, am_hdr->am_type, am_hdr->fi_src_addr));
+                         expected_seqno, am_hdr->seqno, am_hdr->am_type, am_hdr->src_rank));
         mpi_errno = MPIDI_OFI_am_enqueue_unordered_msg(vci, orig_buf);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
 
     /* Received an expected message */
+    uint64_t remote_id;
   fn_repeat:
-    fi_src_addr = am_hdr->fi_src_addr;
+    remote_id = am_hdr->src_id;
     next_seqno = am_hdr->seqno + 1;
 
     void *p_data;
@@ -368,7 +368,8 @@ static int am_recv_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * 
     MPL_free(uo_msg);
 
     /* See if we can process other messages in the queue */
-    if ((uo_msg = MPIDI_OFI_am_claim_unordered_msg(vci, fi_src_addr, next_seqno)) != NULL) {
+    uo_msg = MPIDI_OFI_am_claim_unordered_msg(vci, remote_id, next_seqno);
+    if (uo_msg != NULL) {
         am_hdr = &uo_msg->am_hdr;
         orig_buf = am_hdr;
 #ifdef NEEDS_STRICT_ALIGNMENT
@@ -379,8 +380,8 @@ static int am_recv_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * 
         goto fn_repeat;
     }
 
-    /* Record the next expected sequence number from fi_src_addr */
-    MPIDI_OFI_am_set_next_recv_seqno(vci, fi_src_addr, next_seqno);
+    /* Record the next expected sequence number */
+    MPIDI_OFI_am_set_next_recv_seqno(vci, remote_id, next_seqno);
 
   fn_exit:
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -129,7 +129,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vci, struct fi_cq_tagged_e
         MPIR_Assert(vci_local == vci);
         int nic = 0;
         int ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, nic);
-        fi_addr_t dest_addr = MPIDI_OFI_comm_to_phys(c, r, nic, vci_local, vci_remote);
+        fi_addr_t dest_addr = MPIDI_OFI_comm_to_phys(c, r, nic, vci_remote);
         if (MPIDI_OFI_ENABLE_DATA) {
             MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx, NULL, 0,
                                                 MPIR_Comm_rank(c), dest_addr, ss_bits),

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -128,7 +128,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vci, struct fi_cq_tagged_e
         int vci_remote = vci_src;
         MPIR_Assert(vci_local == vci);
         int nic = 0;
-        int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci_local, nic);
+        int ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, nic);
         fi_addr_t dest_addr = MPIDI_OFI_comm_to_phys(c, r, nic, vci_local, vci_remote);
         if (MPIDI_OFI_ENABLE_DATA) {
             MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx, NULL, 0,

--- a/src/mpid/ch4/netmod/ofi/ofi_huge.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_huge.c
@@ -100,8 +100,7 @@ static int get_huge_issue_read(MPIR_Request * rreq)
     int nic = 0;
     int ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, nic);
     while (bytesLeft > 0) {
-        fi_addr_t addr =
-            MPIDI_OFI_comm_to_phys(comm, info->origin_rank, nic, vci_local, vci_remote);
+        fi_addr_t addr = MPIDI_OFI_comm_to_phys(comm, info->origin_rank, nic, vci_remote);
         uint64_t remote_key = info->rma_keys[nic];
 
         MPI_Aint bytesToGet = MPL_MIN(chunk_size, bytesLeft);

--- a/src/mpid/ch4/netmod/ofi/ofi_huge.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_huge.c
@@ -98,8 +98,8 @@ static int get_huge_issue_read(MPIR_Request * rreq)
     int issued_chunks = 0;
 
     int nic = 0;
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, nic);
     while (bytesLeft > 0) {
-        int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_local, nic);
         fi_addr_t addr =
             MPIDI_OFI_comm_to_phys(comm, info->origin_rank, nic, vci_local, vci_remote);
         uint64_t remote_key = info->rma_keys[nic];
@@ -111,7 +111,7 @@ static int get_huge_issue_read(MPIR_Request * rreq)
         chunk->localreq = rreq;
         chunk->chunks_outstanding = cc_ptr;
 
-        MPIDI_OFI_cntr_incr(comm, vci_local, nic);
+        MPIDI_OFI_cntr_incr(vci_local, nic);
         MPIDI_OFI_CALL_RETRY(fi_read(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                      (void *) ((char *) recv_buf + cur_offset),
                                      bytesToGet, NULL, addr, recv_rbase(info) + cur_offset,

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -436,13 +436,6 @@ MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_av_to_phys(MPIDI_av_entry_t * av, i
 #endif
 }
 
-MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_rank_to_phys(int rank, int nic,
-                                                          int vci_local, int vci_remote)
-{
-    MPIDI_av_entry_t *av = &MPIDIU_get_av(0, rank);
-    return MPIDI_OFI_av_to_phys(av, nic, vci_local, vci_remote);
-}
-
 MPL_STATIC_INLINE_PREFIX fi_addr_t MPIDI_OFI_comm_to_phys(MPIR_Comm * comm, int rank, int nic,
                                                           int vci_local, int vci_remote)
 {

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -554,7 +554,6 @@ int MPIDI_OFI_init_local(int *tag_bits)
     /* Create the id to object maps     */
     /* -------------------------------- */
     MPIDIU_map_create(&MPIDI_OFI_global.win_map, MPL_MEM_RMA);
-    MPIDIU_map_create(&MPIDI_OFI_global.req_map, MPL_MEM_OTHER);
 
     /* Initialize RMA keys allocator */
     MPIDI_OFI_mr_key_allocator_init();
@@ -883,7 +882,6 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     }
 
     MPIDIU_map_destroy(MPIDI_OFI_global.win_map);
-    MPIDIU_map_destroy(MPIDI_OFI_global.req_map);
 
     if (MPIDI_OFI_ENABLE_AM) {
         for (int vci = 0; vci < MPIDI_OFI_global.num_vcis; vci++) {
@@ -894,6 +892,8 @@ int MPIDI_OFI_mpi_finalize_hook(void)
             }
             MPIDIU_map_destroy(MPIDI_OFI_global.per_vci[vci].am_send_seq_tracker);
             MPIDIU_map_destroy(MPIDI_OFI_global.per_vci[vci].am_recv_seq_tracker);
+
+            MPIDIU_map_destroy(MPIDI_OFI_global.per_vci[vci].req_map);
 
             MPIDI_OFI_unregister_am_bufs();
             MPL_free(MPIDI_OFI_global.per_vci[vci].am_bufs);
@@ -1509,6 +1509,8 @@ int ofi_am_init(void)
             MPIDIU_map_create(&MPIDI_OFI_global.per_vci[vci].am_recv_seq_tracker, MPL_MEM_BUFFER);
             MPIDIU_map_create(&MPIDI_OFI_global.per_vci[vci].am_send_seq_tracker, MPL_MEM_BUFFER);
             MPIDI_OFI_global.per_vci[vci].am_unordered_msgs = NULL;
+
+            MPIDIU_map_create(&MPIDI_OFI_global.per_vci[vci].req_map, MPL_MEM_OTHER);
 
             MPIDI_OFI_global.per_vci[vci].deferred_am_isend_q = NULL;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -738,7 +738,7 @@ static int flush_send(int dst, int nic, int vci, MPIDI_OFI_dynamic_process_reque
     req->done = 0;
     req->event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
 
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
     if (MPIDI_OFI_ENABLE_DATA) {
         MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                           &data, 4, NULL, 0, addr, match_bits, &req->context),
@@ -770,7 +770,7 @@ static int flush_recv(int src, int nic, int vci, MPIDI_OFI_dynamic_process_reque
 
     /* we don't care the data and the tag field is not used */
     void *recvbuf = &(req->tag);
-    MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(NULL, vci, nic)].rx,
+    MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(vci, nic)].rx,
                                   recvbuf, 4, NULL, addr, match_bits, mask_bits, &req->context),
                          vci, trecv);
 
@@ -1016,7 +1016,7 @@ static int create_vci_context(int vci, int nic)
         tx = ep;
         rx = ep;
     }
-    ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+    ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
     MPIDI_OFI_global.ctx[ctx_idx].domain = domain;
     MPIDI_OFI_global.ctx[ctx_idx].av = av;
     MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr = rma_cmpl_cntr;
@@ -1034,7 +1034,7 @@ static int create_vci_context(int vci, int nic)
         mpi_errno = create_vci_domain(&domain, &av, &rma_cmpl_cntr, nic);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
-        ctx_idx = MPIDI_OFI_get_ctx_index(NULL, 0, nic);
+        ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
         domain = MPIDI_OFI_global.ctx[ctx_idx].domain;
         av = MPIDI_OFI_global.ctx[ctx_idx].av;
         rma_cmpl_cntr = MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr;
@@ -1058,7 +1058,7 @@ static int create_vci_context(int vci, int nic)
             MPIDI_OFI_CALL(fi_enable(ep), ep_enable);
         }
     } else {
-        ctx_idx = MPIDI_OFI_get_ctx_index(NULL, 0, nic);
+        ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
         ep = MPIDI_OFI_global.ctx[ctx_idx].ep;
     }
 
@@ -1073,7 +1073,7 @@ static int create_vci_context(int vci, int nic)
     }
 
     if (vci == 0) {
-        ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+        ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
         MPIDI_OFI_global.ctx[ctx_idx].domain = domain;
         MPIDI_OFI_global.ctx[ctx_idx].av = av;
         MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr = rma_cmpl_cntr;
@@ -1081,10 +1081,10 @@ static int create_vci_context(int vci, int nic)
     } else {
         /* non-zero vci share most fields with vci 0, copy them
          * so we don't have to switch during runtime */
-        MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(NULL, vci, nic)] =
-            MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(NULL, 0, nic)];
+        MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(vci, nic)] =
+            MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(0, nic)];
     }
-    ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+    ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
     MPIDI_OFI_global.ctx[ctx_idx].cq = cq;
     MPIDI_OFI_global.ctx[ctx_idx].tx = tx;
     MPIDI_OFI_global.ctx[ctx_idx].rx = rx;
@@ -1100,7 +1100,7 @@ static int create_vci_context(int vci, int nic)
 static int destroy_vci_context(int vci, int nic)
 {
     int mpi_errno = MPI_SUCCESS;
-    int ctx_num = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+    int ctx_num = MPIDI_OFI_get_ctx_index(vci, nic);
 
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
@@ -1533,7 +1533,7 @@ int ofi_am_post_recv(int vci, int nic)
     MPIR_Assert(nic == 0);
 
     if (MPIDI_OFI_ENABLE_AM) {
-        int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+        int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
         size_t optlen = MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE;
 
         MPIDI_OFI_CALL(fi_setopt(&(MPIDI_OFI_global.ctx[ctx_idx].rx->fid),
@@ -1573,7 +1573,8 @@ int ofi_am_post_recv(int vci, int nic)
 int MPIDI_OFI_am_repost_buffer(int vci, int am_idx)
 {
     int mpi_errno = MPI_SUCCESS;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, 0);
+    int nic = 0;
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
     MPIDI_OFI_CALL_RETRY_AM(fi_recvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx,
                                        &MPIDI_OFI_global.per_vci[vci].am_msg[am_idx],
                                        FI_MULTI_RECV | FI_COMPLETION), prepost);

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -728,7 +728,7 @@ static int flush_send(int dst, int nic, int vci, MPIDI_OFI_dynamic_process_reque
 {
     int mpi_errno = MPI_SUCCESS;
 
-    fi_addr_t addr = MPIDI_OFI_av_to_phys(&MPIDIU_get_av(0, dst), nic, vci, vci);
+    fi_addr_t addr = MPIDI_OFI_av_to_phys(&MPIDIU_get_av(0, dst), nic, vci);
     static int data = 0;
     uint64_t match_bits = MPIDI_OFI_init_sendtag(MPIDI_OFI_FLUSH_CONTEXT_ID, 0,
                                                  MPIDI_OFI_FLUSH_TAG, MPIDI_OFI_DYNPROC_SEND);
@@ -758,7 +758,7 @@ static int flush_recv(int src, int nic, int vci, MPIDI_OFI_dynamic_process_reque
 {
     int mpi_errno = MPI_SUCCESS;
 
-    fi_addr_t addr = MPIDI_OFI_av_to_phys(&MPIDIU_get_av(0, src), nic, vci, vci);
+    fi_addr_t addr = MPIDI_OFI_av_to_phys(&MPIDIU_get_av(0, src), nic, vci);
     uint64_t mask_bits = 0;
     uint64_t match_bits = MPIDI_OFI_init_sendtag(MPIDI_OFI_FLUSH_CONTEXT_ID, 0,
                                                  MPIDI_OFI_FLUSH_TAG, MPIDI_OFI_DYNPROC_SEND);

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -29,7 +29,6 @@
 #define MPIDI_OFI_AM_TYPE_BITS         8
 #define MPIDI_OFI_AM_HDR_SZ_BITS       8
 #define MPIDI_OFI_AM_PAYLOAD_SZ_BITS  24
-#define MPIDI_OFI_AM_SEQ_NO_BITS      16
 #define MPIDI_OFI_AM_RANK_BITS        32
 #define MPIDI_OFI_AM_MSG_HEADER_SIZE (sizeof(MPIDI_OFI_am_header_t))
 
@@ -94,10 +93,10 @@ typedef struct MPIDI_OFI_am_header_t {
      */
     uint8_t vci_src;
     uint8_t vci_dst;
-    uint16_t seqno:MPIDI_OFI_AM_SEQ_NO_BITS;    /* Sequence number of this message.
-                                                 * Number is unique to (fi_src_addr,
-                                                 * fi_dest_addr) pair. */
-    fi_addr_t fi_src_addr;      /* OFI address of the sender */
+    uint16_t seqno;             /* Sequence number of this message. Number is unique between
+                                 * (src_rank, src_vci) and (dst_rank, dst_vci) */
+    uint64_t src_id;            /* needed for destination to track seqno, combines
+                                 * communicator context_id, rank, and vci */
 } MPIDI_OFI_am_header_t;
 
 /* Represents early-arrived active messages.

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -25,7 +25,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
     int vci_local = vci_dst;
     int vci_remote = vci_src;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_dst, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci_dst, nic);
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -32,7 +32,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
     if (unlikely(MPI_ANY_SOURCE == source))
         remote_proc = FI_ADDR_UNSPEC;
     else
-        remote_proc = MPIDI_OFI_av_to_phys(addr, nic, vci_local, vci_remote);
+        remote_proc = MPIDI_OFI_av_to_phys(addr, nic, vci_remote);
 
     if (message) {
         MPIDI_CH4_REQUEST_CREATE(rreq, MPIR_REQUEST_KIND__MPROBE, vci_dst, 1);

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -22,17 +22,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
     MPIR_Request r, *rreq;      /* don't need to init request, output only */
     struct fi_msg_tagged msg;
     int ofi_err;
-    int vci_local = vci_dst;
-    int vci_remote = vci_src;
-    int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vci_dst, nic);
+    int receiver_nic, ctx_idx;
+
+    receiver_nic = MPIDI_OFI_multx_receiver_nic_index(comm, comm->recvcontext_id,
+                                                      source, comm->rank, tag);
+    ctx_idx = MPIDI_OFI_get_ctx_index(vci_dst, receiver_nic);
 
     MPIR_FUNC_ENTER;
 
-    if (unlikely(MPI_ANY_SOURCE == source))
+    if (unlikely(MPI_ANY_SOURCE == source)) {
         remote_proc = FI_ADDR_UNSPEC;
-    else
-        remote_proc = MPIDI_OFI_av_to_phys(addr, nic, vci_remote);
+    } else {
+        int sender_nic = MPIDI_OFI_multx_sender_nic_index(comm, comm->recvcontext_id,
+                                                          source, comm->rank, tag);
+        remote_proc = MPIDI_OFI_av_to_phys(addr, sender_nic, vci_src);
+    }
 
     if (message) {
         MPIDI_CH4_REQUEST_CREATE(rreq, MPIR_REQUEST_KIND__MPROBE, vci_dst, 1);

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -90,7 +90,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
         mpi_errno = MPIDI_OFI_handle_cq_entries(vci, wc, num);
     } else if (likely(1)) {
         for (int nic = 0; nic < MPIDI_OFI_global.num_nics; nic++) {
-            int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+            int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
             ret = fi_cq_read(MPIDI_OFI_global.ctx[ctx_idx].cq, (void *) wc,
                              MPIDI_OFI_NUM_CQ_ENTRIES);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -53,7 +53,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
         MPIDI_OFI_multx_receiver_nic_index(comm, comm->recvcontext_id, rank, comm->rank,
                                            MPIDI_OFI_init_get_tag(match_bits));
     MPIDI_OFI_REQUEST(rreq, nic_num) = receiver_nic;
-    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_dst, MPIDI_OFI_REQUEST(rreq, nic_num));
+    ctx_idx = MPIDI_OFI_get_ctx_index(vci_dst, MPIDI_OFI_REQUEST(rreq, nic_num));
 
     if (!flags) {
         flags = FI_COMPLETION;
@@ -160,7 +160,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
     receiver_nic =
         MPIDI_OFI_multx_receiver_nic_index(comm, comm->recvcontext_id, rank, comm->rank, tag);
     MPIDI_OFI_REQUEST(rreq, nic_num) = receiver_nic;
-    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_dst, MPIDI_OFI_REQUEST(rreq, nic_num));
+    ctx_idx = MPIDI_OFI_get_ctx_index(vci_dst, MPIDI_OFI_REQUEST(rreq, nic_num));
 
     match_bits = MPIDI_OFI_init_recvtag(&mask_bits, context_id, rank, tag);
 
@@ -350,7 +350,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq, bool 
     MPIR_FUNC_ENTER;
 
     int vci = MPIDI_Request_get_vci(rreq);
-    int ctx_idx = MPIDI_OFI_get_ctx_index(rreq->comm, vci, MPIDI_OFI_REQUEST(rreq, nic_num));
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci, MPIDI_OFI_REQUEST(rreq, nic_num));
 
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno = MPIDIG_mpi_cancel_recv(rreq);

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -34,8 +34,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
     MPI_Aint num_contig, size;
     int vci_remote = vci_src;
     int vci_local = vci_dst;
-    int ctx_idx = 0;
-    int sender_nic = 0, receiver_nic = 0;
+    int ctx_idx;
+    int sender_nic, receiver_nic;
 
     MPIR_FUNC_ENTER;
 
@@ -129,8 +129,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
     bool force_gpu_pack = false;
     int vci_remote = vci_src;
     int vci_local = vci_dst;
-    int sender_nic = 0, receiver_nic = 0;
-    int ctx_idx = 0;
+    int sender_nic, receiver_nic;
+    int ctx_idx;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -88,9 +88,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
     msg.ignore = mask_bits;
     msg.context = (void *) &(MPIDI_OFI_REQUEST(rreq, context));
     msg.data = 0;
-    msg.addr =
-        (MPI_ANY_SOURCE == rank) ? FI_ADDR_UNSPEC : MPIDI_OFI_av_to_phys(addr, sender_nic,
-                                                                         vci_local, vci_remote);
+    msg.addr = (MPI_ANY_SOURCE == rank) ? FI_ADDR_UNSPEC :
+        MPIDI_OFI_av_to_phys(addr, sender_nic, vci_remote);
 
     MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx, &msg, flags), vci_local,
                          trecv);
@@ -240,7 +239,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
                                       data_sz,
                                       NULL,
                                       (MPI_ANY_SOURCE == rank) ? FI_ADDR_UNSPEC :
-                                      MPIDI_OFI_av_to_phys(addr, sender_nic, vci_local, vci_remote),
+                                      MPIDI_OFI_av_to_phys(addr, sender_nic, vci_remote),
                                       match_bits, mask_bits,
                                       (void *) &(MPIDI_OFI_REQUEST(rreq, context))), vci_local,
                              trecv);

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -28,7 +28,7 @@ static MPIDI_OFI_pack_chunk *create_chunk(void *pack_buffer, MPI_Aint unpack_siz
 void MPIDI_OFI_complete_chunks(MPIDI_OFI_win_request_t * winreq)
 {
     MPIDI_OFI_pack_chunk *chunk = winreq->chunks;
-    int vci = winreq->vci;
+    int vci = winreq->vci_local;
 
     while (chunk) {
         if (chunk->unpack_size > 0) {
@@ -66,7 +66,9 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, MPI_Aint origin_count,
     /* allocate request */
     MPIDI_OFI_win_request_t *req = MPIDI_OFI_win_request_create();
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    req->vci = MPIDI_WIN(win, am_vci);
+    req->vci_local = MPIDI_WIN(win, am_vci);
+    req->vci_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
+    req->nic_target = MPIDI_OFI_get_pref_nic(win->comm_ptr, target_rank);
     req->next = MPIDI_OFI_WIN(win).syncQ;
     MPIDI_OFI_WIN(win).syncQ = req;
     req->sigreq = sigreq;
@@ -119,7 +121,7 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, MPI_Aint origin_count,
         msg_len = MPL_MIN(origin_iov[origin_cur].iov_len, target_iov[target_cur].iov_len);
 
         int vci = MPIDI_WIN(win, am_vci);
-        int nic = 0;
+        int nic = MPIDI_OFI_get_pref_nic(win->comm_ptr, target_rank);;
         msg.desc = NULL;
         msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vci);
         msg.context = NULL;
@@ -177,7 +179,9 @@ static int issue_packed_put(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
     struct fi_rma_iov riov;
     uint64_t flags;
     void *pack_buffer;
-    int vci = req->vci;
+    int vci = req->vci_local;
+    int vci_target = req->vci_target;
+    int nic_target = req->nic_target;
 
     if (sigreq)
         flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
@@ -213,9 +217,8 @@ static int issue_packed_put(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
         MPIDI_OFI_pack_chunk *chunk = create_chunk(pack_buffer, 0, 0, req);
         MPIR_ERR_CHKANDSTMT(chunk == NULL, mpi_errno, MPI_ERR_NO_MEM, goto fn_fail, "**nomem");
 
-        int nic = 0;
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.put.target.addr, nic, vci);
+        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.put.target.addr, nic_target, vci_target);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;
@@ -266,7 +269,9 @@ static int issue_packed_get(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
     struct fi_rma_iov riov;
     uint64_t flags;
     void *pack_buffer;
-    int vci = req->vci;
+    int vci = req->vci_local;
+    int vci_target = req->vci_target;
+    int nic_target = req->nic_target;
 
     if (sigreq)
         flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
@@ -297,9 +302,8 @@ static int issue_packed_get(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
             create_chunk(pack_buffer, msg_len, req->noncontig.get.origin.pack_offset, req);
         MPIR_ERR_CHKANDSTMT(chunk == NULL, mpi_errno, MPI_ERR_NO_MEM, goto fn_fail, "**nomem");
 
-        int nic = 0;
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.get.target.addr, nic, vci);
+        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.get.target.addr, nic_target, vci_target);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;
@@ -356,7 +360,9 @@ int MPIDI_OFI_pack_put(const void *origin_addr, MPI_Aint origin_count,
     /* allocate request */
     MPIDI_OFI_win_request_t *req = MPIDI_OFI_win_request_create();
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    req->vci = MPIDI_WIN(win, am_vci);
+    req->vci_local = MPIDI_WIN(win, am_vci);
+    req->vci_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
+    req->nic_target = MPIDI_OFI_get_pref_nic(win->comm_ptr, target_rank);
     req->sigreq = sigreq;
 
     /* allocate target iovecs */
@@ -415,7 +421,9 @@ int MPIDI_OFI_pack_get(void *origin_addr, MPI_Aint origin_count,
     /* allocate request */
     MPIDI_OFI_win_request_t *req = MPIDI_OFI_win_request_create();
     MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    req->vci = MPIDI_WIN(win, am_vci);
+    req->vci_local = MPIDI_WIN(win, am_vci);
+    req->vci_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
+    req->nic_target = MPIDI_OFI_get_pref_nic(win->comm_ptr, target_rank);
     req->sigreq = sigreq;
 
     /* allocate target iovecs */

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -121,7 +121,7 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, MPI_Aint origin_count,
         int vci = MPIDI_WIN(win, am_vci);
         int nic = 0;
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vci, vci);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vci);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;
@@ -215,7 +215,7 @@ static int issue_packed_put(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
 
         int nic = 0;
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.put.target.addr, nic, vci, vci);
+        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.put.target.addr, nic, vci);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;
@@ -299,7 +299,7 @@ static int issue_packed_get(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
 
         int nic = 0;
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.get.target.addr, nic, vci, vci);
+        msg.addr = MPIDI_OFI_av_to_phys(req->noncontig.get.target.addr, nic, vci);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -226,7 +226,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         MPIDI_OFI_CALL_RETRY(fi_inject_write(MPIDI_OFI_WIN(win).ep,
                                              MPIR_get_contig_ptr(origin_addr, origin_true_lb),
                                              target_bytes,
-                                             MPIDI_OFI_av_to_phys(addr, nic, vci, vci_target),
+                                             MPIDI_OFI_av_to_phys(addr, nic, vci_target),
                                              target_mr.addr + target_true_lb,
                                              target_mr.mr_key), vci, rdma_inject_write);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
@@ -243,7 +243,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
             flags = FI_DELIVERY_COMPLETE;
         }
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vci, vci_target);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vci_target);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;
@@ -414,7 +414,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         msg.desc = NULL;
         msg.msg_iov = &iov;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vci, vci_target);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vci_target);
         msg.rma_iov = &riov;
         msg.rma_iov_count = 1;
         msg.context = NULL;
@@ -638,7 +638,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     msg.msg_iov = &originv;
     msg.desc = NULL;
     msg.iov_count = 1;
-    msg.addr = MPIDI_OFI_av_to_phys(av, nic, vci, vci_target);
+    msg.addr = MPIDI_OFI_av_to_phys(av, nic, vci_target);
     msg.rma_iov = &targetv;
     msg.rma_iov_count = 1;
     msg.datatype = fi_dt;
@@ -760,7 +760,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
         msg.msg_iov = &originv;
         msg.desc = NULL;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vci, vci_target);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vci_target);
         msg.rma_iov = &targetv;
         msg.rma_iov_count = 1;
         msg.datatype = fi_dt;
@@ -899,7 +899,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
         msg.msg_iov = &originv;
         msg.desc = NULL;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vci, vci_target);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vci_target);
         msg.rma_iov = &targetv;
         msg.rma_iov_count = 1;
         msg.datatype = fi_dt;
@@ -1127,7 +1127,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     msg.msg_iov = &originv;
     msg.desc = NULL;
     msg.iov_count = 1;
-    msg.addr = MPIDI_OFI_av_to_phys(av, nic, vci, vci_target);
+    msg.addr = MPIDI_OFI_av_to_phys(av, nic, vci_target);
     msg.rma_iov = &targetv;
     msg.rma_iov_count = 1;
     msg.datatype = fi_dt;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -176,7 +176,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
     MPI_Aint origin_true_lb, target_true_lb;
     struct iovec iov;
     struct fi_rma_iov riov;
-    int nic = 0;
+    int nic_target = MPIDI_OFI_get_pref_nic(win->comm_ptr, target_rank);
 
     MPIR_FUNC_ENTER;
 
@@ -226,7 +226,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         MPIDI_OFI_CALL_RETRY(fi_inject_write(MPIDI_OFI_WIN(win).ep,
                                              MPIR_get_contig_ptr(origin_addr, origin_true_lb),
                                              target_bytes,
-                                             MPIDI_OFI_av_to_phys(addr, nic, vci_target),
+                                             MPIDI_OFI_av_to_phys(addr, nic_target, vci_target),
                                              target_mr.addr + target_true_lb,
                                              target_mr.mr_key), vci, rdma_inject_write);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
@@ -243,7 +243,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
             flags = FI_DELIVERY_COMPLETE;
         }
         msg.desc = NULL;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vci_target);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic_target, vci_target);
         msg.context = NULL;
         msg.data = 0;
         msg.msg_iov = &iov;
@@ -362,7 +362,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
     MPI_Aint target_bytes, target_extent;
     struct fi_rma_iov riov;
     struct iovec iov;
-    int nic = 0;
+    int nic_target = MPIDI_OFI_get_pref_nic(win->comm_ptr, target_rank);
 
     MPIR_FUNC_ENTER;
 
@@ -414,7 +414,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         msg.desc = NULL;
         msg.msg_iov = &iov;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vci_target);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic_target, vci_target);
         msg.rma_iov = &riov;
         msg.rma_iov_count = 1;
         msg.context = NULL;
@@ -566,7 +566,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     struct fi_ioc comparev;
     struct fi_rma_ioc targetv;
     struct fi_msg_atomic msg;
-    int nic = 0;
+    int nic_target = MPIDI_OFI_get_pref_nic(win->comm_ptr, target_rank);
 
     int vci = MPIDI_WIN(win, am_vci);
     int vci_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
@@ -638,7 +638,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     msg.msg_iov = &originv;
     msg.desc = NULL;
     msg.iov_count = 1;
-    msg.addr = MPIDI_OFI_av_to_phys(av, nic, vci_target);
+    msg.addr = MPIDI_OFI_av_to_phys(av, nic_target, vci_target);
     msg.rma_iov = &targetv;
     msg.rma_iov_count = 1;
     msg.datatype = fi_dt;
@@ -683,7 +683,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
     int target_contig, origin_contig;
     MPI_Aint target_bytes, origin_bytes, target_extent;
     MPI_Aint origin_true_lb, target_true_lb;
-    int nic = 0;
+    int nic_target = MPIDI_OFI_get_pref_nic(win->comm_ptr, target_rank);
 
     MPIR_FUNC_ENTER;
 
@@ -760,7 +760,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
         msg.msg_iov = &originv;
         msg.desc = NULL;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vci_target);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic_target, vci_target);
         msg.rma_iov = &targetv;
         msg.rma_iov_count = 1;
         msg.datatype = fi_dt;
@@ -820,7 +820,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
     int target_contig, origin_contig, result_contig;
     MPI_Aint target_bytes, target_extent;
     MPI_Aint origin_true_lb, target_true_lb, result_true_lb;
-    int nic = 0;
+    int nic_target = MPIDI_OFI_get_pref_nic(win->comm_ptr, target_rank);
 
     MPIR_FUNC_ENTER;
 
@@ -899,7 +899,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
         msg.msg_iov = &originv;
         msg.desc = NULL;
         msg.iov_count = 1;
-        msg.addr = MPIDI_OFI_av_to_phys(addr, nic, vci_target);
+        msg.addr = MPIDI_OFI_av_to_phys(addr, nic_target, vci_target);
         msg.rma_iov = &targetv;
         msg.rma_iov_count = 1;
         msg.datatype = fi_dt;
@@ -1063,7 +1063,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
 
     int vci = MPIDI_WIN(win, am_vci);
     int vci_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
-    int nic = 0;
+    int nic_target = MPIDI_OFI_get_pref_nic(win->comm_ptr, target_rank);
 
     if (
 #ifndef MPIDI_CH4_DIRECT_NETMOD
@@ -1127,7 +1127,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     msg.msg_iov = &originv;
     msg.desc = NULL;
     msg.iov_count = 1;
-    msg.addr = MPIDI_OFI_av_to_phys(av, nic, vci_target);
+    msg.addr = MPIDI_OFI_av_to_phys(av, nic_target, vci_target);
     msg.rma_iov = &targetv;
     msg.rma_iov_count = 1;
     msg.datatype = fi_dt;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -31,7 +31,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
         MPIDI_OFI_multx_sender_nic_index(comm, comm->context_id, comm->rank, dst_rank, tag);
     receiver_nic =
         MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, comm->rank, dst_rank, tag);
-    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_local, sender_nic);
+    ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, sender_nic);
 
     match_bits = MPIDI_OFI_init_sendtag(comm->context_id + context_offset, comm->rank, tag, 0);
     fi_addr_t dest_addr = MPIDI_OFI_av_to_phys(addr, receiver_nic, vci_local, vci_remote);
@@ -95,7 +95,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
         MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, comm->rank, dst_rank,
                                            MPIDI_OFI_init_get_tag(match_bits));
     MPIDI_OFI_REQUEST(sreq, nic_num) = sender_nic;
-    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_local, MPIDI_OFI_REQUEST(sreq, nic_num));
+    ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, MPIDI_OFI_REQUEST(sreq, nic_num));
 
     /* everything fits in the IOV array */
     flags = FI_COMPLETION | (MPIDI_OFI_ENABLE_DATA ? FI_REMOTE_CQ_DATA : 0);
@@ -188,7 +188,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
     receiver_nic =
         MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, comm->rank, dst_rank, tag);
     MPIDI_OFI_REQUEST(sreq, nic_num) = sender_nic;
-    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_local, MPIDI_OFI_REQUEST(sreq, nic_num));
+    ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, MPIDI_OFI_REQUEST(sreq, nic_num));
 
     if (type == MPIDI_OFI_SYNC_SEND) {  /* Branch should compile out */
         uint64_t ssend_match, ssend_mask;
@@ -202,7 +202,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         ssend_match =
             MPIDI_OFI_init_recvtag(&ssend_mask, comm->context_id + context_offset, dst_rank, tag);
         ssend_match |= MPIDI_OFI_SYNC_SEND_ACK;
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(comm, vci_local, receiver_nic)].rx,  /* endpoint    */
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(vci_local, receiver_nic)].rx,        /* endpoint    */
                                       NULL,     /* recvbuf     */
                                       0,        /* data sz     */
                                       NULL,     /* memregion descr  */
@@ -316,7 +316,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
             }
         }
         for (int i = 0; i < num_nics; i++) {
-            MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(comm, vci_local, i)].domain,  /* In:  Domain Object */
+            MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(vci_local, i)].domain,        /* In:  Domain Object */
                                      send_buf,  /* In:  Lower memory address */
                                      data_sz,   /* In:  Length              */
                                      FI_REMOTE_READ,    /* In:  Expose MR for read  */
@@ -327,7 +327,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                      NULL), mr_reg);    /* In:  context             */
             mpi_errno = MPIDI_OFI_mr_bind(MPIDI_OFI_global.prov_use[0], huge_send_mrs[i],
                                           MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index
-                                                               (comm, vci_local, i)].ep, NULL);
+                                                               (vci_local, i)].ep, NULL);
             MPIR_ERR_CHECK(mpi_errno);
         }
         MPIDI_OFI_REQUEST(sreq, huge.send_mrs) = huge_send_mrs;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -34,7 +34,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
     ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, sender_nic);
 
     match_bits = MPIDI_OFI_init_sendtag(comm->context_id + context_offset, comm->rank, tag, 0);
-    fi_addr_t dest_addr = MPIDI_OFI_av_to_phys(addr, receiver_nic, vci_local, vci_remote);
+    fi_addr_t dest_addr = MPIDI_OFI_av_to_phys(addr, receiver_nic, vci_remote);
     if (MPIDI_OFI_ENABLE_DATA) {
         MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                             buf, data_sz, cq_data, dest_addr, match_bits),
@@ -121,7 +121,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     msg.ignore = 0ULL;
     msg.context = (void *) &(MPIDI_OFI_REQUEST(sreq, context));
     msg.data = MPIDI_OFI_ENABLE_DATA ? cq_data : 0;
-    msg.addr = MPIDI_OFI_av_to_phys(addr, receiver_nic, vci_local, vci_remote);
+    msg.addr = MPIDI_OFI_av_to_phys(addr, receiver_nic, vci_remote);
 
     MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                      &msg, flags), vci_local, tsendv);
@@ -206,7 +206,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                       NULL,     /* recvbuf     */
                                       0,        /* data sz     */
                                       NULL,     /* memregion descr  */
-                                      MPIDI_OFI_av_to_phys(addr, sender_nic, vci_local, vci_remote),    /* remote proc */
+                                      MPIDI_OFI_av_to_phys(addr, sender_nic, vci_remote),       /* remote proc */
                                       ssend_match,      /* match bits  */
                                       0ULL,     /* mask bits   */
                                       (void *) &(ackreq->context)), vci_local, trecvsync);
@@ -261,7 +261,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIDI_OFI_REQUEST(sreq, noncontig.nopack) = NULL;
     }
 
-    fi_addr_t dest_addr = MPIDI_OFI_av_to_phys(addr, receiver_nic, vci_local, vci_remote);
+    fi_addr_t dest_addr = MPIDI_OFI_av_to_phys(addr, receiver_nic, vci_remote);
     if (data_sz <= MPIDI_OFI_global.max_buffered_send) {
         if (MPIDI_OFI_ENABLE_DATA) {
             MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx,
@@ -373,8 +373,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                           send_buf, msg_size, NULL /* desc */ ,
                                           cq_data,
-                                          MPIDI_OFI_av_to_phys(addr, receiver_nic, vci_local,
-                                                               vci_remote),
+                                          MPIDI_OFI_av_to_phys(addr, receiver_nic, vci_remote),
                                           match_bits,
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
                              vci_local, tsenddata);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -20,8 +20,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
     int mpi_errno = MPI_SUCCESS;
     int vci_local = vci_src;
     int vci_remote = vci_dst;
-    int sender_nic = 0, receiver_nic = 0;
-    int ctx_idx = 0;
+    int sender_nic, receiver_nic;
+    int ctx_idx;
     uint64_t match_bits;
 
     MPIR_FUNC_ENTER;
@@ -77,8 +77,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     MPI_Aint num_contig, size;
     int vci_local = vci_src;
     int vci_remote = vci_dst;
-    int sender_nic = 0, receiver_nic = 0;
-    int ctx_idx = 0;
+    int sender_nic, receiver_nic;
+    int ctx_idx;
 
     MPIR_FUNC_ENTER;
 
@@ -155,8 +155,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
     bool force_gpu_pack = false;
     int vci_local = vci_src;
     int vci_remote = vci_dst;
-    int sender_nic = 0, receiver_nic = 0;
-    int ctx_idx = 0;
+    int sender_nic, receiver_nic;
+    int ctx_idx;
 
     MPIR_FUNC_ENTER;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -144,7 +144,7 @@ int MPIDI_OFI_upids_to_gpids(int size, int *remote_upid_size, char *remote_upids
     int n_avts;
     char *curr_upid;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, 0, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
 
     MPIR_CHKLMEM_DECL(2);
 
@@ -220,7 +220,7 @@ int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, int **local_upid_size, char **lo
     int i, total_size = 0;
     char *temp_buf = NULL, *curr_ptr = NULL;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, 0, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
 
     MPIR_CHKPMEM_DECL(2);
     MPIR_CHKLMEM_DECL(1);

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -18,7 +18,7 @@ int MPIDI_OFI_dynamic_send(uint64_t remote_gpid, int tag, const void *buf, int s
     int ctx_idx = 0;
     int avtid = MPIDIU_GPID_GET_AVTID(remote_gpid);
     int lpid = MPIDIU_GPID_GET_LPID(remote_gpid);
-    fi_addr_t remote_addr = MPIDI_OFI_av_to_phys(&MPIDIU_get_av(avtid, lpid), nic, vci, vci);
+    fi_addr_t remote_addr = MPIDI_OFI_av_to_phys(&MPIDIU_get_av(avtid, lpid), nic, vci);
 
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -246,6 +246,9 @@ typedef struct {
     /* Queue (utlist) to store early-arrival active messages */
     MPIDI_OFI_am_unordered_msg_t *am_unordered_msgs;
 
+    /* Used by am pipeline to track rreq */
+    void *req_map;
+
     /* Completion queue buffering */
     struct fi_cq_tagged_entry cq_buffered_static_list[MPIDI_OFI_NUM_CQ_BUFFERED];
     int cq_buffered_static_head;
@@ -391,8 +394,6 @@ typedef struct {
     size_t addrnamelen;         /* OFI uses the same name length within a provider. */
     char pname[MPI_MAX_PROCESSOR_NAME];
     int port_name_tag_mask[MPIR_MAX_CONTEXT_MASK];
-
-    void *req_map;
 
     /* Capability settings */
 #ifdef MPIDI_OFI_ENABLE_RUNTIME_CHECKS

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -451,7 +451,9 @@ typedef struct MPIDI_OFI_pack_chunk {
 typedef struct MPIDI_OFI_win_request {
     struct MPIDI_OFI_win_request *next;
     struct MPIDI_OFI_win_request *prev;
-    int vci;
+    int vci_local;
+    int vci_target;
+    int nic_target;
     int rma_type;
     MPIR_Request **sigreq;
     MPIDI_OFI_pack_chunk *chunks;

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -160,7 +160,7 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
 
     /* we need register mr on the correct domain for the vci */
     int vci = MPIDI_WIN(win, am_vci);
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
 
     /* Register the allocated win buffer or MPI_BOTTOM (NULL) for dynamic win.
      * It is clear that we cannot register NULL when FI_MR_ALLOCATED is set, thus
@@ -274,7 +274,7 @@ static int win_set_per_win_sync(MPIR_Win * win)
     int ret, mpi_errno = MPI_SUCCESS;
     int nic = 0;
     int vci = MPIDI_WIN(win, am_vci);
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
 
     MPIR_FUNC_ENTER;
 
@@ -332,7 +332,7 @@ static int win_init_sep(MPIR_Win * win)
     struct fi_info *finfo;
     int nic = 0;
     int vci = MPIDI_WIN(win, am_vci);
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
 
     MPIR_FUNC_ENTER;
 
@@ -460,7 +460,7 @@ static int win_init_stx(MPIR_Win * win)
     bool have_per_win_cntr = false;
     int nic = 0;
     int vci = MPIDI_WIN(win, am_vci);
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
 
     MPIR_FUNC_ENTER;
 
@@ -575,14 +575,14 @@ static int win_init_global(MPIR_Win * win)
 
     int vci = MPIDI_WIN(win, am_vci);
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
 
     MPIDI_OFI_WIN(win).ep = MPIDI_OFI_global.ctx[ctx_idx].tx;
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
     MPIDI_OFI_WIN(win).cmpl_cntr = MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr;
     MPIDI_OFI_WIN(win).issued_cntr = &MPIDI_OFI_global.ctx[ctx_idx].rma_issued_cntr;
 #else
-    ctx_idx = MPIDI_OFI_get_ctx_index(NULL, 0, nic);
+    ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
     /* NOTE: shared with ctx[0] */
     MPIDI_OFI_WIN(win).cmpl_cntr = MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr;
     MPIDI_OFI_WIN(win).issued_cntr = &MPIDI_OFI_global.ctx[ctx_idx].rma_issued_cntr;
@@ -921,7 +921,7 @@ int MPIDI_OFI_mpi_win_attach_hook(MPIR_Win * win, void *base, MPI_Aint size)
     int mpl_err = MPL_SUCCESS, i;
     int nic = 0;
     int vci = MPIDI_WIN(win, am_vci);
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
 
     MPIR_FUNC_ENTER;
 
@@ -1070,7 +1070,7 @@ int MPIDI_OFI_mpi_win_free_hook(MPIR_Win * win)
 
     if (MPIDI_OFI_ENABLE_RMA) {
         int vci = MPIDI_WIN(win, am_vci);
-        int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
+        int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
         MPIDI_OFI_mr_key_free(MPIDI_OFI_COLL_MR_KEY, MPIDI_OFI_WIN(win).win_id);
         MPIDIU_map_erase(MPIDI_OFI_global.win_map, MPIDI_OFI_WIN(win).win_id);
         /* For scalable EP: push transmit context index back into available pool. */

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -6,6 +6,7 @@
 #include <mpir_pmi.h>
 #include <mpiimpl.h>
 #include "mpir_nodemap.h"
+#include "uthash.h"     /* for hash function */
 
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===
@@ -202,6 +203,7 @@ int MPIR_pmi_init(void)
     MPIR_Process.rank = rank;
     MPIR_Process.size = size;
     MPIR_Process.appnum = appnum;
+    HASH_FNV(pmi_kvs_name, strlen(pmi_kvs_name), MPIR_Process.world_id);
 
     MPIR_Process.node_map = (int *) MPL_malloc(size * sizeof(int), MPL_MEM_ADDRESS);
 


### PR DESCRIPTION
## Pull Request Description
When "multi_nic_pref_nic" hint is used, we inconsistently use the preferred nic despite the am code explicitly setting nic to 0.

Fixes #6419 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
