### PR TITLE
ch4/ofi: add MPIR_CVAR_SINGLE_HOST_ENABLED

### DIFF
--- a/src/mpid/ch4/netmod/ofi/init_provider.c
+++ b/src/mpid/ch4/netmod/ofi/init_provider.c
@@ -25,7 +25,7 @@ cvars:
     - name        : MPIR_CVAR_SINGLE_HOST_ENABLED
       category    : DEVELOPER
       type        : boolean
-      default     : false
+      default     : true
       class       : none
       verbosity   : MPI_T_VERBOSITY_MPIDEV_DETAIL
       scope       : MPI_T_SCOPE_ALL_EQ
@@ -264,7 +264,8 @@ static int provider_preference(const char *prov_name)
         return -2;
     }
 
-    if (MPIR_CVAR_SINGLE_HOST_ENABLED && strcmp(prov_name, "cxi") == 0) {
+    if (MPIR_Process.num_nodes == 1 && MPIR_CVAR_SINGLE_HOST_ENABLED &&
+        strcmp(prov_name, "cxi") == 0) {
         return -100;
     }
 

--- a/src/mpid/ch4/netmod/ofi/init_provider.c
+++ b/src/mpid/ch4/netmod/ofi/init_provider.c
@@ -22,6 +22,18 @@ cvars:
         This variable is no longer supported. Use FI_PROVIDER instead to
         select libfabric providers.
 
+    - name        : MPIR_CVAR_SINGLE_HOST_ENABLED
+      category    : DEVELOPER
+      type        : boolean
+      default     : false
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_MPIDEV_DETAIL
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        Set this variable to true to indicate that processes are
+        launched on a single host. The current implication is to avoid
+        the cxi provider to prevent the use of scarce hardware resources.
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
@@ -250,6 +262,10 @@ static int provider_preference(const char *prov_name)
     if (n > 8 && strcmp(prov_name + n - 8, ";ofi_rxd") == 0) {
         /* ofi_rxd have more test failures */
         return -2;
+    }
+
+    if (MPIR_CVAR_SINGLE_HOST_ENABLED && strcmp(prov_name, "cxi") == 0) {
+        return -100;
     }
 
     return 0;


### PR DESCRIPTION
## Pull Request Description

This CVAR is used by Cray environment when a job step is launched on a single host. It is set when launchers doesn't not provide a VNI for slingshot nic and we need skip the cxi provider.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
