### PR TITLE
errtest: do not fail parrived for inactive request

### DIFF
--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -379,13 +379,13 @@ cvars:
         goto fn_fail;                                                             \
     }
 
-#define MPIR_ERRTEST_PARRIVEDREQ(reqp,err)                                                \
-    if ((reqp)->kind != MPIR_REQUEST_KIND__PART_RECV ||                                   \
-                    !MPIR_Part_request_is_active(reqp)) {                                 \
-        err = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__, \
-                                   MPI_ERR_REQUEST, "**requestinvalidparrived", 0); \
-        goto fn_fail;                                                             \
-    }
+#define MPIR_ERRTEST_PARRIVEDREQ(reqp, err)                                    \
+  if ((reqp)->kind != MPIR_REQUEST_KIND__PART_RECV) {                          \
+    err = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__,    \
+                               __LINE__, MPI_ERR_REQUEST,                      \
+                               "**requestinvalidparrived", 0);                 \
+    goto fn_fail;                                                              \
+  }
 
 #define MPIR_ERRTEST_COMM_INTRA(comm_ptr, err)                          \
     if ((comm_ptr)->comm_kind != MPIR_COMM_KIND__INTRACOMM) {           \


### PR DESCRIPTION
`MPI_Parrived` must return true for inactive requests (#6361).
This commit prevents the error checking to fail if this is the case

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
