### PR TITLE
ch4/prgress: skip MPID_Progress_wait and optimize

### DIFF
--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -43,8 +43,8 @@ Non Native API:
   post_init : int
       NM : void
   progress : int
-      NM*: vci, blocking
-     SHM*: vci, blocking
+      NM*: vci, made_progress
+     SHM*: vci, made_progress
   comm_set_hints : int
       NM : comm_ptr, info
      SHM : comm_ptr, info
@@ -434,7 +434,6 @@ PARAM:
     base-2: const void *
     baseptr: void *
     baseptr_p: void **
-    blocking: int
     buf: const void *
     buf-2: void *
     buffer: void *
@@ -468,6 +467,7 @@ PARAM:
     lock_type: int
     gpid_ptr: uint64_t *
     lpids: const int[]
+    made_progress: int *
     message: MPIR_Request *
     message_p: MPIR_Request **
     newcomm_ptr: MPIR_Comm **

--- a/src/mpid/ch4/include/mpidpost.h
+++ b/src/mpid/ch4/include/mpidpost.h
@@ -26,11 +26,6 @@ MPL_STATIC_INLINE_PREFIX void MPID_Request_free_hook(MPIR_Request * req)
 {
     MPIR_FUNC_ENTER;
 
-    int vci = MPIDI_Request_get_vci(req);
-    /* Increment MPIDI_global.vci[vci].vci.progress_count. */
-    int count = MPL_atomic_relaxed_load_int(&MPIDI_VCI(vci).progress_count);
-    MPL_atomic_relaxed_store_int(&MPIDI_VCI(vci).progress_count, count + 1);
-
     MPIR_FUNC_EXIT;
     return;
 }

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -51,9 +51,7 @@ typedef struct {
 
 typedef struct {
     int flag;
-    int progress_made;
     int vci_count;              /* number of vcis that need progress */
-    int progress_counts[MPIDI_CH4_MAX_VCIS];
     uint8_t vci[MPIDI_CH4_MAX_VCIS];    /* list of vcis that need progress */
 } MPID_Progress_state;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -46,7 +46,8 @@ int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret);
  */
 #define MPIDI_OFI_PROGRESS(vci)                                   \
     do {                                                          \
-        mpi_errno = MPIDI_NM_progress(vci, 0);                   \
+        int made_progress = 0; \
+        mpi_errno = MPIDI_NM_progress(vci, &made_progress); \
         MPIR_ERR_CHECK(mpi_errno);                                \
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
     } while (0)
@@ -104,8 +105,9 @@ int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret);
  * moved down to ofi-layer */
 #define MPIDI_OFI_VCI_PROGRESS(vci_)                                    \
     do {                                                                \
+        int made_progress = 0; \
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci_).lock);                \
-        mpi_errno = MPIDI_NM_progress(vci_, 0);                        \
+        mpi_errno = MPIDI_NM_progress(vci_, &made_progress); \
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci_).lock);                 \
         MPIR_ERR_CHECK(mpi_errno);                                      \
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
@@ -113,9 +115,10 @@ int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret);
 
 #define MPIDI_OFI_VCI_PROGRESS_WHILE(vci_, cond)                            \
     do {                                                                    \
+        int made_progress = 0; \
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci_).lock);                    \
         while (cond) {                                                      \
-            mpi_errno = MPIDI_NM_progress(vci_, 0);                        \
+            mpi_errno = MPIDI_NM_progress(vci_, &made_progress);                        \
             if (mpi_errno) {                                                \
                 MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci_).lock);             \
                 MPIR_ERR_POP(mpi_errno);                                    \

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -801,8 +801,9 @@ static int flush_send_queue(void)
 
     bool all_done = false;
     while (!all_done) {
+        int made_progress;
         for (int vci = 0; vci < num_vcis; vci++) {
-            mpi_errno = MPIDI_NM_progress(vci, 0);
+            mpi_errno = MPIDI_NM_progress(vci, &made_progress);
             MPIR_ERR_CHECK(mpi_errno);
         }
         all_done = true;

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.c
@@ -9,5 +9,6 @@
 
 int MPIDI_OFI_progress_uninlined(int vci)
 {
-    return MPIDI_NM_progress(vci, 0);
+    int made_progress;
+    return MPIDI_NM_progress(vci, &made_progress);
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -69,7 +69,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_handle_cq_entries(int vci, struct fi_cq_t
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int *made_progress)
 {
     int mpi_errno = MPI_SUCCESS;
     struct fi_cq_tagged_entry wc[MPIDI_OFI_NUM_CQ_ENTRIES];

--- a/src/mpid/ch4/netmod/stubnm/stubnm_progress.h
+++ b/src/mpid/ch4/netmod/stubnm/stubnm_progress.h
@@ -6,7 +6,7 @@
 #ifndef STUBNM_PROGRESS_H_INCLUDED
 #define STUBNM_PROGRESS_H_INCLUDED
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_STUBNM_progress(int vci, int blocking)
+MPL_STATIC_INLINE_PREFIX int MPIDI_STUBNM_progress(int vci, int *made_progress)
 {
     MPIR_Assert(0);
     return MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -8,7 +8,7 @@
 
 #include "ucx_impl.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int blocking)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int *made_progress)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/shm/src/shm_progress.h
+++ b/src/mpid/ch4/shm/src/shm_progress.h
@@ -9,13 +9,13 @@
 #include <shm.h>
 #include "../posix/posix_progress.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vci, int blocking)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_progress(int vci, int *made_progress)
 {
     int ret = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_progress(vci, blocking);
+    ret = MPIDI_POSIX_progress(vci, made_progress);
 
     MPIR_FUNC_EXIT;
     return ret;

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -100,6 +100,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_progress_test(MPID_Progress_state * state)
     if (state->flag & MPIDI_PROGRESS_HOOKS) {
         mpi_errno = MPIR_Progress_hook_exec_all(&made_progress);
         MPIR_ERR_CHECK(mpi_errno);
+        if (made_progress) {
+            goto fn_exit;
+        }
     }
     /* todo: progress unexp_list */
 

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -61,7 +61,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_global_progress(void)
     do {                                              \
         if (state->flag & MPIDI_PROGRESS_NM) {	      \
             MPIDI_THREAD_CS_ENTER_VCI_OPTIONAL(vci);  \
-            mpi_errno = MPIDI_NM_progress(vci, 0);    \
+            mpi_errno = MPIDI_NM_progress(vci, &made_progress); \
             MPIDI_THREAD_CS_EXIT_VCI_OPTIONAL(vci);   \
         }                                             \
     } while (0)
@@ -71,12 +71,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_global_progress(void)
     do {                                                \
         if (state->flag & MPIDI_PROGRESS_NM) {                  \
             MPIDI_THREAD_CS_ENTER_VCI_OPTIONAL(vci);            \
-            mpi_errno = MPIDI_NM_progress(vci, 0);              \
+            mpi_errno = MPIDI_NM_progress(vci, &made_progress); \
             MPIDI_THREAD_CS_EXIT_VCI_OPTIONAL(vci);                     \
         }                                                               \
         if (state->flag & MPIDI_PROGRESS_SHM && mpi_errno == MPI_SUCCESS) { \
             MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);             \
-            mpi_errno = MPIDI_SHM_progress(vci, 0);                     \
+            mpi_errno = MPIDI_SHM_progress(vci, &made_progress); \
             MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);              \
         }                                                               \
   } while (0)
@@ -175,10 +175,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_progress_test_vci(int vci)
         mpi_errno = MPID_Progress_test(NULL);
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
     } else {
-        mpi_errno = MPIDI_NM_progress(vci, 0);
+        int made_progress = 0;
+        mpi_errno = MPIDI_NM_progress(vci, &made_progress);
         MPIR_ERR_CHECK(mpi_errno);
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-        mpi_errno = MPIDI_SHM_progress(vci, 0);
+        mpi_errno = MPIDI_SHM_progress(vci, &made_progress);
         MPIR_ERR_CHECK(mpi_errno);
 #endif
     }

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -238,11 +238,6 @@ extern MPID_Thread_mutex_t MPIR_THREAD_VCI_HANDLE_POOL_MUTEXES[REQUEST_POOL_MAX]
 /* per-VCI structure -- using union to force minimum size */
 typedef struct MPIDI_per_vci {
     MPID_Thread_mutex_t lock;
-    /* The progress counts are mostly accessed in a VCI critical section and thus updated in a
-     * relaxed manner.  MPL_atomic_int_t is used here only for MPIDI_set_progress_vci() and
-     * MPIDI_set_progress_vci_n(), which access these progress counts outside a VCI critical
-     * section. */
-    MPL_atomic_int_t progress_count;
 
     MPIR_Request *posted_list;
     MPIR_Request *unexp_list;

--- a/src/mpid/ch4/src/ch4_wait.h
+++ b/src/mpid/ch4/src/ch4_wait.h
@@ -12,11 +12,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_set_progress_vci(MPIR_Request * req,
                                                      MPID_Progress_state * state)
 {
     state->flag = MPIDI_PROGRESS_ALL;   /* TODO: check request is_local/anysource */
-    state->progress_made = 0;
 
     int vci = MPIDI_Request_get_vci(req);
 
-    state->progress_counts[0] = MPL_atomic_relaxed_load_int(&MPIDI_VCI(vci).progress_count);
     state->vci_count = 1;
     state->vci[0] = vci;
 }
@@ -25,7 +23,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_set_progress_vci_n(int n, MPIR_Request ** re
                                                        MPID_Progress_state * state)
 {
     state->flag = MPIDI_PROGRESS_ALL;   /* TODO: check request is_local/anysource */
-    state->progress_made = 0;
 
     int idx = 0;
     for (int i = 0; i < n; i++) {
@@ -47,10 +44,6 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_set_progress_vci_n(int n, MPIR_Request ** re
         }
     }
     state->vci_count = idx;
-    for (int i = 0; i < state->vci_count; i++) {
-        int vci = state->vci[i];
-        state->progress_counts[i] = MPL_atomic_relaxed_load_int(&MPIDI_VCI(vci).progress_count);
-    }
 }
 
 /* MPID_Test, MPID_Testall, MPID_Testany, MPID_Testsome */


### PR DESCRIPTION
## Pull Request Description
CH4 layer only has progress poll, and there is no optimization for blocking progress. Replace `MPID_Progress_wait` with `MPID_Progress_test` allows us to skip blanket progress counter tracking, greatly simplifies the code. 

Add `progress_made` flag to the netmod/shm progress poll API. Shm progress is quick and always knows when it makes progress. Using the flag output allows potentially skipping the costly netmod progress, thus improve latency (TODO: measure it).

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
