### PR TITLE
ch4/ofi: remove comm eagain hints

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -91,7 +91,6 @@ enum MPIR_COMM_HINT_PREDEFINED_t {
     /* device specific hints.
      * Potentially, we can use macros and configure to hide them */
     MPIR_COMM_HINT_EAGER_THRESH,        /* ch3 */
-    MPIR_COMM_HINT_EAGAIN,      /* ch4:ofi */
     MPIR_COMM_HINT_ENABLE_MULTI_NIC_STRIPING,   /* ch4:ofi */
     MPIR_COMM_HINT_ENABLE_MULTI_NIC_HASHING,    /* ch4:ofi */
     MPIR_COMM_HINT_MULTI_NIC_PREF_NIC,  /* ch4:ofi */

--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -145,11 +145,6 @@ int MPIDI_OFI_mpi_comm_commit_pre_hook(MPIR_Comm * comm)
     MPIDI_OFI_COMM(comm).enable_hashing = 0;
     MPIDI_OFI_COMM(comm).pref_nic = NULL;
 
-    /* eagain defaults to off */
-    if (comm->hints[MPIR_COMM_HINT_EAGAIN] == 0) {
-        comm->hints[MPIR_COMM_HINT_EAGAIN] = FALSE;
-    }
-
     if (comm->hints[MPIR_COMM_HINT_ENABLE_MULTI_NIC_STRIPING] == -1) {
         comm->hints[MPIR_COMM_HINT_ENABLE_MULTI_NIC_STRIPING] =
             MPIR_CVAR_CH4_OFI_ENABLE_MULTI_NIC_STRIPING;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -133,11 +133,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vci, struct fi_cq_tagged_e
         if (MPIDI_OFI_ENABLE_DATA) {
             MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx, NULL, 0,
                                                 MPIR_Comm_rank(c), dest_addr, ss_bits),
-                                 vci_local, tinjectdata, FALSE /* eagain */);
+                                 vci_local, tinjectdata);
         } else {
             MPIDI_OFI_CALL_RETRY(fi_tinject(MPIDI_OFI_global.ctx[ctx_idx].tx, NULL, 0,
-                                            dest_addr, ss_bits),
-                                 vci_local, tinject, FALSE /* eagain */);
+                                            dest_addr, ss_bits), vci_local, tinject);
         }
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_huge.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_huge.c
@@ -116,7 +116,7 @@ static int get_huge_issue_read(MPIR_Request * rreq)
                                      (void *) ((char *) recv_buf + cur_offset),
                                      bytesToGet, NULL, addr, recv_rbase(info) + cur_offset,
                                      remote_key, (void *) &chunk->context),
-                             vci_local, rdma_readfrom, FALSE);
+                             vci_local, rdma_readfrom);
         MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_recvd_bytes_count[nic], bytesToGet);
         if (MPIDI_OFI_COMM(comm).enable_striping) {
             MPIR_T_PVAR_COUNTER_INC(MULTINIC, striped_nic_recvd_bytes_count[nic], bytesToGet);

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -69,7 +69,7 @@ int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret);
                               fi_strerror(-_ret));          \
     } while (0)
 
-#define MPIDI_OFI_CALL_RETRY(FUNC,vci_,STR,EAGAIN)      \
+#define MPIDI_OFI_CALL_RETRY(FUNC,vci_,STR)                 \
     do {                                                    \
     ssize_t _ret;                                           \
     int _retry = MPIR_CVAR_CH4_OFI_MAX_EAGAIN_RETRY;        \
@@ -85,7 +85,7 @@ int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret);
                               __LINE__,                     \
                               __func__,                       \
                               fi_strerror(-_ret));          \
-        MPIR_ERR_CHKANDJUMP(_retry == 0 && EAGAIN,          \
+        MPIR_ERR_CHKANDJUMP(_retry == 0,                    \
                             mpi_errno,                      \
                             MPIX_ERR_EAGAIN,                \
                             "**eagain");                    \
@@ -140,34 +140,6 @@ int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret);
                               __LINE__,                     \
                               __func__,                     \
                               fi_strerror(-_ret));          \
-    } while (0)
-
-#define MPIDI_OFI_VCI_CALL_RETRY(FUNC,vci_,STR,EAGAIN)      \
-    do {                                                    \
-    ssize_t _ret;                                           \
-    int _retry = MPIR_CVAR_CH4_OFI_MAX_EAGAIN_RETRY;        \
-    do {                                                    \
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci_).lock);    \
-        _ret = FUNC;                                        \
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci_).lock);     \
-        if (likely(_ret==0)) break;                         \
-        MPIDI_OFI_ERR(_ret!=-FI_EAGAIN,                     \
-                              mpi_errno,                    \
-                              MPI_ERR_OTHER,                \
-                              "**ofid_"#STR,                \
-                              "**ofid_"#STR" %s %d %s %s",  \
-                              __SHORT_FILE__,               \
-                              __LINE__,                     \
-                              __func__,                     \
-                              fi_strerror(-_ret));          \
-        MPIR_ERR_CHKANDJUMP(_retry == 0 && EAGAIN,          \
-                            mpi_errno,                      \
-                            MPIX_ERR_EAGAIN,                \
-                            "**eagain");                    \
-        mpi_errno = MPID_Progress_test(NULL);                   \
-        MPIR_ERR_CHECK(mpi_errno);                          \
-        _retry--;                                           \
-    } while (_ret == -FI_EAGAIN);                           \
     } while (0)
 
 #define MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vci_)            \

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -85,10 +85,10 @@ int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret);
                               __LINE__,                     \
                               __func__,                       \
                               fi_strerror(-_ret));          \
-        MPIR_ERR_CHKANDJUMP(_retry == 0,                    \
-                            mpi_errno,                      \
-                            MPIX_ERR_EAGAIN,                \
-                            "**eagain");                    \
+        if (_retry > 0) { \
+            _retry--; \
+            MPIR_ERR_CHKANDJUMP(_retry == 0, mpi_errno, MPIX_ERR_EAGAIN, "**eagain"); \
+        } \
         /* FIXME: by fixing the recursive locking interface to account
          * for recursive locking in more than one lock (currently limited
          * to one due to scalar TLS counter), this lock yielding
@@ -97,8 +97,7 @@ int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret);
         mpi_errno = MPIDI_OFI_retry_progress();                      \
         MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vci_);			     \
         MPIR_ERR_CHECK(mpi_errno);                               \
-        _retry--;                                           \
-    } while (_ret == -FI_EAGAIN);                           \
+    } while (1);                                            \
     } while (0)
 
 /* per-vci macros - we'll transition into these macros once the locks are

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -559,7 +559,6 @@ int MPIDI_OFI_init_local(int *tag_bits)
     /* Initialize RMA keys allocator */
     MPIDI_OFI_mr_key_allocator_init();
 
-    MPIR_Comm_register_hint(MPIR_COMM_HINT_EAGAIN, "eagain", NULL, MPIR_COMM_HINT_TYPE_BOOL, 0, 0);
     MPIDI_OFI_global.num_comms_enabled_striping = 0;
     MPIDI_OFI_global.num_comms_enabled_hashing = 0;
 
@@ -743,11 +742,10 @@ static int flush_send(int dst, int nic, int vci, MPIDI_OFI_dynamic_process_reque
     if (MPIDI_OFI_ENABLE_DATA) {
         MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                           &data, 4, NULL, 0, addr, match_bits, &req->context),
-                             vci, tsenddata, FALSE);
+                             vci, tsenddata);
     } else {
         MPIDI_OFI_CALL_RETRY(fi_tsend(MPIDI_OFI_global.ctx[ctx_idx].tx,
-                                      &data, 4, NULL, addr, match_bits, &req->context),
-                             vci, tsend, FALSE);
+                                      &data, 4, NULL, addr, match_bits, &req->context), vci, tsend);
     }
 
   fn_exit:
@@ -774,7 +772,7 @@ static int flush_recv(int src, int nic, int vci, MPIDI_OFI_dynamic_process_reque
     void *recvbuf = &(req->tag);
     MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[MPIDI_OFI_get_ctx_index(NULL, vci, nic)].rx,
                                   recvbuf, 4, NULL, addr, match_bits, mask_bits, &req->context),
-                         vci, trecv, FALSE);
+                         vci, trecv);
 
   fn_exit:
     return mpi_errno;
@@ -1561,7 +1559,7 @@ int ofi_am_post_recv(int vci, int nic)
             MPIDI_OFI_global.per_vci[vci].am_msg[i].iov_count = 1;
             MPIDI_OFI_CALL_RETRY(fi_recvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx,
                                             &MPIDI_OFI_global.per_vci[vci].am_msg[i],
-                                            FI_MULTI_RECV | FI_COMPLETION), 0, prepost, FALSE);
+                                            FI_MULTI_RECV | FI_COMPLETION), 0, prepost);
         }
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -93,7 +93,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, size_
                                                                          vci_local, vci_remote);
 
     MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx, &msg, flags), vci_local,
-                         trecv, FALSE);
+                         trecv);
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -243,7 +243,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
                                       MPIDI_OFI_av_to_phys(addr, sender_nic, vci_local, vci_remote),
                                       match_bits, mask_bits,
                                       (void *) &(MPIDI_OFI_REQUEST(rreq, context))), vci_local,
-                             trecv, FALSE);
+                             trecv);
     } else {
         msg.msg_iov = &MPIDI_OFI_REQUEST(rreq, util.iov);
         msg.desc = NULL;
@@ -255,7 +255,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         msg.addr = FI_ADDR_UNSPEC;
 
         MPIDI_OFI_CALL_RETRY(fi_trecvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx, &msg, flags), vci_local,
-                             trecv, FALSE);
+                             trecv);
     }
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -135,12 +135,10 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, MPI_Aint origin_count,
         riov.key = target_mr.mr_key;
         MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
         if (rma_type == MPIDI_OFI_PUT) {
-            MPIDI_OFI_CALL_RETRY(fi_writemsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write,
-                                 FALSE);
+            MPIDI_OFI_CALL_RETRY(fi_writemsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write);
             req->rma_type = MPIDI_OFI_PUT;
         } else {        /* MPIDI_OFI_GET */
-            MPIDI_OFI_CALL_RETRY(fi_readmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write,
-                                 FALSE);
+            MPIDI_OFI_CALL_RETRY(fi_readmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write);
             req->rma_type = MPIDI_OFI_GET;
         }
 
@@ -230,8 +228,7 @@ static int issue_packed_put(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
         riov.len = msg_len;
         riov.key = req->noncontig.put.target.key;
         MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
-        MPIDI_OFI_CALL_RETRY(fi_writemsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write,
-                             FALSE);
+        MPIDI_OFI_CALL_RETRY(fi_writemsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write);
         req->noncontig.put.origin.pack_offset += msg_len;
 
         if (msg_len < req->noncontig.put.target.iov[target_cur].iov_len) {
@@ -315,8 +312,7 @@ static int issue_packed_get(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
         riov.len = msg_len;
         riov.key = req->noncontig.get.target.key;
         MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
-        MPIDI_OFI_CALL_RETRY(fi_readmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write,
-                             FALSE);
+        MPIDI_OFI_CALL_RETRY(fi_readmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write);
         req->noncontig.get.origin.pack_offset += msg_len;
 
         if (msg_len < req->noncontig.get.target.iov[target_cur].iov_len) {

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -228,7 +228,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
                                              target_bytes,
                                              MPIDI_OFI_av_to_phys(addr, nic, vci, vci_target),
                                              target_mr.addr + target_true_lb,
-                                             target_mr.mr_key), vci, rdma_inject_write, FALSE);
+                                             target_mr.mr_key), vci, rdma_inject_write);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
         goto null_op_exit;
     }
@@ -256,8 +256,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         riov.len = target_bytes;
         riov.key = target_mr.mr_key;
         MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
-        MPIDI_OFI_CALL_RETRY(fi_writemsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write,
-                             FALSE);
+        MPIDI_OFI_CALL_RETRY(fi_writemsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
@@ -426,8 +425,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         riov.len = target_bytes;
         riov.key = target_mr.mr_key;
         MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
-        MPIDI_OFI_CALL_RETRY(fi_readmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write,
-                             FALSE);
+        MPIDI_OFI_CALL_RETRY(fi_readmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
@@ -652,7 +650,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     MPIDI_OFI_win_cntr_incr(win);
     MPIDI_OFI_CALL_RETRY(fi_compare_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg,
                                               &comparev, NULL, 1, &resultv, NULL, 1, 0), vci,
-                         atomicto, FALSE);
+                         atomicto);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -770,8 +768,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
         msg.context = NULL;
         msg.data = 0;
         MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
-        MPIDI_OFI_CALL_RETRY(fi_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci,
-                             rdma_atomicto, FALSE);
+        MPIDI_OFI_CALL_RETRY(fi_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_atomicto);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
@@ -911,7 +908,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
         msg.data = 0;
         MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
         MPIDI_OFI_CALL_RETRY(fi_fetch_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg, &resultv,
-                                                NULL, 1, flags), vci, rdma_readfrom, FALSE);
+                                                NULL, 1, flags), vci, rdma_readfrom);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
@@ -1141,7 +1138,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
     MPIDI_OFI_win_cntr_incr(win);
     MPIDI_OFI_CALL_RETRY(fi_fetch_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg, &resultv,
-                                            NULL, 1, 0), vci, rdma_readfrom, FALSE);
+                                            NULL, 1, 0), vci, rdma_readfrom);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -38,11 +38,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_lightweight(const void *buf,
     if (MPIDI_OFI_ENABLE_DATA) {
         MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                             buf, data_sz, cq_data, dest_addr, match_bits),
-                             vci_local, tinjectdata, comm->hints[MPIR_COMM_HINT_EAGAIN]);
+                             vci_local, tinjectdata);
     } else {
         MPIDI_OFI_CALL_RETRY(fi_tinject(MPIDI_OFI_global.ctx[ctx_idx].tx,
-                                        buf, data_sz, dest_addr, match_bits),
-                             vci_local, tinject, comm->hints[MPIR_COMM_HINT_EAGAIN]);
+                                        buf, data_sz, dest_addr, match_bits), vci_local, tinject);
     }
     MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], data_sz);
   fn_exit:
@@ -125,7 +124,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_iov(const void *buf, MPI_Aint count,
     msg.addr = MPIDI_OFI_av_to_phys(addr, receiver_nic, vci_local, vci_remote);
 
     MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[ctx_idx].tx,
-                                     &msg, flags), vci_local, tsendv, FALSE);
+                                     &msg, flags), vci_local, tsendv);
     MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], data_sz);
 
   fn_exit:
@@ -210,7 +209,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                       MPIDI_OFI_av_to_phys(addr, sender_nic, vci_local, vci_remote),    /* remote proc */
                                       ssend_match,      /* match bits  */
                                       0ULL,     /* mask bits   */
-                                      (void *) &(ackreq->context)), vci_local, trecvsync, FALSE);
+                                      (void *) &(ackreq->context)), vci_local, trecvsync);
     }
 
     send_buf = MPIR_get_contig_ptr(buf, dt_true_lb);
@@ -267,11 +266,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         if (MPIDI_OFI_ENABLE_DATA) {
             MPIDI_OFI_CALL_RETRY(fi_tinjectdata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                                 send_buf, data_sz, cq_data, dest_addr, match_bits),
-                                 vci_local, tinjectdata, FALSE /* eagain */);
+                                 vci_local, tinjectdata);
         } else {
             MPIDI_OFI_CALL_RETRY(fi_tinject(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                             send_buf, data_sz, dest_addr, match_bits),
-                                 vci_local, tinject, FALSE /* eagain */);
+                                 vci_local, tinject);
         }
         MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], data_sz);
         MPIDI_OFI_send_event(vci_src, NULL, sreq, MPIDI_OFI_REQUEST(sreq, event_id));
@@ -281,12 +280,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                               send_buf, data_sz, NULL, cq_data, dest_addr,
                                               match_bits,
                                               (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
-                                 vci_local, tsenddata, FALSE /* eagain */);
+                                 vci_local, tsenddata);
         } else {
             MPIDI_OFI_CALL_RETRY(fi_tsend(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                           send_buf, data_sz, NULL, dest_addr, match_bits,
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
-                                 vci_local, tsend, FALSE /* eagain */);
+                                 vci_local, tsend);
         }
         MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], data_sz);
     } else if (unlikely(1)) {
@@ -378,7 +377,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                                                                vci_remote),
                                           match_bits,
                                           (void *) &(MPIDI_OFI_REQUEST(sreq, context))),
-                             vci_local, tsenddata, FALSE /* eagain */);
+                             vci_local, tsenddata);
         MPIR_T_PVAR_COUNTER_INC(MULTINIC, nic_sent_bytes_count[sender_nic], msg_size);
         MPIR_T_PVAR_COUNTER_INC(MULTINIC, striped_nic_sent_bytes_count[sender_nic], msg_size);
     }

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -35,11 +35,10 @@ int MPIDI_OFI_dynamic_send(uint64_t remote_gpid, int tag, const void *buf, int s
         MPIDI_OFI_CALL_RETRY(fi_tsenddata(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                           buf, size, NULL /* desc */ , 0,
                                           remote_addr, match_bits, (void *) &req.context),
-                             vci, tsenddata, FALSE /* eagain */);
+                             vci, tsenddata);
     } else {
         MPIDI_OFI_CALL_RETRY(fi_tsend(MPIDI_OFI_global.ctx[ctx_idx].tx, buf, size, NULL /* desc */ ,
-                                      remote_addr, match_bits, (void *) &req.context),
-                             vci, tsend, FALSE /* eagain */);
+                                      remote_addr, match_bits, (void *) &req.context), vci, tsend);
     }
     do {
         mpi_errno = MPIDI_OFI_progress_uninlined(vci);
@@ -98,8 +97,7 @@ int MPIDI_OFI_dynamic_recv(int tag, void *buf, int size, int timeout)
     MPL_wtime(&time_start);
     MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[ctx_idx].rx,
                                   buf, size, NULL,
-                                  FI_ADDR_UNSPEC, match_bits, mask_bits, &req.context),
-                         vci, trecv, FALSE);
+                                  FI_ADDR_UNSPEC, match_bits, mask_bits, &req.context), vci, trecv);
     do {
         mpi_errno = MPIDI_OFI_progress_uninlined(vci);
         MPIR_ERR_CHECK(mpi_errno);


### PR DESCRIPTION
## Pull Request Description
Seems the usage of the "eagain" comm hint is for lightweight send to
fail after MPIR_CVAR_CH4_OFI_MAX_EAGAIN_RETRY. All the other paths are
hard-coded with unlimited retries. One reason for this design may be to
let user feed back on potential delay in lightweight send. But is very
difficult to utilize. Simplify the design by removing the "eagain" comm
hint and allow MPIR_CVAR_CH4_OFI_MAX_EAGAIN_RETRY to always limit the
number of retries in all paths.

The default is unlimited retries on -FI_EAGAIN and this commit does not
change that.

Fixes https://github.com/pmodels/mpich/issues/6460
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
