### PR TITLE
mpl/hip: add missing MPL_gpu_ipc_handle_destroy

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -132,6 +132,11 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     goto fn_exit;
 }
 
+int MPL_gpu_ipc_handle_destroy(const void *ptr)
+{
+    return MPL_SUCCESS;
+}
+
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;


### PR DESCRIPTION
## Pull Request Description
Commit 2083dc4 added MPL_gpu_ipc_handle_destroy but neglected adding it in mpl_gpu_hip.c.


Fixes #6484 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
