### PR TITLE
ch4/xpmem: remove unneccessary repeat addr check

### DIFF
--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
@@ -50,9 +50,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_get_ipc_attr(const void *vaddr, uintptr
     }
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
     if (MPIR_CVAR_CH4_XPMEM_ENABLE) {
-        if (data_sz < MPIR_CVAR_CH4_IPC_XPMEM_P2P_THRESHOLD && !MPIDI_IPCI_is_repeat_addr(vaddr)) {
-            goto fn_none;
-        }
         ipc_attr->ipc_type = MPIDI_IPCI_TYPE__XPMEM;
         ipc_attr->ipc_handle.xpmem.src_offset = (uint64_t) vaddr;
         ipc_attr->ipc_handle.xpmem.data_sz = data_sz;


### PR DESCRIPTION
## Pull Request Description

Remove the repeat-address check from the XPMEM path. It currently causes compilation failure and isn't necessarily needed.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
