### PR TITLE
ch4: use genq for gpu buffer swapping in collectives

### DIFF
--- a/src/include/mpir_gpu_util.h
+++ b/src/include/mpir_gpu_util.h
@@ -78,11 +78,29 @@ MPL_STATIC_INLINE_PREFIX void *MPIR_gpu_host_swap(const void *buf,
     return host_buf;
 }
 
+MPL_STATIC_INLINE_PREFIX void MPIR_gpu_host_swap_gpu(const void *buf, MPI_Aint count,
+                                                     MPI_Datatype datatype,
+                                                     MPL_pointer_attr_t attr, void *host_buf)
+{
+    if (host_buf) {
+        MPIR_Localcopy_gpu(buf, count, datatype, &attr, host_buf, count, datatype, NULL,
+                           MPL_GPU_COPY_DIRECTION_NONE, MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH,
+                           true);
+    }
+}
+
 MPL_STATIC_INLINE_PREFIX void MPIR_gpu_swap_back(void *host_buf, void *gpu_buf,
                                                  MPI_Aint count, MPI_Datatype datatype)
 {
     MPIR_Localcopy(host_buf, count, datatype, gpu_buf, count, datatype);
     MPIR_gpu_host_free(host_buf, count, datatype);
+}
+
+MPL_STATIC_INLINE_PREFIX void MPIR_gpu_swap_back_gpu(void *host_buf, void *gpu_buf, MPI_Aint count,
+                                                     MPI_Datatype datatype, MPL_pointer_attr_t attr)
+{
+    MPIR_Localcopy_gpu(host_buf, count, datatype, NULL, gpu_buf, count, datatype, &attr,
+                       MPL_GPU_COPY_DIRECTION_NONE, MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH, true);
 }
 
 #endif /* MPIR_GPU_UTIL_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -265,6 +265,8 @@ typedef struct MPIDI_CH4_Global_t {
     MPID_Thread_mutex_t m[MAX_CH4_MUTEXES];
     MPIDIU_map_t *win_map;
 
+    MPIDU_genq_private_pool_t gpu_coll_pool;
+
     MPIR_Request *part_posted_list;
     MPIR_Request *part_unexp_list;
 


### PR DESCRIPTION
## Pull Request Description

For GPU collectives with small message size, the the data is swapped to a host buffer (using GPU fast memcpy) first and then the collective is executed from host. After the collective is done, the data is moved back to the GPU.

Depends on ~~#6571~~ #6587

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
