### PR TITLE
coll: use pointer instead of array in MPIC_Waitall

### DIFF
--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -47,7 +47,7 @@ int MPIC_Issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest
                 MPIR_Comm * comm_ptr, MPIR_Request ** request, MPIR_Errflag_t errflag);
 int MPIC_Irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source,
                int tag, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status statuses[]);
+int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status * statuses);
 
 int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,
                       MPI_Op op);

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -525,7 +525,7 @@ int MPIC_Irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source,
 }
 
 
-int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status statuses[])
+int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status * statuses)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;


### PR DESCRIPTION
## Pull Request Description
Because the statuses parameter can accept MPI_STATUSES_IGNORE, we need use pointer rather than array, or the modern compiler may complain.

Fixes #6366 
[skip warnings]


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
