### PR TITLE
misc: suppress gcc memset warnings

### DIFF
--- a/src/mpi/coll/transports/gentran/gentran_types.h
+++ b/src/mpi/coll/transports/gentran/gentran_types.h
@@ -33,11 +33,11 @@ typedef enum {
 struct MPII_Genutil_sched_t;
 
 typedef struct MPII_Genutil_vtx_t {
+    UT_array out_vtcs;
+
     int vtx_kind;
     int vtx_state;
     int vtx_id;
-
-    UT_array out_vtcs;
 
     int pending_dependencies;
     int num_dependencies;


### PR DESCRIPTION
## Pull Request Description

Gcc 11 warns -
```
LTCC src/mpi/coll/transports/gentran/gentran_utils.lo In file included from /usr/include/string.h:535,
                 from src/mpl/include/mpl_base.h:16,
                 from src/mpl/include/mpl.h:9,
                 from ./src/include/mpiimpl.h:53,
                 from src/mpi/coll/transports/gentran/gentran_utils.c:6:
In function ‘memset’,
    inlined from ‘MPII_Genutil_vtx_create’ at
src/mpi/coll/transports/gentran/gentran_utils.c:473:5: /usr/include/x86_64-linux-gnu/bits/string_fortified.h:59:10: warning: ‘__builtin_memset’ writing 24 bytes into a re
gion of size 0 overflows the destination [-Wstringop-overflow=]
   59 |   return __builtin___memset_chk (__dest, __ch, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   60 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This is a weird warning and likely due to a mistake on GCC's end. Seems GCC confuses when there is struct alignment gap.
Anyway, re-order the struct field make it happy.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
