### PR TITLE
attr: fix attr delete bug

### DIFF
--- a/test/mpi/attr/Makefile.am
+++ b/test/mpi/attr/Makefile.am
@@ -16,6 +16,7 @@ noinst_PROGRAMS =      \
     attrerr            \
     attrerrcomm        \
     attrerrtype        \
+    attrdelete         \
     attrdeleteget      \
     attr2type          \
     attrorder          \

--- a/test/mpi/attr/attrdelete.c
+++ b/test/mpi/attr/attrdelete.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+/*
+  Having attr delete function to delete another attribute.
+ */
+#include "mpitest.h"
+#include <stdio.h>
+
+int key1, key2, key3;
+
+int test_communicator(MPI_Comm comm);
+
+int main(int argc, char **argv)
+{
+    int errs;
+    MTest_Init(&argc, &argv);
+    errs = test_communicator(MPI_COMM_WORLD);
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}
+
+static int key2_delete_fn(MPI_Comm comm, int keyval, void *attribute_val, void *extra_state)
+{
+    MPI_Comm_delete_attr(comm, key1);
+    MPI_Comm_delete_attr(comm, key3);
+    return MPI_SUCCESS;
+}
+
+int test_communicator(MPI_Comm comm)
+{
+    int errs = 0;
+    int rank, size;
+
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &size);
+
+    MPI_Comm_create_keyval(MPI_NULL_COPY_FN, MPI_NULL_DELETE_FN, &key1, NULL);
+    MPI_Comm_create_keyval(MPI_NULL_COPY_FN, key2_delete_fn, &key2, NULL);
+    MPI_Comm_create_keyval(MPI_NULL_COPY_FN, MPI_NULL_DELETE_FN, &key3, NULL);
+
+    MPI_Comm_set_attr(comm, key1, (void *) (MPI_Aint) rank);
+    MPI_Comm_set_attr(comm, key2, (void *) (MPI_Aint) (rank + 100));
+    MPI_Comm_set_attr(comm, key3, (void *) (MPI_Aint) (rank + 200));
+
+    MPI_Comm_delete_attr(comm, key2);
+
+    MPI_Comm_free_keyval(&key1);
+    MPI_Comm_free_keyval(&key2);
+    MPI_Comm_free_keyval(&key3);
+
+    return errs;
+}

--- a/test/mpi/attr/testlist.in
+++ b/test/mpi/attr/testlist.in
@@ -7,6 +7,7 @@ attrend2 1
 attrend2 5
 attrerrcomm 1
 attrerrtype 1
+attrdelete 1
 attrdeleteget 1
 attr2type 1
 attrorder 1


### PR DESCRIPTION
## Pull Request Description
Add a test that demonstrate the bug --

```
$ ./attrdelete
 No Errors
Assertion failed in file src/mpi/attr/attrutil.c at line 256: ((p->keyval))->ref_count >= 0
No backtrace info available
Abort(1) on node 0: Internal error

```
The test inserts 3 attributes then delete the 2nd key. The attr delete function for the 2nd key deletes the 1st and 3rd key. The current MPICH results in a broken attribute list, which triggers an assertion error when we free the communicator.

The second commit fixes this bug.

## Background
PETSc abuses attributes this way -- using attr functions for book keeping purposes and one attribute delete will trigger additional attribute deletions.

We were lucky it evaded this bug due to accidental additional attributes padding the deleted ones.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
