### PR TITLE
ROMIO: fix Lustre file striping information setting

### DIFF
--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_hints.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_hints.c
@@ -60,10 +60,9 @@ void ADIOI_LUSTRE_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
                 str_factor = atoll(value);
             }
 
-            ADIOI_Info_get(users_info, "romio_lustre_start_iodevice",
-                           MPI_MAX_INFO_VAL, value, &flag);
+            ADIOI_Info_get(users_info, "start_iodevice", MPI_MAX_INFO_VAL, value, &flag);
             if (flag) {
-                ADIOI_Info_set(fd->info, "romio_lustre_start_iodevice", value);
+                ADIOI_Info_set(fd->info, "start_iodevice", value);
                 start_iodev = atoll(value);
             }
 

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_open.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_open.c
@@ -15,7 +15,7 @@ int ADIOI_LUSTRE_request_only_lock_ioctl(ADIO_File fd); /* in ad_lustre_lock.c *
 
 void ADIOI_LUSTRE_Open(ADIO_File fd, int *error_code)
 {
-    int perm, old_mask, amode, amode_direct;
+    int perm, old_mask, amode, amode_direct, root;
     int lumlen, myrank, flag, set_layout = 0, err;
     struct lov_user_md *lum = NULL;
     char *value;
@@ -83,13 +83,15 @@ void ADIOI_LUSTRE_Open(ADIO_File fd, int *error_code)
     if (fd->fd_sys == -1)
         goto fn_exit;
 
+    root = (fd->hints->ranklist == NULL) ? 0 : fd->hints->ranklist[0];
+
     /* we can only set these hints on new files */
     /* It was strange and buggy to open the file in the hint path.  Instead,
      * we'll apply the file tunings at open time */
     if ((amode & O_CREAT) && set_layout) {
         /* if user has specified striping info, first aggregator tries to set
          * it */
-        if (myrank == fd->hints->ranklist[0] || fd->comm == MPI_COMM_SELF) {
+        if (myrank == root || fd->comm == MPI_COMM_SELF) {
             lum->lmm_magic = LOV_USER_MAGIC;
             lum->lmm_pattern = 0;
             /* crude check for overflow of lustre internal datatypes.
@@ -124,21 +126,17 @@ void ADIOI_LUSTRE_Open(ADIO_File fd, int *error_code)
      * lov_user_md struct changes in future */
     memset(lum, 0, lumlen);
     lum->lmm_magic = LOV_USER_MAGIC;
-    err = ioctl(fd->fd_sys, LL_IOC_LOV_GETSTRIPE, (void *) lum);
-    if (!err) {
-
-        fd->hints->striping_unit = lum->lmm_stripe_size;
-        snprintf(value, value_sz, "%d", lum->lmm_stripe_size);
-        ADIOI_Info_set(fd->info, "striping_unit", value);
-
-        fd->hints->striping_factor = lum->lmm_stripe_count;
-        snprintf(value, value_sz, "%d", lum->lmm_stripe_count);
-        ADIOI_Info_set(fd->info, "striping_factor", value);
-
-        fd->hints->start_iodevice = lum->lmm_stripe_offset;
-        MPL_snprintf(value, value_sz, "%d", lum->lmm_stripe_offset);
-        ADIOI_Info_set(fd->info, "start_iodevice", value);
-
+    if (myrank == root || fd->comm == MPI_COMM_SELF) {
+        /* only one rank needs to consult the file for striping information.
+         * In fact, only the i/o aggregators are in this path: we'll distribute
+         * stripe information to all processes in ad_opencoll.c and save them
+         * as hints in the generic hint processing code */
+        err = ioctl(fd->fd_sys, LL_IOC_LOV_GETSTRIPE, (void *) lum);
+        if (!err) {
+            fd->hints->striping_unit = lum->lmm_stripe_size;
+            fd->hints->striping_factor = lum->lmm_stripe_count;
+            fd->hints->start_iodevice = lum->lmm_stripe_offset;
+        }
     }
 
     if (fd->access_mode & ADIO_APPEND)

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_open.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_open.c
@@ -66,7 +66,7 @@ void ADIOI_LUSTRE_Open(ADIO_File fd, int *error_code)
         if (flag)
             str_factor = atoll(value);
 
-        ADIOI_Info_get(fd->info, "romio_lustre_start_iodevice", MPI_MAX_INFO_VAL, value, &flag);
+        ADIOI_Info_get(fd->info, "start_iodevice", MPI_MAX_INFO_VAL, value, &flag);
         if (flag)
             start_iodev = atoll(value);
     }
@@ -136,8 +136,8 @@ void ADIOI_LUSTRE_Open(ADIO_File fd, int *error_code)
         ADIOI_Info_set(fd->info, "striping_factor", value);
 
         fd->hints->start_iodevice = lum->lmm_stripe_offset;
-        snprintf(value, value_sz, "%d", lum->lmm_stripe_offset);
-        ADIOI_Info_set(fd->info, "romio_lustre_start_iodevice", value);
+        MPL_snprintf(value, value_sz, "%d", lum->lmm_stripe_offset);
+        ADIOI_Info_set(fd->info, "start_iodevice", value);
 
     }
 

--- a/src/mpi/romio/adio/common/ad_hints.c
+++ b/src/mpi/romio/adio/common/ad_hints.c
@@ -257,10 +257,16 @@ void ADIOI_GEN_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
         ADIOI_Info_check_and_install_int(fd, users_info, "romio_min_fdomain_size",
                                          &(fd->hints->min_fdomain_size), myname, error_code);
 
-        /* Now we use striping unit in common code so we should
+        /* Now we use striping information in common code so we should
          * process hints for it. */
         ADIOI_Info_check_and_install_int(fd, users_info, "striping_unit",
                                          &(fd->hints->striping_unit), myname, error_code);
+
+        ADIOI_Info_check_and_install_int(fd, users_info, "striping_factor",
+                                         &(fd->hints->striping_factor), myname, error_code);
+
+        ADIOI_Info_check_and_install_int(fd, users_info, "start_iodevice",
+                                         &(fd->hints->start_iodevice), myname, error_code);
 
         ADIOI_Info_check_and_install_enabled(fd, users_info, "romio_synchronized_flush",
                                              &(fd->hints->synchronizing_flush), myname, error_code);

--- a/src/mpi/romio/adio/common/ad_open.c
+++ b/src/mpi/romio/adio/common/ad_open.c
@@ -106,7 +106,7 @@ MPI_File ADIO_Open(MPI_Comm orig_comm,
      * 2: have all processes participate in hintfile processing (so we can read-and-broadcast)
      *
      * a code might do an "initialize from 0", so we can only skip hint
-     * processing once everyone has particpiated in hint processing */
+     * processing once everyone has participated in hint processing */
     if (ADIOI_syshints == MPI_INFO_NULL)
         syshints_processed = 0;
     else
@@ -138,7 +138,7 @@ MPI_File ADIO_Open(MPI_Comm orig_comm,
      * (which means the user hinted 'no_indep_rw' and collective buffering).
      * Furthermore, we only do this if our collective read/write routines use
      * our generic function, and not an fs-specific routine (we can defer opens
-     * only if we use our aggreagation code). */
+     * only if we use our aggregation code). */
     if (fd->hints->deferred_open && !(uses_generic_read(fd)
                                       && uses_generic_write(fd))) {
         fd->hints->deferred_open = 0;
@@ -176,14 +176,14 @@ MPI_File ADIO_Open(MPI_Comm orig_comm,
      * i/o for metadata), that deferred open will use the access_mode provided
      * by the user.  CREATE|EXCL only makes sense here -- exclusive access in
      * the deferred open case is going to fail and surprise the user.  Turn off
-     * the excl amode bit. Save user's ammode for MPI_FILE_GET_AMODE */
+     * the excl amode bit. Save user's amode for MPI_FILE_GET_AMODE */
     fd->orig_access_mode = access_mode;
     if (fd->access_mode & ADIO_EXCL)
         fd->access_mode ^= ADIO_EXCL;
 
 
     /* for debugging, it can be helpful to see the hints selected. Some file
-     * systes set up the hints in the open call (e.g. lustre) */
+     * systems set up the hints in the open call (e.g. lustre) */
     p = getenv("ROMIO_PRINT_HINTS");
     if (rank == 0 && p != NULL) {
         ADIOI_Info_print_keyvals(fd->info);
@@ -227,7 +227,7 @@ MPI_File ADIO_Open(MPI_Comm orig_comm,
     return fd;
 }
 
-/* a simple linear search. possible enancement: add a my_cb_nodes_index member
+/* a simple linear search. possible enhancement: add a my_cb_nodes_index member
  * (index into cb_nodes, else -1 if not aggregator) for faster lookups
  *
  * fd->hints->cb_nodes is the number of aggregators

--- a/src/mpi/romio/adio/common/ad_opencoll.c
+++ b/src/mpi/romio/adio/common/ad_opencoll.c
@@ -129,8 +129,8 @@ void ADIOI_GEN_OpenColl(ADIO_File fd, int rank, int access_mode, int *error_code
             snprintf(value, sizeof(value), "%d", fd->hints->striping_factor);
             ADIOI_Info_set(fd->info, "striping_factor", value);
 
-            snprintf(value, sizeof(value), "%d", fd->hints->start_iodevice);
-            ADIOI_Info_set(fd->info, "romio_lustre_start_iodevice", value);
+            MPL_snprintf(value, sizeof(value), "%d", fd->hints->start_iodevice);
+            ADIOI_Info_set(fd->info, "start_iodevice", value);
 
             *error_code = MPI_SUCCESS;
             MPI_Type_free(&stats_type);

--- a/src/mpi/romio/adio/common/ad_opencoll.c
+++ b/src/mpi/romio/adio/common/ad_opencoll.c
@@ -117,6 +117,9 @@ void ADIOI_GEN_OpenColl(ADIO_File fd, int rank, int access_mode, int *error_code
              * lower-level file system driver (e.g. 'bluegene') collected it
              * (not all do)*/
             stats_type = make_stats_type(fd);
+            /* in this branch the non-aggregators are returning early.
+             * MPI_Bcast here matches the MPI_Bcast from the aggregators after
+             * they open the file and find out striping information */
             MPI_Bcast(MPI_BOTTOM, 1, stats_type, fd->hints->ranklist[0], fd->comm);
             ADIOI_Assert(fd->blksize > 0);
             /* some file systems (e.g. lustre) will inform the user via the

--- a/src/mpi/romio/adio/common/ad_opencoll.c
+++ b/src/mpi/romio/adio/common/ad_opencoll.c
@@ -60,6 +60,7 @@ static MPI_Datatype make_stats_type(ADIO_File fd)
 
 void ADIOI_GEN_OpenColl(ADIO_File fd, int rank, int access_mode, int *error_code)
 {
+    char value[MPI_MAX_INFO_VAL + 1];
     int orig_amode_excl, orig_amode_wronly;
     MPI_Comm tmp_comm;
     MPI_Datatype stats_type;    /* deferred open: some processes might not
@@ -105,7 +106,6 @@ void ADIOI_GEN_OpenColl(ADIO_File fd, int rank, int access_mode, int *error_code
     /* if we are doing deferred open, non-aggregators should return now */
     if (fd->hints->deferred_open) {
         if (!(fd->is_agg)) {
-            char value[MPI_MAX_INFO_VAL + 1];
             /* we might have turned off EXCL for the aggregators.
              * restore access_mode that non-aggregators get the right
              * value from get_amode */
@@ -129,7 +129,7 @@ void ADIOI_GEN_OpenColl(ADIO_File fd, int rank, int access_mode, int *error_code
             snprintf(value, sizeof(value), "%d", fd->hints->striping_factor);
             ADIOI_Info_set(fd->info, "striping_factor", value);
 
-            MPL_snprintf(value, sizeof(value), "%d", fd->hints->start_iodevice);
+            snprintf(value, sizeof(value), "%d", fd->hints->start_iodevice);
             ADIOI_Info_set(fd->info, "start_iodevice", value);
 
             *error_code = MPI_SUCCESS;
@@ -174,6 +174,16 @@ void ADIOI_GEN_OpenColl(ADIO_File fd, int rank, int access_mode, int *error_code
     /* file domain code will get terribly confused in a hard-to-debug way if
      * gpfs blocksize not sensible */
     ADIOI_Assert(fd->blksize > 0);
+
+    /* set file striping hints */
+    snprintf(value, sizeof(value), "%d", fd->hints->striping_unit);
+    ADIOI_Info_set(fd->info, "striping_unit", value);
+
+    snprintf(value, sizeof(value), "%d", fd->hints->striping_factor);
+    ADIOI_Info_set(fd->info, "striping_factor", value);
+
+    snprintf(value, sizeof(value), "%d", fd->hints->start_iodevice);
+    ADIOI_Info_set(fd->info, "start_iodevice", value);
 
     /* for deferred open: this process has opened the file (because if we are
      * not an aggregaor and we are doing deferred open, we returned earlier)*/

--- a/test/mpi/io/Makefile.am
+++ b/test/mpi/io/Makefile.am
@@ -29,7 +29,8 @@ noinst_PROGRAMS = \
     simple_collective \
     external32_derived_dtype \
     tst_fileview \
-    zero_count
+    zero_count \
+    striped_hints
 
 
 if BUILD_MPIX_TESTS

--- a/test/mpi/io/striped_hints.c
+++ b/test/mpi/io/striped_hints.c
@@ -1,0 +1,61 @@
+
+#include <mpi.h>
+#include <stdio.h>
+
+#define CHECK(fn) {int errcode; errcode = (fn); if (errcode != MPI_SUCCESS) handle_error(errcode, NULL); }
+
+static void handle_error(int errcode, char *str)
+{
+    char msg[MPI_MAX_ERROR_STRING];
+    int resultlen;
+    MPI_Error_string(errcode, msg, &resultlen);
+    fprintf(stderr, "%s: %s\n", str, msg);
+    MPI_Abort(MPI_COMM_WORLD, 1);
+}
+
+
+int main(int argc, char *argv[])
+{
+    int my_rank;
+    MPI_Info info;
+    MPI_Info info_used;
+    MPI_File fh;
+
+    MPI_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
+
+    MPI_Info_create(&info);
+    MPI_Info_set(info, "romio_no_indep_rw", "true");
+
+    CHECK(MPI_File_open(MPI_COMM_WORLD, argv[1], MPI_MODE_CREATE | MPI_MODE_WRONLY, info, &fh));
+    CHECK(MPI_File_get_info(fh, &info_used));
+
+    if (info_used != MPI_INFO_NULL) {
+        int i, nkeys;
+
+        MPI_Info_get_nkeys(info_used, &nkeys);
+
+        for (i = 0; i < nkeys; i++) {
+            char key[MPI_MAX_INFO_KEY], value[MPI_MAX_INFO_VAL];
+            int valuelen, flag;
+
+            MPI_Info_get_nthkey(info_used, i, key);
+            MPI_Info_get_valuelen(info_used, key, &valuelen, &flag);
+            MPI_Info_get(info_used, key, valuelen + 1, value, &flag);
+
+            MPI_Info_set(info, key, value);
+        }
+
+        MPI_Info_free(&info_used);
+    }
+
+    CHECK(MPI_File_set_view(fh, 0, MPI_INT, MPI_INT, "native", info));
+
+    CHECK(MPI_File_close(&fh));
+    MPI_Info_free(&info);
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/test/mpi/io/testlist.in
+++ b/test/mpi/io/testlist.in
@@ -30,3 +30,4 @@ i_hindexed 4
 i_noncontig_coll 2
 i_noncontig_coll2 4
 i_types_with_zeros 2
+striped_hints 4


### PR DESCRIPTION
## Pull Request Description

Before this fix, for Lustre ADIO driver, a file's striping unit/count/start_iodevice
may only be obtained by the I/O aggregators. As file striping unit and count are
used by all processes to calculate file domains, this PR broadcasts them to
ensure they are consistent among all processes.

Also, hint `romio_lustre_start_iodevice` does not appear to be used. This PR
merges it into existing hint `start_iodevice`.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
