### PR TITLE
ch4: Yield vci lock in progress while loops

### DIFF
--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -401,8 +401,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIU_valid_group_rank(MPIR_Comm * comm, int rank,
  * CAUTION: the macro uses MPIR_ERR_CHECK, be careful of it escaping the
  * critical section.
  *
- * NOTE: when used in a loop, we insert a yield of global lock to prevent
- * blocking other progress (under global granularity).
+ * NOTE: when used in a loop, we insert a yield of global or vci lock to
+ * prevent blocking other progress.
  */
 
 /* declare to avoid header order dance */
@@ -413,6 +413,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_progress_test_vci(int vci);
         mpi_errno = MPIDI_progress_test_vci(vci);   \
         MPIR_ERR_CHECK(mpi_errno); \
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
+        MPID_THREAD_CS_YIELD(VCI, MPIDI_VCI(vci).lock);                 \
     }
 
 #define MPIDIU_PROGRESS_DO_WHILE(cond, vci) \
@@ -420,6 +421,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_progress_test_vci(int vci);
         mpi_errno = MPIDI_progress_test_vci(vci); \
         MPIR_ERR_CHECK(mpi_errno); \
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
+        MPID_THREAD_CS_YIELD(VCI, MPIDI_VCI(vci).lock);                 \
     } while (cond)
 
 #ifdef HAVE_ERROR_CHECKING


### PR DESCRIPTION
## Pull Request Description

MPIDIU_PROGRESS_WHILE and MPIDIU_PROGRESS_DO_WHILE can monopolize the vci lock when the total number of vcis==1. Add a yield to avoid potential application deadlock.

Reported-by: Thomas Gillis <thoma.gillis@gmail.com>

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
