### PR TITLE
coll/gpu: Stream read bcast and alltoall

### DIFF
--- a/src/mpid/ch4/shm/posix/Makefile.mk
+++ b/src/mpid/ch4/shm/posix/Makefile.mk
@@ -24,7 +24,8 @@ noinst_HEADERS += src/mpid/ch4/shm/posix/posix_am.h        \
                   src/mpid/ch4/shm/posix/posix_pre.h       \
                   src/mpid/ch4/shm/posix/posix_types.h     \
                   src/mpid/ch4/shm/posix/posix_progress.h  \
-                  src/mpid/ch4/shm/posix/posix_coll_release_gather.h
+                  src/mpid/ch4/shm/posix/posix_coll_release_gather.h    \
+                  src/mpid/ch4/shm/posix/posix_coll_gpu_ipc.h
 
 mpi_core_sources += src/mpid/ch4/shm/posix/globals.c    \
                     src/mpid/ch4/shm/posix/posix_comm.c \

--- a/src/mpid/ch4/shm/posix/posix_coll.h
+++ b/src/mpid/ch4/shm/posix/posix_coll.h
@@ -97,6 +97,18 @@ cvars:
         release_gather - Force shm optimized algo using release, gather primitives
         auto - Internal algorithm selection (can be overridden with MPIR_CVAR_CH4_POSIX_COLL_SELECTION_TUNING_JSON_FILE)
 
+    - name        : MPIR_CVAR_ALLTOALL_POSIX_INTRA_ALGORITHM
+      category    : COLLECTIVE
+      type        : enum
+      default     : mpir
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : |-
+        Variable to select algorithm for intra-node alltoall
+        mpir           - Fallback to MPIR collectives (default)
+        ipc_read    - Uses read-based collective with ipc
+
     - name        : MPIR_CVAR_POSIX_POLL_FREQUENCY
       category    : COLLECTIVE
       type        : int
@@ -454,18 +466,34 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoall(const void *sendbuf, MPI_A
                                                       MPI_Aint recvcount, MPI_Datatype recvtype,
                                                       MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
-    int mpi_errno;
+    int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Alltoall_impl(sendbuf, sendcount, sendtype,
-                                   recvbuf, recvcount, recvtype, comm, errflag);
+    switch (MPIR_CVAR_ALLTOALL_POSIX_INTRA_ALGORITHM) {
+        case MPIR_CVAR_ALLTOALL_POSIX_INTRA_ALGORITHM_ipc_read:
+            mpi_errno = MPIDI_POSIX_mpi_alltoall_gpu_ipc_read(sendbuf, sendcount, sendtype,
+                                                              recvbuf, recvcount, recvtype,
+                                                              comm, errflag);
+            break;
+
+        case MPIR_CVAR_ALLTOALL_POSIX_INTRA_ALGORITHM_mpir:
+            goto fallback;
+
+        default:
+            MPIR_Assert(0);
+    }
 
     MPIR_ERR_CHECK(mpi_errno);
+    goto fn_exit;
 
-    MPIR_FUNC_EXIT;
+  fallback:
+    mpi_errno = MPIR_Alltoall_impl(sendbuf, sendcount, sendtype,
+                                   recvbuf, recvcount, recvtype, comm, errflag);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
+    MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpid/ch4/shm/posix/posix_coll.h
+++ b/src/mpid/ch4/shm/posix/posix_coll.h
@@ -9,6 +9,7 @@
 #include "posix_impl.h"
 #include "ch4_impl.h"
 #include "posix_coll_release_gather.h"
+#include "posix_coll_gpu_ipc.h"
 #include "posix_csel_container.h"
 
 
@@ -28,6 +29,7 @@ cvars:
         mpir           - Fallback to MPIR collectives
         release_gather - Force shm optimized algo using release, gather primitives
         auto - Internal algorithm selection (can be overridden with MPIR_CVAR_CH4_POSIX_COLL_SELECTION_TUNING_JSON_FILE)
+        ipc_read - Uses read-based collective with ipc
 
     - name        : MPIR_CVAR_IBCAST_POSIX_INTRA_ALGORITHM
       category    : COLLECTIVE
@@ -189,6 +191,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast(void *buffer, MPI_Aint count,
                                            "Bcast release_gather cannot be applied.\n");
             mpi_errno =
                 MPIDI_POSIX_mpi_bcast_release_gather(buffer, count, datatype, root, comm, errflag);
+            break;
+
+        case MPIR_CVAR_BCAST_POSIX_INTRA_ALGORITHM_ipc_read:
+            mpi_errno =
+                MPIDI_POSIX_mpi_bcast_gpu_ipc_read(buffer, count, datatype, root, comm, errflag);
             break;
 
         case MPIR_CVAR_BCAST_POSIX_INTRA_ALGORITHM_mpir:

--- a/src/mpid/ch4/shm/posix/posix_coll_gpu_ipc.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_gpu_ipc.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+
+cvars:
+    - name        : MPIR_CVAR_BCAST_IPC_READ_MSG_SIZE_THRESHOLD
+      category    : COLLECTIVE
+      type        : int
+      default     : 256
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        Use gpu ipc read bcast only when the message size is larger than this
+        threshold.
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
+#ifndef POSIX_COLL_GPU_IPC_H_INCLUDED
+#define POSIX_COLL_GPU_IPC_H_INCLUDED
+
+#include "../ipc/src/ipc_types.h"
+#include "../ipc/src/ipc_p2p.h"
+#include "../gpu/gpu_post.h"
+#include "../../../include/mpir_err.h"
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_gpu_ipc_read(void *buffer,
+                                                                MPI_Aint count,
+                                                                MPI_Datatype datatype,
+                                                                int root, MPIR_Comm * comm_ptr,
+                                                                MPIR_Errflag_t errflag)
+{
+    MPIR_FUNC_ENTER;
+    MPIR_CHKLMEM_DECL(1);
+
+    int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
+
+    MPI_Aint true_lb;
+    MPIR_Datatype *dt_ptr;
+    bool dt_contig;
+    uintptr_t data_sz;
+    MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, true_lb);
+    /* fallback if datatype is not contiguous or data size is not large enough */
+    if (!dt_contig || data_sz <= MPIR_CVAR_BCAST_IPC_READ_MSG_SIZE_THRESHOLD) {
+        goto fallback;
+    }
+
+    void *mem_addr = MPIR_get_contig_ptr(buffer, true_lb);
+    int my_rank = MPIR_Comm_rank(comm_ptr);
+    int comm_size = MPIR_Comm_size(comm_ptr);
+
+    MPIDI_IPCI_ipc_attr_t ipc_attr;
+    memset(&ipc_attr, 0, sizeof(ipc_attr));
+    MPIR_GPU_query_pointer_attr(mem_addr, &ipc_attr.gpu_attr);
+
+    /* set up ipc_handles */
+    MPIDI_IPCI_ipc_handle_t *ipc_handles = NULL;
+    MPIR_CHKLMEM_MALLOC(ipc_handles, MPIDI_IPCI_ipc_handle_t *,
+                        sizeof(MPIDI_IPCI_ipc_handle_t) * comm_size, mpi_errno, "IPC handles",
+                        MPL_MEM_COLL);
+
+    MPIDI_IPCI_ipc_handle_t my_ipc_handle;
+    memset(&my_ipc_handle, 0, sizeof(my_ipc_handle));
+    int dev_id = MPL_gpu_get_dev_id_from_attr(&ipc_attr.gpu_attr);
+    /* CPU memory, registered host memory and USM fallback to P2P bcast,
+     * GPU memory will use ipc read bcast
+     */
+    if (dev_id >= 0 && ipc_attr.gpu_attr.type == MPL_GPU_POINTER_DEV) {
+        mpi_errno = MPIDI_GPU_get_ipc_attr(mem_addr, my_rank, comm_ptr, &ipc_attr);
+        MPIR_ERR_CHECK(mpi_errno);
+        my_ipc_handle = ipc_attr.ipc_handle;
+    } else {
+        my_ipc_handle.gpu.global_dev_id = -1;
+    }
+
+    /* allgather is needed to exchange all the IPC handles */
+    mpi_errno =
+        MPIR_Allgather_impl(&my_ipc_handle, sizeof(MPIDI_IPCI_ipc_handle_t), MPI_BYTE, ipc_handles,
+                            sizeof(MPIDI_IPCI_ipc_handle_t), MPI_BYTE, comm_ptr, errflag);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* check the ipc_handles to make sure all the buffers are on GPU */
+    int errs = 0;
+    for (int i = 0; i < comm_size; i++) {
+        if (ipc_handles[i].gpu.global_dev_id < 0) {
+            errs++;
+            break;
+        }
+    }
+    if (errs > 0) {
+        goto fallback;
+    }
+
+    if (my_rank != root) {
+        /* map root's ipc_handle to remote_buf */
+        void *remote_buf = NULL;
+        bool do_mmap = (data_sz <= MPIR_CVAR_CH4_IPC_GPU_FAST_COPY_MAX_SIZE);
+        int root_dev =
+            MPIDI_GPU_ipc_get_map_dev(ipc_handles[root].gpu.global_dev_id, dev_id, datatype);
+        mpi_errno = MPIDI_GPU_ipc_handle_map(ipc_handles[root].gpu, root_dev, &remote_buf, do_mmap);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        /* get engine type */
+        MPL_gpu_engine_type_t engine_type =
+            MPIDI_IPCI_choose_engine(ipc_handles[root].gpu.global_dev_id,
+                                     my_ipc_handle.gpu.global_dev_id);
+
+        /* copy data from root */
+        mpi_errno = MPIR_Localcopy_gpu(remote_buf, count, datatype, NULL,
+                                       mem_addr, count, datatype, &ipc_attr.gpu_attr,
+                                       MPL_GPU_COPY_D2D_INCOMING, engine_type, true);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
+  fn_exit:
+    MPIR_CHKLMEM_FREEALL();
+    MPIR_FUNC_EXIT;
+    return mpi_errno_ret;
+  fn_fail:
+    goto fn_exit;
+  fallback:
+    /* Fall back to other algorithms as gpu ipc bcast cannot be used */
+    mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    goto fn_exit;
+
+}
+
+#endif /* POSIX_COLL_GPU_IPC_H_INCLUDED */

--- a/src/mpid/ch4/shm/posix/posix_coll_gpu_ipc.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_gpu_ipc.h
@@ -18,6 +18,17 @@ cvars:
         Use gpu ipc read bcast only when the message size is larger than this
         threshold.
 
+    - name        : MPIR_CVAR_ALLTOALL_IPC_READ_MSG_SIZE_THRESHOLD
+      category    : COLLECTIVE
+      type        : int
+      default     : 256
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        Use gpu ipc read alltoall only when the message size is larger than this
+        threshold.
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
@@ -129,6 +140,134 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_gpu_ipc_read(void *buffer,
     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     goto fn_exit;
 
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoall_gpu_ipc_read(const void *sendbuf,
+                                                                   MPI_Aint sendcount,
+                                                                   MPI_Datatype sendtype,
+                                                                   void *recvbuf,
+                                                                   MPI_Aint recvcount,
+                                                                   MPI_Datatype recvtype,
+                                                                   MPIR_Comm * comm_ptr,
+                                                                   MPIR_Errflag_t errflag)
+{
+    MPIR_FUNC_ENTER;
+    MPIR_CHKLMEM_DECL(3);
+
+    int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
+
+    /* fallback if sendtype and recvtype is different */
+    if (sendtype != recvtype || sendcount != recvcount) {
+        goto fallback;
+    }
+    MPI_Aint true_lb;
+    MPIR_Datatype *dt_ptr;
+    bool dt_contig;
+    uintptr_t data_sz;
+    MPIDI_Datatype_get_info(sendcount, sendtype, dt_contig, data_sz, dt_ptr, true_lb);
+    /* fallback if datatype is not contiguous or data size is not large enough */
+    if (!dt_contig || data_sz <= MPIR_CVAR_ALLTOALL_IPC_READ_MSG_SIZE_THRESHOLD) {
+        goto fallback;
+    }
+
+    void *send_mem_addr = MPIR_get_contig_ptr(sendbuf, true_lb);
+    void *recv_mem_addr = MPIR_get_contig_ptr(recvbuf, true_lb);
+    MPIDI_IPCI_ipc_attr_t ipc_attr;
+    memset(&ipc_attr, 0, sizeof(ipc_attr));
+    MPIR_GPU_query_pointer_attr(send_mem_addr, &ipc_attr.gpu_attr);
+
+    int my_rank = MPIR_Comm_rank(comm_ptr);
+    int comm_size = MPIR_Comm_size(comm_ptr);
+    /* set up ipc_handles */
+    MPIDI_IPCI_ipc_handle_t *ipc_handles = NULL;
+    MPIR_CHKLMEM_MALLOC(ipc_handles, MPIDI_IPCI_ipc_handle_t *,
+                        sizeof(MPIDI_IPCI_ipc_handle_t) * comm_size, mpi_errno, "IPC handles",
+                        MPL_MEM_COLL);
+    MPIDI_IPCI_ipc_handle_t my_ipc_handle;
+    memset(&my_ipc_handle, 0, sizeof(my_ipc_handle));
+    int dev_id = MPL_gpu_get_dev_id_from_attr(&ipc_attr.gpu_attr);
+    /* CPU memory, registered host memory and USM fallback to P2P alltoall,
+     * GPU memory will use ipc read alltoall
+     */
+    if (dev_id >= 0 && ipc_attr.gpu_attr.type == MPL_GPU_POINTER_DEV) {
+        mpi_errno = MPIDI_GPU_get_ipc_attr(send_mem_addr, my_rank, comm_ptr, &ipc_attr);
+        MPIR_ERR_CHECK(mpi_errno);
+        my_ipc_handle = ipc_attr.ipc_handle;
+    } else {
+        my_ipc_handle.gpu.global_dev_id = -1;
+    }
+    /* allgather is needed to exchange all the IPC handles */
+    mpi_errno =
+        MPIR_Allgather_impl(&my_ipc_handle, sizeof(MPIDI_IPCI_ipc_handle_t), MPI_BYTE, ipc_handles,
+                            sizeof(MPIDI_IPCI_ipc_handle_t), MPI_BYTE, comm_ptr, errflag);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* check the ipc_handles to make sure all the buffers are on GPU */
+    int errs = 0;
+    for (int i = 0; i < comm_size; i++) {
+        if (ipc_handles[i].gpu.global_dev_id < 0) {
+            errs++;
+            break;
+        }
+    }
+    if (errs > 0) {
+        goto fallback;
+    }
+
+    /* map ipc_handles to remote_bufs */
+    void **remote_bufs = NULL;
+    MPIR_CHKLMEM_MALLOC(remote_bufs, void **, sizeof(void *) * comm_size, mpi_errno, "Remote bufs",
+                        MPL_MEM_COLL);
+    for (int i = 0; i < comm_size; i++) {
+        if (i != my_rank) {
+            int remote_dev =
+                MPIDI_GPU_ipc_get_map_dev(ipc_handles[i].gpu.global_dev_id, dev_id, sendtype);
+            mpi_errno =
+                MPIDI_GPU_ipc_handle_map(ipc_handles[i].gpu, remote_dev, &(remote_bufs[i]), false);
+            MPIR_ERR_CHECK(mpi_errno);
+        } else {
+            remote_bufs[i] = send_mem_addr;
+        }
+    }
+    /* use imemcpy to copy the data concurrently */
+    MPL_gpu_request *reqs = NULL;
+    MPIR_CHKLMEM_MALLOC(reqs, MPL_gpu_request *, sizeof(MPL_gpu_request) * comm_size, mpi_errno,
+                        "Memcpy requests", MPL_MEM_COLL);
+    for (int i = 0; i < comm_size; i++) {
+        char *temp_recv = (char *) recv_mem_addr + i * data_sz;
+        char *temp_send = (char *) (remote_bufs[i]) + my_rank * data_sz;
+        /* get engine type */
+        MPL_gpu_engine_type_t engine_type =
+            MPIDI_IPCI_choose_engine(ipc_handles[i].gpu.global_dev_id,
+                                     my_ipc_handle.gpu.global_dev_id);
+        mpi_errno =
+            MPL_gpu_imemcpy((char *) MPIR_get_contig_ptr(temp_recv, true_lb),
+                            (char *) MPIR_get_contig_ptr(temp_send, true_lb),
+                            data_sz, dev_id, MPL_GPU_COPY_DIRECTION_NONE,
+                            engine_type, &reqs[i], true);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+    /* wait for the imemcpy to finish */
+    for (int i = 0; i < comm_size; i++) {
+        int completed = 0;
+        while (!completed) {
+            mpi_errno = MPL_gpu_test(&reqs[i], &completed);
+            MPIR_ERR_CHECK(mpi_errno);
+        }
+    }
+
+  fn_exit:
+    MPIR_CHKLMEM_FREEALL();
+    MPIR_FUNC_EXIT;
+    return mpi_errno_ret;
+  fn_fail:
+    goto fn_exit;
+  fallback:
+    /* Fall back to other algorithms as gpu ipc alltoall cannot be used */
+    mpi_errno = MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
+                                   comm_ptr, errflag);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    goto fn_exit;
 }
 
 #endif /* POSIX_COLL_GPU_IPC_H_INCLUDED */

--- a/test/mpi/coll/Makefile.am
+++ b/test/mpi/coll/Makefile.am
@@ -27,6 +27,7 @@ noinst_PROGRAMS =      \
     allred_float       \
     allredmany         \
     alltoall1          \
+    alltoall_gpu       \
     alltoallv          \
     alltoallv0         \
     alltoallw1         \
@@ -154,6 +155,7 @@ noinst_PROGRAMS =      \
     neighb_alltoallw2  \
     bcast              \
     bcast_comm_world_only \
+    bcast_gpu          \
     coll_large	       \
     ring_neighbor_alltoall
 

--- a/test/mpi/coll/alltoall_gpu.c
+++ b/test/mpi/coll/alltoall_gpu.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpitest.h"
+#include "mpi.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include "mtest_dtp.h"
+
+/*
+static char MTEST_Descrip[] = "Test MPI_Alltoall";
+*/
+
+static void set_sendbuf(int rank, int size, int count, int *buf)
+{
+    int i, j;
+    int *p = buf;
+    for (j = 0; j < size; j++) {
+        for (i = 0; i < count; i++) {
+            *p++ = j * size + rank + i;
+        }
+    }
+}
+
+static void set_recvbuf(int size, int count, int *buf)
+{
+    int i;
+    for (i = 0; i < count; i++) {
+        buf[i] = -1;
+    }
+}
+
+
+static void check_buf(int rank, int size, int count, int *errs, int *buf)
+{
+    int i, j;
+    int *p = buf;
+    for (j = 0; j < size; j++) {
+        for (i = 0; i < count; i++) {
+            if (*p != rank * size + j + i) {
+                (*errs)++;
+                if ((*errs) < 10) {
+                    fprintf(stderr, "Error with communicator %s and size=%d count=%d\n",
+                            MTestGetIntracommName(), size, count);
+                    fprintf(stderr, "recvbuf[%d,%d] = %d, should be %d\n",
+                            j, i, *p, rank * size + j + i);
+                }
+            }
+            p++;
+        }
+    }
+}
+
+static int test_alltoall(mtest_mem_type_e oddmem, mtest_mem_type_e evenmem)
+{
+    int errs = 0;
+    int rank, size;
+    int reps = 0;
+    int num_reps = 2;
+    int minsize = 2, count;
+    MPI_Comm comm;
+    void *sendbuf_h, *sendbuf;
+    void *recvbuf_h, *recvbuf;
+    mtest_mem_type_e memtype;
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (rank % 2 == 0)
+        memtype = evenmem;
+    else
+        memtype = oddmem;
+
+    while (MTestGetIntracommGeneral(&comm, minsize, 1)) {
+        if (comm == MPI_COMM_NULL)
+            continue;
+
+        MPI_Comm_size(comm, &size);
+        MPI_Comm_rank(comm, &rank);
+
+        for (count = 1; count < 65000; count = count * 2) {
+            MTestMalloc(count * size * sizeof(int), memtype, &sendbuf_h, &sendbuf, rank);
+            MTestMalloc(count * size * sizeof(int), memtype, &recvbuf_h, &recvbuf, rank);
+
+            for (reps = 0; reps < num_reps; reps++) {
+                set_sendbuf(rank, size, count, sendbuf_h);
+                MTestCopyContent(sendbuf_h, sendbuf, count * size * sizeof(int), memtype);
+                set_recvbuf(size, count, recvbuf_h);
+                MTestCopyContent(recvbuf_h, recvbuf, count * size * sizeof(int), memtype);
+
+                MPI_Alltoall(sendbuf, count, MPI_INT, recvbuf, count, MPI_INT, comm);
+
+                MTestCopyContent(recvbuf, recvbuf_h, count * size * sizeof(int), memtype);
+                check_buf(rank, size, count, &errs, recvbuf_h);
+            }
+
+            MTestFree(memtype, sendbuf_h, sendbuf);
+        }
+        MTestFreeComm(&comm);
+    }
+    return errs;
+}
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    MTest_Init(&argc, &argv);
+
+    struct dtp_args dtp_args;
+    dtp_args_init(&dtp_args, MTEST_COLL_NOCOUNT, argc, argv);
+    while (dtp_args_get_next(&dtp_args)) {
+        errs += test_alltoall(dtp_args.u.coll.evenmem, dtp_args.u.coll.oddmem);
+    }
+    dtp_args_finalize(&dtp_args);
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/coll/bcast_gpu.c
+++ b/test/mpi/coll/bcast_gpu.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpitest.h"
+#include "mpi.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include "mtest_dtp.h"
+
+/*
+static char MTEST_Descrip[] = "Test MPI_Bcast";
+*/
+
+static void set_buf(int rank, int count, int *buf)
+{
+    int i;
+    for (i = 0; i < count; i++) {
+        int val = rank + i;
+        buf[i] = val;
+    }
+}
+
+static void check_buf(int size, int count, int *errs, int *buf, int root)
+{
+    int i;
+    for (i = 0; i < count; i++) {
+        if (buf[i] != root + i) {
+            (*errs)++;
+            if ((*errs) < 10) {
+                fprintf(stderr, "buf[%d] = %d expected %d\n", i, buf[i], root + i);
+            }
+        }
+    }
+}
+
+static int test_bcast(mtest_mem_type_e oddmem, mtest_mem_type_e evenmem)
+{
+    int errs = 0;
+    int rank, size;
+    int root = 0;
+    int reps = 0;
+    int num_reps = 3;
+    int minsize = 2, count;
+    MPI_Comm comm;
+    void *buf_h, *buf;
+    mtest_mem_type_e memtype;
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (rank % 2 == 0)
+        memtype = evenmem;
+    else
+        memtype = oddmem;
+
+    while (MTestGetIntracommGeneral(&comm, minsize, 1)) {
+        if (comm == MPI_COMM_NULL)
+            continue;
+
+        MPI_Comm_size(comm, &size);
+        MPI_Comm_rank(comm, &rank);
+
+        for (count = 1; count < 65000; count = count * 2) {
+            MTestMalloc(count * sizeof(int), memtype, &buf_h, &buf, rank);
+            for (root = 0; root < size; root++) {
+                for (reps = 0; reps < num_reps; reps++) {
+                    set_buf(rank, count, buf_h);
+                    MTestCopyContent(buf_h, buf, count * sizeof(int), memtype);
+
+                    MPI_Bcast(buf, count, MPI_INT, root, comm);
+
+                    MTestCopyContent(buf, buf_h, count * sizeof(int), memtype);
+                    check_buf(size, count, &errs, buf_h, root);
+                }
+            }
+
+            MTestFree(memtype, buf_h, buf);
+        }
+        MTestFreeComm(&comm);
+    }
+    return errs;
+}
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    MTest_Init(&argc, &argv);
+
+    struct dtp_args dtp_args;
+    dtp_args_init(&dtp_args, MTEST_COLL_NOCOUNT, argc, argv);
+    while (dtp_args_get_next(&dtp_args)) {
+        errs += test_bcast(dtp_args.u.coll.evenmem, dtp_args.u.coll.oddmem);
+    }
+    dtp_args_finalize(&dtp_args);
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/coll/testlist.gpu
+++ b/test/mpi/coll/testlist.gpu
@@ -34,3 +34,7 @@ bcast 4 arg=-typelist=MPI_INT,MPI_INT:4+MPI_DOUBLE:8 arg=-counts=1,17,50,100,512
 bcast 4 arg=-typelist=MPI_INT,MPI_INT:4+MPI_DOUBLE:8 arg=-counts=1,17,50,100,512,65530 arg=-seed=100 arg=-testsizes=2,50 arg=-evenmemtype=shared arg=-oddmemtype=host
 bcast 4 arg=-typelist=MPI_INT,MPI_INT:4+MPI_DOUBLE:8 arg=-counts=1,17,50,100,512,65530 arg=-seed=100 arg=-testsizes=2,50 arg=-evenmemtype=shared arg=-oddmemtype=reg_host
 bcast 4 arg=-typelist=MPI_INT,MPI_INT:4+MPI_DOUBLE:8 arg=-counts=1,17,50,100,512,65530 arg=-seed=100 arg=-testsizes=2,50 arg=-evenmemtype=shared arg=-oddmemtype=shared
+
+# test ipc read bcast and alltoall test
+bcast_gpu 6 arg=-memtype=all env=MPIR_CVAR_BCAST_COMPOSITION=1 env=MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD=1 env=MPIR_CVAR_BCAST_POSIX_INTRA_ALGORITHM=ipc_read env=MPIR_CVAR_BCAST_IPC_READ_MSG_SIZE_THRESHOLD=1024 env=MTEST_GPU_VISIBILITY_AFFINITY=CONTIGUOUS_DEVICE
+alltoall_gpu 6 arg=-memtype=all env=MPIR_CVAR_ALLTOALL_COMPOSITION=2 env=MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD=1 env=MPIR_CVAR_ALLTOALL_POSIX_INTRA_ALGORITHM=ipc_read env=MPIR_CVAR_ALLTOALL_IPC_READ_MSG_SIZE_THRESHOLD=1024 env=MTEST_GPU_VISIBILITY_AFFINITY=CONTIGUOUS_DEVICE

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -102,3 +102,8 @@ mpich-.*-arm.* * * * * /^alltoall /           xfail=ticket0       threads/pt2pt/
 * * pmi2 * *            /^session_re_init/      xfail=ticket6446    init/testlist
 # MPI_Abort a sub group is not fully working
 * * * * *               /^(inter|sub)comm_abort/   xfail=ticket6634    errors/comm/testlist
+
+# IPC read bcast and alltoall fails as MPL_gpu_imemcpy is not implemented in CUDA
+# https://github.com/pmodels/mpich/issues/6657
+* * * * *               /^bcast_gpu/   xfail=ticket6657    coll/testlist.gpu
+* * * * *               /^alltoall_gpu/   xfail=ticket6657    coll/testlist.gpu


### PR DESCRIPTION
## Pull Request Description
Add an intra-node MPI_Bcast and MPI_Alltoall algorithm (stream_read) with Level 0 API for Intel GPU. 
In MPI_Bcast, non-root processes read data from the root's send buffer, and in MPI_Alltoall, every process reads data from other processes' send buffers.

Last 6 commits only
Depends on ~~#6571~~ #6587

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
