### PR TITLE
Sessions: integration of PMIx process sets

### DIFF
--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -61,6 +61,7 @@ noinst_HEADERS +=                   \
     src/include/mpir_op.h           \
     src/include/mpir_pmi.h          \
     src/include/mpir_process.h      \
+    src/include/mpir_pset.h         \
     src/include/mpir_session.h      \
     src/include/mpir_misc.h         \
     src/include/mpir_tags.h         \

--- a/src/include/mpiimpl.h
+++ b/src/include/mpiimpl.h
@@ -148,6 +148,12 @@ typedef struct MPIR_Topology MPIR_Topology;
 struct MPIR_Session;
 typedef struct MPIR_Session MPIR_Session;
 
+struct MPIR_Pset;
+typedef struct MPIR_Pset MPIR_Pset;
+
+struct MPIR_Pset_member;
+typedef int MPIR_Pset_member;
+
 struct MPIR_Stream;
 typedef struct MPIR_Stream MPIR_Stream;
 
@@ -211,6 +217,7 @@ typedef struct MPIR_Stream MPIR_Stream;
 #include "mpir_bsend.h"
 #include "mpir_process.h"
 #include "mpir_session.h"
+#include "mpir_pset.h"
 #include "mpir_typerep.h"
 #include "mpir_datatype.h"
 #include "mpir_threadcomm.h"

--- a/src/include/mpir_pset.h
+++ b/src/include/mpir_pset.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef MPIR_PSET_H_INCLUDED
+#define MPIR_PSET_H_INCLUDED
+
+#include "mpiimpl.h"
+
+struct MPIR_Pset {
+    char *uri;                  /* Name of the process set */
+    int size;                   /* Number of processes in the set */
+    bool is_valid;              /* True if process set is valid, false if not */
+    MPIR_Pset_member *members;  /* Array of members of the process set sorted in ascending order
+                                 * TODO: This should be optimized using compressed methods of process
+                                 * representation to improve scalability */
+};
+
+int MPIR_Pset_init(void);
+int MPIR_Pset_finalize(void);
+int MPIR_Pset_count(void);
+int MPIR_Pset_by_name(const char *pset_name, MPIR_Pset ** pset);
+int MPIR_Pset_by_idx(int idx, MPIR_Pset ** pset);
+int MPIR_Pset_add(MPIR_Pset * pset);
+int MPIR_Pset_invalidate(char *pset_name);
+int MPIR_Pset_member_compare(void const *a, void const *b);
+int MPIR_Pset_member_is_self(MPIR_Pset_member * member);
+
+#endif /* MPIR_PSET_H_INCLUDED */

--- a/src/include/mpir_session.h
+++ b/src/include/mpir_session.h
@@ -8,6 +8,9 @@
 
 #include "mpiimpl.h"
 
+#define MPIR_SESSION_WORLD_PSET_NAME "mpi://WORLD"
+#define MPIR_SESSION_SELF_PSET_NAME "mpi://SELF"
+
 /* Session structure */
 struct MPIR_Session {
     MPIR_OBJECT_HEADER;

--- a/src/include/mpir_session.h
+++ b/src/include/mpir_session.h
@@ -59,4 +59,4 @@ int MPIR_Session_get_pset_info_impl(MPIR_Session * session_ptr, const char *pset
 int MPIR_Session_init_impl(MPIR_Info * info_ptr, MPIR_Errhandler * errhandler_ptr,
                            MPIR_Session ** session_ptr);
 
-#endif /* MPIR_SESSSION_H_INCLUDED */
+#endif /* MPIR_SESSION_H_INCLUDED */

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -6,6 +6,7 @@
 #include "mpiimpl.h"
 #include "mpir_info.h"
 #include "mpi_init.h"
+#include "mpir_pset.h"
 #include <strings.h>
 #include "mpir_async_things.h"
 
@@ -201,6 +202,8 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     MPIR_Typerep_init();
     MPII_thread_mutex_create();
     MPII_init_request();
+    mpi_errno = MPIR_Pset_init();
+    MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_pmi_init();
     MPIR_ERR_CHECK(mpi_errno);
     MPII_hwtopo_init();
@@ -446,6 +449,8 @@ int MPII_Finalize(MPIR_Session * session_ptr)
 
     mpi_errno = MPII_Coll_finalize();
     MPIR_ERR_CHECK(mpi_errno);
+
+    MPIR_Pset_finalize();
 
     /* Call the low-priority (post Finalize) callbacks */
     MPII_Call_finalize_callbacks(0, MPIR_FINALIZE_CALLBACK_PRIO);

--- a/src/mpi/session/Makefile.mk
+++ b/src/mpi/session/Makefile.mk
@@ -5,4 +5,5 @@
 
 mpi_core_sources += \
     src/mpi/session/session_impl.c \
-    src/mpi/session/session_util.c
+    src/mpi/session/session_util.c \
+    src/mpi/session/mpir_pset.c

--- a/src/mpi/session/mpir_pset.c
+++ b/src/mpi/session/mpir_pset.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpir_pset.h"
+
+/* Global array of known psets managed by the process manager */
+UT_array *pm_pset_array;
+
+/* Mutex to protect global pset array from concurrent accesses of
+ * MPI process and PMIx event thread
+ *
+ * This is required independent of multi-threaded support
+ * because the PMIx event thread and MPI worker process/thread
+ * may access the global PM pset array concurrently -
+ * MPID_THREAD_CS_ENTER and MPID_THREAD_CS_EXIT cannot be used here.
+ */
+MPID_Thread_mutex_t pm_pset_mutex;
+
+/**
+ * @brief Copy function for MPIR_Psets in UT_arrays
+ */
+static
+void pset_copy(void *_dst, const void *_src)
+{
+    MPIR_Pset *dst = (MPIR_Pset *) _dst;
+    MPIR_Pset *src = (MPIR_Pset *) _src;
+
+    dst->is_valid = src->is_valid;
+    dst->size = src->size;
+    dst->uri = src->uri ? MPL_strdup(src->uri) : NULL;
+    dst->members = MPL_malloc(sizeof(MPIR_Pset_member) * src->size, MPL_MEM_SESSION);
+    memcpy(dst->members, src->members, sizeof(MPIR_Pset_member) * src->size);
+}
+
+/**
+ * @brief Destructor for MPIR_Psets in UT_arrays.
+ */
+static
+void pset_dtor(void *_elt)
+{
+    MPIR_Pset *elt = (MPIR_Pset *) _elt;
+    if (elt->uri != NULL)
+        MPL_free(elt->uri);
+
+    if (elt->members != NULL)
+        MPL_free(elt->members);
+}
+
+/**
+ * @brief Structure used to work with MPIR_Psets in UT_arrays. Configures init, copy and destructor methods for MPIR_Psets.
+ */
+static const UT_icd pset_array_icd = { sizeof(MPIR_Pset), NULL, pset_copy, pset_dtor };
+
+/**
+ * @brief   Find pset by its name (not thread-safe).
+ */
+static
+int pset_find_by_name(const char *pset_name, MPIR_Pset ** pset)
+{
+    int ret = MPI_ERR_OTHER;
+    MPIR_Pset *p = NULL;
+    *pset = NULL;
+    for (unsigned i = 0; i < utarray_len(pm_pset_array); i++) {
+        p = (MPIR_Pset *) utarray_eltptr(pm_pset_array, i);
+        if (strncasecmp(pset_name, p->uri, MAX(strlen(pset_name), strlen(p->uri))) == 0) {
+            ret = MPI_SUCCESS;
+            *pset = p;
+            break;
+        }
+    }
+    return ret;
+}
+
+int MPIR_Pset_by_name(const char *pset_name, MPIR_Pset ** pset)
+{
+    int ret, thr_err;
+
+    MPID_Thread_mutex_lock(&pm_pset_mutex, &thr_err);
+    MPIR_Assert(thr_err == MPI_SUCCESS);
+
+    if (pset_name != NULL) {
+        ret = pset_find_by_name(pset_name, pset);
+    } else {
+        ret = MPI_ERR_OTHER;
+    }
+
+    MPID_Thread_mutex_unlock(&pm_pset_mutex, &thr_err);
+    MPIR_Assert(thr_err == MPI_SUCCESS);
+
+    return ret;
+}
+
+int MPIR_Pset_by_idx(int idx, MPIR_Pset ** pset)
+{
+    int ret = MPI_SUCCESS;
+    int thr_err;
+
+    MPID_Thread_mutex_lock(&pm_pset_mutex, &thr_err);
+    MPIR_Assert(thr_err == MPI_SUCCESS);
+
+    if (idx >= 0 && idx < MPIR_Pset_count()) {
+        *pset = (MPIR_Pset *) utarray_eltptr(pm_pset_array, idx);
+    } else {
+        ret = MPI_ERR_OTHER;
+    }
+
+    MPID_Thread_mutex_unlock(&pm_pset_mutex, &thr_err);
+    MPIR_Assert(thr_err == MPI_SUCCESS);
+
+    return ret;
+}
+
+int MPIR_Pset_init(void)
+{
+    int mpi_errno;
+
+    utarray_new(pm_pset_array, &pset_array_icd, MPL_MEM_SESSION);
+    MPID_Thread_mutex_create(&pm_pset_mutex, &mpi_errno);
+
+    return mpi_errno;
+}
+
+int MPIR_Pset_finalize(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    utarray_free(pm_pset_array);
+    MPID_Thread_mutex_destroy(&pm_pset_mutex, &mpi_errno);
+
+    return mpi_errno;
+}
+
+int MPIR_Pset_count(void)
+{
+    unsigned count = utarray_len(pm_pset_array);
+
+    /* Overflow check */
+    MPIR_Assert(count < INT_MAX);
+
+    return (int) count;
+}
+
+int MPIR_Pset_add(MPIR_Pset * pset)
+{
+    int ret, thr_err;
+    MPIR_Pset *p;
+
+    MPID_Thread_mutex_lock(&pm_pset_mutex, &thr_err);
+    MPIR_Assert(thr_err == MPI_SUCCESS);
+
+    if (pset_find_by_name(pset->uri, &p) == MPI_ERR_OTHER) {
+        /* Pset with uri NOT found in the parray */
+        utarray_push_back(pm_pset_array, pset, MPL_MEM_SESSION);
+        ret = MPI_SUCCESS;
+    } else {
+        ret = MPI_ERR_OTHER;
+    }
+
+    MPID_Thread_mutex_unlock(&pm_pset_mutex, &thr_err);
+    MPIR_Assert(thr_err == MPI_SUCCESS);
+
+    return ret;
+}
+
+int MPIR_Pset_invalidate(char *pset_name)
+{
+    int ret, thr_err;
+    MPIR_Pset *p = NULL;
+
+    MPID_Thread_mutex_lock(&pm_pset_mutex, &thr_err);
+    MPIR_Assert(thr_err == MPI_SUCCESS);
+
+    ret = pset_find_by_name(pset_name, &p);
+    if (ret == MPI_SUCCESS) {
+        p->is_valid = false;    /* Set to invalid */
+    }
+
+    MPID_Thread_mutex_unlock(&pm_pset_mutex, &thr_err);
+    MPIR_Assert(thr_err == MPI_SUCCESS);
+
+    return ret;
+}
+
+int MPIR_Pset_member_compare(void const *a, void const *b)
+{
+    /* This function is used to compare to pset members on qsort;
+     * a and b are of tpye (MPIR_Pset_member *) which is an (int *) for now.
+     * Hence, we can use an arithmetic operation to compare */
+    return *(const int *) a - *(const int *) b;
+}
+
+int MPIR_Pset_member_is_self(MPIR_Pset_member * member)
+{
+    return ((int) *member == MPIR_Process.rank);
+}

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -852,6 +852,8 @@ int MPID_Type_free_hook(MPIR_Datatype * type);
 int MPID_Op_commit_hook(MPIR_Op * op);
 int MPID_Op_free_hook(MPIR_Op * op);
 
+int MPID_Pset_member_get_lpid(MPIR_Pset_member * member_ptr, uint64_t * lpid_ptr);
+
 MPL_STATIC_INLINE_PREFIX int MPID_Stream_create_hook(MPIR_Stream * stream)
 {
     return MPI_SUCCESS;

--- a/src/mpid/ch3/src/mpid_vc.c
+++ b/src/mpid/ch3/src/mpid_vc.c
@@ -837,3 +837,20 @@ int MPIDI_Populate_vc_node_ids(MPIDI_PG_t *pg, int our_pg_rank)
     return mpi_errno;
 }
 
+int MPID_Pset_member_get_lpid(MPIR_Pset_member * member_ptr, uint64_t * lpid_ptr)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_ENTER;
+
+    if (!member_ptr || !lpid_ptr) {
+        mpi_errno = MPI_ERR_OTHER;
+        goto fn_exit;
+    }
+
+    /* As long as MPIR_Pset_member is an int we can use a type cast here */
+    *lpid_ptr = (uint64_t) *member_ptr;
+
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+}

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -418,6 +418,7 @@ int MPID_Waitall_enqueue(int count, MPI_Request * array_of_requests,
                          MPI_Status * array_of_statuses);
 int MPID_Abort(struct MPIR_Comm *comm, int mpi_errno, int exit_code, const char *error_msg);
 
+int MPID_Pset_member_get_lpid(MPIR_Pset_member * member_ptr, uint64_t * lpid_ptr);
 /* This function is not exposed to the upper layers but functions in a way
  * similar to the functions above. Other CH4-level functions should call this
  * function to query locality. This function will determine whether to call the

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -1219,3 +1219,21 @@ int MPID_Op_free_hook(MPIR_Op * op)
   fn_fail:
     goto fn_exit;
 }
+
+int MPID_Pset_member_get_lpid(MPIR_Pset_member * member_ptr, uint64_t * lpid_ptr)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_FUNC_ENTER;
+
+    if (!member_ptr || !lpid_ptr) {
+        mpi_errno = MPI_ERR_OTHER;
+        goto fn_exit;
+    }
+
+    /* As long as MPIR_Pset_member is an int we can use a type cast here */
+    *lpid_ptr = (uint64_t) * member_ptr;
+
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+}

--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -50,6 +50,7 @@ typedef enum {
     MPL_MEM_PM,                 /* Data for process managers */
     MPL_MEM_COLL,               /* Memory related to collective operations */
     MPL_MEM_USER,               /* User memory allocations */
+    MPL_MEM_SESSION,            /* Sessions and process sets */
     MPL_MEM_OTHER,              /* Other small memory allocations */
     MPL_MAX_MEMORY_CLASS
 } MPL_memory_class;

--- a/src/mpl/src/mem/mpl_trmem.c
+++ b/src/mpl/src/mem/mpl_trmem.c
@@ -1192,4 +1192,3 @@ void MPL_Memcpy_stream(void *dest, const void *src, size_t n)
 #endif /* HAVE_SSE2 */
 
 #endif
-

--- a/src/mpl/src/mem/mpl_trmem.c
+++ b/src/mpl/src/mem/mpl_trmem.c
@@ -133,6 +133,7 @@ static const char *allocation_class_strings[] = {
     "MPL_MEM_PM",
     "MPL_MEM_COLL",
     "MPL_MEM_USER",
+    "MPL_MEM_SESSION",
     "MPL_MEM_OTHER"
 };
 

--- a/src/pmi/errnames.txt
+++ b/src/pmi/errnames.txt
@@ -114,6 +114,10 @@
 **pmix_load_topo %d: PMIx_Load_topology failed with error %d
 **pmix_unknown_topo: PMIx_Load_topology returns unknown topology
 **pmix_unknown_topo %s: PMIx_Load_topology returns unknown topology with error %s
+**pmix_register_event_handler:PMIX_Register_event_handler failed
+**pmix_register_event_handler %d:PMIX_Register_event_handler returned %d
+**pmix_deregister_event_handler:PMIX_Deregister_event_handler failed
+**pmix_deregister_event_handler %d:PMIX_Deregister_event_handler returned %d
 #
 # PMI finalize exit handler registration
 #

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -4,6 +4,7 @@
  */
 
 #include <mpir_pmi.h>
+#include <mpir_pset.h>
 #include <mpiimpl.h>
 #include "uthash.h"     /* for hash function */
 
@@ -213,6 +214,8 @@ static void fallback_free_hwloc_topology(void);
 
 void MPIR_pmi_finalize(void)
 {
+    SWITCH_PMI(break, break, pmix_deregister_event_handlers());
+
     /* Finalize of PM interface happens in exit handler,
      * here: free allocated memory */
     MPL_free(pmi_kvs_name);

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -51,6 +51,12 @@ static int pmix_prep_spawn(int count, char *commands[], char **argvs[], const in
                            size_t * njob_info);
 static int pmix_fence_nspace_proc(const char *nspace, const char *parent_nspace, int parent_rank);
 
+/* Array of PMIx process IDs for implicitly defining their unique MPIR_Process.rank
+ * via their position in the array (also across multiple namespaces) */
+static pmix_data_array_t *pmix_procs = NULL;
+static void pmix_id_to_mpi_rank(pmix_proc_t proc, int *rank, int *size);
+static void mpi_rank_to_pmix_id(int rank, pmix_proc_t * proc);
+
 static int pmix_pset_define_hdlr;
 static int pmix_pset_delete_hdlr;
 static int pmix_register_event_handlers(void);
@@ -85,13 +91,30 @@ static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
         pmi_kvs_name = MPL_strdup(pmix_proc.nspace);
     }
 
-    *rank = pmix_proc.rank;
-
     pmi_errno = PMIx_Get(&pmix_wcproc, PMIX_JOB_SIZE, NULL, 0, &pvalue);
     MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                          "**pmix_get", "**pmix_get %d", pmi_errno);
     *size = pvalue->data.uint32;
     PMIX_VALUE_RELEASE(pvalue);
+
+    /* Fill pmix_procs array with all processes
+     * Currently this is trivial for only one namespace, but once multiple
+     * namespaces and terminating processes are considered this will become
+     * more complicated and needs additional mechanisms such as PMIx Process
+     * Group and PMIx Connect to determine the size and the participating
+     * processes. */
+    if (pmix_procs != NULL) {
+        PMIX_DATA_ARRAY_FREE(pmix_procs);
+    }
+    PMIX_DATA_ARRAY_CREATE(pmix_procs, *size, PMIX_PROC);
+    pmix_proc_t *procs = (pmix_proc_t *) pmix_procs->array;
+    for (int i = 0; i < *size; i++) {
+        PMIX_LOAD_PROCID(&(procs[i]), pmix_proc.nspace, i);
+    }
+
+    /* Set the MPI rank based on the pmix_procs array
+     * For now this is trivial, *rank = pmix_proc.rank would do the same */
+    pmix_id_to_mpi_rank(pmix_proc, rank, NULL);
 
     /* sessions: pmi_kvs_name is freed during finalize, so we need to set it
      * again in the reinitialization case */
@@ -125,12 +148,8 @@ static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
     pmix_value_t value;
     pmix_value_t *val = &value;
 
-    pmix_proc_t proc;
-    PMIX_PROC_CONSTRUCT(&proc);
-    MPL_strncpy(proc.nspace, pmix_proc.nspace, PMIX_MAX_NSLEN);
     for (int i = 0; i < *size; i++) {
-        proc.rank = i;
-        pmi_errno = PMIx_Get(&proc, PMIX_FABRIC_COORDINATES, NULL, 0, &val);
+        pmi_errno = PMIx_Get(&(procs[i]), PMIX_FABRIC_COORDINATES, NULL, 0, &val);
         if (pmi_errno != PMIX_SUCCESS) {
             MPIR_Process.coords = NULL;
             break;
@@ -171,6 +190,9 @@ static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
 
 static void pmix_exit(void)
 {
+    if (pmix_procs != NULL) {
+        PMIX_DATA_ARRAY_FREE(pmix_procs);
+    }
     PMIx_Finalize(NULL, 0);
 }
 
@@ -206,11 +228,13 @@ static int pmix_get(int src, const char *key, char *val, int val_size)
 
     pmix_value_t *pvalue;
     if (src < 0) {
+        /* TODO: We must not use pmix_wcproc here once we have cases where there can be
+         * multiple namespaces in pmix_procs */
         pmi_errno = PMIx_Get(&pmix_wcproc, key, NULL, 0, &pvalue);
     } else {
         pmix_proc_t proc;
         PMIX_PROC_CONSTRUCT(&proc);
-        proc.rank = src;
+        mpi_rank_to_pmix_id(src, &proc);
 
         pmi_errno = PMIx_Get(&proc, key, NULL, 0, &pvalue);
     }
@@ -263,6 +287,8 @@ static bool pmix_get_jobattr(const char *key, char *valbuf)
     int flag = 1;
     PMIx_Info_load(info, PMIX_IMMEDIATE, &flag, PMIX_BOOL);
 
+    /* TODO: check if pmix_wcproc is sufficient here if there are multiple
+     * namespaces in pmix_procs */
     int pmi_errno = PMIx_Get(&pmix_wcproc, key, info, 1, &pvalue);
     if (pmi_errno == PMIX_SUCCESS) {
         strncpy(valbuf, pvalue->data.string, pmi_max_val_size);
@@ -284,8 +310,7 @@ static int pmix_barrier(void)
     int flag = 1;
     PMIx_Info_load(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
 
-    /* use global wildcard proc set */
-    pmi_errno = PMIx_Fence(&pmix_wcproc, 1, info, 1);
+    pmi_errno = PMIx_Fence((pmix_proc_t *) pmix_procs->array, pmix_procs->size, info, 1);
     MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                          "**pmix_fence", "**pmix_fence %d", pmi_errno);
     PMIX_INFO_FREE(info, 1);
@@ -301,8 +326,7 @@ static int pmix_barrier_only(void)
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
 
-    /* use global wildcard proc set */
-    pmi_errno = PMIx_Fence(&pmix_wcproc, 1, NULL, 0);
+    pmi_errno = PMIx_Fence((pmix_proc_t *) pmix_procs->array, pmix_procs->size, NULL, 0);
     MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                          "**pmix_fence", "**pmix_fence %d", pmi_errno);
 
@@ -321,7 +345,7 @@ static int pmix_barrier_local(void)
     pmix_proc_t *procs = NULL;
     PMIX_PROC_CREATE(procs, local_size);
     for (int i = 0; i < local_size; i++) {
-        PMIX_LOAD_PROCID(&(procs[i]), pmix_proc.nspace, MPIR_Process.node_local_map[i]);
+        mpi_rank_to_pmix_id(MPIR_Process.node_local_map[i], &(procs[i]));
     }
 
     pmix_info_t *info;
@@ -397,11 +421,13 @@ static int pmix_get_binary(int src, const char *key, char *buf, int *p_size, int
     int bufsize ATTRIBUTE((unused)) = *p_size;
     pmix_value_t *pvalue;
     if (src < 0) {
+        /* TODO: We must not use pmix_wcproc here once we have cases where there can be
+         * multiple namespaces in pmix_procs */
         pmi_errno = PMIx_Get(&pmix_wcproc, key, NULL, 0, &pvalue);
     } else {
         pmix_proc_t proc;
         PMIX_PROC_CONSTRUCT(&proc);
-        proc.rank = src;
+        mpi_rank_to_pmix_id(src, &proc);
 
         pmi_errno = PMIx_Get(&proc, key, NULL, 0, &pvalue);
     }
@@ -436,6 +462,9 @@ static int pmix_get_universe_size(int *universe_size)
     int pmi_errno;
     pmix_value_t *pvalue = NULL;
 
+    /* TODO: Double-check if using pmix_wcproc here yields correct results for
+     * the PMIX_UNIV_SIZE if there are multiple namespaces in pmix_procs.
+     * Is this a case that must be supported here? */
     pmi_errno = PMIx_Get(&pmix_wcproc, PMIX_UNIV_SIZE, NULL, 0, &pvalue);
     if (pmi_errno == PMIX_ERR_NOT_FOUND) {
         *universe_size = MPIR_UNIVERSE_SIZE_NOT_AVAILABLE;
@@ -995,30 +1024,22 @@ void pmix_pset_define_callback(size_t refid, pmix_status_t status, const pmix_pr
                 if (!PMIX_CHECK_NSPACE(proc.nspace, pmix_proc.nspace)) {
                     /* Currently PMIx process sets only work if all MPI processes
                      * are in one PMIx namespace due to a lack of consistent mapping
-                     * from PMIx process ID to MPI rank. For now, ignore the pset if
-                     * it includes a process from a different namespace */
+                     * from PMIx process ID to MPI rank across different namespaces.
+                     * See comments in pmix_init.
+                     *
+                     * For now, ignore the pset if it includes a process from a
+                     * different namespace.
+                     *
+                     * TODO: Remove this case here once multiple namespaces in
+                     * pmix_procs are supported */
                     MPL_DBG_MSG_FMT(MPIR_DBG_INIT, TYPICAL, (MPL_DBG_FDEST,
                                                              "PMIx pset define callback: \
                                                              pset '%s' includes process from different namespace: %s. \
                                                              This is not supported yet and the pset is ignored.", pset_name, proc.nspace));
                     goto fn_exit;
                 }
-                /* TODO: Use a global mapping of PMIx proc ID (namespace + rank) to MPI rank.
-                 * We plan to to this based on a PMIx Process Group that will be created upon
-                 * MPI_Session_init when previously no MPI session existed (first session or
-                 * re-init). The PMIx Process Group shall include all active (i.e., not
-                 * terminated, running, including spawned) processes. Based on the overall group
-                 * membership, the PMIx process ID will be mapped to an MPI rank. This mapping
-                 * will be used here instead of relying solely on the PMIx rank.
-                 *
-                 * Constraint for dynamic resources/ malleability operations: All MPI sessions
-                 * that exist when a resource change shall take place will have to undergo the
-                 * malleability operation. Meaning: All sessions have to be finalized to have a
-                 * clean re-init and update of global parameters when the PMIx Process Group is
-                 * re-created. There will be a (short) time during a malleability operation when
-                 * no session exists. MPI parameters such as rank, size, node map, etc. will be
-                 * updated during the re-init. */
-                members[k] = (MPIR_Pset_member) proc.rank;
+
+                pmix_id_to_mpi_rank(proc, (int *) &(members[k]), NULL);
             }
         }
 
@@ -1206,9 +1227,52 @@ int pmix_deregister_event_handlers(void)
 #endif
 }
 
+static
+void pmix_id_to_mpi_rank(pmix_proc_t proc, int *rank, int *size)
+{
+    size_t n = pmix_procs->size;
+    pmix_proc_t *procs = (pmix_proc_t *) pmix_procs->array;
+    size_t i;
+
+    /* Overflow check */
+    MPIR_Assert(n <= INT_MAX);
+    if (size) {
+        *size = (int) n;
+    }
+
+    if (!rank) {
+        return;
+    }
+
+    /* Find the proc in the array */
+    for (i = 0; i < n; i++) {
+        if (PMIX_CHECK_RANK(procs[i].rank, proc.rank) &&
+            PMIX_CHECK_NSPACE(procs[i].nspace, proc.nspace)) {
+            /* Overflow check */
+            MPIR_Assert(i <= INT_MAX);
+            *rank = (int) i;
+            break;
+        }
+    }
+}
+
+static
+void mpi_rank_to_pmix_id(int rank, pmix_proc_t * proc)
+{
+    /* Sanity check */
+    MPIR_Assert(rank < pmix_procs->size);
+
+    if (proc == NULL) {
+        PMIX_PROC_CREATE(proc, 1);
+    }
+
+    /* MPI rank is index of proc in the array */
+    pmix_proc_t *procs = (pmix_proc_t *) pmix_procs->array;
+    PMIX_LOAD_PROCID(proc, procs[rank].nspace, procs[rank].rank);
+}
 
 
-#else  /* ENABLE_PMIX */
+#else /* ENABLE_PMIX */
 
 static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
 {
@@ -1313,7 +1377,8 @@ static int pmix_unpublish(const char name[])
     return MPI_ERR_INTERN;
 }
 
-static int pmix_deregister_event_handlers(void) {
+static int pmix_deregister_event_handlers(void)
+{
     return MPI_ERR_INTERN;
 }
 
@@ -1327,31 +1392,93 @@ static int pmix_build_nodemap(int *nodemap, int sz)
 #else
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
-    char *nodelist = NULL, *node = NULL;
-    pmix_proc_t *procs = NULL;
-    size_t nprocs, node_id = 0;
+    UT_array *nspaces = NULL;
+    UT_array *nodelist = NULL;
+    pmix_proc_t *procs = (pmix_proc_t *) pmix_procs->array;
 
-    pmi_errno = PMIx_Resolve_nodes(pmix_proc.nspace, &nodelist);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_resolve_nodes", "**pmix_resolve_nodes %d", pmi_errno);
-    MPIR_Assert(nodelist);
-
-    node = strtok(nodelist, ",");
-    while (node) {
-        pmi_errno = PMIx_Resolve_peers(node, pmix_proc.nspace, &procs, &nprocs);
-        MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                             "**pmix_resolve_peers", "**pmix_resolve_peers %d", pmi_errno);
-        for (int i = 0; i < nprocs; i++) {
-            nodemap[procs[i].rank] = node_id;
+    /* STEP 1: Build list of namespaces
+     * This is trivial for cases with only one namespace, i.e. nspaces,
+     * will contain exactly one element in this case. */
+    utarray_new(nspaces, &ut_str_icd, MPL_MEM_OTHER);
+    for (size_t i = 0; i < pmix_procs->size; i++) {
+        /* Add non-duplicate nspaces to list */
+        bool is_duplicate = false;
+        char *nspace = procs[i].nspace;
+        for (unsigned u = 0; u < utarray_len(nspaces); u++) {
+            char *n = *(char **) utarray_eltptr(nspaces, u);
+            if (strncmp(nspace, n, MIN(strlen(nspace), strlen(n))) == 0) {
+                is_duplicate = true;
+                break;
+            }
         }
-        node_id++;
-        node = strtok(NULL, ",");
+        if (!is_duplicate) {
+            utarray_push_back(nspaces, &nspace, MPL_MEM_OTHER);
+        }
     }
-    /* PMIx latest adds pmix_free. We should switch to that at some point */
-    MPL_external_free(nodelist);
-    PMIX_PROC_FREE(procs, nprocs);
+
+    /* STEP 2: Build list of nodes, resolve nodes and processes for all namespaces */
+    utarray_new(nodelist, &ut_str_icd, MPL_MEM_OTHER);
+
+    for (unsigned i = 0; i < utarray_len(nspaces); i++) {
+        char *nspace = *(char **) utarray_eltptr(nspaces, i);
+        char *nodes = NULL, *node = NULL;
+
+        pmi_errno = PMIx_Resolve_nodes(nspace, &nodes);
+        MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                             "**pmix_resolve_nodes", "**pmix_resolve_nodes %d", pmi_errno);
+        MPIR_Assert(nodes);
+
+        node = strtok(nodes, ",");
+        while (node) {
+            /* Add non-duplicate nodes to list */
+            bool is_duplicate = false;
+            unsigned node_id = 0;
+            for (node_id = 0; node_id < utarray_len(nodelist); node_id++) {
+                char *n = *(char **) utarray_eltptr(nodelist, node_id);
+                if (strncmp(node, n, MIN(strlen(node), strlen(n))) == 0) {
+                    is_duplicate = true;
+                    break;
+                }
+            }
+            if (!is_duplicate) {
+                utarray_push_back(nodelist, &node, MPL_MEM_OTHER);
+            }
+
+            /* Resolve processes of this nspace on node */
+            pmix_proc_t *node_procs = NULL;
+            size_t nnode_procs = 0;
+            pmi_errno = PMIx_Resolve_peers(node, nspace, &node_procs, &nnode_procs);
+            MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                                 "**pmix_resolve_peers", "**pmix_resolve_peers %d", pmi_errno);
+
+            if (nnode_procs > 0) {
+                /* Iterate over peers to set their node id (outer loop) */
+                for (size_t j = 0; j < nnode_procs; j++) {
+                    int rank = -1;
+                    pmix_id_to_mpi_rank(node_procs[j], &rank, NULL);
+                    MPIR_Assert(rank < MPIR_Process.size);
+                    /* rank == -1 means that node_procs[j] is not participating in pmix_procs => terminated */
+                    if (rank != -1) {
+                        /* node_id is determined above where this node is compared to
+                         * the content of the nodelist and eventually added to it */
+                        nodemap[rank] = node_id;
+                    }
+                }
+                PMIX_PROC_FREE(node_procs, nnode_procs);
+            }
+            node = strtok(NULL, ",");
+        }
+        /* PMIx latest adds pmix_free. We should switch to that at some point */
+        MPL_external_free(nodes);
+    }
 
   fn_exit:
+    if (nodelist) {
+        utarray_free(nodelist);
+    }
+    if (nspaces) {
+        utarray_free(nspaces);
+    }
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -5,6 +5,22 @@
 
 #ifdef ENABLE_PMIX
 
+/* Assumption: We are using OpenPMIx if all of
+ * - PMIX_VERSION_{MAJOR, MINOR, RELEASE}
+ * - PMIX_NUMERIC_VERSION
+ * are defined. These are not part of the PMIx standard but are
+ * provided by OpenPMIx in pmix_version.h. Macros for checks about
+ * specific versions only work for OpenPMIx. If we are not using
+ * OpenPMIx: Enable features and rely on compiler and PMIx runtime
+ * environment to detect unsupported features or APIs. */
+#if defined (PMIX_VERSION_MAJOR) && defined (PMIX_VERSION_MINOR) && \
+    defined (PMIX_VERSION_RELEASE) && defined (PMIX_NUMERIC_VERSION)
+/* PMIx Process Sets are supported since OpenPMIx major version 4 */
+#define HAVE_PMIX_MIN_VERSION_4 (PMIX_VERSION_MAJOR >= 4)
+#else
+#define HAVE_PMIX_MIN_VERSION_4 1
+#endif
+
 /* PMIx_Info_load is only in OpenPMIx >= 5.0. Previous versions provide a macro. */
 #ifdef NEED_PMIX_INFO_LOAD
 #define PMIx_Info_load PMIX_INFO_LOAD
@@ -34,6 +50,10 @@ static int pmix_prep_spawn(int count, char *commands[], char **argvs[], const in
                            MPIR_Info * info_ptrs[], pmix_app_t * apps, pmix_info_t ** job_info,
                            size_t * njob_info);
 static int pmix_fence_nspace_proc(const char *nspace, const char *parent_nspace, int parent_rank);
+
+static int pmix_pset_define_hdlr;
+static int pmix_pset_delete_hdlr;
+static int pmix_register_event_handlers(void);
 
 static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
 {
@@ -133,6 +153,8 @@ static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
             }
         }
     }
+
+    pmix_register_event_handlers();
 
   fn_exit:
     return mpi_errno;
@@ -919,7 +941,274 @@ int pmix_fence_nspace_proc(const char *nspace, const char *parent_nspace, int pa
     goto fn_exit;
 }
 
-#else /* ENABLE_PMIX */
+/**
+ * @brief Callback for PMIx process set define event handler
+ *        (for function prototype see PMIx 4 standard)
+ */
+static
+void pmix_pset_define_callback(size_t refid, pmix_status_t status, const pmix_proc_t * source,
+                               pmix_info_t * info, size_t ninfo, pmix_info_t * results,
+                               size_t nresults, pmix_event_notification_cbfunc_fn_t cbfunc,
+                               void *cbdata)
+{
+    pmix_status_t cb_status = PMIX_EVENT_ACTION_COMPLETE;
+#if HAVE_PMIX_MIN_VERSION_4
+    char *pset_name = NULL;
+    pmix_proc_t *membership = NULL;
+    MPIR_Pset_member *members = NULL;
+    int size = 0;
+    bool name_key_found = false;
+    bool membership_key_found = false;
+    bool process_in_pset = false;
+    MPIR_Pset *new_pset = NULL;
+
+    /* Extract pset name and membership from the info object */
+    for (size_t i = 0; i < ninfo; i++) {
+        if (PMIX_CHECK_KEY(&(info[i]), PMIX_PSET_NAME)) {
+            name_key_found = true;
+            pset_name = info[i].value.data.string;
+        } else if (PMIX_CHECK_KEY(&(info[i]), PMIX_PSET_MEMBERS)) {
+            membership_key_found = true;
+
+            /* Overflow check */
+            MPIR_Assert(info[i].value.data.darray->size <= INT_MAX);
+            size = (int) info[i].value.data.darray->size;
+
+            /* Create members array for new pset  */
+            membership = (pmix_proc_t *) info[i].value.data.darray->array;
+            members = MPL_malloc(size * sizeof(MPIR_Pset_member), MPL_MEM_OTHER);
+            if (members == NULL) {
+                cb_status = PMIX_EVENT_NO_ACTION_TAKEN;
+                goto fn_exit;
+            }
+            for (int k = 0; k < size; k++) {
+                pmix_proc_t proc = membership[k];
+
+                /* Check overflow */
+                MPIR_Assert(proc.rank <= INT_MAX);
+
+                if (PMIX_CHECK_RANK(proc.rank, pmix_proc.rank) &&
+                    PMIX_CHECK_NSPACE(proc.nspace, pmix_proc.nspace)) {
+                    process_in_pset = true;
+                }
+
+                if (!PMIX_CHECK_NSPACE(proc.nspace, pmix_proc.nspace)) {
+                    /* Currently PMIx process sets only work if all MPI processes
+                     * are in one PMIx namespace due to a lack of consistent mapping
+                     * from PMIx process ID to MPI rank. For now, ignore the pset if
+                     * it includes a process from a different namespace */
+                    MPL_DBG_MSG_FMT(MPIR_DBG_INIT, TYPICAL, (MPL_DBG_FDEST,
+                                                             "PMIx pset define callback: \
+                                                             pset '%s' includes process from different namespace: %s. \
+                                                             This is not supported yet and the pset is ignored.", pset_name, proc.nspace));
+                    goto fn_exit;
+                }
+                /* TODO: Use a global mapping of PMIx proc ID (namespace + rank) to MPI rank.
+                 * We plan to to this based on a PMIx Process Group that will be created upon
+                 * MPI_Session_init when previously no MPI session existed (first session or
+                 * re-init). The PMIx Process Group shall include all active (i.e., not
+                 * terminated, running, including spawned) processes. Based on the overall group
+                 * membership, the PMIx process ID will be mapped to an MPI rank. This mapping
+                 * will be used here instead of relying solely on the PMIx rank.
+                 *
+                 * Constraint for dynamic resources/ malleability operations: All MPI sessions
+                 * that exist when a resource change shall take place will have to undergo the
+                 * malleability operation. Meaning: All sessions have to be finalized to have a
+                 * clean re-init and update of global parameters when the PMIx Process Group is
+                 * re-created. There will be a (short) time during a malleability operation when
+                 * no session exists. MPI parameters such as rank, size, node map, etc. will be
+                 * updated during the re-init. */
+                members[k] = (MPIR_Pset_member) proc.rank;
+            }
+        }
+
+        if (name_key_found && membership_key_found) {
+            break;
+        }
+    }
+
+    if (!name_key_found || !membership_key_found || pset_name == NULL || members == NULL) {
+        cb_status = PMIX_EVENT_NO_ACTION_TAKEN;
+        goto fn_exit;
+    }
+
+    if (size == 0) {
+        /* Prevent adding empty psets (no error) */
+        MPL_DBG_MSG_FMT(MPIR_DBG_INIT, TYPICAL, (MPL_DBG_FDEST,
+                                                 "PMIx pset define callback: pset '%s' has size 0 and is not added.",
+                                                 pset_name));
+        goto fn_exit;
+    }
+
+    if (!process_in_pset) {
+        /* Prevent adding a pset in which the process is not a member (no error) */
+        MPL_DBG_MSG_FMT(MPIR_DBG_INIT, TYPICAL, (MPL_DBG_FDEST,
+                                                 "PMIx pset define callback: not a member of pset '%s', pset not added.",
+                                                 pset_name));
+        goto fn_exit;
+    }
+
+    /* Sort members array, required for group creation from pset */
+    qsort(members, (size_t) size, sizeof(MPIR_Pset_member), MPIR_Pset_member_compare);
+
+    /* Create the new pset and add it to the global pmix pset array */
+    new_pset = MPL_malloc(sizeof(MPIR_Pset), MPL_MEM_OTHER);
+    new_pset->uri = pset_name;
+    new_pset->size = size;
+    new_pset->is_valid = true;
+    new_pset->members = members;
+
+    int add_status = MPIR_Pset_add(new_pset);
+    if (add_status == MPI_ERR_OTHER) {
+        cb_status = PMIX_EVENT_NO_ACTION_TAKEN;
+        MPL_DBG_MSG_FMT(MPIR_DBG_INIT, TYPICAL, (MPL_DBG_FDEST,
+                                                 "PMIx pset define callback: pset '%s' already exists, not added again.",
+                                                 pset_name));
+        goto fn_exit;
+    }
+
+  fn_exit:
+    if (members != NULL)
+        MPL_free(members);
+    if (new_pset != NULL)
+        MPL_free(new_pset);
+#endif
+    /* If a callback function is provided, we have to call it.
+     * We cannot treat errors here, but we can give a hint via cbfunc status that something went wrong */
+    if (NULL != cbfunc) {
+        cbfunc(cb_status, NULL, 0, NULL, NULL, cbdata);
+    }
+
+    return;
+}
+
+/**
+ * @brief Callback for PMIx process set delete event handler
+ *        (for function prototype see PMIx 4 standard)
+ */
+static
+void pmix_pset_delete_callback(size_t refid, pmix_status_t status, const pmix_proc_t * source,
+                               pmix_info_t * info, size_t ninfo, pmix_info_t * results,
+                               size_t nresults, pmix_event_notification_cbfunc_fn_t cbfunc,
+                               void *cbdata)
+{
+    pmix_status_t cb_status = PMIX_EVENT_ACTION_COMPLETE;
+#if HAVE_PMIX_MIN_VERSION_4
+    char *pset_name = NULL;
+    bool key_found = false;
+
+    /* Extract pset name from the info object */
+    for (size_t i = 0; i < ninfo; i++) {
+        if (PMIX_CHECK_KEY(&(info[i]), PMIX_PSET_NAME)) {
+            key_found = true;
+            pset_name = info[i].value.data.string;
+            break;
+        }
+    }
+
+    if (!key_found) {
+        cb_status = PMIX_EVENT_NO_ACTION_TAKEN;
+        goto fn_exit;
+    }
+
+    /* Search in known PMIx psets for pset_name and invalidate the pset */
+    int ret = MPIR_Pset_invalidate(pset_name);
+    if (ret == MPI_ERR_OTHER) {
+        /* Pset not found in this process (not an error!) */
+        MPL_DBG_MSG_FMT(MPIR_DBG_INIT, TYPICAL, (MPL_DBG_FDEST,
+                                                 "PMIx pset delete callback: pset '%s' not found.",
+                                                 pset_name));
+    }
+
+  fn_exit:
+#endif
+    if (NULL != cbfunc) {
+        /* If a callback function is provided, we have to call it
+         * We cannot treat an error here, but we can give a hint via cbfunc status that something went wrong */
+        cbfunc(cb_status, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static
+int pmix_register_event_handlers(void)
+{
+#if HAVE_PMIX_MIN_VERSION_4
+    int mpi_errno = MPI_SUCCESS;
+    /* Set the PMIX codes of the events for which handlers shall be registered */
+    pmix_status_t code_pset_define[1] = { PMIX_PROCESS_SET_DEFINE };
+    pmix_status_t code_pset_delete[1] = { PMIX_PROCESS_SET_DELETE };
+
+    /* Give handlers a name so we can identify them more easily */
+    pmix_info_t info_pset_define[1];
+    pmix_info_t info_pset_delete[1];
+
+    PMIX_INFO_LOAD(&info_pset_define[0], PMIX_EVENT_HDLR_NAME, "Process-Set-Define", PMIX_STRING);
+    PMIX_INFO_LOAD(&info_pset_delete[0], PMIX_EVENT_HDLR_NAME, "Process-Set-Delete", PMIX_STRING);
+
+    /* Register event handlers for PMIx process set define and delete events
+     * in a blocking way (last two parameters are NULL) and treat errors */
+    pmix_pset_define_hdlr =
+        (int) PMIx_Register_event_handler(code_pset_define, 1, info_pset_define, 1,
+                                          pmix_pset_define_callback, NULL, NULL);
+    if (pmix_pset_define_hdlr < 0) {
+        MPIR_ERR_CHKANDJUMP1(pmix_pset_define_hdlr != PMIX_SUCCESS, mpi_errno,
+                             MPI_ERR_OTHER, "**pmix_register_event_handler",
+                             "**pmix_register_event_handler %d", pmix_pset_define_hdlr);
+    }
+    pmix_pset_delete_hdlr =
+        (int) PMIx_Register_event_handler(code_pset_delete, 1, info_pset_delete, 1,
+                                          pmix_pset_delete_callback, NULL, NULL);
+    if (pmix_pset_delete_hdlr < 0) {
+        MPIR_ERR_CHKANDJUMP1(pmix_pset_delete_hdlr != PMIX_SUCCESS, mpi_errno,
+                             MPI_ERR_OTHER, "**pmix_register_event_handler",
+                             "**pmix_register_event_handler %d", pmix_pset_delete_hdlr);
+    }
+
+    /* Release PMIx info objects */
+    PMIX_INFO_DESTRUCT(&info_pset_define[0]);
+    PMIX_INFO_DESTRUCT(&info_pset_delete[0]);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+#else
+    return MPI_SUCCESS;
+#endif
+}
+
+static
+int pmix_deregister_event_handlers(void)
+{
+#if HAVE_PMIX_MIN_VERSION_4
+    int mpi_errno = MPI_SUCCESS;
+    /* Deregister PMIx event handler for pset define and delete events
+     * in a blocking way (last two parameters are NULL) and treat errors */
+    pmix_status_t rc;
+    rc = PMIx_Deregister_event_handler((size_t) pmix_pset_define_hdlr, NULL, NULL);
+    MPIR_ERR_CHKANDJUMP1(rc != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_deregister_event_handler", "**pmix_deregister_event_handler %d",
+                         rc);
+    pmix_pset_define_hdlr = 0;
+
+    rc = PMIx_Deregister_event_handler((size_t) pmix_pset_delete_hdlr, NULL, NULL);
+    MPIR_ERR_CHKANDJUMP1(rc != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_deregister_event_handler", "**pmix_deregister_event_handler %d",
+                         rc);
+    pmix_pset_delete_hdlr = 0;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+#else
+    return MPI_SUCCESS;
+#endif
+}
+
+
+
+#else  /* ENABLE_PMIX */
 
 static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
 {
@@ -1021,6 +1310,10 @@ static int pmix_lookup(const char name[], char port[], int port_len)
 
 static int pmix_unpublish(const char name[])
 {
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_deregister_event_handlers(void) {
     return MPI_ERR_INTERN;
 }
 


### PR DESCRIPTION
## Pull Request Description

This PR is a contribution from ParTec AG, Germany. It is originally developed and tested with [ParaStation MPI](https://github.com/ParaStation/psmpi) as part of the European High Performance Computing Joint Undertaking [DEEP-SEA](https://www.deep-projects.eu/).

The PR adds two enhancements for MPI Sessions:
1. New infrastructure for process set management
2. Integration of PMIx process sets
    - Make process sets accessible that are defined by the process manager, e.g., based on node attributes such as cluster or booster type
    - Receive resource updates during runtime in an MPI Session, e.g., for malleability operations a new process set with a different size

We thought about splitting the enhancements into two separate PRs. However, based on the experience of our internal review and due to the tight coupling, it makes more sense to keep the discussions in one place.

### 1. New infrastructure for process set management
The goals of this enhancement are:
- Adding a new memory class `MPL_MEM_SESSION` for memory allocations related to MPI Sessions
- Introducing an `MPIR_Pset` data structure that contains information about a process set including its URI, size, members and validity status
- Providing each MPI Session with its own view of available process sets 
- Providing routines that enable the initialization, destruction, addition, and invalidation of process sets for multiple sources of process sets (e.g. MPI standard and process manager)
- Providing routines that manage access to process sets (count, access via URI or index) independent of their source

### 2. Integration of PMIx process sets

#### Concept and approach
The [PMIx 4.1 standard](https://github.com/pmix/pmix-standard/releases/tag/v4.1) provides a concept to define and delete process sets in the PMIx Server (see Sec. 13.1). These process sets are exposed to PMIx clients in two ways: Either by queries  (see Ch. 5) or via the event notification mechanism of PMIx (see Ch. 9) upon definition and deletion of a process set.

For scalability reasons, our proposed solution is based on the event notification mechanism of PMIx. We believe that the number of queries required to keep a consistent view on PMIx process sets would lead to a large overhead in the PMIx server and (eventually) waiting times or inconsistencies on client side.

#### Concurrency
The event-based approach comes with the challenge of concurrency of the MPI ranks and event thread of the PMIx client library (one such thread per MPI process). Upon definition or deletion of a process set, the PMIx server emits an event. A client who registered for the event calls an event handler asynchronously  via the event thread that is started by the PMIx client library upon startup (`PMIx_Init`).

To add a process set (define event) and to mark a process set as invalid (delete event) in MPI, the event handlers need to work on the global data structure `MPIR_Process.pm_pset_array` that is potentially used by MPI ranks concurrently. Hence, there are critical sections that need to be protected independent of the MPI being compiled as multi-threaded or not.

In future work, we plan to explore an alternative solution without the event thread in the PMIx client using external PMIx progress. First investigations in this direction lead us to the conclusion that we should not mix such a change of PMIx progress management with the features of this PR.

#### Requirements and testing

We tested our solution with [OpenPMIx](https://github.com/openpmix/openpmix/releases/tag/v4.2.3) and the [ParaStation Management](https://github.com/ParaStation/psmgmt) process manager (min version 5.1.54).

**Remark 1:** Please note that PMIx 4 is required to compile and use the proposed solution. Conditional pragmas  prevent the PMIx process set solution from being added to the MPI library if PMIx 3 or PMI(2) is used. In these cases, only the MPI default process sets are available using the new process set infrastructure described as enhancement 1 above.

**Remark 2:** It is not sufficient to have a PMIx 4-compatible process manager to actually "see" PMIx process sets in MPI. The PM has to define the process sets explicitly using the respective API of the PMIx 4 standard. ParaStation Management defines some process sets using the naming prefix `pspmix:` as of version 5.1.54.

**Remark 3:** If PMIx-based process sets are provided by the process manager, the `init/session_psets` test will test MPI Session routines for them without any changes to the test.

## Author Checklist
* [X] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [X] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [X] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
