### PR TITLE
Session: revision of thread level parameter handling

### DIFF
--- a/src/mpi/init/init_util.c
+++ b/src/mpi/init/init_util.c
@@ -69,7 +69,14 @@ void MPII_Call_finalize_callbacks(int min_prio, int max_prio)
     }
 }
 
-static const char *threadlevel_name(int threadlevel)
+/**
+ * @brief   Convert thread level integer to a string representation
+ *
+ * @param   threadlevel Thread level integer (input)
+ *
+ * @return  char*       String representation of thread level
+ */
+const char *MPII_threadlevel_name(int threadlevel)
 {
     if (threadlevel == MPI_THREAD_SINGLE) {
         return "MPI_THREAD_SINGLE";
@@ -106,7 +113,7 @@ void MPII_dump_debug_summary(void)
 #else
     print_setting("debugger support", "disabled");
 #endif
-    print_setting("thread level", threadlevel_name(MPIR_ThreadInfo.thread_provided));
+    print_setting("thread level", MPII_threadlevel_name(MPIR_ThreadInfo.thread_provided));
 #if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__GLOBAL
     print_setting("thread CS", "global");
 #elif MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI

--- a/src/mpi/init/mpi_init.h
+++ b/src/mpi/init/mpi_init.h
@@ -49,6 +49,8 @@ int MPII_Finalize(MPIR_Session * session_ptr);
 void MPII_thread_mutex_create(void);
 void MPII_thread_mutex_destroy(void);
 
+const char *MPII_threadlevel_name(int threadlevel);
+
 int MPII_init_local_proc_attrs(int *p_thread_required);
 int MPII_init_tag_ub(void);
 int MPII_init_builtin_infos(void);

--- a/test/mpi/init/session.c
+++ b/test/mpi/init/session.c
@@ -55,6 +55,20 @@ int main(int argc, char *argv[])
 static MPI_Session lib_shandle = MPI_SESSION_NULL;
 static MPI_Comm lib_comm = MPI_COMM_NULL;
 
+int check_thread_level(char *value)
+{
+    int ret = MPI_SUCCESS;
+
+    if (strcmp(value, "MPI_THREAD_MULTIPLE") &&
+        strcmp(value, "MPI_THREAD_SERIALIZED") &&
+        strcmp(value, "MPI_THREAD_SINGLE") && strcmp(value, "MPI_THREAD_FUNNELED")) {
+
+        ret = MPI_ERR_OTHER;
+    }
+
+    return ret;
+}
+
 int library_foo_test(void)
 {
     int rank, size;
@@ -111,8 +125,8 @@ void library_foo_init(void)
         errs++;
         goto fn_exit;
     }
-    if (strcmp(out_value, mt_value)) {
-        printf("Did not get thread multiple support, got %s\n", out_value);
+    if (check_thread_level(out_value)) {
+        printf("Did not get valid thread level, got %s\n", out_value);
         errs++;
         goto fn_exit;
     }


### PR DESCRIPTION
## Pull Request Description

Goal: Make the `thread_level` parameter of MPI sessions transparent to users. Concrete improvements:
* Thread level requested by the user on `MPI_Session_init` via Info object is no longer ignored
* Hard-coded `MPI_THREAD_MULTIPLE` is no longer returned as response to `MPI_Session_get_info`, but the actual provided thread level
* The `init/session` test is modified to check the provided thread level of a session based on the allowed values defined in the MPI-4 standard

Note: This PR does not make any changes regarding the (functionally) supported thread levels for MPI sessions.

## Author Checklist
* [X] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [X] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [X] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
