### PR TITLE
test/io: Fix io/zero_count test fo out-of-tree execution.

### DIFF
--- a/test/mpi/io/zero_count.c
+++ b/test/mpi/io/zero_count.c
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     int errs = 0;
     int len, rank, get_size;
     char buf[10];
-    const char *filename = __FILE__;
+    const char *filename = argv[0];
     MPI_File fh;
     MPI_Status status;
 


### PR DESCRIPTION
The io/zero_count test tries to read from its source file. This only works for its execution within the source tree. This patch opens the binary for reading instead.

(This patch re-applies the fix from: db1bd3f09)

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
