### PR TITLE
session: Enhance error handling

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -531,6 +531,8 @@ def process_func_parameters(func):
             func['_has_comm'] = name
         elif name == "win":
             func['_has_win'] = name
+        elif name == "session":
+            func['_has_session'] = name
 
         if 'ANY' in func['_skip_validate'] or kind in func['_skip_validate'] or name in func['_skip_validate']:
             # -- user bypass --
@@ -1614,6 +1616,10 @@ def dump_mpi_fn_fail(func):
             G.out.append("mpi_errno = MPIR_Err_return_comm(%s_ptr, __func__, mpi_errno);" % func['_has_comm'])
         elif '_has_win' in func:
             G.out.append("mpi_errno = MPIR_Err_return_win(win_ptr, __func__, mpi_errno);")
+        elif RE.match(r'mpi_session_init', func['name'], re.IGNORECASE):
+            G.out.append("mpi_errno = MPIR_Err_return_session_init(errhandler_ptr, __func__, mpi_errno);")
+        elif '_has_session' in func:
+            G.out.append("mpi_errno = MPIR_Err_return_session(session_ptr, __func__, mpi_errno);")
         else:
             G.out.append("mpi_errno = MPIR_Err_return_comm(0, __func__, mpi_errno);")
 

--- a/src/binding/c/errhan_api.txt
+++ b/src/binding/c/errhan_api.txt
@@ -178,6 +178,7 @@ MPI_Session_call_errhandler:
 
 MPI_Session_create_errhandler:
     .desc: Create an error handler for use with MPI session
+    .skip: initcheck
 
 MPI_Session_get_errhandler:
     .desc: Get the error handler for the MPI session

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -12,10 +12,12 @@
 
 struct MPIR_Comm;
 struct MPIR_Win;
+struct MPIR_Session;
 
 /* Bindings for internal routines */
 MPICH_API_PUBLIC int MPIR_Err_return_comm(struct MPIR_Comm *, const char[], int);
 MPICH_API_PUBLIC int MPIR_Err_return_win(struct MPIR_Win *, const char[], int);
+MPICH_API_PUBLIC int MPIR_Err_return_session(struct MPIR_Session *, const char[], int);
 #ifdef MPI__FILE_DEFINED
 /* Only define if we have MPI_File */
 MPICH_API_PUBLIC int MPIR_Err_return_file(MPI_File, const char[], int); /* Romio version */

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -13,11 +13,13 @@
 struct MPIR_Comm;
 struct MPIR_Win;
 struct MPIR_Session;
+struct MPIR_Errhandler;
 
 /* Bindings for internal routines */
 MPICH_API_PUBLIC int MPIR_Err_return_comm(struct MPIR_Comm *, const char[], int);
 MPICH_API_PUBLIC int MPIR_Err_return_win(struct MPIR_Win *, const char[], int);
 MPICH_API_PUBLIC int MPIR_Err_return_session(struct MPIR_Session *, const char[], int);
+MPICH_API_PUBLIC int MPIR_Err_return_session_init(struct MPIR_Errhandler *, const char[], int);
 #ifdef MPI__FILE_DEFINED
 /* Only define if we have MPI_File */
 MPICH_API_PUBLIC int MPIR_Err_return_file(MPI_File, const char[], int); /* Romio version */

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -499,6 +499,86 @@ int MPIR_Err_return_session(struct MPIR_Session *session_ptr, const char fcname[
     return errcode;
 }
 
+/* This error routine is used by MPI_Session_init */
+int MPIR_Err_return_session_init(MPIR_Errhandler * errhandler_ptr, const char fcname[], int errcode)
+{
+    const int error_class = ERROR_GET_CLASS(errcode);
+    checkValidErrcode(error_class, fcname, &errcode);
+    int errhandler_handle;
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (!MPIR_Errutil_is_initialized()) {
+        /* we aren't initialized; perhaps MPI_Session_init failed
+         * before error stack init */
+        MPIR_Handle_fatal_error(NULL, fcname, errcode);
+        return MPI_ERR_INTERN;
+    }
+    /* --END ERROR HANDLING-- */
+
+    /* Fallback to MPIR_Err_return_comm if no errhandler provided */
+    if (errhandler_ptr == NULL) {
+        return MPIR_Err_return_comm(NULL, fcname, errcode);
+    }
+
+    MPL_DBG_MSG_FMT(MPIR_DBG_ERRHAND, TERSE,
+                    (MPL_DBG_FDEST,
+                     "MPIR_Err_return_session_init(errhandler_ptr=%p, fcname=%s, errcode=%d)",
+                     errhandler_ptr, fcname, errcode));
+
+    MPIR_Assert(errhandler_ptr != NULL);
+    errhandler_handle = errhandler_ptr->handle;
+    MPI_Session session_null_handle = MPI_SESSION_NULL;
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (MPIR_Err_is_fatal(errcode) ||
+        errhandler_handle == MPI_ERRORS_ARE_FATAL || errhandler_handle == MPI_ERRORS_ABORT) {
+        /* Calls MPID_Abort */
+        MPIR_Handle_fatal_error(NULL, fcname, errcode);
+        /* never get here */
+    }
+    /* --END ERROR HANDLING-- */
+
+    /* Check for the special case of a user-provided error code */
+    errcode = checkForUserErrcode(errcode);
+    if (errhandler_handle != MPI_ERRORS_RETURN && errhandler_handle != MPIR_ERRORS_THROW_EXCEPTIONS) {
+        /* We pass a final 0 (for a null pointer) to these routines
+         * because MPICH-1 expected that */
+        switch (errhandler_ptr->language) {
+            case MPIR_LANG__C:
+                (*errhandler_ptr->errfn.C_Session_Handler_function) (&session_null_handle, &errcode,
+                                                                     0);
+                break;
+#ifdef HAVE_CXX_BINDING
+            case MPIR_LANG__CXX:
+                (*MPIR_Process.cxx_call_errfn) (0, &session_null_handle, &errcode,
+                                                (void (*)(void)) *errhandler_ptr->
+                                                errfn.C_Session_Handler_function);
+                /* The C++ code throws an exception if the error handler
+                 * returns something other than MPI_SUCCESS. There is no "return"
+                 * of an error code. */
+                errcode = MPI_SUCCESS;
+                break;
+#endif /* CXX_BINDING */
+#ifdef HAVE_FORTRAN_BINDING
+            case MPIR_LANG__FORTRAN90:
+            case MPIR_LANG__FORTRAN:
+                {
+                    /* If int and MPI_Fint aren't the same size, we need to
+                     * convert.  As this is not performance critical, we
+                     * do this even if MPI_Fint and int are the same size. */
+                    MPI_Fint ferr = errcode;
+                    MPI_Fint handle = (MPI_Fint) session_null_handle;
+                    (*errhandler_ptr->errfn.F77_Handler_function) (&handle, &ferr);
+                }
+                break;
+#endif /* FORTRAN_BINDING */
+        }
+    }
+
+    return errcode;
+
+}
+
 /* ------------------------------------------------------------------------- */
 /* Group 3: Routines to handle error messages.  These are organized into
  * several subsections:

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -1790,6 +1790,7 @@ AC_OUTPUT(maint/testmerge \
           errors/group/Makefile \
           errors/pt2pt/Makefile \
           errors/rma/Makefile \
+          errors/session/Makefile \
           errors/spawn/Makefile \
           errors/spawn/testlist \
           errors/topo/Makefile \

--- a/test/mpi/errhan/Makefile.am
+++ b/test/mpi/errhan/Makefile.am
@@ -15,6 +15,7 @@ EXTRA_DIST = testlist
 noinst_PROGRAMS =   \
     adderr          \
     commcall        \
+    sessioncall     \
     errfatal        \
     predef_eh       \
     errstring2      \

--- a/test/mpi/errhan/sessioncall.c
+++ b/test/mpi/errhan/sessioncall.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include "mpitest.h"
+
+/* Test for MPI_Session_call_errhandler() with user-defined error handler */
+
+static int calls = 0;
+static int errs = 0;
+static MPI_Session mysession;
+
+void eh(MPI_Session * session, int *err, ...)
+{
+    if (*err != MPI_ERR_OTHER) {
+        errs++;
+        fprintf(stderr, "Unexpected error code\n");
+    }
+    if (*session != mysession) {
+        errs++;
+        fprintf(stderr, "Unexpected session\n");
+    }
+    calls++;
+    return;
+}
+
+int main(int argc, char *argv[])
+{
+    MPI_Session session;
+    MPI_Errhandler newerr;
+
+    MPI_Session_create_errhandler(eh, &newerr);
+
+    MPI_Session_init(MPI_INFO_NULL, newerr, &session);
+
+    mysession = session;
+
+    MPI_Session_set_errhandler(session, newerr);
+    MPI_Session_call_errhandler(session, MPI_ERR_OTHER);
+    MPI_Errhandler_free(&newerr);
+    if (calls != 1) {
+        errs++;
+        fprintf(stderr, "Error handler called %d times (expected exactly 1 call)\n", calls);
+    }
+
+    MPI_Session_finalize(&session);
+
+    if (errs == 0) {
+        fprintf(stdout, " No Errors\n");
+    } else {
+        fprintf(stderr, "%d Errors\n", errs);
+    }
+
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/errhan/testlist
+++ b/test/mpi/errhan/testlist
@@ -1,6 +1,7 @@
 adderr 1
 commcall 2
 commcall_oldapi 2 strict=FALSE
+sessioncall 1
 errfatal 1 resultTest=TestErrFatal
 predef_eh 1
 predef_eh 2

--- a/test/mpi/errors/session/Makefile.am
+++ b/test/mpi/errors/session/Makefile.am
@@ -1,0 +1,13 @@
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+include $(top_srcdir)/Makefile_single.mtest
+
+EXTRA_DIST = testlist
+
+## for all programs that are just built from the single corresponding source
+## file, we don't need per-target _SOURCES rules, automake will infer them
+## correctly
+noinst_PROGRAMS = sessioninit getpsetinfo getnthpset

--- a/test/mpi/errors/session/getnthpset.c
+++ b/test/mpi/errors/session/getnthpset.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <stdio.h>
+#include "mpi.h"
+#include "mpitest.h"
+
+/* Test for error handling of MPI_Session_get_nth_pset */
+
+int main(int argc, char *argv[])
+{
+    int errs, rc, n_psets, psetname_len;
+    errs = 0;
+    n_psets = 0;
+    psetname_len = 0;
+    char *pset_name;
+
+    MPI_Session shandle = MPI_SESSION_NULL;
+
+    rc = MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &shandle);
+    if (rc != MPI_SUCCESS) {
+        errs++;
+        fprintf(stderr, "MPI_Session_init returned error code: %i\n", rc);
+        goto fn_exit;
+    }
+
+    MPI_Session_set_errhandler(shandle, MPI_ERRORS_RETURN);
+
+    /* Test positive case: pset at position 0 always exists because of MPI default psets */
+    rc = MPI_Session_get_nth_pset(shandle, MPI_INFO_NULL, 0, &psetname_len, NULL);
+    if (rc != MPI_SUCCESS) {
+        fprintf(stderr,
+                "MPI_Session_get_nth_pset: requesting pset name length at index 0 returned error code: %i\n",
+                rc);
+        errs++;
+    }
+
+    /* Provoke error with null pointer as pset_name */
+    rc = MPI_Session_get_nth_pset(shandle, MPI_INFO_NULL, 0, &psetname_len, NULL);
+    if (rc == MPI_SUCCESS) {
+        fprintf(stderr, "MPI_Session_get_nth_pset: null pointer pset_name did not return error\n");
+        errs++;
+    }
+
+    pset_name = (char *) malloc(sizeof(char) * psetname_len);
+    rc = MPI_Session_get_nth_pset(shandle, MPI_INFO_NULL, 0, &psetname_len, pset_name);
+    if (rc != MPI_SUCCESS) {
+        fprintf(stderr,
+                "MPI_Session_get_nth_pset: requesting pset at index 0 returned error code: %i\n",
+                rc);
+        errs++;
+    }
+    free(pset_name);
+
+    /* Test negative case: pset at position n_psets + 1 does not exist */
+    rc = MPI_Session_get_num_psets(shandle, MPI_INFO_NULL, &n_psets);
+    if (rc != MPI_SUCCESS) {
+        fprintf(stderr, "MPI_Session_get_num_psets: returned error code: %i\n", rc);
+        errs++;
+    }
+
+    psetname_len = 0;
+    rc = MPI_Session_get_nth_pset(shandle, MPI_INFO_NULL, n_psets + 1, &psetname_len, NULL);
+    if (rc == MPI_SUCCESS) {
+        fprintf(stderr,
+                "MPI_Session_get_nth_pset: requesting pset name length at index n + 1 did not return error\n");
+        errs++;
+    }
+
+    psetname_len = 10;
+    pset_name = (char *) malloc(sizeof(char) * psetname_len);
+    rc = MPI_Session_get_nth_pset(shandle, MPI_INFO_NULL, n_psets + 1, &psetname_len, pset_name);
+    if (rc == MPI_SUCCESS) {
+        fprintf(stderr,
+                "MPI_Session_get_nth_pset: requesting pset at index n + 1 did not return error\n");
+        errs++;
+    }
+    free(pset_name);
+
+    rc = MPI_Session_finalize(&shandle);
+    if (rc != MPI_SUCCESS) {
+        errs++;
+        fprintf(stderr, "MPI_Session_finalize returned error code: %i\n", rc);
+    }
+
+  fn_exit:
+    if (errs == 0) {
+        fprintf(stdout, " No Errors\n");
+    } else {
+        fprintf(stderr, "%d Errors\n", errs);
+    }
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/errors/session/getpsetinfo.c
+++ b/test/mpi/errors/session/getpsetinfo.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <stdio.h>
+#include "mpi.h"
+#include "mpitest.h"
+
+/* Test for error handling of MPI_Session_get_pset_info */
+
+int main(int argc, char *argv[])
+{
+    int errs, rc;
+    errs = 0;
+
+    MPI_Info sinfo = MPI_INFO_NULL;
+    MPI_Session shandle = MPI_SESSION_NULL;
+
+    rc = MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &shandle);
+    if (rc != MPI_SUCCESS) {
+        errs++;
+        fprintf(stderr, "MPI_Session_init returned error code: %i\n", rc);
+        goto fn_exit;
+    }
+
+    MPI_Session_set_errhandler(shandle, MPI_ERRORS_RETURN);
+
+    /* Test positive case */
+    rc = MPI_Session_get_pset_info(shandle, "mpi://WORLD", &sinfo);
+    if (rc != MPI_SUCCESS) {
+        fprintf(stderr, "MPI_Session_get_pset_info: got error code for mpi://WORLD pset: %i\n", rc);
+        errs++;
+    }
+    if (sinfo == MPI_INFO_NULL) {
+        fprintf(stderr, "MPI_Session_get_pset_info: returned no error but info is MPI_INFO_NULL\n");
+        errs++;
+    } else {
+        MPI_Info_free(&sinfo);
+    }
+
+    /* Test negative case */
+    rc = MPI_Session_get_pset_info(shandle, "does-not-exist", &sinfo);
+    if (rc == MPI_SUCCESS) {
+        fprintf(stderr, "MPI_Session_get_pset_info: got MPI_SUCCESS for non-existing pset\n");
+        MPI_Info_free(&sinfo);
+        errs++;
+    }
+
+    rc = MPI_Session_finalize(&shandle);
+    if (rc != MPI_SUCCESS) {
+        errs++;
+        fprintf(stderr, "MPI_Session_finalize returned error code: %i\n", rc);
+    }
+
+  fn_exit:
+    if (errs == 0) {
+        fprintf(stdout, " No Errors\n");
+    } else {
+        fprintf(stderr, "%d Errors\n", errs);
+    }
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/errors/session/sessioninit.c
+++ b/test/mpi/errors/session/sessioninit.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <stdio.h>
+#include "mpi.h"
+#include "mpitest.h"
+
+/* Test for error handling of MPI_Session_init */
+
+int main(int argc, char *argv[])
+{
+    int rc;
+    int errs = 0;
+    const char mt_key[] = "thread_level";
+    const char mt_value[] = "MPI_THREAD_MULTIPLE";
+    const char mt_invalid[] = "THIS_IS_NOT_VALID";
+
+    MPI_Session shandle = MPI_SESSION_NULL;
+    MPI_Info sinfo = MPI_INFO_NULL;
+    MPI_Info_create(&sinfo);
+
+    MPI_Info_set(sinfo, mt_key, mt_invalid);
+    rc = MPI_Session_init(sinfo, MPI_ERRORS_RETURN, &shandle);
+    if (rc == MPI_SUCCESS) {
+        errs++;
+        fprintf(stderr, "MPI_Session_init returned no error for invalid info param\n");
+        MPI_Session_finalize(&shandle);
+        goto fn_exit;
+    }
+
+    MPI_Info_set(sinfo, mt_key, mt_value);
+    rc = MPI_Session_init(sinfo, MPI_ERRORS_RETURN, &shandle);
+    if (rc != MPI_SUCCESS) {
+        errs++;
+        fprintf(stderr, "MPI_Session_init returned error code: %i\n", rc);
+        goto fn_exit;
+    }
+
+    MPI_Session_set_errhandler(shandle, MPI_ERRORS_RETURN);
+
+    rc = MPI_Session_finalize(&shandle);
+    if (rc != MPI_SUCCESS) {
+        errs++;
+        fprintf(stderr, "MPI_Session_finalize returned error code: %i\n", rc);
+    }
+
+  fn_exit:
+    if (sinfo != MPI_INFO_NULL) {
+        MPI_Info_free(&sinfo);
+    }
+
+    if (errs == 0) {
+        fprintf(stdout, " No Errors\n");
+    } else {
+        fprintf(stderr, "%d Errors\n", errs);
+    }
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/errors/session/testlist
+++ b/test/mpi/errors/session/testlist
@@ -1,0 +1,3 @@
+sessioninit 1
+getnthpset 1
+getpsetinfo 1

--- a/test/mpi/errors/testlist.in
+++ b/test/mpi/errors/testlist.in
@@ -4,6 +4,7 @@ comm
 datatype
 group
 pt2pt
+session
 topo
 @rmadir@
 @spawndir@


### PR DESCRIPTION
This PR provides enhancements for the error handling of MPI sessions:
- MPI session routines use the error handler attached to the session (if any) for error handling
- If no error handler is attached to a session, the previous error handling solution via comms is used as fallback
- Special case for `MPI_Session_init`: Use the `errhandler` provided to this function for error handling (if any); fallback solution is the same as above
- Skip the init check in `MPI_Session_create_errhandler()` so that custom session error handlers can be used on `MPI_Session_init`
- New tests for error handling and errors of MPI session routines


## Author Checklist
* [X] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [X] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [X] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
