### PR TITLE
ch4/gpu: Optimized copy operations for netmod paths

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -14,6 +14,19 @@
 int MPIDI_OFI_rma_done_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * in_req);
 int MPIDI_OFI_dispatch_function(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * req);
 
+MPL_STATIC_INLINE_PREFIX MPL_gpu_engine_type_t MPIDI_OFI_gpu_get_recv_engine_type(int cvar)
+{
+    if (cvar == MPIR_CVAR_CH4_OFI_GPU_RECEIVE_ENGINE_TYPE_compute) {
+        return MPL_GPU_ENGINE_TYPE_COMPUTE;
+    } else if (cvar == MPIR_CVAR_CH4_OFI_GPU_RECEIVE_ENGINE_TYPE_copy_high_bandwidth) {
+        return MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH;
+    } else if (cvar == MPIR_CVAR_CH4_OFI_GPU_RECEIVE_ENGINE_TYPE_copy_low_latency) {
+        return MPL_GPU_ENGINE_TYPE_COPY_LOW_LATENCY;
+    } else {
+        return MPL_GPU_ENGINE_TYPE_LAST;
+    }
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_cqe_get_source(struct fi_cq_tagged_entry *wc, bool has_err)
 {
     if (MPIDI_OFI_ENABLE_DATA) {
@@ -81,11 +94,31 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vci, struct fi_cq_tagged_e
     if ((event_id == MPIDI_OFI_EVENT_RECV_PACK || event_id == MPIDI_OFI_EVENT_GET_HUGE) &&
         (MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer))) {
         MPI_Aint actual_unpack_bytes;
-        MPIR_Typerep_unpack(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer), count,
-                            MPIDI_OFI_REQUEST(rreq, noncontig.pack.buf),
-                            MPIDI_OFI_REQUEST(rreq, noncontig.pack.count),
-                            MPIDI_OFI_REQUEST(rreq, noncontig.pack.datatype), 0,
-                            &actual_unpack_bytes, MPIR_TYPEREP_FLAG_NONE);
+        int is_contig;
+        MPL_pointer_attr_t attr;
+        MPI_Aint true_lb, true_extent;
+        MPIR_Type_get_true_extent_impl(MPIDI_OFI_REQUEST(rreq, noncontig.pack.datatype), &true_lb,
+                                       &true_extent);
+        MPIR_Datatype_is_contig(MPIDI_OFI_REQUEST(rreq, noncontig.pack.datatype), &is_contig);
+        void *recv_buf = MPIR_get_contig_ptr(MPIDI_OFI_REQUEST(rreq, noncontig.pack.buf), true_lb);
+        MPIR_GPU_query_pointer_attr(recv_buf, &attr);
+        MPL_gpu_engine_type_t engine =
+            MPIDI_OFI_gpu_get_recv_engine_type(MPIR_CVAR_CH4_OFI_GPU_RECEIVE_ENGINE_TYPE);
+        if (is_contig && engine != MPL_GPU_ENGINE_TYPE_LAST &&
+            MPL_gpu_query_pointer_is_dev(recv_buf, &attr)) {
+            actual_unpack_bytes = wc->len;
+            mpi_errno =
+                MPIR_Localcopy_gpu(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer), count,
+                                   MPI_BYTE, NULL, recv_buf, count, MPI_BYTE, &attr,
+                                   MPL_GPU_COPY_DIRECTION_NONE, engine, true);
+            MPIR_ERR_CHECK(mpi_errno);
+        } else {
+            MPIR_Typerep_unpack(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer), count,
+                                MPIDI_OFI_REQUEST(rreq, noncontig.pack.buf),
+                                MPIDI_OFI_REQUEST(rreq, noncontig.pack.count),
+                                MPIDI_OFI_REQUEST(rreq, noncontig.pack.datatype), 0,
+                                &actual_unpack_bytes, MPIR_TYPEREP_FLAG_NONE);
+        }
         MPL_free(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer));
         if (actual_unpack_bytes != (MPI_Aint) count) {
             rreq->status.MPI_ERROR =

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -440,6 +440,34 @@ cvars:
       description : >-
         If true, enable OFI triggered ops for MPI collectives.
 
+    - name        : MPIR_CVAR_CH4_OFI_GPU_SEND_ENGINE_TYPE
+      category    : CH4_OFI
+      type        : enum
+      default     : copy_low_latency
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : |-
+        Specifies GPU engine type for GPU pt2pt on the sender side.
+        compute - use a compute engine
+        copy_high_bandwidth - use a high-bandwidth copy engine
+        copy_low_latency - use a low-latency copy engine
+        yaksa - use Yaksa
+
+    - name        : MPIR_CVAR_CH4_OFI_GPU_RECEIVE_ENGINE_TYPE
+      category    : CH4_OFI
+      type        : enum
+      default     : copy_low_latency
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : |-
+        Specifies GPU engine type for GPU pt2pt on the receiver side.
+        compute - use a compute engine
+        copy_high_bandwidth - use a high-bandwidth copy engine
+        copy_low_latency - use a low-latency copy engine
+        yaksa - use Yaksa
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -222,12 +222,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
             /* FIXME: at this point, GPU data takes host-buffer staging
              * path for the whole chunk. For large memory size, pipeline
              * transfer should be applied. */
-            dt_contig = 0;
             force_gpu_pack = true;
         }
     }
 
-    if (!dt_contig && data_sz) {
+    if ((!dt_contig || force_gpu_pack) && data_sz) {
         if (MPIDI_OFI_ENABLE_PT2PT_NOPACK && !force_gpu_pack &&
             ((data_sz < MPIDI_OFI_global.max_msg_size && !MPIDI_OFI_COMM(comm).enable_striping) ||
              (data_sz < MPIDI_OFI_global.stripe_threshold &&
@@ -251,10 +250,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         MPIR_ERR_CHKANDJUMP1(MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer) == NULL, mpi_errno,
                              MPI_ERR_OTHER, "**nomem", "**nomem %s", "Send Pack buffer alloc");
 
-        MPI_Aint actual_pack_bytes;
-        MPIR_Typerep_pack(buf, count, datatype, 0,
-                          MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer), data_sz,
-                          &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
+        int fast_copy = 0;
+        if (attr.type == MPL_GPU_POINTER_DEV && dt_contig &&
+            data_sz <= MPIR_CVAR_CH4_IPC_GPU_FAST_COPY_MAX_SIZE) {
+            int mpl_err = MPL_gpu_fast_memcpy(send_buf, &attr,
+                                              MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer),
+                                              NULL, data_sz);
+            if (mpl_err == MPL_SUCCESS)
+                fast_copy = 1;
+        }
+        if (!fast_copy) {
+            MPI_Aint actual_pack_bytes;
+            MPIR_Typerep_pack(buf, count, datatype, 0,
+                              MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer), data_sz,
+                              &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
+        }
         send_buf = MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer);
     } else {
         MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer) = NULL;
@@ -416,10 +426,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
             MPIDI_OFI_register_am_bufs();
             if (!MPIDI_OFI_ENABLE_HMEM) {
                 /* Force pack for GPU buffer. */
-                void *host_buf = NULL;
-                host_buf = MPL_malloc(data_sz, MPL_MEM_OTHER);
-                MPIR_Typerep_pack(buf, count, datatype, 0, host_buf, data_sz, &actual_pack_bytes,
-                                  MPIR_TYPEREP_FLAG_NONE);
+                void *host_buf = MPL_malloc(data_sz, MPL_MEM_OTHER);
+                int fast_copy = 0;
+                if (attr.type == MPL_GPU_POINTER_DEV && dt_contig &&
+                    data_sz <= MPIR_CVAR_CH4_IPC_GPU_FAST_COPY_MAX_SIZE) {
+                    int mpl_err;
+                    mpl_err = MPL_gpu_fast_memcpy(send_buf, &attr, host_buf, NULL, data_sz);
+                    if (mpl_err == MPL_SUCCESS) {
+                        fast_copy = 1;
+                        actual_pack_bytes = data_sz;
+                    }
+                }
+                if (!fast_copy) {
+                    MPIR_Typerep_pack(buf, count, datatype, 0, host_buf, data_sz,
+                                      &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE);
+                }
                 MPIR_Assert(actual_pack_bytes == data_sz);
                 send_buf = host_buf;
             }


### PR DESCRIPTION
## Pull Request Description

This PR adds support for Fast GPU memcpy and for bypassing Yaksa for contiguous buffers inside the netmod path.

Last 4 commits only
Depends on ~~#6571~~ #6587

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
