### PR TITLE
ipc/gpu: use local device index instead of global index in caching

### DIFF
--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -37,7 +37,7 @@ static void ipc_handle_free_hook(void *dptr)
     void *pbase;
     uintptr_t len;
     int mpl_err ATTRIBUTE((unused));
-    int local_dev_id, global_dev_id;
+    int local_dev_id;
     MPL_pointer_attr_t gpu_attr;
 
     MPIR_FUNC_ENTER;
@@ -48,10 +48,9 @@ static void ipc_handle_free_hook(void *dptr)
 
         MPIR_GPU_query_pointer_attr(pbase, &gpu_attr);
         local_dev_id = MPL_gpu_get_dev_id_from_attr(&gpu_attr);
-        global_dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
 
         for (int i = 0; i < MPIR_Process.local_size; ++i) {
-            MPL_gavl_tree_t track_tree = MPIDI_GPUI_global.ipc_handle_track_trees[i][global_dev_id];
+            MPL_gavl_tree_t track_tree = MPIDI_GPUI_global.ipc_handle_track_trees[i][local_dev_id];
             mpl_err = MPL_gavl_tree_delete_range(track_tree, pbase, len);
             MPIR_Assert(mpl_err == MPL_SUCCESS);
         }

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -119,7 +119,7 @@ int MPIDI_GPU_ipc_handle_cache_insert(int rank, MPIR_Comm * comm, MPIDI_GPU_ipc_
         handle_obj->handle_status = MPIDI_GPU_IPC_HANDLE_VALID;
 
         mpi_errno = ipc_handle_cache_insert(MPIDI_GPUI_global.ipc_handle_track_trees[recv_lrank]
-                                            [handle.global_dev_id],
+                                            [handle.local_dev_id],
                                             (void *) handle.remote_base_addr, handle.len,
                                             handle_obj, &insert_successful);
         MPIR_ERR_CHECK(mpi_errno);
@@ -158,8 +158,7 @@ int MPIDI_GPU_get_ipc_attr(const void *vaddr, int rank, MPIR_Comm * comm,
     mpl_err = MPL_gpu_get_buffer_bounds(vaddr, &pbase, &len);
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_get_buffer_info");
 
-    MPL_gavl_tree_t track_tree =
-        MPIDI_GPUI_global.ipc_handle_track_trees[recv_lrank][global_dev_id];
+    MPL_gavl_tree_t track_tree = MPIDI_GPUI_global.ipc_handle_track_trees[recv_lrank][local_dev_id];
     mpi_errno = ipc_handle_cache_search(track_tree, pbase, len, (void **) &handle_obj);
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -183,6 +182,7 @@ int MPIDI_GPU_get_ipc_attr(const void *vaddr, int rank, MPIR_Comm * comm,
     ipc_attr->ipc_handle.gpu.offset = (uintptr_t) vaddr - (uintptr_t) pbase;
 
     ipc_attr->ipc_handle.gpu.global_dev_id = global_dev_id;
+    ipc_attr->ipc_handle.gpu.local_dev_id = local_dev_id;
     ipc_attr->threshold.send_lmt_sz = MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD;
   fn_fail:
 #else
@@ -236,7 +236,7 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int map_dev_id, void
     int mpl_err = MPL_SUCCESS;
     MPIDI_GPUI_handle_obj_s *handle_obj = NULL;
 
-#define MAPPED_TREE(i) MPIDI_GPUI_global.ipc_handle_mapped_trees[handle.node_rank][handle.global_dev_id][i]
+#define MAPPED_TREE(i) MPIDI_GPUI_global.ipc_handle_mapped_trees[handle.node_rank][handle.local_dev_id][i]
     if (handle.handle_status == MPIDI_GPU_IPC_HANDLE_REMAP_REQUIRED) {
         for (int i = 0; i < MPIDI_GPUI_global.local_device_count; ++i) {
             mpi_errno = ipc_handle_cache_delete(MAPPED_TREE(i),

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
@@ -16,6 +16,7 @@ enum {
 typedef struct MPIDI_GPU_ipc_handle {
     MPL_gpu_ipc_mem_handle_t ipc_handle;
     int global_dev_id;
+    int local_dev_id;
     uintptr_t remote_base_addr;
     uintptr_t len;
     int node_rank;


### PR DESCRIPTION
Since the caching is for local device pointers, a local device index is sufficient. Using global device index can be an overkill and hard to achieve with affinity masks.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
