### PR TITLE
ch4: rename vni/vsi to vci

### DIFF
--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
@@ -20,14 +20,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
     MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
     bool syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr);
 
-    int vni_src, vni_dst;
-    vni_src = 0;
-    vni_dst = 0;
+    int vci_src, vci_dst;
+    vci_src = 0;
+    vci_dst = 0;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci_src).lock);
     mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                 vni_src, vni_dst, request, syncflag, errflag);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
+                                 vci_src, vci_dst, request, syncflag, errflag);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci_src).lock);
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.c
@@ -19,13 +19,13 @@ int MPIDI_OFI_am_rdma_read_ack_handler(void *am_hdr, void *data,
     ack_msg = (MPIDI_OFI_am_rdma_read_ack_msg_t *) am_hdr;
     sreq = ack_msg->sreq_ptr;
 
-    int vni_local = MPIDIG_AM_ATTR_DST_VCI(attr);
+    int vci_local = MPIDIG_AM_ATTR_DST_VCI(attr);
     if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
         uint64_t mr_key = fi_mr_key(MPIDI_OFI_AM_SREQ_HDR(sreq, lmt_mr));
         MPIDI_OFI_mr_key_free(MPIDI_OFI_LOCAL_MR_KEY, mr_key);
     }
     MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_AM_SREQ_HDR(sreq, lmt_mr)->fid), mr_unreg);
-    MPIDI_OFI_global.per_vni[vni_local].am_inflight_rma_send_mrs -= 1;
+    MPIDI_OFI_global.per_vci[vci_local].am_inflight_rma_send_mrs -= 1;
 
     MPL_free(MPIDI_OFI_AM_SREQ_HDR(sreq, pack_buffer));
 

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -12,28 +12,28 @@
  * value that is generally common across the different providers. */
 #define MPIDI_OFI_MAX_ERR_DATA_SIZE 64
 
-static int peek_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
-static int peek_empty_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
-static int send_huge_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
-static int ssend_ack_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
-static int chunk_done_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * req);
-static int inject_emu_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * req);
-static int accept_probe_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
-static int dynproc_done_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
-static int am_isend_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
-static int am_isend_rdma_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
-static int am_isend_pipeline_event(int vni, struct fi_cq_tagged_entry *wc,
+static int peek_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
+static int peek_empty_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
+static int send_huge_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
+static int ssend_ack_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
+static int chunk_done_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * req);
+static int inject_emu_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * req);
+static int accept_probe_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
+static int dynproc_done_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
+static int am_isend_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
+static int am_isend_rdma_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq);
+static int am_isend_pipeline_event(int vci, struct fi_cq_tagged_entry *wc,
                                    MPIR_Request * dont_use_me);
-static int am_recv_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
-static int am_read_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_me);
+static int am_recv_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
+static int am_read_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_me);
 
-static int peek_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
+static int peek_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
     if (MPIDI_OFI_HUGE_SEND & wc->tag) {
-        mpi_errno = MPIDI_OFI_peek_huge_event(vni, wc, rreq);
+        mpi_errno = MPIDI_OFI_peek_huge_event(vci, wc, rreq);
         goto fn_exit;
     }
 
@@ -51,7 +51,7 @@ static int peek_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rre
     return mpi_errno;
 }
 
-static int peek_empty_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
+static int peek_empty_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     MPIR_FUNC_ENTER;
     MPIDI_OFI_dynamic_process_request_t *ctrl;
@@ -80,7 +80,7 @@ static int peek_empty_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request
     return MPI_SUCCESS;
 }
 
-static int send_huge_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
+static int send_huge_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     int c, num_nics;
@@ -121,13 +121,13 @@ static int send_huge_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request 
     goto fn_exit;
 }
 
-static int ssend_ack_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
+static int ssend_ack_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
 {
     int mpi_errno;
     MPIDI_OFI_ssendack_request_t *req = (MPIDI_OFI_ssendack_request_t *) sreq;
     MPIR_FUNC_ENTER;
     mpi_errno =
-        MPIDI_OFI_send_event(vni, NULL, req->signal_req,
+        MPIDI_OFI_send_event(vci, NULL, req->signal_req,
                              MPIDI_OFI_REQUEST(req->signal_req, event_id));
 
     MPL_free(req);
@@ -135,7 +135,7 @@ static int ssend_ack_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request 
     return mpi_errno;
 }
 
-static int chunk_done_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * req)
+static int chunk_done_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * req)
 {
     int c;
     MPIR_FUNC_ENTER;
@@ -151,7 +151,7 @@ static int chunk_done_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request
     return MPI_SUCCESS;
 }
 
-static int inject_emu_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * req)
+static int inject_emu_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * req)
 {
     int incomplete;
     MPIR_FUNC_ENTER;
@@ -161,14 +161,14 @@ static int inject_emu_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request
     if (!incomplete) {
         MPL_free(MPIDI_OFI_REQUEST(req, util.inject_buf));
         MPIDI_CH4_REQUEST_FREE(req);
-        MPIDI_OFI_global.per_vni[vni].am_inflight_inject_emus -= 1;
+        MPIDI_OFI_global.per_vci[vci].am_inflight_inject_emus -= 1;
     }
 
     MPIR_FUNC_EXIT;
     return MPI_SUCCESS;
 }
 
-static int accept_probe_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
+static int accept_probe_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     MPIR_FUNC_ENTER;
     MPIDI_OFI_dynamic_process_request_t *ctrl = (MPIDI_OFI_dynamic_process_request_t *) rreq;
@@ -180,7 +180,7 @@ static int accept_probe_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Reque
     return MPI_SUCCESS;
 }
 
-static int dynproc_done_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
+static int dynproc_done_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     MPIR_FUNC_ENTER;
     MPIDI_OFI_dynamic_process_request_t *ctrl = (MPIDI_OFI_dynamic_process_request_t *) rreq;
@@ -189,7 +189,7 @@ static int dynproc_done_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Reque
     return MPI_SUCCESS;
 }
 
-static int am_isend_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
+static int am_isend_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t *msg_hdr;
@@ -199,7 +199,7 @@ static int am_isend_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request *
     msg_hdr = &MPIDI_OFI_AM_SREQ_HDR(sreq, msg_hdr);
     MPID_Request_complete(sreq);
 
-    MPIDU_genq_private_pool_free_cell(MPIDI_global.per_vci[vni].pack_buf_pool,
+    MPIDU_genq_private_pool_free_cell(MPIDI_global.per_vci[vci].pack_buf_pool,
                                       MPIDI_OFI_AM_SREQ_HDR(sreq, pack_buffer));
     MPIDI_OFI_AM_SREQ_HDR(sreq, pack_buffer) = NULL;
     mpi_errno = MPIDIG_global.origin_cbs[msg_hdr->handler_id] (sreq);
@@ -212,7 +212,7 @@ static int am_isend_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request *
     goto fn_exit;
 }
 
-static int am_isend_rdma_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
+static int am_isend_rdma_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * sreq)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -226,7 +226,7 @@ static int am_isend_rdma_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Requ
     return mpi_errno;
 }
 
-static int am_isend_pipeline_event(int vni, struct fi_cq_tagged_entry *wc,
+static int am_isend_pipeline_event(int vci, struct fi_cq_tagged_entry *wc,
                                    MPIR_Request * dont_use_me)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -240,10 +240,10 @@ static int am_isend_pipeline_event(int vni, struct fi_cq_tagged_entry *wc,
     sreq = ofi_req->sreq;
     MPID_Request_complete(sreq);        /* FIXME: Should not call MPIDI in NM ? */
 
-    MPIDU_genq_private_pool_free_cell(MPIDI_global.per_vci[vni].pack_buf_pool,
+    MPIDU_genq_private_pool_free_cell(MPIDI_global.per_vci[vci].pack_buf_pool,
                                       ofi_req->pack_buffer);
 
-    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[vni].am_hdr_buf_pool, ofi_req);
+    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vci[vci].am_hdr_buf_pool, ofi_req);
 
     int is_done = MPIDIG_am_send_async_finish_seg(sreq);
 
@@ -260,7 +260,7 @@ static int am_isend_pipeline_event(int vni, struct fi_cq_tagged_entry *wc,
     goto fn_exit;
 }
 
-static int am_recv_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
+static int am_recv_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_OFI_am_header_t *am_hdr;
@@ -294,7 +294,7 @@ static int am_recv_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * 
     }
 #endif
 
-    expected_seqno = MPIDI_OFI_am_get_next_recv_seqno(vni, am_hdr->fi_src_addr);
+    expected_seqno = MPIDI_OFI_am_get_next_recv_seqno(vci, am_hdr->fi_src_addr);
     if (am_hdr->seqno != expected_seqno) {
         /* This message came earlier than the one that we were expecting.
          * Put it in the queue to process it later. */
@@ -303,7 +303,7 @@ static int am_recv_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * 
                          "Expected seqno=%d but got %d (am_type=%d addr=%" PRIx64 "). "
                          "Enqueueing it to the queue.\n",
                          expected_seqno, am_hdr->seqno, am_hdr->am_type, am_hdr->fi_src_addr));
-        mpi_errno = MPIDI_OFI_am_enqueue_unordered_msg(vni, orig_buf);
+        mpi_errno = MPIDI_OFI_am_enqueue_unordered_msg(vci, orig_buf);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     }
@@ -368,7 +368,7 @@ static int am_recv_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * 
     MPL_free(uo_msg);
 
     /* See if we can process other messages in the queue */
-    if ((uo_msg = MPIDI_OFI_am_claim_unordered_msg(vni, fi_src_addr, next_seqno)) != NULL) {
+    if ((uo_msg = MPIDI_OFI_am_claim_unordered_msg(vci, fi_src_addr, next_seqno)) != NULL) {
         am_hdr = &uo_msg->am_hdr;
         orig_buf = am_hdr;
 #ifdef NEEDS_STRICT_ALIGNMENT
@@ -380,7 +380,7 @@ static int am_recv_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * 
     }
 
     /* Record the next expected sequence number from fi_src_addr */
-    MPIDI_OFI_am_set_next_recv_seqno(vni, fi_src_addr, next_seqno);
+    MPIDI_OFI_am_set_next_recv_seqno(vci, fi_src_addr, next_seqno);
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -389,7 +389,7 @@ static int am_recv_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * 
     goto fn_exit;
 }
 
-static int am_read_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_me)
+static int am_read_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * dont_use_me)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq;
@@ -429,105 +429,105 @@ static int am_read_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * 
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
     MPID_Request_complete(rreq);
   fn_exit:
-    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vni[vni].am_hdr_buf_pool, ofi_req);
+    MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vci[vci].am_hdr_buf_pool, ofi_req);
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
-int MPIDI_OFI_dispatch_function(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * req)
+int MPIDI_OFI_dispatch_function(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * req)
 {
     int mpi_errno = MPI_SUCCESS;
 
     if (MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_SEND) {
         /* Passing the event_id as a parameter; do not need to load it from the
          * request object each time the send_event handler is invoked */
-        mpi_errno = MPIDI_OFI_send_event(vni, wc, req, MPIDI_OFI_EVENT_SEND);
+        mpi_errno = MPIDI_OFI_send_event(vci, wc, req, MPIDI_OFI_EVENT_SEND);
         goto fn_exit;
     } else if (MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_RECV) {
         /* Passing the event_id as a parameter; do not need to load it from the
          * request object each time the send_event handler is invoked */
-        mpi_errno = MPIDI_OFI_recv_event(vni, wc, req, MPIDI_OFI_EVENT_RECV);
+        mpi_errno = MPIDI_OFI_recv_event(vci, wc, req, MPIDI_OFI_EVENT_RECV);
         goto fn_exit;
     } else if (likely(MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_AM_SEND)) {
-        mpi_errno = am_isend_event(vni, wc, req);
+        mpi_errno = am_isend_event(vci, wc, req);
         goto fn_exit;
     } else if (likely(MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_AM_SEND_RDMA)) {
-        mpi_errno = am_isend_rdma_event(vni, wc, req);
+        mpi_errno = am_isend_rdma_event(vci, wc, req);
         goto fn_exit;
     } else if (likely(MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_AM_SEND_PIPELINE)) {
-        mpi_errno = am_isend_pipeline_event(vni, wc, req);
+        mpi_errno = am_isend_pipeline_event(vci, wc, req);
         goto fn_exit;
     } else if (likely(MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_AM_RECV)) {
         if (wc->flags & FI_RECV)
-            mpi_errno = am_recv_event(vni, wc, req);
+            mpi_errno = am_recv_event(vci, wc, req);
 
         if (unlikely(wc->flags & FI_MULTI_RECV)) {
             MPIDI_OFI_am_repost_request_t *am = (MPIDI_OFI_am_repost_request_t *) req;
-            mpi_errno = MPIDI_OFI_am_repost_buffer(vni, am->index);
+            mpi_errno = MPIDI_OFI_am_repost_buffer(vci, am->index);
         }
 
         goto fn_exit;
     } else if (likely(MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_AM_READ)) {
-        mpi_errno = am_read_event(vni, wc, req);
+        mpi_errno = am_read_event(vci, wc, req);
         goto fn_exit;
     } else if (unlikely(1)) {
         switch (MPIDI_OFI_REQUEST(req, event_id)) {
             case MPIDI_OFI_EVENT_PEEK:
-                mpi_errno = peek_event(vni, wc, req);
+                mpi_errno = peek_event(vci, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_RECV_HUGE:
                 if (wc->tag & MPIDI_OFI_HUGE_SEND) {
-                    mpi_errno = MPIDI_OFI_recv_huge_event(vni, wc, req);
+                    mpi_errno = MPIDI_OFI_recv_huge_event(vci, wc, req);
                 } else {
-                    mpi_errno = MPIDI_OFI_recv_event(vni, wc, req, MPIDI_OFI_EVENT_RECV_HUGE);
+                    mpi_errno = MPIDI_OFI_recv_event(vci, wc, req, MPIDI_OFI_EVENT_RECV_HUGE);
                 }
                 break;
 
             case MPIDI_OFI_EVENT_RECV_PACK:
-                mpi_errno = MPIDI_OFI_recv_event(vni, wc, req, MPIDI_OFI_EVENT_RECV_PACK);
+                mpi_errno = MPIDI_OFI_recv_event(vci, wc, req, MPIDI_OFI_EVENT_RECV_PACK);
                 break;
 
             case MPIDI_OFI_EVENT_RECV_NOPACK:
-                mpi_errno = MPIDI_OFI_recv_event(vni, wc, req, MPIDI_OFI_EVENT_RECV_NOPACK);
+                mpi_errno = MPIDI_OFI_recv_event(vci, wc, req, MPIDI_OFI_EVENT_RECV_NOPACK);
                 break;
 
             case MPIDI_OFI_EVENT_SEND_HUGE:
-                mpi_errno = send_huge_event(vni, wc, req);
+                mpi_errno = send_huge_event(vci, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_SEND_PACK:
-                mpi_errno = MPIDI_OFI_send_event(vni, wc, req, MPIDI_OFI_EVENT_SEND_PACK);
+                mpi_errno = MPIDI_OFI_send_event(vci, wc, req, MPIDI_OFI_EVENT_SEND_PACK);
                 break;
 
             case MPIDI_OFI_EVENT_SEND_NOPACK:
-                mpi_errno = MPIDI_OFI_send_event(vni, wc, req, MPIDI_OFI_EVENT_SEND_NOPACK);
+                mpi_errno = MPIDI_OFI_send_event(vci, wc, req, MPIDI_OFI_EVENT_SEND_NOPACK);
                 break;
 
             case MPIDI_OFI_EVENT_SSEND_ACK:
-                mpi_errno = ssend_ack_event(vni, wc, req);
+                mpi_errno = ssend_ack_event(vci, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_CHUNK_DONE:
-                mpi_errno = chunk_done_event(vni, wc, req);
+                mpi_errno = chunk_done_event(vci, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_HUGE_CHUNK_DONE:
-                mpi_errno = MPIDI_OFI_huge_chunk_done_event(vni, wc, req);
+                mpi_errno = MPIDI_OFI_huge_chunk_done_event(vci, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_INJECT_EMU:
-                mpi_errno = inject_emu_event(vni, wc, req);
+                mpi_errno = inject_emu_event(vci, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_DYNPROC_DONE:
-                mpi_errno = dynproc_done_event(vni, wc, req);
+                mpi_errno = dynproc_done_event(vci, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_ACCEPT_PROBE:
-                mpi_errno = accept_probe_event(vni, wc, req);
+                mpi_errno = accept_probe_event(vci, wc, req);
                 break;
 
             case MPIDI_OFI_EVENT_ABORT:
@@ -542,7 +542,7 @@ int MPIDI_OFI_dispatch_function(int vni, struct fi_cq_tagged_entry *wc, MPIR_Req
     return mpi_errno;
 }
 
-int MPIDI_OFI_handle_cq_error(int vni, int nic, ssize_t ret)
+int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret)
 {
     int mpi_errno = MPI_SUCCESS;
     struct fi_cq_err_entry e;
@@ -551,7 +551,7 @@ int MPIDI_OFI_handle_cq_error(int vni, int nic, ssize_t ret)
     ssize_t ret_cqerr;
     MPIR_FUNC_ENTER;
 
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
     switch (ret) {
         case -FI_EAVAIL:
             /* Provide separate error buffer for each thread. This makes the
@@ -572,13 +572,13 @@ int MPIDI_OFI_handle_cq_error(int vni, int nic, ssize_t ret)
 
                     switch (req->kind) {
                         case MPIR_REQUEST_KIND__SEND:
-                            mpi_errno = MPIDI_OFI_dispatch_function(vni, NULL, req);
+                            mpi_errno = MPIDI_OFI_dispatch_function(vci, NULL, req);
                             break;
 
                         case MPIR_REQUEST_KIND__RECV:
                             req->status.MPI_ERROR = MPI_ERR_TRUNCATE;
                             mpi_errno =
-                                MPIDI_OFI_dispatch_function(vni, (struct fi_cq_tagged_entry *) &e,
+                                MPIDI_OFI_dispatch_function(vci, (struct fi_cq_tagged_entry *) &e,
                                                             req);
                             break;
 
@@ -597,7 +597,7 @@ int MPIDI_OFI_handle_cq_error(int vni, int nic, ssize_t ret)
                      */
                     int event_id = MPIDI_OFI_REQUEST(req, event_id);
                     if (event_id == MPIDI_OFI_EVENT_DYNPROC_DONE) {
-                        dynproc_done_event(vni, e.op_context, req);
+                        dynproc_done_event(vci, e.op_context, req);
                     } else {
                         /* assume it is a pending recv */
                         MPIR_STATUS_SET_CANCEL_BIT(req->status, TRUE);
@@ -618,7 +618,7 @@ int MPIDI_OFI_handle_cq_error(int vni, int nic, ssize_t ret)
 
                 case FI_ENOMSG:
                     req = MPIDI_OFI_context_to_request(e.op_context);
-                    mpi_errno = peek_empty_event(vni, NULL, req);
+                    mpi_errno = peek_empty_event(vci, NULL, req);
                     break;
 
                 default:

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -11,8 +11,8 @@
 #include "ofi_am_events.h"
 #include "utlist.h"
 
-int MPIDI_OFI_rma_done_event(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * in_req);
-int MPIDI_OFI_dispatch_function(int vni, struct fi_cq_tagged_entry *wc, MPIR_Request * req);
+int MPIDI_OFI_rma_done_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * in_req);
+int MPIDI_OFI_dispatch_function(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * req);
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_cqe_get_source(struct fi_cq_tagged_entry *wc, bool has_err)
 {
@@ -26,7 +26,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_cqe_get_source(struct fi_cq_tagged_entry 
     }
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_event(int vni,
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_event(int vci,
                                                   struct fi_cq_tagged_entry *wc /* unused */ ,
                                                   MPIR_Request * sreq, int event_id)
 {
@@ -50,7 +50,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_event(int vni,
     return MPI_SUCCESS;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vni, struct fi_cq_tagged_entry *wc,
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vci, struct fi_cq_tagged_entry *wc,
                                                   MPIR_Request * rreq, int event_id)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -58,7 +58,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vni, struct fi_cq_tagged_e
     MPIR_FUNC_ENTER;
 
     if (wc->tag & MPIDI_OFI_HUGE_SEND) {
-        mpi_errno = MPIDI_OFI_recv_huge_event(vni, wc, rreq);
+        mpi_errno = MPIDI_OFI_recv_huge_event(vci, wc, rreq);
         goto fn_exit;
     }
     rreq->status.MPI_SOURCE = MPIDI_OFI_cqe_get_source(wc, true);
@@ -122,22 +122,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vni, struct fi_cq_tagged_e
                                    MPIDI_OFI_SYNC_SEND_ACK);
         int r = rreq->status.MPI_SOURCE;
         /* NOTE: use target rank, reply to src */
-        int vni_src = MPIDI_get_vci(SRC_VCI_FROM_RECVER, c, r, c->rank, rreq->status.MPI_TAG);
-        int vni_dst = MPIDI_get_vci(DST_VCI_FROM_RECVER, c, r, c->rank, rreq->status.MPI_TAG);
-        int vni_local = vni_dst;
-        int vni_remote = vni_src;
-        MPIR_Assert(vni_local == vni);
+        int vci_src = MPIDI_get_vci(SRC_VCI_FROM_RECVER, c, r, c->rank, rreq->status.MPI_TAG);
+        int vci_dst = MPIDI_get_vci(DST_VCI_FROM_RECVER, c, r, c->rank, rreq->status.MPI_TAG);
+        int vci_local = vci_dst;
+        int vci_remote = vci_src;
+        MPIR_Assert(vci_local == vci);
         int nic = 0;
-        int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni_local, nic);
-        fi_addr_t dest_addr = MPIDI_OFI_comm_to_phys(c, r, nic, vni_local, vni_remote);
+        int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci_local, nic);
+        fi_addr_t dest_addr = MPIDI_OFI_comm_to_phys(c, r, nic, vci_local, vci_remote);
         if (MPIDI_OFI_ENABLE_DATA) {
             MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx, NULL, 0,
                                                 MPIR_Comm_rank(c), dest_addr, ss_bits),
-                                 vni_local, tinjectdata, FALSE /* eagain */);
+                                 vci_local, tinjectdata, FALSE /* eagain */);
         } else {
             MPIDI_OFI_CALL_RETRY(fi_tinject(MPIDI_OFI_global.ctx[ctx_idx].tx, NULL, 0,
                                             dest_addr, ss_bits),
-                                 vni_local, tinject, FALSE /* eagain */);
+                                 vci_local, tinject, FALSE /* eagain */);
         }
     }
 
@@ -151,18 +151,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vni, struct fi_cq_tagged_e
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dispatch_optimized(int vni, struct fi_cq_tagged_entry *wc,
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_dispatch_optimized(int vci, struct fi_cq_tagged_entry *wc,
                                                           MPIR_Request * req)
 {
     /* fast path */
     if (MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_SEND) {
-        return MPIDI_OFI_send_event(vni, wc, req, MPIDI_OFI_EVENT_SEND);
+        return MPIDI_OFI_send_event(vci, wc, req, MPIDI_OFI_EVENT_SEND);
     } else if (MPIDI_OFI_REQUEST(req, event_id) == MPIDI_OFI_EVENT_RECV) {
-        return MPIDI_OFI_recv_event(vni, wc, req, MPIDI_OFI_EVENT_RECV);
+        return MPIDI_OFI_recv_event(vci, wc, req, MPIDI_OFI_EVENT_RECV);
     }
 
     /* slow path */
-    return MPIDI_OFI_dispatch_function(vni, wc, req);
+    return MPIDI_OFI_dispatch_function(vci, wc, req);
 }
 
 #endif /* OFI_EVENTS_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -423,12 +423,12 @@ cvars:
 static int update_global_limits(struct fi_info *prov);
 static void dump_global_settings(void);
 static void dump_dynamic_settings(void);
-static int create_vni_context(int vni, int nic);
-static int destroy_vni_context(int vni, int nic);
+static int create_vci_context(int vci, int nic);
+static int destroy_vci_context(int vci, int nic);
 static int ofi_pvar_init(void);
 
 static int ofi_am_init(void);
-static int ofi_am_post_recv(int vni, int nic);
+static int ofi_am_post_recv(int vci, int nic);
 
 static void *host_alloc(uintptr_t size);
 static void host_free(void *ptr);
@@ -509,7 +509,7 @@ static void set_sep_counters(int nic)
         /* Note: currently we request a single tx and rx ctx under MPIDI_OFI_VNI_USE_DOMAIN */
         int num_ctx_per_nic = 1;
 #else
-        int num_ctx_per_nic = MPIDI_OFI_global.num_vnis;
+        int num_ctx_per_nic = MPIDI_OFI_global.num_vcis;
 #endif
         int max_by_prov = MPL_MIN(MPIDI_OFI_global.prov_use[nic]->domain_attr->tx_ctx_cnt,
                                   MPIDI_OFI_global.prov_use[nic]->domain_attr->rx_ctx_cnt);
@@ -599,23 +599,23 @@ int MPIDI_OFI_init_local(int *tag_bits)
     /* ------------------------------------------------------------------------ */
 
     /* TODO: check provider capabilities, such as prov_use->domain_attr->{tx,rx}_ctx_cnt,
-     *       abort if we can't support the requested number of vnis.
+     *       abort if we can't support the requested number of vcis.
      */
-    int num_vnis = MPIDI_global.n_total_vcis;
+    int num_vcis = MPIDI_global.n_total_vcis;
 
-    /* Multiple vni without using domain require MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS */
+    /* Multiple vci without using domain require MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS */
 #ifndef MPIDI_OFI_VNI_USE_DOMAIN
-    MPIR_Assert(num_vnis == 1 || MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS);
+    MPIR_Assert(num_vcis == 1 || MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS);
 #endif
 
-    MPIDI_OFI_global.num_vnis = num_vnis;
+    MPIDI_OFI_global.num_vcis = num_vcis;
 
     /* set rx_ctx_cnt and tx_ctx_cnt for nic 0 */
     set_sep_counters(0);
 
-    /* Creating the context for vni 0 and nic 0.
+    /* Creating the context for vci 0 and nic 0.
      * This code maybe moved to a later stage */
-    mpi_errno = create_vni_context(0, 0);
+    mpi_errno = create_vci_context(0, 0);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* index datatypes for RMA atomics. */
@@ -658,16 +658,16 @@ int MPIDI_OFI_post_init(void)
     int mpi_errno = MPI_SUCCESS;
 
     int num_nics = MPIDI_OFI_global.num_nics;
-    int tmp_num_vnis = MPIDI_OFI_global.num_vnis;
+    int tmp_num_vcis = MPIDI_OFI_global.num_vcis;
     int tmp_num_nics = MPIDI_OFI_global.num_nics;
 
     /* Set the number of NICs and VNIs to 1 temporarily to avoid problems during the collective */
-    MPIDI_OFI_global.num_vnis = MPIDI_OFI_global.num_nics = 1;
+    MPIDI_OFI_global.num_vcis = MPIDI_OFI_global.num_nics = 1;
 
     /* Confirm that all processes have the same number of NICs */
     mpi_errno = MPIR_Allreduce_allcomm_auto(&tmp_num_nics, &num_nics, 1, MPI_INT,
                                             MPI_MIN, MPIR_Process.comm_world, MPIR_ERR_NONE);
-    MPIDI_OFI_global.num_vnis = tmp_num_vnis;
+    MPIDI_OFI_global.num_vcis = tmp_num_vcis;
     MPIDI_OFI_global.num_nics = tmp_num_nics;
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -696,22 +696,22 @@ int MPIDI_OFI_post_init(void)
         set_sep_counters(nic);
     }
 
-    for (int vni = 0; vni < MPIDI_OFI_global.num_vnis; vni++) {
+    for (int vci = 0; vci < MPIDI_OFI_global.num_vcis; vci++) {
         for (int nic = 0; nic < MPIDI_OFI_global.num_nics; nic++) {
-            /* vni 0 nic 0 already created */
-            if (vni > 0 || nic > 0) {
-                mpi_errno = create_vni_context(vni, nic);
+            /* vci 0 nic 0 already created */
+            if (vci > 0 || nic > 0) {
+                mpi_errno = create_vci_context(vci, nic);
                 MPIR_ERR_CHECK(mpi_errno);
             }
         }
     }
 
-    if (MPIDI_OFI_global.num_vnis > 1 || MPIDI_OFI_global.num_nics > 1) {
+    if (MPIDI_OFI_global.num_vcis > 1 || MPIDI_OFI_global.num_nics > 1) {
         mpi_errno = MPIDI_OFI_addr_exchange_all_ctx();
     }
 
-    for (int vni = 1; vni < MPIDI_OFI_global.num_vnis; vni++) {
-        ofi_am_post_recv(vni, 0);
+    for (int vci = 1; vci < MPIDI_OFI_global.num_vcis; vci++) {
+        ofi_am_post_recv(vci, 0);
     }
 
   fn_exit:
@@ -726,11 +726,11 @@ int MPIDI_OFI_post_init(void)
 #define MPIDI_OFI_FLUSH_TAG        1
 
 /* send a dummy message to flush the send queue */
-static int flush_send(int dst, int nic, int vni, MPIDI_OFI_dynamic_process_request_t * req)
+static int flush_send(int dst, int nic, int vci, MPIDI_OFI_dynamic_process_request_t * req)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    fi_addr_t addr = MPIDI_OFI_av_to_phys(&MPIDIU_get_av(0, dst), nic, vni, vni);
+    fi_addr_t addr = MPIDI_OFI_av_to_phys(&MPIDIU_get_av(0, dst), nic, vci, vci);
     static int data = 0;
     uint64_t match_bits = MPIDI_OFI_init_sendtag(MPIDI_OFI_FLUSH_CONTEXT_ID, 0,
                                                  MPIDI_OFI_FLUSH_TAG, MPIDI_OFI_DYNPROC_SEND);
@@ -739,15 +739,15 @@ static int flush_send(int dst, int nic, int vni, MPIDI_OFI_dynamic_process_reque
     req->done = 0;
     req->event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
 
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
     if (MPIDI_OFI_ENABLE_DATA) {
         MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                           &data, 4, NULL, 0, addr, match_bits, &req->context),
-                             vni, tsenddata, FALSE);
+                             vci, tsenddata, FALSE);
     } else {
         MPIDI_OFI_CALL_RETRY(fi_tsend(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                       &data, 4, NULL, addr, match_bits, &req->context),
-                             vni, tsend, FALSE);
+                             vci, tsend, FALSE);
     }
 
   fn_exit:
@@ -757,11 +757,11 @@ static int flush_send(int dst, int nic, int vni, MPIDI_OFI_dynamic_process_reque
 }
 
 /* recv the dummy message the other process sent for the purpose flushing send queue */
-static int flush_recv(int src, int nic, int vni, MPIDI_OFI_dynamic_process_request_t * req)
+static int flush_recv(int src, int nic, int vci, MPIDI_OFI_dynamic_process_request_t * req)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    fi_addr_t addr = MPIDI_OFI_av_to_phys(&MPIDIU_get_av(0, src), nic, vni, vni);
+    fi_addr_t addr = MPIDI_OFI_av_to_phys(&MPIDIU_get_av(0, src), nic, vci, vci);
     uint64_t mask_bits = 0;
     uint64_t match_bits = MPIDI_OFI_init_sendtag(MPIDI_OFI_FLUSH_CONTEXT_ID, 0,
                                                  MPIDI_OFI_FLUSH_TAG, MPIDI_OFI_DYNPROC_SEND);
@@ -772,9 +772,9 @@ static int flush_recv(int src, int nic, int vni, MPIDI_OFI_dynamic_process_reque
 
     /* we don't care the data and the tag field is not used */
     void *recvbuf = &(req->tag);
-    MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(NULL, vni, nic)].rx,
+    MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(NULL, vci, nic)].rx,
                                   recvbuf, 4, NULL, addr, match_bits, mask_bits, &req->context),
-                         vni, trecv, FALSE);
+                         vci, trecv, FALSE);
 
   fn_exit:
     return mpi_errno;
@@ -789,23 +789,23 @@ static int flush_send_queue(void)
     MPIDI_OFI_dynamic_process_request_t *reqs;
     /* TODO - Iterate over each NIC in addition to each VNI when multi-NIC within the same
      * process is implemented. */
-    int num_vnis = (MPIDI_global.is_initialized ? MPIDI_OFI_global.num_vnis : 1);
-    int num_reqs = num_vnis * 2;
+    int num_vcis = (MPIDI_global.is_initialized ? MPIDI_OFI_global.num_vcis : 1);
+    int num_reqs = num_vcis * 2;
     reqs = MPL_malloc(sizeof(MPIDI_OFI_dynamic_process_request_t) * num_reqs, MPL_MEM_OTHER);
 
     /* Apparently by sending self messages can flush the send queue */
     int rank = MPIR_Process.rank;
-    for (int vni = 0; vni < num_vnis; vni++) {
-        mpi_errno = flush_send(rank, 0, vni, &reqs[vni * 2]);
+    for (int vci = 0; vci < num_vcis; vci++) {
+        mpi_errno = flush_send(rank, 0, vci, &reqs[vci * 2]);
         MPIR_ERR_CHECK(mpi_errno);
-        mpi_errno = flush_recv(rank, 0, vni, &reqs[vni * 2 + 1]);
+        mpi_errno = flush_recv(rank, 0, vci, &reqs[vci * 2 + 1]);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
     bool all_done = false;
     while (!all_done) {
-        for (int vni = 0; vni < num_vnis; vni++) {
-            mpi_errno = MPIDI_NM_progress(vni, 0);
+        for (int vci = 0; vci < num_vcis; vci++) {
+            mpi_errno = MPIDI_NM_progress(vci, 0);
             MPIR_ERR_CHECK(mpi_errno);
         }
         all_done = true;
@@ -832,10 +832,10 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     MPIR_FUNC_ENTER;
 
     /* Progress until we drain all inflight RMA send long buffers */
-    /* NOTE: am currently only use vni 0. Need update once that changes */
-    for (int vni = 0; vni < MPIDI_OFI_global.num_vnis; vni++) {
-        while (MPIDI_OFI_global.per_vni[vni].am_inflight_rma_send_mrs > 0) {
-            MPIDI_OFI_PROGRESS(vni);
+    /* NOTE: am currently only use vci 0. Need update once that changes */
+    for (int vci = 0; vci < MPIDI_OFI_global.num_vcis; vci++) {
+        while (MPIDI_OFI_global.per_vci[vci].am_inflight_rma_send_mrs > 0) {
+            MPIDI_OFI_PROGRESS(vci);
         }
     }
 
@@ -860,19 +860,19 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     }
 
     /* Progress until we drain all inflight injection emulation requests */
-    /* NOTE: am currently only use vni 0. Need update once that changes */
-    for (int vni = 0; vni < MPIDI_OFI_global.num_vnis; vni++) {
-        while (MPIDI_OFI_global.per_vni[vni].am_inflight_inject_emus > 0) {
-            MPIDI_OFI_PROGRESS(vni);
+    /* NOTE: am currently only use vci 0. Need update once that changes */
+    for (int vci = 0; vci < MPIDI_OFI_global.num_vcis; vci++) {
+        while (MPIDI_OFI_global.per_vci[vci].am_inflight_inject_emus > 0) {
+            MPIDI_OFI_PROGRESS(vci);
         }
-        MPIR_Assert(MPIDI_OFI_global.per_vni[vni].am_inflight_inject_emus == 0);
+        MPIR_Assert(MPIDI_OFI_global.per_vci[vci].am_inflight_inject_emus == 0);
     }
 
     /* Tearing down endpoints in reverse order they were created */
     for (int nic = MPIDI_OFI_global.num_nics - 1; nic >= 0; nic--) {
-        for (int vni = MPIDI_OFI_global.num_vnis - 1; vni >= 0; vni--) {
-            if (MPIDI_global.is_initialized || (vni == 0 && nic == 0)) {
-                mpi_errno = destroy_vni_context(vni, nic);
+        for (int vci = MPIDI_OFI_global.num_vcis - 1; vci >= 0; vci--) {
+            if (MPIDI_global.is_initialized || (vci == 0 && nic == 0)) {
+                mpi_errno = destroy_vci_context(vci, nic);
                 MPIR_ERR_CHECK(mpi_errno);
             }
         }
@@ -888,23 +888,23 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     MPIDIU_map_destroy(MPIDI_OFI_global.req_map);
 
     if (MPIDI_OFI_ENABLE_AM) {
-        for (int vni = 0; vni < MPIDI_OFI_global.num_vnis; vni++) {
-            while (MPIDI_OFI_global.per_vni[vni].am_unordered_msgs) {
+        for (int vci = 0; vci < MPIDI_OFI_global.num_vcis; vci++) {
+            while (MPIDI_OFI_global.per_vci[vci].am_unordered_msgs) {
                 MPIDI_OFI_am_unordered_msg_t *uo_msg =
-                    MPIDI_OFI_global.per_vni[vni].am_unordered_msgs;
-                DL_DELETE(MPIDI_OFI_global.per_vni[vni].am_unordered_msgs, uo_msg);
+                    MPIDI_OFI_global.per_vci[vci].am_unordered_msgs;
+                DL_DELETE(MPIDI_OFI_global.per_vci[vci].am_unordered_msgs, uo_msg);
             }
-            MPIDIU_map_destroy(MPIDI_OFI_global.per_vni[vni].am_send_seq_tracker);
-            MPIDIU_map_destroy(MPIDI_OFI_global.per_vni[vni].am_recv_seq_tracker);
+            MPIDIU_map_destroy(MPIDI_OFI_global.per_vci[vci].am_send_seq_tracker);
+            MPIDIU_map_destroy(MPIDI_OFI_global.per_vci[vci].am_recv_seq_tracker);
 
             MPIDI_OFI_unregister_am_bufs();
-            MPL_free(MPIDI_OFI_global.per_vni[vni].am_bufs);
+            MPL_free(MPIDI_OFI_global.per_vci[vci].am_bufs);
 
-            MPIDU_genq_private_pool_destroy(MPIDI_OFI_global.per_vni[vni].am_hdr_buf_pool);
+            MPIDU_genq_private_pool_destroy(MPIDI_OFI_global.per_vci[vci].am_hdr_buf_pool);
 
-            MPIR_Assert(MPIDI_OFI_global.per_vni[vni].cq_buffered_static_head ==
-                        MPIDI_OFI_global.per_vni[vni].cq_buffered_static_tail);
-            MPIR_Assert(NULL == MPIDI_OFI_global.per_vni[vni].cq_buffered_dynamic_head);
+            MPIR_Assert(MPIDI_OFI_global.per_vci[vci].cq_buffered_static_head ==
+                        MPIDI_OFI_global.per_vci[vci].cq_buffered_static_tail);
+            MPIR_Assert(NULL == MPIDI_OFI_global.per_vci[vci].cq_buffered_dynamic_head);
         }
     }
 
@@ -940,8 +940,8 @@ int MPIDI_OFI_mpi_free_mem(void *ptr)
     return MPIDIG_mpi_free_mem(ptr);
 }
 
-/* ---- static functions for vni contexts ---- */
-static int create_vni_domain(struct fid_domain **p_domain, struct fid_av **p_av,
+/* ---- static functions for vci contexts ---- */
+static int create_vci_domain(struct fid_domain **p_domain, struct fid_av **p_av,
                              struct fid_cntr **p_cntr, int nic);
 static int create_cq(struct fid_domain *domain, struct fid_cq **p_cq);
 static int create_sep_tx(struct fid_ep *ep, int idx, struct fid_ep **p_tx,
@@ -951,15 +951,15 @@ static int create_sep_rx(struct fid_ep *ep, int idx, struct fid_ep **p_rx, struc
 static int try_open_shared_av(struct fid_domain *domain, struct fid_av **p_av, int nic);
 static int open_local_av(struct fid_domain *p_domain, struct fid_av **p_av);
 
-/* This function creates a vni context which includes all of the OFI-level objects needed to
+/* This function creates a vci context which includes all of the OFI-level objects needed to
  * initialize OFI (e.g. domain, address vector, endpoint, etc.). This function takes two arguments:
  *
- * vni - The VNI index within a nic to use when assigning the OFI information being created.
+ * vci - The VNI index within a nic to use when assigning the OFI information being created.
  * nic - The NIC that should be used when setting up the OFI interfaces.
  *
- * Each nic will restart its vni indexing. This allows each VNI to use any nic if desired.
+ * Each nic will restart its vci indexing. This allows each VNI to use any nic if desired.
  */
-static int create_vni_context(int vni, int nic)
+static int create_vci_context(int vci, int nic)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -995,7 +995,7 @@ static int create_vni_context(int vni, int nic)
     struct fid_ep *rx;
 
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
-    mpi_errno = create_vni_domain(&domain, &av, &rma_cmpl_cntr, nic);
+    mpi_errno = create_vci_domain(&domain, &av, &rma_cmpl_cntr, nic);
     MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = create_cq(domain, &cq);
     MPIR_ERR_CHECK(mpi_errno);
@@ -1018,7 +1018,7 @@ static int create_vni_context(int vni, int nic)
         tx = ep;
         rx = ep;
     }
-    ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
+    ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
     MPIDI_OFI_global.ctx[ctx_idx].domain = domain;
     MPIDI_OFI_global.ctx[ctx_idx].av = av;
     MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr = rma_cmpl_cntr;
@@ -1031,9 +1031,9 @@ static int create_vni_context(int vni, int nic)
 #else /* MPIDI_OFI_VNI_USE_SEPCTX */
     /* Endpoints are used to bundle together all VNIs. In addition, we have to duplicate these
      * endpoints such that each NIC gets its own endpoint. So now we have a endpoint per nic and a
-     * transmit/receive context per vni. */
-    if (vni == 0) {
-        mpi_errno = create_vni_domain(&domain, &av, &rma_cmpl_cntr, nic);
+     * transmit/receive context per vci. */
+    if (vci == 0) {
+        mpi_errno = create_vci_domain(&domain, &av, &rma_cmpl_cntr, nic);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         ctx_idx = MPIDI_OFI_get_ctx_index(NULL, 0, nic);
@@ -1044,9 +1044,9 @@ static int create_vni_context(int vni, int nic)
     mpi_errno = create_cq(domain, &cq);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* If this is the first vni in the bundle, we need to create the endpoint. Otherwise, just copy
-     * it from the first vni. */
-    if (vni == 0) {
+    /* If this is the first vci in the bundle, we need to create the endpoint. Otherwise, just copy
+     * it from the first vci. */
+    if (vci == 0) {
         if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
             MPIDI_OFI_CALL(fi_scalable_ep(domain, prov_use, &ep, NULL), ep);
             MPIDI_OFI_CALL(fi_scalable_ep_bind(ep, &av->fid, 0), bind);
@@ -1065,28 +1065,28 @@ static int create_vni_context(int vni, int nic)
     }
 
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
-        mpi_errno = create_sep_tx(ep, vni, &tx, cq, rma_cmpl_cntr, nic);
+        mpi_errno = create_sep_tx(ep, vci, &tx, cq, rma_cmpl_cntr, nic);
         MPIR_ERR_CHECK(mpi_errno);
-        mpi_errno = create_sep_rx(ep, vni, &rx, cq, nic);
+        mpi_errno = create_sep_rx(ep, vci, &rx, cq, nic);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         tx = ep;
         rx = ep;
     }
 
-    if (vni == 0) {
-        ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
+    if (vci == 0) {
+        ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
         MPIDI_OFI_global.ctx[ctx_idx].domain = domain;
         MPIDI_OFI_global.ctx[ctx_idx].av = av;
         MPIDI_OFI_global.ctx[ctx_idx].rma_cmpl_cntr = rma_cmpl_cntr;
         MPIDI_OFI_global.ctx[ctx_idx].ep = ep;
     } else {
-        /* non-zero vni share most fields with vni 0, copy them
+        /* non-zero vci share most fields with vci 0, copy them
          * so we don't have to switch during runtime */
-        MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(NULL, vni, nic)] =
+        MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(NULL, vci, nic)] =
             MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(NULL, 0, nic)];
     }
-    ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
+    ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
     MPIDI_OFI_global.ctx[ctx_idx].cq = cq;
     MPIDI_OFI_global.ctx[ctx_idx].tx = tx;
     MPIDI_OFI_global.ctx[ctx_idx].rx = rx;
@@ -1099,10 +1099,10 @@ static int create_vni_context(int vni, int nic)
     goto fn_exit;
 }
 
-static int destroy_vni_context(int vni, int nic)
+static int destroy_vci_context(int vci, int nic)
 {
     int mpi_errno = MPI_SUCCESS;
-    int ctx_num = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
+    int ctx_num = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
 
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
@@ -1127,14 +1127,14 @@ static int destroy_vni_context(int vni, int nic)
         MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].tx->fid), epclose);
         MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].rx->fid), epclose);
         MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].cq->fid), cqclose);
-        if (vni == 0) {
+        if (vci == 0) {
             MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].ep->fid), epclose);
             MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].av->fid), avclose);
             MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].rma_cmpl_cntr->fid), cntrclose);
             MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].domain->fid), domainclose);
         }
     } else {    /* normal endpoint */
-        MPIR_Assert(vni == 0);
+        MPIR_Assert(vci == 0);
         MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].ep->fid), epclose);
         MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].cq->fid), cqclose);
         MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.ctx[ctx_num].av->fid), avclose);
@@ -1163,7 +1163,7 @@ static int destroy_vni_context(int vni, int nic)
     goto fn_exit;
 }
 
-static int create_vni_domain(struct fid_domain **p_domain, struct fid_av **p_av,
+static int create_vci_domain(struct fid_domain **p_domain, struct fid_av **p_av,
                              struct fid_cntr **p_cntr, int nic)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1466,7 +1466,7 @@ static void dump_global_settings(void)
     fprintf(stdout, "MPIDI_OFI_MAX_AM_HDR_SIZE: %d\n", (int) MPIDI_OFI_MAX_AM_HDR_SIZE);
     fprintf(stdout, "sizeof(MPIDI_OFI_am_request_header_t): %d\n",
             (int) sizeof(MPIDI_OFI_am_request_header_t));
-    fprintf(stdout, "sizeof(MPIDI_OFI_per_vni_t): %d\n", (int) sizeof(MPIDI_OFI_per_vni_t));
+    fprintf(stdout, "sizeof(MPIDI_OFI_per_vci_t): %d\n", (int) sizeof(MPIDI_OFI_per_vci_t));
     fprintf(stdout, "MPIDI_OFI_AM_HDR_POOL_CELL_SIZE: %d\n", (int) MPIDI_OFI_AM_HDR_POOL_CELL_SIZE);
     fprintf(stdout, "MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE: %d\n",
             (int) MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE);
@@ -1475,7 +1475,7 @@ static void dump_global_settings(void)
 static void dump_dynamic_settings(void)
 {
     fprintf(stdout, "==== OFI dynamic settings ====\n");
-    fprintf(stdout, "num_vnis: %d\n", MPIDI_OFI_global.num_vnis);
+    fprintf(stdout, "num_vcis: %d\n", MPIDI_OFI_global.num_vcis);
     fprintf(stdout, "num_nics: %d\n", MPIDI_OFI_global.num_nics);
     fprintf(stdout, "======================================\n");
 }
@@ -1494,28 +1494,28 @@ int ofi_am_init(void)
                                 < MPIDI_OFI_AM_HDR_POOL_CELL_SIZE);
         MPL_COMPILE_TIME_ASSERT(MPIDI_OFI_AM_HDR_POOL_CELL_SIZE
                                 >= sizeof(MPIDI_OFI_am_send_pipeline_request_t));
-        for (int vni = 0; vni < MPIDI_OFI_global.num_vnis; vni++) {
+        for (int vci = 0; vci < MPIDI_OFI_global.num_vcis; vci++) {
             mpi_errno = MPIDU_genq_private_pool_create(MPIDI_OFI_AM_HDR_POOL_CELL_SIZE,
                                                        MPIDI_OFI_AM_HDR_POOL_NUM_CELLS_PER_CHUNK,
                                                        0 /* unlimited */ ,
                                                        host_alloc, host_free,
                                                        &MPIDI_OFI_global.
-                                                       per_vni[vni].am_hdr_buf_pool);
+                                                       per_vci[vci].am_hdr_buf_pool);
             MPIR_ERR_CHECK(mpi_errno);
 
-            MPIDI_OFI_global.per_vni[vni].cq_buffered_dynamic_head = NULL;
-            MPIDI_OFI_global.per_vni[vni].cq_buffered_dynamic_tail = NULL;
-            MPIDI_OFI_global.per_vni[vni].cq_buffered_static_head = 0;
-            MPIDI_OFI_global.per_vni[vni].cq_buffered_static_tail = 0;
+            MPIDI_OFI_global.per_vci[vci].cq_buffered_dynamic_head = NULL;
+            MPIDI_OFI_global.per_vci[vci].cq_buffered_dynamic_tail = NULL;
+            MPIDI_OFI_global.per_vci[vci].cq_buffered_static_head = 0;
+            MPIDI_OFI_global.per_vci[vci].cq_buffered_static_tail = 0;
 
-            MPIDIU_map_create(&MPIDI_OFI_global.per_vni[vni].am_recv_seq_tracker, MPL_MEM_BUFFER);
-            MPIDIU_map_create(&MPIDI_OFI_global.per_vni[vni].am_send_seq_tracker, MPL_MEM_BUFFER);
-            MPIDI_OFI_global.per_vni[vni].am_unordered_msgs = NULL;
+            MPIDIU_map_create(&MPIDI_OFI_global.per_vci[vci].am_recv_seq_tracker, MPL_MEM_BUFFER);
+            MPIDIU_map_create(&MPIDI_OFI_global.per_vci[vci].am_send_seq_tracker, MPL_MEM_BUFFER);
+            MPIDI_OFI_global.per_vci[vci].am_unordered_msgs = NULL;
 
-            MPIDI_OFI_global.per_vni[vni].deferred_am_isend_q = NULL;
+            MPIDI_OFI_global.per_vci[vci].deferred_am_isend_q = NULL;
 
-            MPIDI_OFI_global.per_vni[vni].am_inflight_inject_emus = 0;
-            MPIDI_OFI_global.per_vni[vni].am_inflight_rma_send_mrs = 0;
+            MPIDI_OFI_global.per_vci[vci].am_inflight_inject_emus = 0;
+            MPIDI_OFI_global.per_vci[vci].am_inflight_rma_send_mrs = 0;
         }
         MPIDIG_am_reg_cb(MPIDI_OFI_INTERNAL_HANDLER_CONTROL, NULL, &MPIDI_OFI_control_handler);
         MPIDIG_am_reg_cb(MPIDI_OFI_AM_RDMA_READ_ACK, NULL, &MPIDI_OFI_am_rdma_read_ack_handler);
@@ -1527,7 +1527,7 @@ int ofi_am_init(void)
     goto fn_exit;
 }
 
-int ofi_am_post_recv(int vni, int nic)
+int ofi_am_post_recv(int vci, int nic)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -1535,7 +1535,7 @@ int ofi_am_post_recv(int vni, int nic)
     MPIR_Assert(nic == 0);
 
     if (MPIDI_OFI_ENABLE_AM) {
-        int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
+        int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
         size_t optlen = MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE;
 
         MPIDI_OFI_CALL(fi_setopt(&(MPIDI_OFI_global.ctx[ctx_idx].rx->fid),
@@ -1543,24 +1543,24 @@ int ofi_am_post_recv(int vni, int nic)
                                  FI_OPT_MIN_MULTI_RECV, &optlen, sizeof(optlen)), setopt);
 
         /* we allocate a single buffer and post recvs using an offset */
-        MPIDI_OFI_global.per_vni[vni].am_bufs =
+        MPIDI_OFI_global.per_vci[vci].am_bufs =
             MPL_malloc(MPIDI_OFI_AM_BUFF_SZ * MPIDI_OFI_NUM_AM_BUFFERS, MPL_MEM_BUFFER);
         for (int i = 0; i < MPIDI_OFI_NUM_AM_BUFFERS; i++) {
-            MPIDI_OFI_global.per_vni[vni].am_reqs[i].event_id = MPIDI_OFI_EVENT_AM_RECV;
-            MPIDI_OFI_global.per_vni[vni].am_reqs[i].index = i;
-            MPIR_Assert(MPIDI_OFI_global.per_vni[vni].am_bufs);
-            MPIDI_OFI_global.per_vni[vni].am_iov[i].iov_base =
-                (char *) MPIDI_OFI_global.per_vni[vni].am_bufs + (MPIDI_OFI_AM_BUFF_SZ * i);
-            MPIDI_OFI_global.per_vni[vni].am_iov[i].iov_len = MPIDI_OFI_AM_BUFF_SZ;
-            MPIDI_OFI_global.per_vni[vni].am_msg[i].msg_iov =
-                &MPIDI_OFI_global.per_vni[vni].am_iov[i];
-            MPIDI_OFI_global.per_vni[vni].am_msg[i].desc = NULL;
-            MPIDI_OFI_global.per_vni[vni].am_msg[i].addr = FI_ADDR_UNSPEC;
-            MPIDI_OFI_global.per_vni[vni].am_msg[i].context =
-                &MPIDI_OFI_global.per_vni[vni].am_reqs[i].context;
-            MPIDI_OFI_global.per_vni[vni].am_msg[i].iov_count = 1;
+            MPIDI_OFI_global.per_vci[vci].am_reqs[i].event_id = MPIDI_OFI_EVENT_AM_RECV;
+            MPIDI_OFI_global.per_vci[vci].am_reqs[i].index = i;
+            MPIR_Assert(MPIDI_OFI_global.per_vci[vci].am_bufs);
+            MPIDI_OFI_global.per_vci[vci].am_iov[i].iov_base =
+                (char *) MPIDI_OFI_global.per_vci[vci].am_bufs + (MPIDI_OFI_AM_BUFF_SZ * i);
+            MPIDI_OFI_global.per_vci[vci].am_iov[i].iov_len = MPIDI_OFI_AM_BUFF_SZ;
+            MPIDI_OFI_global.per_vci[vci].am_msg[i].msg_iov =
+                &MPIDI_OFI_global.per_vci[vci].am_iov[i];
+            MPIDI_OFI_global.per_vci[vci].am_msg[i].desc = NULL;
+            MPIDI_OFI_global.per_vci[vci].am_msg[i].addr = FI_ADDR_UNSPEC;
+            MPIDI_OFI_global.per_vci[vci].am_msg[i].context =
+                &MPIDI_OFI_global.per_vci[vci].am_reqs[i].context;
+            MPIDI_OFI_global.per_vci[vci].am_msg[i].iov_count = 1;
             MPIDI_OFI_CALL_RETRY(fi_recvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx,
-                                            &MPIDI_OFI_global.per_vni[vni].am_msg[i],
+                                            &MPIDI_OFI_global.per_vci[vci].am_msg[i],
                                             FI_MULTI_RECV | FI_COMPLETION), 0, prepost, FALSE);
         }
     }
@@ -1572,12 +1572,12 @@ int ofi_am_post_recv(int vni, int nic)
 }
 
 /* called in MPIDI_OFI_dispatch_function when FI_MULTI_RECV is flagged */
-int MPIDI_OFI_am_repost_buffer(int vni, int am_idx)
+int MPIDI_OFI_am_repost_buffer(int vci, int am_idx)
 {
     int mpi_errno = MPI_SUCCESS;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, 0);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, 0);
     MPIDI_OFI_CALL_RETRY_AM(fi_recvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx,
-                                       &MPIDI_OFI_global.per_vni[vni].am_msg[am_idx],
+                                       &MPIDI_OFI_global.per_vci[vci].am_msg[am_idx],
                                        FI_MULTI_RECV | FI_COMPLETION), prepost);
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -87,13 +87,13 @@ typedef struct MPIDI_OFI_am_header_t {
     uint64_t payload_sz:MPIDI_OFI_AM_PAYLOAD_SZ_BITS;   /* data size on this OFI message. This
                                                          * could be the size of a pipeline segment
                                                          * */
-    /* vnis are needed for callbacks and to reply.
-     * Note: technically the vni_dst don't need be transported since the receiver
-     * always know which vni it receives the message. However, having both of them
+    /* vcis are needed for callbacks and to reply.
+     * Note: technically the vci_dst don't need be transported since the receiver
+     * always know which vci it receives the message. However, having both of them
      * in the header makes the design symmetric and thus easier to maintain.
      */
-    uint8_t vni_src;
-    uint8_t vni_dst;
+    uint8_t vci_src;
+    uint8_t vci_dst;
     uint16_t seqno:MPIDI_OFI_AM_SEQ_NO_BITS;    /* Sequence number of this message.
                                                  * Number is unique to (fi_src_addr,
                                                  * fi_dest_addr) pair. */
@@ -167,8 +167,8 @@ typedef struct MPIDI_OFI_deferred_am_isend_req {
     MPIR_Request *sreq;
     bool need_packing;
     MPI_Aint data_sz;
-    int vni_src;
-    int vni_dst;
+    int vci_src;
+    int vci_dst;
 
     struct MPIDI_OFI_deferred_am_isend_req *prev;
     struct MPIDI_OFI_deferred_am_isend_req *next;
@@ -288,7 +288,7 @@ typedef struct {
 
 typedef struct {
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
-    fi_addr_t dest[MPIDI_OFI_MAX_NICS][MPIDI_CH4_MAX_VCIS];     /* [nic][vni] */
+    fi_addr_t dest[MPIDI_OFI_MAX_NICS][MPIDI_CH4_MAX_VCIS];     /* [nic][vci] */
 #else
     fi_addr_t dest[MPIDI_OFI_MAX_NICS][1];
 #endif

--- a/src/mpid/ch4/netmod/ofi/ofi_probe.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_probe.h
@@ -12,7 +12,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
                                                  int tag,
                                                  MPIR_Comm * comm,
                                                  int context_offset,
-                                                 MPIDI_av_entry_t * addr, int vni_src, int vni_dst,
+                                                 MPIDI_av_entry_t * addr, int vci_src, int vci_dst,
                                                  int *flag,
                                                  MPI_Status * status, MPIR_Request ** message)
 {
@@ -22,20 +22,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
     MPIR_Request r, *rreq;      /* don't need to init request, output only */
     struct fi_msg_tagged msg;
     int ofi_err;
-    int vni_local = vni_dst;
-    int vni_remote = vni_src;
+    int vci_local = vci_dst;
+    int vci_remote = vci_src;
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_dst, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_dst, nic);
 
     MPIR_FUNC_ENTER;
 
     if (unlikely(MPI_ANY_SOURCE == source))
         remote_proc = FI_ADDR_UNSPEC;
     else
-        remote_proc = MPIDI_OFI_av_to_phys(addr, nic, vni_local, vni_remote);
+        remote_proc = MPIDI_OFI_av_to_phys(addr, nic, vci_local, vci_remote);
 
     if (message) {
-        MPIDI_CH4_REQUEST_CREATE(rreq, MPIR_REQUEST_KIND__MPROBE, vni_dst, 1);
+        MPIDI_CH4_REQUEST_CREATE(rreq, MPIR_REQUEST_KIND__MPROBE, vci_dst, 1);
         MPIR_ERR_CHKANDSTMT((rreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     } else {
         rreq = &r;
@@ -78,7 +78,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
 
     MPIDI_OFI_CALL(ofi_err, trecvmsg);
     MPIDI_OFI_PROGRESS_WHILE(MPL_atomic_acquire_load_int(&(MPIDI_OFI_REQUEST(rreq, util_id))) ==
-                             MPIDI_OFI_PEEK_START, vni_dst);
+                             MPIDI_OFI_PEEK_START, vci_dst);
 
     /* Ordering constraint for util_id is unnecessary after the thread unblocks */
     switch (MPL_atomic_relaxed_load_int(&(MPIDI_OFI_REQUEST(rreq, util_id)))) {
@@ -116,13 +116,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_iprobe(int source,
 }
 
 /* Common macro used by all MPIDI_NM_mpi_probe routines to facilitate tuning */
-#define MPIDI_OFI_PROBE_VNIS(vni_src_, vni_dst_) \
+#define MPIDI_OFI_PROBE_VNIS(vci_src_, vci_dst_) \
     do { \
         /* NOTE: hashing is based on target rank */ \
-        MPIDI_EXPLICIT_VCIS(comm, attr, source, comm->rank, vni_src_, vni_dst_); \
-        if (vni_src_ == 0 && vni_dst_ == 0) { \
-            vni_src_ = MPIDI_get_vci(SRC_VCI_FROM_RECVER, comm, source, comm->rank, tag); \
-            vni_dst_ = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag); \
+        MPIDI_EXPLICIT_VCIS(comm, attr, source, comm->rank, vci_src_, vci_dst_); \
+        if (vci_src_ == 0 && vci_dst_ == 0) { \
+            vci_src_ = MPIDI_get_vci(SRC_VCI_FROM_RECVER, comm, source, comm->rank, tag); \
+            vci_dst_ = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag); \
         } \
     } while (0)
 
@@ -138,19 +138,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
     MPIR_FUNC_ENTER;
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-    int vni_src, vni_dst;
-    MPIDI_OFI_PROBE_VNIS(vni_src, vni_dst);
+    int vci_src, vci_dst;
+    MPIDI_OFI_PROBE_VNIS(vci_src, vci_dst);
 
-    MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_dst);
+    MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vci_dst);
     if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno = MPIDIG_mpi_improbe(source, tag, comm, context_offset, vni_dst, flag, message,
+        mpi_errno = MPIDIG_mpi_improbe(source, tag, comm, context_offset, vci_dst, flag, message,
                                        status);
     } else {
         /* Set flags for mprobe peek, when ready */
-        mpi_errno = MPIDI_OFI_do_iprobe(source, tag, comm, context_offset, addr, vni_src, vni_dst,
+        mpi_errno = MPIDI_OFI_do_iprobe(source, tag, comm, context_offset, addr, vci_src, vci_dst,
                                         flag, status, message);
     }
-    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_dst);
+    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vci_dst);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -166,17 +166,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
     MPIR_FUNC_ENTER;
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-    int vni_src, vni_dst;
-    MPIDI_OFI_PROBE_VNIS(vni_src, vni_dst);
+    int vci_src, vci_dst;
+    MPIDI_OFI_PROBE_VNIS(vci_src, vci_dst);
 
-    MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_dst);
+    MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vci_dst);
     if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, vni_dst, flag, status);
+        mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, vci_dst, flag, status);
     } else {
         mpi_errno = MPIDI_OFI_do_iprobe(source, tag, comm, context_offset, addr,
-                                        vni_src, vni_dst, flag, status, NULL);
+                                        vci_src, vci_dst, flag, status, NULL);
     }
-    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_dst);
+    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vci_dst);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.c
@@ -7,7 +7,7 @@
 #include "ofi_impl.h"
 #include "ofi_events.h"
 
-int MPIDI_OFI_progress_uninlined(int vni)
+int MPIDI_OFI_progress_uninlined(int vci)
 {
-    return MPIDI_NM_progress(vni, 0);
+    return MPIDI_NM_progress(vci, 0);
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -8,11 +8,11 @@
 
 #include "ofi_impl.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_deferred_ops(int vni)
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_deferred_ops(int vci)
 {
 
     int mpi_errno = MPI_SUCCESS;
-    MPIDI_OFI_deferred_am_isend_req_t *dreq = MPIDI_OFI_global.per_vni[vni].deferred_am_isend_q;
+    MPIDI_OFI_deferred_am_isend_req_t *dreq = MPIDI_OFI_global.per_vci[vci].deferred_am_isend_q;
 
     MPIR_FUNC_ENTER;
 
@@ -21,20 +21,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_deferred_ops(int vni)
             case MPIDI_OFI_DEFERRED_AM_OP__ISEND_EAGER:
                 mpi_errno = MPIDI_OFI_do_am_isend_eager(dreq->rank, dreq->comm, dreq->handler_id,
                                                         NULL, 0, dreq->buf, dreq->count,
-                                                        dreq->datatype, dreq->sreq, true, vni,
-                                                        dreq->vni_dst);
+                                                        dreq->datatype, dreq->sreq, true, vci,
+                                                        dreq->vci_dst);
                 break;
             case MPIDI_OFI_DEFERRED_AM_OP__ISEND_PIPELINE:
                 mpi_errno = MPIDI_OFI_do_am_isend_pipeline(dreq->rank, dreq->comm, dreq->handler_id,
                                                            NULL, 0, dreq->buf, dreq->count,
                                                            dreq->datatype, dreq->sreq,
-                                                           dreq->data_sz, true, vni, dreq->vni_dst);
+                                                           dreq->data_sz, true, vci, dreq->vci_dst);
                 break;
             case MPIDI_OFI_DEFERRED_AM_OP__ISEND_RDMA_READ:
                 mpi_errno = MPIDI_OFI_do_am_isend_rdma_read(dreq->rank, dreq->comm,
                                                             dreq->handler_id, NULL, 0, dreq->buf,
                                                             dreq->count, dreq->datatype, dreq->sreq,
-                                                            true, vni, dreq->vni_dst);
+                                                            true, vci, dreq->vci_dst);
                 break;
             default:
                 MPIR_Assert(0);
@@ -49,7 +49,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_deferred_ops(int vni)
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_entries(int vni, struct fi_cq_tagged_entry *wc,
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_entries(int vci, struct fi_cq_tagged_entry *wc,
                                                          ssize_t num)
 {
     int i, mpi_errno = MPI_SUCCESS;
@@ -58,7 +58,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_entries(int vni, struct fi_cq_t
 
     for (i = 0; i < num; i++) {
         req = MPIDI_OFI_context_to_request(wc[i].op_context);
-        mpi_errno = MPIDI_OFI_dispatch_optimized(vni, &wc[i], req);
+        mpi_errno = MPIDI_OFI_dispatch_optimized(vci, &wc[i], req);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -76,35 +76,34 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
     ssize_t ret;
     MPIR_FUNC_ENTER;
 
-    int vni = MPIDI_OFI_vci_to_vni(vci);
-    if (vni >= MPIDI_OFI_global.num_vnis) {
-        /* The requests generated from ofi will have vni/vci within our range.
-         * All requests that have vci beyond num_vnis are not from us, nothing
+    if (vci >= MPIDI_OFI_global.num_vcis) {
+        /* The requests generated from ofi will have vci within our range.
+         * All requests that have vci beyond num_vcis are not from us, nothing
          * to do, so simply return.
          * NOTE: it is not an error since global progress will poll every vci.
          */
         return MPI_SUCCESS;
     }
 
-    if (unlikely(MPIDI_OFI_has_cq_buffered(vni))) {
-        int num = MPIDI_OFI_get_buffered(vni, wc);
-        mpi_errno = MPIDI_OFI_handle_cq_entries(vni, wc, num);
+    if (unlikely(MPIDI_OFI_has_cq_buffered(vci))) {
+        int num = MPIDI_OFI_get_buffered(vci, wc);
+        mpi_errno = MPIDI_OFI_handle_cq_entries(vci, wc, num);
     } else if (likely(1)) {
         for (int nic = 0; nic < MPIDI_OFI_global.num_nics; nic++) {
-            int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vni, nic);
+            int ctx_idx = MPIDI_OFI_get_ctx_index(NULL, vci, nic);
             ret = fi_cq_read(MPIDI_OFI_global.ctx[ctx_idx].cq, (void *) wc,
                              MPIDI_OFI_NUM_CQ_ENTRIES);
 
             if (likely(ret > 0))
-                mpi_errno = MPIDI_OFI_handle_cq_entries(vni, wc, ret);
+                mpi_errno = MPIDI_OFI_handle_cq_entries(vci, wc, ret);
             else if (ret == -FI_EAGAIN)
                 mpi_errno = MPI_SUCCESS;
             else
-                mpi_errno = MPIDI_OFI_handle_cq_error(vni, nic, ret);
+                mpi_errno = MPIDI_OFI_handle_cq_error(vci, nic, ret);
         }
 
-        if (unlikely(mpi_errno == MPI_SUCCESS && MPIDI_OFI_global.per_vni[vni].deferred_am_isend_q)) {
-            mpi_errno = MPIDI_OFI_handle_deferred_ops(vni);
+        if (unlikely(mpi_errno == MPI_SUCCESS && MPIDI_OFI_global.per_vci[vci].deferred_am_isend_q)) {
+            mpi_errno = MPIDI_OFI_handle_deferred_ops(vci);
         }
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -24,7 +24,7 @@
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_t data_sz,      /* data_sz passed in here for reusing */
                                                 int rank, uint64_t match_bits, uint64_t mask_bits,
                                                 MPIR_Comm * comm, MPIR_Context_id_t context_id,
-                                                MPIDI_av_entry_t * addr, int vni_src, int vni_dst,
+                                                MPIDI_av_entry_t * addr, int vci_src, int vci_dst,
                                                 MPIR_Request * rreq,
                                                 MPIR_Datatype * dt_ptr, uint64_t flags)
 {
@@ -32,8 +32,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
     struct iovec *originv = NULL;
     struct fi_msg_tagged msg;
     MPI_Aint num_contig, size;
-    int vni_remote = vni_src;
-    int vni_local = vni_dst;
+    int vci_remote = vci_src;
+    int vci_local = vci_dst;
     int ctx_idx = 0;
     int sender_nic = 0, receiver_nic = 0;
 
@@ -53,7 +53,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
         MPIDI_OFI_multx_receiver_nic_index(comm, comm->recvcontext_id, rank, comm->rank,
                                            MPIDI_OFI_init_get_tag(match_bits));
     MPIDI_OFI_REQUEST(rreq, nic_num) = receiver_nic;
-    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_dst, MPIDI_OFI_REQUEST(rreq, nic_num));
+    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_dst, MPIDI_OFI_REQUEST(rreq, nic_num));
 
     if (!flags) {
         flags = FI_COMPLETION;
@@ -90,9 +90,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
     msg.data = 0;
     msg.addr =
         (MPI_ANY_SOURCE == rank) ? FI_ADDR_UNSPEC : MPIDI_OFI_av_to_phys(addr, sender_nic,
-                                                                         vni_local, vni_remote);
+                                                                         vci_local, vci_remote);
 
-    MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx, &msg, flags), vni_local,
+    MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx, &msg, flags), vci_local,
                          trecv, FALSE);
 
   fn_exit:
@@ -114,7 +114,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
                                                 int tag,
                                                 MPIR_Comm * comm,
                                                 int context_offset,
-                                                MPIDI_av_entry_t * addr, int vni_src, int vni_dst,
+                                                MPIDI_av_entry_t * addr, int vci_src, int vci_dst,
                                                 MPIR_Request ** request, int mode, uint64_t flags)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -128,15 +128,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
     struct fi_msg_tagged msg;
     char *recv_buf;
     bool force_gpu_pack = false;
-    int vni_remote = vni_src;
-    int vni_local = vni_dst;
+    int vci_remote = vci_src;
+    int vci_local = vci_dst;
     int sender_nic = 0, receiver_nic = 0;
     int ctx_idx = 0;
 
     MPIR_FUNC_ENTER;
 
     if (mode == MPIDI_OFI_ON_HEAP) {    /* Branch should compile out */
-        MPIDI_OFI_REQUEST_CREATE(*request, MPIR_REQUEST_KIND__RECV, vni_dst);
+        MPIDI_OFI_REQUEST_CREATE(*request, MPIR_REQUEST_KIND__RECV, vci_dst);
         rreq = *request;
 
         /* Need to set the source to UNDEFINED for anysource matching */
@@ -160,7 +160,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
     receiver_nic =
         MPIDI_OFI_multx_receiver_nic_index(comm, comm->recvcontext_id, rank, comm->rank, tag);
     MPIDI_OFI_REQUEST(rreq, nic_num) = receiver_nic;
-    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_dst, MPIDI_OFI_REQUEST(rreq, nic_num));
+    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_dst, MPIDI_OFI_REQUEST(rreq, nic_num));
 
     match_bits = MPIDI_OFI_init_recvtag(&mask_bits, context_id, rank, tag);
 
@@ -189,7 +189,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
               MPIDI_OFI_COMM(comm).enable_striping))) {
             mpi_errno =
                 MPIDI_OFI_recv_iov(buf, count, data_sz, rank, match_bits, mask_bits, comm,
-                                   context_id, addr, vni_src, vni_dst, rreq, dt_ptr, flags);
+                                   context_id, addr, vci_src, vci_dst, rreq, dt_ptr, flags);
             if (mpi_errno == MPI_SUCCESS)       /* Receive posted using iov */
                 goto fn_exit;
             else if (mpi_errno != MPIDI_OFI_RECV_NEEDS_UNPACK)
@@ -240,9 +240,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
                                       data_sz,
                                       NULL,
                                       (MPI_ANY_SOURCE == rank) ? FI_ADDR_UNSPEC :
-                                      MPIDI_OFI_av_to_phys(addr, sender_nic, vni_local, vni_remote),
+                                      MPIDI_OFI_av_to_phys(addr, sender_nic, vci_local, vci_remote),
                                       match_bits, mask_bits,
-                                      (void *) &(MPIDI_OFI_REQUEST(rreq, context))), vni_local,
+                                      (void *) &(MPIDI_OFI_REQUEST(rreq, context))), vci_local,
                              trecv, FALSE);
     } else {
         msg.msg_iov = &MPIDI_OFI_REQUEST(rreq, util.iov);
@@ -254,7 +254,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         msg.data = 0;
         msg.addr = FI_ADDR_UNSPEC;
 
-        MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx, &msg, flags), vni_local,
+        MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx, &msg, flags), vci_local,
                              trecv, FALSE);
     }
 
@@ -266,18 +266,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
 }
 
 /* Common macro used by all MPIDI_NM_mpi_irecv routines to facilitate tuning */
-#define MPIDI_OFI_RECV_VNIS(vni_src_, vni_dst_) \
+#define MPIDI_OFI_RECV_VNIS(vci_src_, vci_dst_) \
     do { \
         if (*request != NULL) { \
             /* workq path  or collectives */ \
-            vni_src_ = 0; \
-            vni_dst_ = 0; \
+            vci_src_ = 0; \
+            vci_dst_ = 0; \
         } else { \
             /* NOTE: hashing is based on target rank */ \
-            MPIDI_EXPLICIT_VCIS(comm, attr, rank, comm->rank, vni_src_, vni_dst_); \
-            if (vni_src_ == 0 && vni_dst_ == 0) { \
-                vni_src_ = MPIDI_get_vci(SRC_VCI_FROM_RECVER, comm, rank, comm->rank, tag); \
-                vni_dst_ = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag); \
+            MPIDI_EXPLICIT_VCIS(comm, attr, rank, comm->rank, vci_src_, vci_dst_); \
+            if (vci_src_ == 0 && vci_dst_ == 0) { \
+                vci_src_ = MPIDI_get_vci(SRC_VCI_FROM_RECVER, comm, rank, comm->rank, tag); \
+                vci_dst_ = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag); \
             } \
         } \
     } while (0)
@@ -298,7 +298,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
     } else {
         rreq = message;
         av = MPIDIU_comm_rank_to_av(rreq->comm, message->status.MPI_SOURCE);
-        /* FIXME: need get vni_src in the request */
+        /* FIXME: need get vci_src in the request */
         mpi_errno = MPIDI_OFI_do_irecv(buf, count, datatype, message->status.MPI_SOURCE,
                                        message->status.MPI_TAG, rreq->comm, 0, av, 0, vci,
                                        &rreq, MPIDI_OFI_USE_EXISTING, FI_CLAIM | FI_COMPLETION);
@@ -322,22 +322,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
     MPIR_FUNC_ENTER;
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-    int vni_src, vni_dst;
-    MPIDI_OFI_RECV_VNIS(vni_src, vni_dst);
+    int vci_src, vci_dst;
+    MPIDI_OFI_RECV_VNIS(vci_src, vci_dst);
 
     /* For anysource recv, we may be called while holding the vci lock of shm request (to
      * prevent shm progress). Therefore, recursive locking is allowed here */
-    MPIDI_OFI_THREAD_CS_ENTER_REC_VCI_OPTIONAL(vni_dst);
+    MPIDI_OFI_THREAD_CS_ENTER_REC_VCI_OPTIONAL(vci_dst);
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno = MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
-                                     vni_dst, request, 0, partner);
+                                     vci_dst, request, 0, partner);
     } else {
         mpi_errno = MPIDI_OFI_do_irecv(buf, count, datatype, rank, tag, comm,
-                                       context_offset, addr, vni_src, vni_dst, request,
+                                       context_offset, addr, vci_src, vci_dst, request,
                                        MPIDI_OFI_ON_HEAP, 0ULL);
         MPIDI_REQUEST_SET_LOCAL(*request, 0, partner);
     }
-    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_dst);
+    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vci_dst);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -349,8 +349,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq, bool 
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    int vni = MPIDI_Request_get_vci(rreq);
-    int ctx_idx = MPIDI_OFI_get_ctx_index(rreq->comm, vni, MPIDI_OFI_REQUEST(rreq, nic_num));
+    int vci = MPIDI_Request_get_vci(rreq);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(rreq->comm, vci, MPIDI_OFI_REQUEST(rreq, nic_num));
 
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         mpi_errno = MPIDIG_mpi_cancel_recv(rreq);
@@ -366,12 +366,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq, bool 
         /* progress until the rreq complets, either with cancel-bit set,
          * or with message received */
         while (!MPIR_cc_is_complete(&rreq->cc)) {
-            mpi_errno = MPIDI_OFI_progress_uninlined(vni);
+            mpi_errno = MPIDI_OFI_progress_uninlined(vci);
             MPIR_ERR_CHECK(mpi_errno);
         }
     } else {
         /* run progress once to prevent accumulating cq errors. */
-        mpi_errno = MPIDI_OFI_progress_uninlined(vni);
+        mpi_errno = MPIDI_OFI_progress_uninlined(vci);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -15,11 +15,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
                                                         int tag, MPIR_Comm * comm,
                                                         int context_offset,
                                                         MPIDI_av_entry_t * addr,
-                                                        int vni_src, int vni_dst)
+                                                        int vci_src, int vci_dst)
 {
     int mpi_errno = MPI_SUCCESS;
-    int vni_local = vni_src;
-    int vni_remote = vni_dst;
+    int vci_local = vci_src;
+    int vci_remote = vci_dst;
     int sender_nic = 0, receiver_nic = 0;
     int ctx_idx = 0;
     uint64_t match_bits;
@@ -31,18 +31,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
         MPIDI_OFI_multx_sender_nic_index(comm, comm->context_id, comm->rank, dst_rank, tag);
     receiver_nic =
         MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, comm->rank, dst_rank, tag);
-    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_local, sender_nic);
+    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_local, sender_nic);
 
     match_bits = MPIDI_OFI_init_sendtag(comm->context_id + context_offset, comm->rank, tag, 0);
-    fi_addr_t dest_addr = MPIDI_OFI_av_to_phys(addr, receiver_nic, vni_local, vni_remote);
+    fi_addr_t dest_addr = MPIDI_OFI_av_to_phys(addr, receiver_nic, vci_local, vci_remote);
     if (MPIDI_OFI_ENABLE_DATA) {
         MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                             buf, data_sz, cq_data, dest_addr, match_bits),
-                             vni_local, tinjectdata, comm->hints[MPIR_COMM_HINT_EAGAIN]);
+                             vci_local, tinjectdata, comm->hints[MPIR_COMM_HINT_EAGAIN]);
     } else {
         MPIDI_OFI_CALL_RETRY(fi_tinject(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                         buf, data_sz, dest_addr, match_bits),
-                             vni_local, tinject, comm->hints[MPIR_COMM_HINT_EAGAIN]);
+                             vci_local, tinject, comm->hints[MPIR_COMM_HINT_EAGAIN]);
     }
     MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], data_sz);
   fn_exit:
@@ -68,7 +68,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count, size_t data_sz,
                                                 uint64_t cq_data,
                                                 int dst_rank, uint64_t match_bits, MPIR_Comm * comm,
-                                                MPIDI_av_entry_t * addr, int vni_src, int vni_dst,
+                                                MPIDI_av_entry_t * addr, int vci_src, int vci_dst,
                                                 MPIR_Request * sreq, MPIR_Datatype * dt_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -76,8 +76,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     struct fi_msg_tagged msg;
     uint64_t flags;
     MPI_Aint num_contig, size;
-    int vni_local = vni_src;
-    int vni_remote = vni_dst;
+    int vci_local = vci_src;
+    int vci_remote = vci_dst;
     int sender_nic = 0, receiver_nic = 0;
     int ctx_idx = 0;
 
@@ -96,7 +96,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
         MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, comm->rank, dst_rank,
                                            MPIDI_OFI_init_get_tag(match_bits));
     MPIDI_OFI_REQUEST(sreq, nic_num) = sender_nic;
-    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_local, MPIDI_OFI_REQUEST(sreq, nic_num));
+    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_local, MPIDI_OFI_REQUEST(sreq, nic_num));
 
     /* everything fits in the IOV array */
     flags = FI_COMPLETION | (MPIDI_OFI_ENABLE_DATA ? FI_REMOTE_CQ_DATA : 0);
@@ -122,10 +122,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     msg.ignore = 0ULL;
     msg.context = (void *) &(MPIDI_OFI_REQUEST(sreq, context));
     msg.data = MPIDI_OFI_ENABLE_DATA ? cq_data : 0;
-    msg.addr = MPIDI_OFI_av_to_phys(addr, receiver_nic, vni_local, vni_remote);
+    msg.addr = MPIDI_OFI_av_to_phys(addr, receiver_nic, vci_local, vci_remote);
 
     MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[ctx_idx].tx,
-                                     &msg, flags), vni_local, tsendv, FALSE);
+                                     &msg, flags), vci_local, tsendv, FALSE);
     MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], data_sz);
 
   fn_exit:
@@ -144,8 +144,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                                    MPI_Datatype datatype,
                                                    uint64_t cq_data, int dst_rank, int tag,
                                                    MPIR_Comm * comm, int context_offset,
-                                                   MPIDI_av_entry_t * addr, int vni_src,
-                                                   int vni_dst, MPIR_Request ** request,
+                                                   MPIDI_av_entry_t * addr, int vci_src,
+                                                   int vci_dst, MPIR_Request ** request,
                                                    int dt_contig, size_t data_sz,
                                                    MPIR_Datatype * dt_ptr, MPI_Aint dt_true_lb,
                                                    uint64_t type)
@@ -154,14 +154,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
     char *send_buf;
     uint64_t match_bits;
     bool force_gpu_pack = false;
-    int vni_local = vni_src;
-    int vni_remote = vni_dst;
+    int vci_local = vci_src;
+    int vci_remote = vci_dst;
     int sender_nic = 0, receiver_nic = 0;
     int ctx_idx = 0;
 
     MPIR_FUNC_ENTER;
 
-    MPIDI_OFI_REQUEST_CREATE(*request, MPIR_REQUEST_KIND__SEND, vni_src);
+    MPIDI_OFI_REQUEST_CREATE(*request, MPIR_REQUEST_KIND__SEND, vci_src);
 
     MPIR_Request *sreq = *request;
 
@@ -189,7 +189,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
     receiver_nic =
         MPIDI_OFI_multx_receiver_nic_index(comm, comm->context_id, comm->rank, dst_rank, tag);
     MPIDI_OFI_REQUEST(sreq, nic_num) = sender_nic;
-    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vni_local, MPIDI_OFI_REQUEST(sreq, nic_num));
+    ctx_idx = MPIDI_OFI_get_ctx_index(comm, vci_local, MPIDI_OFI_REQUEST(sreq, nic_num));
 
     if (type == MPIDI_OFI_SYNC_SEND) {  /* Branch should compile out */
         uint64_t ssend_match, ssend_mask;
@@ -203,14 +203,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         ssend_match =
             MPIDI_OFI_init_recvtag(&ssend_mask, comm->context_id + context_offset, dst_rank, tag);
         ssend_match |= MPIDI_OFI_SYNC_SEND_ACK;
-        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(comm, vni_local, receiver_nic)].rx,  /* endpoint    */
+        MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(comm, vci_local, receiver_nic)].rx,  /* endpoint    */
                                       NULL,     /* recvbuf     */
                                       0,        /* data sz     */
                                       NULL,     /* memregion descr  */
-                                      MPIDI_OFI_av_to_phys(addr, sender_nic, vni_local, vni_remote),    /* remote proc */
+                                      MPIDI_OFI_av_to_phys(addr, sender_nic, vci_local, vci_remote),    /* remote proc */
                                       ssend_match,      /* match bits  */
                                       0ULL,     /* mask bits   */
-                                      (void *) &(ackreq->context)), vni_local, trecvsync, FALSE);
+                                      (void *) &(ackreq->context)), vci_local, trecvsync, FALSE);
     }
 
     send_buf = MPIR_get_contig_ptr(buf, dt_true_lb);
@@ -234,7 +234,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
              (data_sz < MPIDI_OFI_global.stripe_threshold &&
               MPIDI_OFI_COMM(comm).enable_striping))) {
             mpi_errno = MPIDI_OFI_send_iov(buf, count, data_sz, cq_data, dst_rank, match_bits,
-                                           comm, addr, vni_src, vni_dst, sreq, dt_ptr);
+                                           comm, addr, vci_src, vci_dst, sreq, dt_ptr);
             if (mpi_errno == MPI_SUCCESS)       /* Send posted using iov */
                 goto fn_exit;
             else if (mpi_errno != MPIDI_OFI_SEND_NEEDS_PACK)
@@ -262,31 +262,31 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIDI_OFI_REQUEST(sreq, noncontig.nopack) = NULL;
     }
 
-    fi_addr_t dest_addr = MPIDI_OFI_av_to_phys(addr, receiver_nic, vni_local, vni_remote);
+    fi_addr_t dest_addr = MPIDI_OFI_av_to_phys(addr, receiver_nic, vci_local, vci_remote);
     if (data_sz <= MPIDI_OFI_global.max_buffered_send) {
         if (MPIDI_OFI_ENABLE_DATA) {
             MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                                 send_buf, data_sz, cq_data, dest_addr, match_bits),
-                                 vni_local, tinjectdata, FALSE /* eagain */);
+                                 vci_local, tinjectdata, FALSE /* eagain */);
         } else {
             MPIDI_OFI_CALL_RETRY(fi_tinject(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                             send_buf, data_sz, dest_addr, match_bits),
-                                 vni_local, tinject, FALSE /* eagain */);
+                                 vci_local, tinject, FALSE /* eagain */);
         }
         MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], data_sz);
-        MPIDI_OFI_send_event(vni_src, NULL, sreq, MPIDI_OFI_REQUEST(sreq, event_id));
+        MPIDI_OFI_send_event(vci_src, NULL, sreq, MPIDI_OFI_REQUEST(sreq, event_id));
     } else if (!is_huge_send) {
         if (MPIDI_OFI_ENABLE_DATA) {
             MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                               send_buf, data_sz, NULL, cq_data, dest_addr,
                                               match_bits,
                                               (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
-                                 vni_local, tsenddata, FALSE /* eagain */);
+                                 vci_local, tsenddata, FALSE /* eagain */);
         } else {
             MPIDI_OFI_CALL_RETRY(fi_tsend(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                           send_buf, data_sz, NULL, dest_addr, match_bits,
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
-                                 vni_local, tsend, FALSE /* eagain */);
+                                 vci_local, tsend, FALSE /* eagain */);
         }
         MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], data_sz);
     } else if (unlikely(1)) {
@@ -317,7 +317,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
             }
         }
         for (int i = 0; i < num_nics; i++) {
-            MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(comm, vni_local, i)].domain,  /* In:  Domain Object */
+            MPIDI_OFI_CALL(fi_mr_reg(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(comm, vci_local, i)].domain,  /* In:  Domain Object */
                                      send_buf,  /* In:  Lower memory address */
                                      data_sz,   /* In:  Length              */
                                      FI_REMOTE_READ,    /* In:  Expose MR for read  */
@@ -328,7 +328,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                      NULL), mr_reg);    /* In:  context             */
             mpi_errno = MPIDI_OFI_mr_bind(MPIDI_OFI_global.prov_use[0], huge_send_mrs[i],
                                           MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index
-                                                               (comm, vni_local, i)].ep, NULL);
+                                                               (comm, vci_local, i)].ep, NULL);
             MPIR_ERR_CHECK(mpi_errno);
         }
         MPIDI_OFI_REQUEST(sreq, huge.send_mrs) = huge_send_mrs;
@@ -357,14 +357,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         ctrl.u.huge.info.comm_id = comm->context_id;
         ctrl.u.huge.info.tag = tag;
         ctrl.u.huge.info.origin_rank = comm->rank;
-        ctrl.u.huge.info.vni_src = vni_src;
-        ctrl.u.huge.info.vni_dst = vni_dst;
+        ctrl.u.huge.info.vci_src = vci_src;
+        ctrl.u.huge.info.vci_dst = vci_dst;
         ctrl.u.huge.info.send_buf = send_buf;
         ctrl.u.huge.info.msgsize = data_sz;
         ctrl.u.huge.info.ackreq = sreq;
 
         mpi_errno = MPIDI_NM_am_send_hdr(dst_rank, comm, MPIDI_OFI_INTERNAL_HANDLER_CONTROL,
-                                         &ctrl, sizeof(ctrl), vni_src, vni_dst);
+                                         &ctrl, sizeof(ctrl), vci_src, vci_dst);
         MPIR_ERR_CHECK(mpi_errno);
 
         /* send main native message next */
@@ -374,11 +374,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                           send_buf, msg_size, NULL /* desc */ ,
                                           cq_data,
-                                          MPIDI_OFI_av_to_phys(addr, receiver_nic, vni_local,
-                                                               vni_remote),
+                                          MPIDI_OFI_av_to_phys(addr, receiver_nic, vci_local,
+                                                               vci_remote),
                                           match_bits,
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
-                             vni_local, tsenddata, FALSE /* eagain */);
+                             vci_local, tsenddata, FALSE /* eagain */);
         MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], msg_size);
         MPIR_T_PVAR_COUNTER_INC(MULTINIC, striped_nic_sent_bytes_count[sender_nic], msg_size);
     }
@@ -393,7 +393,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI_Datatype datatype,
                                             int dst_rank, int tag, MPIR_Comm * comm,
                                             int context_offset, MPIDI_av_entry_t * addr,
-                                            int vni_src, int vni_dst,
+                                            int vci_src, int vci_dst,
                                             MPIR_Request ** request, int noreq,
                                             uint64_t syncflag, MPIR_Errflag_t err_flag)
 {
@@ -427,7 +427,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
             }
         }
         mpi_errno = MPIDI_OFI_send_lightweight(send_buf, data_sz, cq_data, dst_rank, tag, comm,
-                                               context_offset, addr, vni_src, vni_dst);
+                                               context_offset, addr, vci_src, vci_dst);
         if (actual_pack_bytes > 0) {
             /* Free stage host buf (assigned to send_buf already) after
              * lightweight_send. */
@@ -438,7 +438,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
         }
     } else {
         mpi_errno = MPIDI_OFI_send_normal(buf, count, datatype, cq_data, dst_rank, tag, comm,
-                                          context_offset, addr, vni_src, vni_dst, request,
+                                          context_offset, addr, vci_src, vci_dst, request,
                                           dt_contig, data_sz, dt_ptr, dt_true_lb, syncflag);
     }
 
@@ -447,17 +447,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
 }
 
 /* Common macro used by all MPIDI_NM_mpi_send routines to facilitate tuning */
-#define MPIDI_OFI_SEND_VNIS(vni_src_, vni_dst_) \
+#define MPIDI_OFI_SEND_VNIS(vci_src_, vci_dst_) \
     do { \
         if (*request != NULL) { \
             /* workq path */ \
-            vni_src_ = 0; \
-            vni_dst_ = 0; \
+            vci_src_ = 0; \
+            vci_dst_ = 0; \
         } else { \
-            MPIDI_EXPLICIT_VCIS(comm, attr, comm->rank, rank, vni_src_, vni_dst_); \
-            if (vni_src_ == 0 && vni_dst_ == 0) { \
-                vni_src_ = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
-                vni_dst_ = MPIDI_get_vci(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
+            MPIDI_EXPLICIT_VCIS(comm, attr, comm->rank, rank, vci_src_, vci_dst_); \
+            if (vci_src_ == 0 && vci_dst_ == 0) { \
+                vci_src_ = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
+                vci_dst_ = MPIDI_get_vci(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
             } \
         } \
     } while (0)
@@ -473,21 +473,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
 
-    int vni_src, vni_dst;
-    MPIDI_OFI_SEND_VNIS(vni_src, vni_dst);      /* defined just above */
+    int vci_src, vci_dst;
+    MPIDI_OFI_SEND_VNIS(vci_src, vci_dst);      /* defined just above */
 
-    MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vni_src);
+    MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vci_src);
     if (!MPIDI_OFI_ENABLE_TAGGED) {
         bool syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr) ? MPIDIG_AM_SEND_FLAGS_SYNC : 0;
         mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                     vni_src, vni_dst, request, syncflag, errflag);
+                                     vci_src, vci_dst, request, syncflag, errflag);
     } else {
         uint64_t syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr) ? MPIDI_OFI_SYNC_SEND : 0;
         mpi_errno = MPIDI_OFI_send(buf, count, datatype, rank, tag, comm,
-                                   context_offset, addr, vni_src, vni_dst,
+                                   context_offset, addr, vci_src, vci_dst,
                                    request, 0, syncflag, errflag);
     }
-    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vni_src);
+    MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vci_src);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -223,7 +223,7 @@ typedef struct MPIDI_OFI_cq_list_t {
     struct MPIDI_OFI_cq_list_t *next;
 } MPIDI_OFI_cq_list_t;
 
-/* global per-vni am related fields */
+/* global per-vci am related fields */
 typedef struct {
     struct iovec am_iov[MPIDI_OFI_MAX_NUM_AM_BUFFERS];
     struct fi_msg am_msg[MPIDI_OFI_MAX_NUM_AM_BUFFERS];
@@ -259,7 +259,7 @@ typedef struct {
     struct MPIDI_OFI_huge_recv_list *huge_recv_tail;
 
     char pad MPL_ATTR_ALIGNED(MPL_CACHELINE_SIZE);
-} MPIDI_OFI_per_vni_t;
+} MPIDI_OFI_per_vci_t;
 
 typedef struct {
     struct fid_domain *domain;
@@ -365,8 +365,8 @@ typedef struct {
     /* Mutexes and endpoints */
     MPIDI_OFI_cacheline_mutex_t mutexes[MAX_OFI_MUTEXES];
     MPIDI_OFI_context_t ctx[MPIDI_OFI_MAX_VNIS * MPIDI_OFI_MAX_NICS];
-    MPIDI_OFI_per_vni_t per_vni[MPIDI_OFI_MAX_VNIS];
-    int num_vnis;
+    MPIDI_OFI_per_vci_t per_vci[MPIDI_OFI_MAX_VNIS];
+    int num_vcis;
     int num_nics;
     int num_close_nics;
     int num_comms_enabled_striping;     /* Number of active communicators with striping enabled */
@@ -408,8 +408,8 @@ typedef struct {
     void *send_buf;
     size_t msgsize;
     uint64_t rma_keys[MPIDI_OFI_MAX_NICS];
-    int vni_src;
-    int vni_dst;
+    int vci_src;
+    int vci_dst;
 } MPIDI_OFI_huge_remote_info_t;
 
 typedef struct {
@@ -450,7 +450,7 @@ typedef struct MPIDI_OFI_pack_chunk {
 typedef struct MPIDI_OFI_win_request {
     struct MPIDI_OFI_win_request *next;
     struct MPIDI_OFI_win_request *prev;
-    int vni;
+    int vci;
     int rma_type;
     MPIR_Request **sigreq;
     MPIDI_OFI_pack_chunk *chunks;

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -23,7 +23,7 @@ MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_OFI_win_read_issued_cntr(MPIR_Win * win)
 /*
  * Blocking progress function to complete outstanding RMA operations on the input window.
  */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_do_progress(MPIR_Win * win, int vni)
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_do_progress(MPIR_Win * win, int vci)
 {
     int mpi_errno = MPI_SUCCESS;
     int itercount = 0;
@@ -41,7 +41,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_do_progress(MPIR_Win * win, int vni)
 
         while (tcount > donecount) {
             MPIR_Assert(donecount <= tcount);
-            MPIDI_OFI_PROGRESS(vni);
+            MPIDI_OFI_PROGRESS(vci);
             /* rma issued_cntr may be updated during MPIDI_OFI_PROGRESS if active messages
              * arrive and trigger RDMA calls, so we need to update it after progress call */
             tcount = MPIDI_OFI_win_read_issued_cntr(win);
@@ -89,7 +89,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_do_progress(MPIR_Win * win, int vni)
 /* If the OFI provider does not have automatic progress, check to see if the progress engine should
  * be manually triggered to keep performance from suffering when doing large, non-continuguous
  * transfers. */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_trigger_rma_progress(MPIR_Win * win, int vni)
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_trigger_rma_progress(MPIR_Win * win, int vci)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -98,7 +98,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_trigger_rma_progress(MPIR_Win * win, 
     if (!MPIDI_OFI_ENABLE_DATA_AUTO_PROGRESS && MPIR_CVAR_CH4_OFI_RMA_PROGRESS_INTERVAL != -1) {
         MPIDI_OFI_WIN(win).progress_counter++;
         if (MPIDI_OFI_WIN(win).progress_counter >= MPIR_CVAR_CH4_OFI_RMA_PROGRESS_INTERVAL) {
-            MPIDI_OFI_win_do_progress(win, vni);
+            MPIDI_OFI_win_do_progress(win, vci);
             MPIDI_OFI_WIN(win).progress_counter = 0;
         }
     }
@@ -310,10 +310,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_cmpl_hook(MPIR_Win * win)
     MPIR_FUNC_ENTER;
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        int vni = MPIDI_WIN(win, am_vci);
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
-        mpi_errno = MPIDI_OFI_win_do_progress(win, vni);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
+        int vci = MPIDI_WIN(win, am_vci);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        mpi_errno = MPIDI_OFI_win_do_progress(win, vci);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -330,10 +330,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
     MPIR_FUNC_ENTER;
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        int vni = MPIDI_WIN(win, am_vci);
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
-        mpi_errno = MPIDI_OFI_win_do_progress(win, vni);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
+        int vci = MPIDI_WIN(win, am_vci);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        mpi_errno = MPIDI_OFI_win_do_progress(win, vci);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -351,10 +351,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank ATTRIBUTE((u
     MPIR_FUNC_ENTER;
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        int vni = MPIDI_WIN(win, am_vci);
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
-        mpi_errno = MPIDI_OFI_win_do_progress(win, vni);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
+        int vci = MPIDI_WIN(win, am_vci);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        mpi_errno = MPIDI_OFI_win_do_progress(win, vci);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -372,10 +372,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank ATTRIB
     MPIR_FUNC_ENTER;
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
-        int vni = MPIDI_WIN(win, am_vci);
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni).lock);
-        mpi_errno = MPIDI_OFI_win_do_progress(win, vni);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni).lock);
+        int vci = MPIDI_WIN(win, am_vci);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        mpi_errno = MPIDI_OFI_win_do_progress(win, vci);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -352,7 +352,7 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
     fi
 
     AC_ARG_ENABLE(ofi-domain, [
-  --enable-ofi-domain - Use fi_domain for vni contexts. This is the default.
+  --enable-ofi-domain - Use fi_domain for vci contexts. This is the default.
                         Use --disable-ofi-domain to use fi_contexts within
                         a scalable endpoint instead.
                             yes        - Enabled (default)
@@ -360,7 +360,7 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
 ],,enable_ofi_domain=yes)
 
     if test "$enable_ofi_domain" = "yes"; then
-        AC_DEFINE(MPIDI_OFI_VNI_USE_DOMAIN, 1, [CH4/OFI should use domain for vni contexts])
+        AC_DEFINE(MPIDI_OFI_VNI_USE_DOMAIN, 1, [CH4/OFI should use domain for vci contexts])
     fi
 
     AC_MSG_CHECKING([if fi_info struct has nic field])

--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -181,8 +181,8 @@ int MPIDI_OFI_control_handler(void *am_hdr, void *data, MPI_Aint data_sz,
             break;
 
         case MPIDI_OFI_CTRL_HUGE:
-            MPIR_Assert(local_vci == ctrlsend->u.huge.info.vni_dst);
-            MPIR_Assert(remote_vci == ctrlsend->u.huge.info.vni_src);
+            MPIR_Assert(local_vci == ctrlsend->u.huge.info.vci_dst);
+            MPIR_Assert(remote_vci == ctrlsend->u.huge.info.vci_src);
             mpi_errno = MPIDI_OFI_recv_huge_control(local_vci,
                                                     ctrlsend->u.huge.info.comm_id,
                                                     ctrlsend->u.huge.info.origin_rank,

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -54,11 +54,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
 
     MPIR_FUNC_ENTER;
 
-    int src_vni = src_vci;
-    int dst_vni = dst_vci;
-    MPIR_Assert(src_vni < MPIDI_UCX_global.num_vnis);
-    MPIR_Assert(dst_vni < MPIDI_UCX_global.num_vnis);
-    ep = MPIDI_UCX_COMM_TO_EP(comm, rank, src_vni, dst_vni);
+    MPIR_Assert(src_vci < MPIDI_UCX_global.num_vcis);
+    MPIR_Assert(dst_vci < MPIDI_UCX_global.num_vcis);
+    ep = MPIDI_UCX_COMM_TO_EP(comm, rank, src_vci, dst_vci);
 
     int dt_contig;
     size_t data_sz;
@@ -68,8 +66,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
 
     /* initialize our portion of the hdr */
     ucx_hdr.handler_id = handler_id;
-    ucx_hdr.src_vci = src_vni;
-    ucx_hdr.dst_vci = dst_vni;
+    ucx_hdr.src_vci = src_vci;
+    ucx_hdr.dst_vci = dst_vci;
     ucx_hdr.data_sz = data_sz;
 
     MPL_pointer_attr_t attr;
@@ -188,16 +186,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr(int rank,
 
     MPIR_FUNC_ENTER;
 
-    int src_vni = src_vci;
-    int dst_vni = dst_vci;
-    MPIR_Assert(src_vni < MPIDI_UCX_global.num_vnis);
-    MPIR_Assert(dst_vni < MPIDI_UCX_global.num_vnis);
-    ep = MPIDI_UCX_COMM_TO_EP(comm, rank, src_vni, dst_vni);
+    MPIR_Assert(src_vci < MPIDI_UCX_global.num_vcis);
+    MPIR_Assert(dst_vci < MPIDI_UCX_global.num_vcis);
+    ep = MPIDI_UCX_COMM_TO_EP(comm, rank, src_vci, dst_vci);
 
     /* initialize our portion of the hdr */
     ucx_hdr.handler_id = handler_id;
-    ucx_hdr.src_vci = src_vni;
-    ucx_hdr.dst_vci = dst_vni;
+    ucx_hdr.src_vci = src_vci;
+    ucx_hdr.dst_vci = dst_vci;
     ucx_hdr.data_sz = 0;
 
     /* just pack and send for now */

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -16,9 +16,9 @@
 #define MPIDI_UCX_COMM(comm)     ((comm)->dev.ch4.netmod.ucx)
 #define MPIDI_UCX_REQ(req)       ((req)->dev.ch4.netmod.ucx)
 #define COMM_TO_INDEX(comm,rank) MPIDIU_comm_rank_to_pid(comm, rank, NULL, NULL)
-#define MPIDI_UCX_COMM_TO_EP(comm,rank,vni_src,vni_dst) \
-    MPIDI_UCX_AV(MPIDIU_comm_rank_to_av(comm, rank)).dest[vni_src][vni_dst]
-#define MPIDI_UCX_AV_TO_EP(av,vni_src,vni_dst) MPIDI_UCX_AV((av)).dest[vni_src][vni_dst]
+#define MPIDI_UCX_COMM_TO_EP(comm,rank,vci_src,vci_dst) \
+    MPIDI_UCX_AV(MPIDIU_comm_rank_to_av(comm, rank)).dest[vci_src][vci_dst]
+#define MPIDI_UCX_AV_TO_EP(av,vci_src,vci_dst) MPIDI_UCX_AV((av)).dest[vci_src][vci_dst]
 
 #define MPIDI_UCX_WIN(win) ((win)->dev.netmod.ucx)
 #define MPIDI_UCX_WIN_INFO(win, rank) MPIDI_UCX_WIN(win).info_table[rank]
@@ -120,20 +120,12 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_UCX_is_reachable_target(int rank, MPIR_Win *
                                                       MPIDI_UCX_WIN_INFO(win, rank).rkey != NULL);
 }
 
-/* This function implements netmod vci to vni(context) mapping.
- * It returns -1 if the vci does not have a mapping.
- */
-MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_vci_to_vni(int vci)
-{
-    return vci < MPIDI_UCX_global.num_vnis ? vci : -1;
-}
-
-/* Need both local and remote vni to be the same, or the synchronization call
+/* Need both local and remote vci to be the same, or the synchronization call
  * may blocked at flushing the remote ep (due to missing remote progress) */
-#define MPIDI_UCX_WIN_TO_EP(win,rank,vni,vni_target) \
-    MPIDI_UCX_AV(MPIDIU_comm_rank_to_av(win->comm_ptr, rank)).dest[vni][vni_target]
+#define MPIDI_UCX_WIN_TO_EP(win,rank,vci,vci_target) \
+    MPIDI_UCX_AV(MPIDIU_comm_rank_to_av(win->comm_ptr, rank)).dest[vci][vci_target]
 
-#define MPIDI_UCX_WIN_AV_TO_EP(av, vni, vni_target) MPIDI_UCX_AV((av)).dest[vni][vni_target]
+#define MPIDI_UCX_WIN_AV_TO_EP(av, vci, vci_target) MPIDI_UCX_AV((av)).dest[vci][vci_target]
 
 ucs_status_t MPIDI_UCX_am_handler(void *arg, void *data, size_t length, ucp_ep_h reply_ep,
                                   unsigned flags);

--- a/src/mpid/ch4/netmod/ucx/ucx_probe.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_probe.h
@@ -8,12 +8,12 @@
 
 #include "ucx_impl.h"
 
-#define MPIDI_UCX_PROBE_VNIS(vni_dst_) \
+#define MPIDI_UCX_PROBE_VNIS(vci_dst_) \
     do { \
-        int vni_src_tmp; \
-        MPIDI_EXPLICIT_VCIS(comm, attr, source, comm->rank, vni_src_tmp, vni_dst_); \
-        if (vni_src_tmp == 0 && vni_dst_ == 0) { \
-            vni_dst_ = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag); \
+        int vci_src_tmp; \
+        MPIDI_EXPLICIT_VCIS(comm, attr, source, comm->rank, vci_src_tmp, vci_dst_); \
+        if (vci_src_tmp == 0 && vci_dst_ == 0) { \
+            vci_dst_ = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag); \
         } \
     } while (0)
 
@@ -34,19 +34,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
-    int vni_dst;
-    MPIDI_UCX_PROBE_VNIS(vni_dst);
+    int vci_dst;
+    MPIDI_UCX_PROBE_VNIS(vci_dst);
 
-    MPIDI_UCX_THREAD_CS_ENTER_VCI(vni_dst);
+    MPIDI_UCX_THREAD_CS_ENTER_VCI(vci_dst);
 
     tag_mask = MPIDI_UCX_tag_mask(tag, source);
     ucp_tag = MPIDI_UCX_recv_tag(tag, source, comm->recvcontext_id + context_offset);
 
-    message_h = ucp_tag_probe_nb(MPIDI_UCX_global.ctx[vni_dst].worker, ucp_tag, tag_mask, 1, &info);
+    message_h = ucp_tag_probe_nb(MPIDI_UCX_global.ctx[vci_dst].worker, ucp_tag, tag_mask, 1, &info);
 
     if (message_h) {
         *flag = 1;
-        req = (MPIR_Request *) MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__MPROBE, vni_dst, 2);
+        req = (MPIR_Request *) MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__MPROBE, vci_dst, 2);
         MPIR_ERR_CHKANDSTMT((req) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         req->comm = comm;
         MPIR_Comm_add_ref(comm);
@@ -64,7 +64,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
     *message = req;
 
   fn_exit:
-    MPIDI_UCX_THREAD_CS_EXIT_VCI(vni_dst);
+    MPIDI_UCX_THREAD_CS_EXIT_VCI(vci_dst);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -86,15 +86,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
-    int vni_dst;
-    MPIDI_UCX_PROBE_VNIS(vni_dst);
+    int vci_dst;
+    MPIDI_UCX_PROBE_VNIS(vci_dst);
 
-    MPIDI_UCX_THREAD_CS_ENTER_VCI(vni_dst);
+    MPIDI_UCX_THREAD_CS_ENTER_VCI(vci_dst);
 
     tag_mask = MPIDI_UCX_tag_mask(tag, source);
     ucp_tag = MPIDI_UCX_recv_tag(tag, source, comm->recvcontext_id + context_offset);
 
-    message_h = ucp_tag_probe_nb(MPIDI_UCX_global.ctx[vni_dst].worker, ucp_tag, tag_mask, 0, &info);
+    message_h = ucp_tag_probe_nb(MPIDI_UCX_global.ctx[vci_dst].worker, ucp_tag, tag_mask, 0, &info);
 
     if (message_h) {
         *flag = 1;
@@ -110,7 +110,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
         *flag = 0;
     }
 
-    MPIDI_UCX_THREAD_CS_EXIT_VCI(vni_dst);
+    MPIDI_UCX_THREAD_CS_EXIT_VCI(vci_dst);
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -12,16 +12,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    int vni = MPIDI_UCX_vci_to_vni(vci);
-
     MPIR_FUNC_ENTER;
 
-    if (vni < 0) {
+    MPIR_Assert(vci < MPIDI_UCX_global.num_vcis);
+    if (vci < 0) {
         /* skip if the vci is not for us */
         return MPI_SUCCESS;
     }
 
-    ucp_worker_progress(MPIDI_UCX_global.ctx[vni].worker);
+    ucp_worker_progress(MPIDI_UCX_global.ctx[vci].worker);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ucx/ucx_rma.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_rma.h
@@ -29,7 +29,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
                                                   int target_rank,
                                                   MPI_Aint target_disp, MPI_Aint true_lb,
                                                   MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                                  MPIR_Request ** reqptr, int vni, int vni_target)
+                                                  MPIR_Request ** reqptr, int vci, int vci_target)
 {
 
     MPIDI_UCX_win_info_t *win_info = &(MPIDI_UCX_WIN_INFO(win, target_rank));
@@ -37,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_put(const void *origin_addr,
     uint64_t base;
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request ATTRIBUTE((unused)) = NULL;
-    ucp_ep_h ep = MPIDI_UCX_WIN_AV_TO_EP(addr, vni, vni_target);
+    ucp_ep_h ep = MPIDI_UCX_WIN_AV_TO_EP(addr, vci, vci_target);
 
     base = win_info->addr;
     offset = target_disp * win_info->disp + true_lb;
@@ -92,14 +92,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_noncontig_put(const void *origin_addr,
                                                      MPI_Aint true_lb, MPIR_Win * win,
                                                      MPIDI_av_entry_t * addr,
                                                      MPIR_Request ** reqptr ATTRIBUTE((unused)),
-                                                     int vni, int vni_target)
+                                                     int vci, int vci_target)
 {
     MPIDI_UCX_win_info_t *win_info = &(MPIDI_UCX_WIN_INFO(win, target_rank));
     size_t base, offset;
     int mpi_errno = MPI_SUCCESS;
     ucs_status_t status;
     char *buffer = NULL;
-    ucp_ep_h ep = MPIDI_UCX_WIN_AV_TO_EP(addr, vni, vni_target);
+    ucp_ep_h ep = MPIDI_UCX_WIN_AV_TO_EP(addr, vci, vci_target);
 
     buffer = MPL_malloc(size, MPL_MEM_BUFFER);
     MPIR_Assert(buffer);
@@ -132,14 +132,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_contig_get(void *origin_addr,
                                                   int target_rank,
                                                   MPI_Aint target_disp, MPI_Aint true_lb,
                                                   MPIR_Win * win, MPIDI_av_entry_t * addr,
-                                                  MPIR_Request ** reqptr, int vni, int vni_target)
+                                                  MPIR_Request ** reqptr, int vci, int vci_target)
 {
 
     MPIDI_UCX_win_info_t *win_info = &(MPIDI_UCX_WIN_INFO(win, target_rank));
     size_t base, offset;
     int mpi_errno = MPI_SUCCESS;
     MPIDI_UCX_ucp_request_t *ucp_request ATTRIBUTE((unused)) = NULL;
-    ucp_ep_h ep = MPIDI_UCX_WIN_AV_TO_EP(addr, vni, vni_target);
+    ucp_ep_h ep = MPIDI_UCX_WIN_AV_TO_EP(addr, vci, vci_target);
 
     base = win_info->addr;
     offset = target_disp * win_info->disp + true_lb;
@@ -219,22 +219,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_put(const void *origin_addr,
     }
 
     if (origin_contig && target_contig) {
-        int vni = MPIDI_WIN(win, am_vci);
-        int vni_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
-        MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
+        int vci = MPIDI_WIN(win, am_vci);
+        int vci_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
+        MPIDI_UCX_THREAD_CS_ENTER_VCI(vci);
         mpi_errno =
             MPIDI_UCX_contig_put(MPIR_get_contig_ptr(origin_addr, origin_true_lb), origin_bytes,
                                  target_rank, target_disp, target_true_lb, win, addr,
-                                 reqptr, vni, vni_target);
-        MPIDI_UCX_THREAD_CS_EXIT_VCI(vni);
+                                 reqptr, vci, vci_target);
+        MPIDI_UCX_THREAD_CS_EXIT_VCI(vci);
     } else if (target_contig) {
-        int vni = MPIDI_WIN(win, am_vci);
-        int vni_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
-        MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
+        int vci = MPIDI_WIN(win, am_vci);
+        int vci_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
+        MPIDI_UCX_THREAD_CS_ENTER_VCI(vci);
         mpi_errno = MPIDI_UCX_noncontig_put(origin_addr, origin_count, origin_datatype, target_rank,
                                             target_bytes, target_disp, target_true_lb, win, addr,
-                                            reqptr, vni, vni_target);
-        MPIDI_UCX_THREAD_CS_EXIT_VCI(vni);
+                                            reqptr, vci, vci_target);
+        MPIDI_UCX_THREAD_CS_EXIT_VCI(vci);
     } else {
         mpi_errno = MPIDIG_mpi_put(origin_addr, origin_count, origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, win);
@@ -283,14 +283,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_do_get(void *origin_addr,
     }
 
     if (origin_contig && target_contig) {
-        int vni = MPIDI_WIN(win, am_vci);
-        int vni_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
-        MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
+        int vci = MPIDI_WIN(win, am_vci);
+        int vci_target = MPIDI_WIN_TARGET_VCI(win, target_rank);
+        MPIDI_UCX_THREAD_CS_ENTER_VCI(vci);
         mpi_errno =
             MPIDI_UCX_contig_get(MPIR_get_contig_ptr(origin_addr, origin_true_lb), origin_bytes,
-                                 target_rank, target_disp, target_true_lb, win, addr, reqptr, vni,
-                                 vni_target);
-        MPIDI_UCX_THREAD_CS_EXIT_VCI(vni);
+                                 target_rank, target_disp, target_true_lb, win, addr, reqptr, vci,
+                                 vci_target);
+        MPIDI_UCX_THREAD_CS_EXIT_VCI(vci);
     } else {
         mpi_errno = MPIDIG_mpi_get(origin_addr, origin_count, origin_datatype, target_rank,
                                    target_disp, target_count, target_datatype, win);

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -36,7 +36,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_send(const void *buf,
                                             int context_offset,
                                             MPIDI_av_entry_t * addr,
                                             MPIR_Request ** request,
-                                            int vni_src, int vni_dst, int have_request, int is_sync)
+                                            int vci_src, int vci_dst, int have_request, int is_sync)
 {
     int dt_contig;
     size_t data_sz;
@@ -55,7 +55,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_send(const void *buf,
         .cb.send = MPIDI_UCX_send_cmpl_cb,
     };
 
-    ep = MPIDI_UCX_AV_TO_EP(addr, vni_src, vni_dst);
+    ep = MPIDI_UCX_AV_TO_EP(addr, vci_src, vci_dst);
     ucx_tag = MPIDI_UCX_init_tag(comm->context_id + context_offset, comm->rank, tag);
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, dt_true_lb);
 
@@ -84,7 +84,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_send(const void *buf,
 
     if (ucp_request) {
         if (req == NULL) {
-            req = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, vni_src, 2);
+            req = MPIR_Request_create_from_pool(MPIR_REQUEST_KIND__SEND, vci_src, 2);
         } else {
             MPIR_Request_add_ref(req);
         }
@@ -104,12 +104,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_send(const void *buf,
     goto fn_exit;
 }
 
-#define MPIDI_UCX_SEND_VNIS(vni_src_, vni_dst_) \
+#define MPIDI_UCX_SEND_VNIS(vci_src_, vci_dst_) \
     do { \
-        MPIDI_EXPLICIT_VCIS(comm, attr, comm->rank, rank, vni_src_, vni_dst_); \
-        if (vni_src_ == 0 && vni_dst_ == 0) { \
-            vni_src = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
-            vni_dst = MPIDI_get_vci(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
+        MPIDI_EXPLICIT_VCIS(comm, attr, comm->rank, rank, vci_src_, vci_dst_); \
+        if (vci_src_ == 0 && vci_dst_ == 0) { \
+            vci_src = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
+            vci_dst = MPIDI_get_vci(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
         } \
     } while (0)
 
@@ -127,8 +127,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int is_sync = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr) ? 1 : 0;
 
-    int vni_src, vni_dst;
-    MPIDI_UCX_SEND_VNIS(vni_src, vni_dst);
+    int vci_src, vci_dst;
+    MPIDI_UCX_SEND_VNIS(vci_src, vci_dst);
 
     MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
     switch (errflag) {
@@ -141,10 +141,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
             MPIR_TAG_SET_ERROR_BIT(tag);
     }
 
-    MPIDI_UCX_THREAD_CS_ENTER_VCI(vni_src);
+    MPIDI_UCX_THREAD_CS_ENTER_VCI(vci_src);
     mpi_errno = MPIDI_UCX_send(buf, count, datatype, rank, tag, comm, context_offset,
-                               addr, request, vni_src, vni_dst, 1, is_sync);
-    MPIDI_UCX_THREAD_CS_EXIT_VCI(vni_src);
+                               addr, request, vci_src, vci_dst, 1, is_sync);
+    MPIDI_UCX_THREAD_CS_EXIT_VCI(vci_src);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ucx/ucx_types.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_types.h
@@ -31,7 +31,7 @@ typedef struct {
 typedef struct {
     ucp_context_h context;
     MPIDI_UCX_context_t ctx[MPIDI_CH4_MAX_VCIS];
-    int num_vnis;
+    int num_vcis;
 } MPIDI_UCX_global_t;
 
 #define MPIDI_UCX_AV(av)     ((av)->netmod.ucx)

--- a/src/mpid/ch4/netmod/ucx/ucx_win.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.c
@@ -108,7 +108,7 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
      * and remote windows (at least now). If win_create is used, the key cannot be unpackt -
      * then we need our fallback-solution */
 
-    int vni = MPIDI_WIN(win, am_vci);
+    int vci = MPIDI_WIN(win, am_vci);
     bool all_reachable = true, none_reachable = true;
     for (i = 0; i < comm_ptr->local_size; i++) {
         /* Skip unmapped remote region. */
@@ -118,8 +118,8 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
             continue;
         }
 
-        int vni_target = MPIDI_WIN_TARGET_VCI(win, i);
-        status = ucp_ep_rkey_unpack(MPIDI_UCX_WIN_TO_EP(win, i, vni, vni_target),
+        int vci_target = MPIDI_WIN_TARGET_VCI(win, i);
+        status = ucp_ep_rkey_unpack(MPIDI_UCX_WIN_TO_EP(win, i, vci, vci_target),
                                     &rkey_recv_buff[recv_disps[i]],
                                     &(MPIDI_UCX_WIN_INFO(win, i).rkey));
         if (status == UCS_ERR_UNREACHABLE) {
@@ -180,7 +180,7 @@ static int win_init(MPIR_Win * win)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    MPIR_Assert(MPIDI_WIN(win, am_vci) < MPIDI_UCX_global.num_vnis);
+    MPIR_Assert(MPIDI_WIN(win, am_vci) < MPIDI_UCX_global.num_vcis);
 
     memset(&MPIDI_UCX_WIN(win), 0, sizeof(MPIDI_UCX_win_t));
 

--- a/src/mpid/ch4/netmod/ucx/ucx_win.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.h
@@ -129,9 +129,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_UCX_flush_cmpl_cb(void *request, ucs_status_
 {
 }
 
-MPL_STATIC_INLINE_PREFIX ucs_status_t MPIDI_UCX_flush(int vni)
+MPL_STATIC_INLINE_PREFIX ucs_status_t MPIDI_UCX_flush(int vci)
 {
-    void *request = ucp_worker_flush_nb(MPIDI_UCX_global.ctx[vni].worker,
+    void *request = ucp_worker_flush_nb(MPIDI_UCX_global.ctx[vci].worker,
                                         0, &MPIDI_UCX_flush_cmpl_cb);
     if (request == NULL) {
         return UCS_OK;
@@ -140,7 +140,7 @@ MPL_STATIC_INLINE_PREFIX ucs_status_t MPIDI_UCX_flush(int vni)
     } else {
         ucs_status_t status;
         do {
-            ucp_worker_progress(MPIDI_UCX_global.ctx[vni].worker);
+            ucp_worker_progress(MPIDI_UCX_global.ctx[vci].worker);
             status = ucp_request_check_status(request);
         } while (status == UCS_INPROGRESS);
         ucp_request_release(request);
@@ -155,10 +155,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_cmpl_hook(MPIR_Win * win)
 
     if (MPIDI_UCX_WIN(win).info_table && MPIDI_UCX_win_need_flush(win)) {
         ucs_status_t ucp_status;
-        int vni = MPIDI_WIN(win, am_vci);
-        MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
-        ucp_status = MPIDI_UCX_flush(vni);
-        MPIDI_UCX_THREAD_CS_EXIT_VCI(vni);
+        int vci = MPIDI_WIN(win, am_vci);
+        MPIDI_UCX_THREAD_CS_ENTER_VCI(vci);
+        ucp_status = MPIDI_UCX_flush(vci);
+        MPIDI_UCX_THREAD_CS_EXIT_VCI(vci);
         MPIDI_UCX_CHK_STATUS(ucp_status);
         MPIDI_UCX_win_unset_sync(win);
     }
@@ -180,10 +180,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
 
         /* currently, UCP does not support local flush, so we have to call
          * a global flush. This is not good for performance - but OK for now */
-        int vni = MPIDI_WIN(win, am_vci);
-        MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
-        ucp_status = MPIDI_UCX_flush(vni);
-        MPIDI_UCX_THREAD_CS_EXIT_VCI(vni);
+        int vci = MPIDI_WIN(win, am_vci);
+        MPIDI_UCX_THREAD_CS_ENTER_VCI(vci);
+        ucp_status = MPIDI_UCX_flush(vci);
+        MPIDI_UCX_THREAD_CS_EXIT_VCI(vci);
         MPIDI_UCX_CHK_STATUS(ucp_status);
 
         /* TODO: should set to FLUSH after replace with real local flush. */
@@ -207,13 +207,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank, MPIR_Win * 
         MPIDI_UCX_WIN(win).target_sync[rank].need_sync >= MPIDI_UCX_WIN_SYNC_FLUSH_LOCAL) {
 
         ucs_status_t ucp_status;
-        int vni = MPIDI_WIN(win, am_vci);
-        int vni_target = MPIDI_WIN_TARGET_VCI(win, rank);
-        ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vni, vni_target);
+        int vci = MPIDI_WIN(win, am_vci);
+        int vci_target = MPIDI_WIN_TARGET_VCI(win, rank);
+        ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vci, vci_target);
         /* only flush the endpoint */
-        MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
+        MPIDI_UCX_THREAD_CS_ENTER_VCI(vci);
         ucp_status = ucp_ep_flush(ep);
-        MPIDI_UCX_THREAD_CS_EXIT_VCI(vni);
+        MPIDI_UCX_THREAD_CS_EXIT_VCI(vci);
         MPIDI_UCX_CHK_STATUS(ucp_status);
         MPIDI_UCX_WIN(win).target_sync[rank].need_sync = MPIDI_UCX_WIN_SYNC_UNSET;
     }
@@ -234,14 +234,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank, MPIR_
         MPIDI_UCX_WIN(win).target_sync[rank].need_sync == MPIDI_UCX_WIN_SYNC_FLUSH_LOCAL) {
         ucs_status_t ucp_status;
 
-        int vni = MPIDI_WIN(win, am_vci);
-        int vni_target = MPIDI_WIN_TARGET_VCI(win, rank);
-        ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vni, vni_target);
+        int vci = MPIDI_WIN(win, am_vci);
+        int vci_target = MPIDI_WIN_TARGET_VCI(win, rank);
+        ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vci, vci_target);
         /* currently, UCP does not support local flush, so we have to call
          * a global flush. This is not good for performance - but OK for now */
-        MPIDI_UCX_THREAD_CS_ENTER_VCI(vni);
+        MPIDI_UCX_THREAD_CS_ENTER_VCI(vci);
         ucp_status = ucp_ep_flush(ep);
-        MPIDI_UCX_THREAD_CS_EXIT_VCI(vni);
+        MPIDI_UCX_THREAD_CS_EXIT_VCI(vci);
         MPIDI_UCX_CHK_STATUS(ucp_status);
 
         /* TODO: should set to FLUSH after replace with real local flush. */

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -35,7 +35,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_lmt(const void *buf, MPI_Aint count
                                                  int rank, int tag, MPIR_Comm * comm,
                                                  int context_offset, MPIDI_av_entry_t * addr,
                                                  MPIDI_IPCI_ipc_attr_t ipc_attr,
-                                                 int vsi_src, int vsi_dst, MPIR_Request ** request,
+                                                 int vci_src, int vci_dst, MPIR_Request ** request,
                                                  bool syncflag, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -48,7 +48,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_lmt(const void *buf, MPI_Aint count
 
     /* Create send request */
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2, vsi_src, vsi_dst);
+    sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2, vci_src, vci_dst);
     MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     *request = sreq;
     sreq->comm = comm;
@@ -103,7 +103,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_lmt(const void *buf, MPI_Aint count
         memcpy((char *) hdr + sizeof(am_hdr), flattened_dt, flattened_sz);
 
     }
-    CH4_CALL(am_send_hdr(rank, comm, MPIDIG_SEND, hdr, hdr_sz, vsi_src, vsi_dst),
+    CH4_CALL(am_send_hdr(rank, comm, MPIDIG_SEND, hdr, hdr_sz, vci_src, vci_dst),
              is_local, mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -61,11 +61,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
     bool syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr);
-    int vsi_src, vsi_dst;
+    int vci_src, vci_dst;
     /* note: MPIDI_POSIX_SEND_VSIS defined in posix_send.h */
-    MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
+    MPIDI_POSIX_SEND_VSIS(vci_src, vci_dst);
 
-    MPIDI_POSIX_THREAD_CS_ENTER_VCI(vsi_src);
+    MPIDI_POSIX_THREAD_CS_ENTER_VCI(vci_src);
 
     MPIR_Datatype *dt_ptr;
     bool dt_contig;
@@ -143,14 +143,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
     if (do_ipc) {
         mpi_errno = MPIDI_IPCI_send_lmt(buf, count, datatype, data_sz, dt_contig,
                                         rank, tag, comm, context_offset, addr, ipc_attr,
-                                        vsi_src, vsi_dst, request, syncflag, errflag);
+                                        vci_src, vci_dst, request, syncflag, errflag);
         MPIR_ERR_CHECK(mpi_errno);
         *done = true;
         /* TODO: add flattening datatype protocol for noncontig send. Different
          * threshold may be required to tradeoff the flattening overhead.*/
     }
   fn_exit:
-    MPIDI_POSIX_THREAD_CS_EXIT_VCI(vsi_src);
+    MPIDI_POSIX_THREAD_CS_EXIT_VCI(vci_src);
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager.h
@@ -16,9 +16,9 @@ typedef int (*MPIDI_POSIX_eager_finalize_t) (void);
 typedef int (*MPIDI_POSIX_eager_send_t) (int grank, MPIDI_POSIX_am_header_t * msg_hdr,
                                          const void *am_hdr, MPI_Aint am_hdr_sz, const void *buf,
                                          MPI_Aint count, MPI_Datatype datatype, MPI_Aint offset,
-                                         int src_vsi, int dst_vsi, MPI_Aint * bytes_sent);
+                                         int src_vci, int dst_vci, MPI_Aint * bytes_sent);
 
-typedef int (*MPIDI_POSIX_eager_recv_begin_t) (int vsi,
+typedef int (*MPIDI_POSIX_eager_recv_begin_t) (int vci,
                                                MPIDI_POSIX_eager_recv_transaction_t * transaction);
 
 typedef void (*MPIDI_POSIX_eager_recv_memcpy_t) (MPIDI_POSIX_eager_recv_transaction_t * transaction,
@@ -62,10 +62,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_he
                                                     const void *am_hdr, MPI_Aint am_hdr_sz,
                                                     const void *buf, MPI_Aint count,
                                                     MPI_Datatype datatype, MPI_Aint offset,
-                                                    int src_vsi, int dst_vsi,
+                                                    int src_vci, int dst_vci,
                                                     MPI_Aint * bytes_sent) MPL_STATIC_INLINE_SUFFIX;
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_recv_begin(int vsi,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_recv_begin(int vci,
                                                           MPIDI_POSIX_eager_recv_transaction_t *
                                                           transaction) MPL_STATIC_INLINE_SUFFIX;
 

--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager_impl.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager_impl.h
@@ -13,17 +13,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_he
                                                     const void *am_hdr, MPI_Aint am_hdr_sz,
                                                     const void *buf, MPI_Aint count,
                                                     MPI_Datatype datatype, MPI_Aint offset,
-                                                    int src_vsi, int dst_vsi, MPI_Aint * bytes_sent)
+                                                    int src_vci, int dst_vci, MPI_Aint * bytes_sent)
 {
     return MPIDI_POSIX_eager_func->send(grank, msg_hdr, am_hdr, am_hdr_sz, buf, count, datatype,
-                                        offset, src_vsi, dst_vsi, bytes_sent);
+                                        offset, src_vci, dst_vci, bytes_sent);
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_recv_begin(int vsi,
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_recv_begin(int vci,
                                                           MPIDI_POSIX_eager_recv_transaction_t *
                                                           transaction)
 {
-    return MPIDI_POSIX_eager_func->recv_begin(vsi, transaction);
+    return MPIDI_POSIX_eager_func->recv_begin(vci, transaction);
 }
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_eager_recv_memcpy(MPIDI_POSIX_eager_recv_transaction_t *

--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager_transaction.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager_transaction.h
@@ -18,8 +18,8 @@ typedef struct MPIDI_POSIX_eager_recv_transaction {
     size_t payload_sz;          /* 2GB limit */
 
     int src_local_rank;
-    int src_vsi;
-    int dst_vsi;
+    int src_vci;
+    int dst_vci;
 
     /* Private */
 

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
@@ -50,10 +50,10 @@ int MPIDI_POSIX_iqueue_init(int rank, int size)
     /* Create one terminal for each process with which we will be able to communicate. */
     size_of_terminals = (size_t) MPIDI_POSIX_global.num_local * sizeof(MPIDU_genq_shmem_queue_u);
 
-    for (int vsi_src = 0; vsi_src < MPIDI_POSIX_global.num_vsis; vsi_src++) {
-        for (int vsi_dst = 0; vsi_dst < MPIDI_POSIX_global.num_vsis; vsi_dst++) {
+    for (int vci_src = 0; vci_src < MPIDI_POSIX_global.num_vcis; vci_src++) {
+        for (int vci_dst = 0; vci_dst < MPIDI_POSIX_global.num_vcis; vci_dst++) {
             MPIDI_POSIX_eager_iqueue_transport_t *transport;
-            transport = MPIDI_POSIX_eager_iqueue_get_transport(vsi_src, vsi_dst);
+            transport = MPIDI_POSIX_eager_iqueue_get_transport(vci_src, vci_dst);
 
             transport->num_cells = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_NUM_CELLS;
             transport->size_of_cell = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE;
@@ -94,10 +94,10 @@ int MPIDI_POSIX_iqueue_finalize(void)
 
     MPIR_FUNC_ENTER;
 
-    for (int vsi_src = 0; vsi_src < MPIDI_POSIX_global.num_vsis; vsi_src++) {
-        for (int vsi_dst = 0; vsi_dst < MPIDI_POSIX_global.num_vsis; vsi_dst++) {
+    for (int vci_src = 0; vci_src < MPIDI_POSIX_global.num_vcis; vci_src++) {
+        for (int vci_dst = 0; vci_dst < MPIDI_POSIX_global.num_vcis; vci_dst++) {
             MPIDI_POSIX_eager_iqueue_transport_t *transport;
-            transport = MPIDI_POSIX_eager_iqueue_get_transport(vsi_src, vsi_dst);
+            transport = MPIDI_POSIX_eager_iqueue_get_transport(vci_src, vci_dst);
 
             mpi_errno = MPIDU_Init_shm_free(transport->terminals);
             MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
@@ -10,7 +10,7 @@
 #include "mpidu_genq.h"
 
 MPL_STATIC_INLINE_PREFIX int
-MPIDI_POSIX_eager_recv_begin(int vsi, MPIDI_POSIX_eager_recv_transaction_t * transaction)
+MPIDI_POSIX_eager_recv_begin(int vci, MPIDI_POSIX_eager_recv_transaction_t * transaction)
 {
     MPIDI_POSIX_eager_iqueue_transport_t *transport;
     MPIDI_POSIX_eager_iqueue_cell_t *cell = NULL;
@@ -18,16 +18,16 @@ MPIDI_POSIX_eager_recv_begin(int vsi, MPIDI_POSIX_eager_recv_transaction_t * tra
 
     MPIR_FUNC_ENTER;
 
-    /* TODO: measure the latency overhead due to multiple vsi */
-    for (int vsi_src = 0; vsi_src < MPIDI_POSIX_global.num_vsis; vsi_src++) {
-        transport = MPIDI_POSIX_eager_iqueue_get_transport(vsi_src, vsi);
+    /* TODO: measure the latency overhead due to multiple vci */
+    for (int vci_src = 0; vci_src < MPIDI_POSIX_global.num_vcis; vci_src++) {
+        transport = MPIDI_POSIX_eager_iqueue_get_transport(vci_src, vci);
 
         MPIDU_genq_shmem_queue_dequeue(transport->cell_pool, transport->my_terminal,
                                        (void **) &cell);
         if (cell) {
             transaction->src_local_rank = cell->from;
-            transaction->src_vsi = vsi_src;
-            transaction->dst_vsi = vsi;
+            transaction->src_vci = vci_src;
+            transaction->dst_vci = vci;
             transaction->payload = MPIDI_POSIX_EAGER_IQUEUE_CELL_PAYLOAD(cell);
             transaction->payload_sz = cell->payload_size;
 
@@ -64,7 +64,7 @@ MPIDI_POSIX_eager_recv_commit(MPIDI_POSIX_eager_recv_transaction_t * transaction
 
     MPIR_FUNC_ENTER;
 
-    transport = MPIDI_POSIX_eager_iqueue_get_transport(transaction->src_vsi, transaction->dst_vsi);
+    transport = MPIDI_POSIX_eager_iqueue_get_transport(transaction->src_vci, transaction->dst_vci);
     cell = (MPIDI_POSIX_eager_iqueue_cell_t *) transaction->transport.iqueue.pointer_to_cell;
     MPIDU_genq_shmem_pool_cell_free(transport->cell_pool, cell);
 

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -37,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX size_t MPIDI_POSIX_eager_buf_limit(void)
 MPL_STATIC_INLINE_PREFIX int
 MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void *am_hdr,
                        MPI_Aint am_hdr_sz, const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                       MPI_Aint offset, int src_vsi, int dst_vsi, MPI_Aint * bytes_sent)
+                       MPI_Aint offset, int src_vci, int dst_vci, MPI_Aint * bytes_sent)
 {
     MPIDI_POSIX_eager_iqueue_transport_t *transport;
     MPIDI_POSIX_eager_iqueue_cell_t *cell;
@@ -50,7 +50,7 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
     MPIR_FUNC_ENTER;
 
     /* Get the transport object that holds all of the global variables. */
-    transport = MPIDI_POSIX_eager_iqueue_get_transport(src_vsi, dst_vsi);
+    transport = MPIDI_POSIX_eager_iqueue_get_transport(src_vci, dst_vci);
 
     /* Try to get a new cell to hold the message */
     /* Select the appropriate pool depending on whether we are using sender-side or receiver-side

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_types.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_types.h
@@ -34,16 +34,16 @@ typedef struct MPIDI_POSIX_eager_iqueue_transport {
 } MPIDI_POSIX_eager_iqueue_transport_t;
 
 typedef struct MPIDI_POSIX_eager_iqueue_global {
-    /* 2d array indexed with [src_vsi][dst_vsi] */
+    /* 2d array indexed with [src_vci][dst_vci] */
     MPIDI_POSIX_eager_iqueue_transport_t transports[MPIDI_CH4_MAX_VCIS][MPIDI_CH4_MAX_VCIS];
 } MPIDI_POSIX_eager_iqueue_global_t;
 
 extern MPIDI_POSIX_eager_iqueue_global_t MPIDI_POSIX_eager_iqueue_global;
 
 MPL_STATIC_INLINE_PREFIX MPIDI_POSIX_eager_iqueue_transport_t
-    * MPIDI_POSIX_eager_iqueue_get_transport(int vsi_src, int vsi_dst)
+    * MPIDI_POSIX_eager_iqueue_get_transport(int vci_src, int vci_dst)
 {
-    return &MPIDI_POSIX_eager_iqueue_global.transports[vsi_src][vsi_dst];
+    return &MPIDI_POSIX_eager_iqueue_global.transports[vci_src][vci_dst];
 }
 
 #define MPIDI_POSIX_EAGER_IQUEUE_CELL_PAYLOAD(cell) \

--- a/src/mpid/ch4/shm/posix/posix_am_impl.h
+++ b/src/mpid/ch4/shm/posix/posix_am_impl.h
@@ -17,8 +17,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_release_req_hdr(MPIDI_POSIX_am_reque
     MPIR_FUNC_ENTER;
 
 #ifndef POSIX_AM_REQUEST_INLINE
-    int vsi = (*req_hdr_ptr)->src_vsi;
-    MPIDU_genq_private_pool_free_cell(MPIDI_POSIX_global.per_vsi[vsi].am_hdr_buf_pool,
+    int vci = (*req_hdr_ptr)->src_vci;
+    MPIDU_genq_private_pool_free_cell(MPIDI_POSIX_global.per_vci[vci].am_hdr_buf_pool,
                                       (*req_hdr_ptr));
 #endif
 
@@ -29,7 +29,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_release_req_hdr(MPIDI_POSIX_am_reque
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_init_req_hdr(const void *am_hdr,
                                                          size_t am_hdr_sz,
                                                          MPIDI_POSIX_am_request_header_t **
-                                                         req_hdr_ptr, MPIR_Request * sreq, int vsi)
+                                                         req_hdr_ptr, MPIR_Request * sreq, int vci)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_POSIX_am_request_header_t *req_hdr = *req_hdr_ptr;
@@ -42,7 +42,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_am_init_req_hdr(const void *am_hdr,
 #endif /* POSIX_AM_REQUEST_INLINE */
 
     if (req_hdr == NULL) {
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_POSIX_global.per_vsi[vsi].am_hdr_buf_pool,
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_POSIX_global.per_vci[vci].am_hdr_buf_pool,
                                            (void **) &req_hdr);
         MPIR_ERR_CHKANDJUMP(!req_hdr, mpi_errno, MPI_ERR_OTHER, "**nomem");
 

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -150,25 +150,25 @@ int MPIDI_POSIX_init_local(int *tag_bits /* unused */)
 
     MPIDI_POSIX_global.local_rank_0 = local_rank_0;
 
-    MPIDI_POSIX_global.num_vsis = MPIDI_global.n_total_vcis;
+    MPIDI_POSIX_global.num_vcis = MPIDI_global.n_total_vcis;
     /* This is used to track messages that the eager submodule was not ready to send. */
-    for (int vsi = 0; vsi < MPIDI_global.n_total_vcis; vsi++) {
+    for (int vci = 0; vci < MPIDI_global.n_total_vcis; vci++) {
         mpi_errno = MPIDU_genq_private_pool_create(MPIDI_POSIX_AM_HDR_POOL_CELL_SIZE,
                                                    MPIDI_POSIX_AM_HDR_POOL_NUM_CELLS_PER_CHUNK,
                                                    0 /* unlimited */ ,
                                                    host_alloc, host_free,
                                                    &MPIDI_POSIX_global.
-                                                   per_vsi[vsi].am_hdr_buf_pool);
+                                                   per_vci[vci].am_hdr_buf_pool);
         MPIR_ERR_CHECK(mpi_errno);
 
-        MPIDI_POSIX_global.per_vsi[vsi].postponed_queue = NULL;
+        MPIDI_POSIX_global.per_vci[vci].postponed_queue = NULL;
 
-        MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_global.per_vsi[vsi].active_rreq, MPIR_Request **,
+        MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_global.per_vci[vci].active_rreq, MPIR_Request **,
                             MPIR_Process.local_size * sizeof(MPIR_Request *), mpi_errno,
                             "active recv req", MPL_MEM_SHM);
 
         for (i = 0; i < MPIR_Process.local_size; i++) {
-            MPIDI_POSIX_global.per_vsi[vsi].active_rreq[i] = NULL;
+            MPIDI_POSIX_global.per_vci[vci].active_rreq[i] = NULL;
         }
 
     }
@@ -251,9 +251,9 @@ int MPIDI_POSIX_mpi_finalize_hook(void)
         utarray_free(shm_mutex_free_list);
     }
 
-    for (int vsi = 0; vsi < MPIDI_global.n_total_vcis; vsi++) {
-        MPIDU_genq_private_pool_destroy(MPIDI_POSIX_global.per_vsi[vsi].am_hdr_buf_pool);
-        MPL_free(MPIDI_POSIX_global.per_vsi[vsi].active_rreq);
+    for (int vci = 0; vci < MPIDI_global.n_total_vcis; vci++) {
+        MPIDU_genq_private_pool_destroy(MPIDI_POSIX_global.per_vci[vci].am_hdr_buf_pool);
+        MPL_free(MPIDI_POSIX_global.per_vci[vci].active_rreq);
     }
 
     MPL_free(MPIDI_POSIX_global.local_ranks);

--- a/src/mpid/ch4/shm/posix/posix_pre.h
+++ b/src/mpid/ch4/shm/posix/posix_pre.h
@@ -66,8 +66,8 @@ typedef struct MPIDI_POSIX_am_request_header {
     void *rreq_ptr;
     void *am_hdr;
 
-    int8_t src_vsi;
-    int8_t dst_vsi;
+    int8_t src_vci;
+    int8_t dst_vci;
     uint16_t am_hdr_sz;
     uint8_t pad[4];
 

--- a/src/mpid/ch4/shm/posix/posix_probe.h
+++ b/src/mpid/ch4/shm/posix/posix_probe.h
@@ -9,12 +9,12 @@
 #include "mpidch4r.h"
 #include "posix_impl.h"
 
-#define MPIDI_POSIX_PROBE_VSI(vsi_) \
+#define MPIDI_POSIX_PROBE_VSI(vci_) \
     do { \
-        int vsi_src_tmp; \
-        MPIDI_EXPLICIT_VCIS(comm, attr, source, comm->rank, vsi_src_tmp, vsi_); \
-        if (vsi_src_tmp == 0 && vsi_ == 0) { \
-            vsi_ = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag); \
+        int vci_src_tmp; \
+        MPIDI_EXPLICIT_VCIS(comm, attr, source, comm->rank, vci_src_tmp, vci_); \
+        if (vci_src_tmp == 0 && vci_ == 0) { \
+            vci_ = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, source, comm->rank, tag); \
         } \
     } while (0)
 
@@ -30,12 +30,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_improbe(int source,
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
-    int vsi;
-    MPIDI_POSIX_PROBE_VSI(vsi);
+    int vci;
+    MPIDI_POSIX_PROBE_VSI(vci);
 
-    MPIDI_POSIX_THREAD_CS_ENTER_VCI(vsi);
-    mpi_errno = MPIDIG_mpi_improbe(source, tag, comm, context_offset, vsi, flag, message, status);
-    MPIDI_POSIX_THREAD_CS_EXIT_VCI(vsi);
+    MPIDI_POSIX_THREAD_CS_ENTER_VCI(vci);
+    mpi_errno = MPIDIG_mpi_improbe(source, tag, comm, context_offset, vci, flag, message, status);
+    MPIDI_POSIX_THREAD_CS_EXIT_VCI(vci);
 
     return mpi_errno;
 }
@@ -49,12 +49,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_iprobe(int source,
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
-    int vsi;
-    MPIDI_POSIX_PROBE_VSI(vsi);
+    int vci;
+    MPIDI_POSIX_PROBE_VSI(vci);
 
-    MPIDI_POSIX_THREAD_CS_ENTER_VCI(vsi);
-    mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, vsi, flag, status);
-    MPIDI_POSIX_THREAD_CS_EXIT_VCI(vsi);
+    MPIDI_POSIX_THREAD_CS_ENTER_VCI(vci);
+    mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, vci, flag, status);
+    MPIDI_POSIX_THREAD_CS_EXIT_VCI(vci);
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/shm/posix/posix_recv.h
+++ b/src/mpid/ch4/shm/posix/posix_recv.h
@@ -10,13 +10,13 @@
 #include "posix_eager.h"
 #include "ch4_impl.h"
 
-/* Active message only need local vsi since all messages go to the same per-vsi queue */
-#define MPIDI_POSIX_RECV_VSI(vsi_) \
+/* Active message only need local vci since all messages go to the same per-vci queue */
+#define MPIDI_POSIX_RECV_VSI(vci_) \
     do { \
-        int vsi_src_tmp; \
-        MPIDI_EXPLICIT_VCIS(comm, attr, rank, comm->rank, vsi_src_tmp, vsi_); \
-        if (vsi_src_tmp == 0 && vsi_ == 0) { \
-            vsi_ = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag); \
+        int vci_src_tmp; \
+        MPIDI_EXPLICIT_VCIS(comm, attr, rank, comm->rank, vci_src_tmp, vci_); \
+        if (vci_src_tmp == 0 && vci_ == 0) { \
+            vci_ = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag); \
         } \
     } while (0)
 
@@ -37,10 +37,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_imrecv(void *buf, MPI_Aint count,
 {
     int mpi_errno = MPI_SUCCESS;
 
-    int vsi = MPIDI_Request_get_vci(message);
-    MPIDI_POSIX_THREAD_CS_ENTER_VCI(vsi);
+    int vci = MPIDI_Request_get_vci(message);
+    MPIDI_POSIX_THREAD_CS_ENTER_VCI(vci);
     mpi_errno = MPIDIG_mpi_imrecv(buf, count, datatype, message);
-    MPIDI_POSIX_THREAD_CS_EXIT_VCI(vsi);
+    MPIDI_POSIX_THREAD_CS_EXIT_VCI(vci);
 
     return mpi_errno;
 }
@@ -56,19 +56,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_irecv(void *buf,
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
     bool need_lock;
-    int vsi;
+    int vci;
     if (*request) {
         need_lock = false;
-        vsi = MPIDI_Request_get_vci(*request);
+        vci = MPIDI_Request_get_vci(*request);
     } else {
         need_lock = true;
-        MPIDI_POSIX_RECV_VSI(vsi);
-        MPIDI_POSIX_THREAD_CS_ENTER_VCI(vsi);
+        MPIDI_POSIX_RECV_VSI(vci);
+        MPIDI_POSIX_THREAD_CS_ENTER_VCI(vci);
     }
     int mpi_errno = MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
-                                     vsi, request, 1, NULL);
+                                     vci, request, 1, NULL);
     if (need_lock) {
-        MPIDI_POSIX_THREAD_CS_EXIT_VCI(vsi);
+        MPIDI_POSIX_THREAD_CS_EXIT_VCI(vci);
     }
 
     MPIDI_POSIX_recv_posted_hook(*request, rank, comm);

--- a/src/mpid/ch4/shm/posix/posix_send.h
+++ b/src/mpid/ch4/shm/posix/posix_send.h
@@ -16,12 +16,12 @@
 
 #include "posix_impl.h"
 
-#define MPIDI_POSIX_SEND_VSIS(vsi_src_, vsi_dst_) \
+#define MPIDI_POSIX_SEND_VSIS(vci_src_, vci_dst_) \
     do { \
-        MPIDI_EXPLICIT_VCIS(comm, attr, comm->rank, rank, vsi_src_, vsi_dst_); \
-        if (vsi_src_ == 0 && vsi_dst_ == 0) { \
-            vsi_src_ = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
-            vsi_dst_ = MPIDI_get_vci(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
+        MPIDI_EXPLICIT_VCIS(comm, attr, comm->rank, rank, vci_src_, vci_dst_); \
+        if (vci_src_ == 0 && vci_dst_ == 0) { \
+            vci_src_ = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
+            vci_dst_ = MPIDI_get_vci(DST_VCI_FROM_SENDER, comm, comm->rank, rank, tag); \
         } \
     } while (0)
 
@@ -36,13 +36,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_isend(const void *buf, MPI_Aint cou
     MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
     bool syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr);
 
-    int vsi_src, vsi_dst;
-    MPIDI_POSIX_SEND_VSIS(vsi_src, vsi_dst);
+    int vci_src, vci_dst;
+    MPIDI_POSIX_SEND_VSIS(vci_src, vci_dst);
 
-    MPIDI_POSIX_THREAD_CS_ENTER_VCI(vsi_src);
+    MPIDI_POSIX_THREAD_CS_ENTER_VCI(vci_src);
     mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                 vsi_src, vsi_dst, request, syncflag, errflag);
-    MPIDI_POSIX_THREAD_CS_EXIT_VCI(vsi_src);
+                                 vci_src, vci_dst, request, syncflag, errflag);
+    MPIDI_POSIX_THREAD_CS_EXIT_VCI(vci_src);
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/shm/posix/posix_types.h
+++ b/src/mpid/ch4/shm/posix/posix_types.h
@@ -29,10 +29,10 @@ typedef struct {
     MPIDI_POSIX_am_request_header_t *postponed_queue;
     MPIR_Request **active_rreq;
     char pad MPL_ATTR_ALIGNED(MPL_CACHELINE_SIZE);
-} MPIDI_POSIX_per_vsi_t;
+} MPIDI_POSIX_per_vci_t;
 
 typedef struct {
-    MPIDI_POSIX_per_vsi_t per_vsi[MPIDI_CH4_MAX_VCIS];
+    MPIDI_POSIX_per_vci_t per_vci[MPIDI_CH4_MAX_VCIS];
     void *shm_ptr;
     /* Keep track of all of the local processes in MPI_COMM_WORLD and what their original rank was
      * in that communicator. */
@@ -41,7 +41,7 @@ typedef struct {
     int *local_ranks;
     int *local_procs;
     int local_rank_0;
-    int num_vsis;
+    int num_vcis;
 } MPIDI_POSIX_global_t;
 
 extern MPIDI_POSIX_global_t MPIDI_POSIX_global;

--- a/src/mpid/ch4/shm/posix/posix_win.c
+++ b/src/mpid/ch4/shm/posix/posix_win.c
@@ -129,7 +129,7 @@ int MPIDI_POSIX_mpi_win_create_dynamic(MPIR_Info * info, MPIR_Comm * comm, MPIR_
 
 static void posix_win_init_common(MPIR_Win * win)
 {
-    MPIR_Assert(MPIDI_WIN(win, am_vci) < MPIDI_POSIX_global.num_vsis);
+    MPIR_Assert(MPIDI_WIN(win, am_vci) < MPIDI_POSIX_global.num_vcis);
 
     MPIDI_POSIX_win_t *posix_win = &win->dev.shm.posix;
     posix_win->shm_mutex_ptr = NULL;

--- a/src/mpid/ch4/shm/src/shm_am_fallback_send.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_send.h
@@ -20,14 +20,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf,
     MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
     bool syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr);
 
-    int vni_src, vni_dst;
-    vni_src = 0;
-    vni_dst = 0;
+    int vci_src, vci_dst;
+    vci_src = 0;
+    vci_dst = 0;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vni_src).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci_src).lock);
     mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
-                                 vni_src, vni_dst, request, syncflag, errflag);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vni_src).lock);
+                                 vci_src, vci_dst, request, syncflag, errflag);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci_src).lock);
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -22,11 +22,11 @@ MPL_STATIC_INLINE_PREFIX int anysource_irecv(void *buf, MPI_Aint count, MPI_Data
      * 3. MPIDI_NM_mpi_irecv need use recursive locking in case it share the shm vci lock
      */
 #if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
-    int vsi;
-    MPIDI_POSIX_RECV_VSI(vsi);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vsi).lock);
+    int vci;
+    MPIDI_POSIX_RECV_VSI(vci);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
 
-    MPIDI_CH4_REQUEST_CREATE(*request, MPIR_REQUEST_KIND__RECV, vsi, 1);
+    MPIDI_CH4_REQUEST_CREATE(*request, MPIR_REQUEST_KIND__RECV, vci, 1);
     MPIR_Assert(*request);
 #endif
 
@@ -54,7 +54,7 @@ MPL_STATIC_INLINE_PREFIX int anysource_irecv(void *buf, MPI_Aint count, MPI_Data
     }
   fn_exit:
 #if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vsi).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
 #endif
     return mpi_errno;
   fn_fail:


### PR DESCRIPTION
## Pull Request Description
Now we always use one-to-one mapping between vci and vni/vsi, it is cleaner to use vci everywhere. This also helps to avoid potential term collisions.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
