### PR TITLE
misc: threadcomm preparation commits

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -2196,12 +2196,6 @@ def dump_validate_userbuffer_reduce(func, sbuf, rbuf, ct, dt, op):
         G.out.append("MPIR_ERRTEST_NAMED_BUF_INPLACE(%s, \"%s\", %s, mpi_errno);" % (sbuf, sbuf, ct))
         G.out.append("MPIR_ERRTEST_NAMED_BUF_INPLACE(%s, \"%s\", %s, mpi_errno);" % (rbuf, rbuf, ct))
     elif RE.match(r'mpi_i?reduce(_init)?$', func['name'], re.IGNORECASE):
-        G.out.append("if (" + cond_intra + ") {")
-        G.out.append("    MPIR_ERRTEST_INTRA_ROOT(comm_ptr, root, mpi_errno);")
-        G.out.append("} else {")
-        G.out.append("    MPIR_ERRTEST_INTER_ROOT(comm_ptr, root, mpi_errno);")
-        G.out.append("}")
-
         # exclude intercomm MPI_PROC_NULL
         G.out.append("if (" + cond_intra + " || root != MPI_PROC_NULL) {")
         G.out.append("INDENT")

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -1411,9 +1411,6 @@ def push_impl_decl(func, impl_name=None):
         G.impl_declares.append("int %s(%s);" % (mpir_name, params))
     # dump MPIR_Xxx_impl(...)
     G.impl_declares.append("int %s(%s);" % (impl_name, params))
-    if func['dir'] == 'coll':
-        mpir_name = re.sub(r'^MPIX?_', 'MPIR_', func['name'])
-        G.impl_declares.append("int %s(%s);" % (mpir_name, params))
 
 def dump_CHECKENUM(var, errname, t, type="ENUM"):
     val_list = t.split()

--- a/src/binding/c/coll_api.txt
+++ b/src/binding/c/coll_api.txt
@@ -55,7 +55,7 @@ MPI_Allgatherv:
      clarification to the MPI standard by the MPI-Forum.
 */
 { -- early_return --
-    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && MPIR_Comm_size(comm_ptr) == 1) {
+    if (MPIR_is_self_comm(comm_ptr)) {
         if (sendbuf != MPI_IN_PLACE) {
             MPI_Aint recvtype_extent;
             MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
@@ -74,7 +74,7 @@ MPI_Allreduce:
     .desc: Combines values from all processes and distributes the result back to all processes
     .docnotes: collops
 { -- early_return --
-    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && MPIR_Comm_size(comm_ptr) == 1) {
+    if (MPIR_is_self_comm(comm_ptr)) {
         if (sendbuf != MPI_IN_PLACE) {
             MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
         }
@@ -117,7 +117,7 @@ MPI_Barrier:
     communicator have entered the call.
 */
 { -- early_return --
-    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && MPIR_Comm_size(comm_ptr) == 1) {
+    if (MPIR_is_self_comm(comm_ptr)) {
         goto fn_exit;
     }
 }
@@ -128,7 +128,7 @@ MPI_Barrier_init:
 MPI_Bcast:
     .desc: Broadcasts a message from the process with rank "root" to all other processes of the communicator
 { -- early_return --
-    if (count == 0 || (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && MPIR_Comm_size(comm_ptr) == 1)) {
+    if (count == 0 || MPIR_is_self_comm(comm_ptr)) {
         goto fn_exit;
     }
 }
@@ -189,7 +189,7 @@ MPI_Iallgather:
 MPI_Iallgatherv:
     .desc: Gathers data from all tasks and deliver the combined data to all tasks in a nonblocking way
 { -- early_return --
-    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && MPIR_Comm_size(comm_ptr) == 1) {
+    if (MPIR_is_self_comm(comm_ptr)) {
         if (sendbuf != MPI_IN_PLACE) {
             MPI_Aint recvtype_extent;
             MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
@@ -205,7 +205,7 @@ MPI_Iallgatherv:
 MPI_Iallreduce:
     .desc: Combines values from all processes and distributes the result back to all processes in a nonblocking way
 { -- early_return --
-    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && MPIR_Comm_size(comm_ptr) == 1) {
+    if (MPIR_is_self_comm(comm_ptr)) {
         if (sendbuf != MPI_IN_PLACE) {
             MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
         }
@@ -245,7 +245,7 @@ MPI_Ibarrier:
     group have called MPI_Ibarrier.
 */
 { -- early_return --
-    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && MPIR_Comm_size(comm_ptr) == 1) {
+    if (MPIR_is_self_comm(comm_ptr)) {
         MPIR_Request *request_ptr = MPIR_Request_create_complete(MPIR_REQUEST_KIND__COLL);
         *request = request_ptr->handle;
         goto fn_exit;
@@ -255,7 +255,7 @@ MPI_Ibarrier:
 MPI_Ibcast:
     .desc: Broadcasts a message from the process with rank "root" to all other processes of the communicator in a nonblocking way
 { -- early_return --
-    if (count == 0 || (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && MPIR_Comm_size(comm_ptr) == 1)) {
+    if (count == 0 || MPIR_is_self_comm(comm_ptr)) {
         MPIR_Request *request_ptr = MPIR_Request_create_complete(MPIR_REQUEST_KIND__COLL);
         *request = request_ptr->handle;
         goto fn_exit;
@@ -307,7 +307,7 @@ MPI_Ineighbor_alltoallw:
 MPI_Ireduce:
     .desc: Reduces values on all processes to a single value in a nonblocking way
 { -- early_return --
-    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && (count == 0 || MPIR_Comm_size(comm_ptr) == 1)) {
+    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && (count == 0 || MPIR_is_self_comm(comm_ptr))) {
         if (sendbuf != MPI_IN_PLACE) {
             MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
         }
@@ -320,7 +320,7 @@ MPI_Ireduce:
 MPI_Ireduce_scatter:
     .desc: Combines values and scatters the results in a nonblocking way
 { -- early_return --
-    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && MPIR_Comm_size(comm_ptr) == 1) {
+    if (MPIR_is_self_comm(comm_ptr)) {
         if (sendbuf != MPI_IN_PLACE) {
             MPIR_Localcopy(sendbuf, recvcounts[0], datatype, recvbuf, recvcounts[0], datatype);
         }
@@ -333,7 +333,7 @@ MPI_Ireduce_scatter:
 MPI_Ireduce_scatter_block:
     .desc: Combines values and scatters the results in a nonblocking way
 { -- early_return --
-    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && (MPIR_Comm_size(comm_ptr) == 1 || recvcount == 0)) {
+    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && (recvcount == 0 || MPIR_is_self_comm(comm_ptr))) {
         if (sendbuf != MPI_IN_PLACE) {
             MPIR_Localcopy(sendbuf, recvcount, datatype, recvbuf, recvcount, datatype);
         }
@@ -413,7 +413,10 @@ MPI_Reduce:
     .desc: Reduces values on all processes to a single value
     .docnotes: collops
 { -- early_return --
-    if ((comm_ptr->remote_size == 1 || count == 0) && comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
+    if (count == 0 && comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
+        goto fn_exit;
+    }
+    if (MPIR_is_self_comm(comm_ptr)) {
         if (sendbuf == MPI_IN_PLACE) {
             goto fn_exit;
         }
@@ -443,7 +446,7 @@ MPI_Reduce_scatter:
     .desc: Combines values and scatters the results
     .docnotes: collops
 { -- early_return --
-    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && MPIR_Comm_size(comm_ptr) == 1) {
+    if (MPIR_is_self_comm(comm_ptr)) {
         if (sendbuf != MPI_IN_PLACE) {
             MPIR_Localcopy(sendbuf, recvcounts[0], datatype, recvbuf, recvcounts[0], datatype);
         }
@@ -458,7 +461,7 @@ MPI_Reduce_scatter_block:
     .desc: Combines values and scatters the results
     .docnotes: collops
 { -- early_return --
-    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && (MPIR_Comm_size(comm_ptr) == 1 || recvcount == 0)) {
+    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && (recvcount == 0 || MPIR_is_self_comm(comm_ptr))) {
         if (sendbuf != MPI_IN_PLACE) {
             MPIR_Localcopy(sendbuf, recvcount, datatype, recvbuf, recvcount, datatype);
         }

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -263,6 +263,10 @@ struct MPIR_Comm {
      MPID_DEV_COMM_DECL
 #endif
 };
+
+#define MPIR_is_self_comm(comm) \
+    ((comm)->remote_size == 1 && (comm)->comm_kind == MPIR_COMM_KIND__INTRACOMM)
+
 extern MPIR_Object_alloc_t MPIR_Comm_mem;
 
 /* this function should not be called by normal code! */

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -54,9 +54,6 @@ int MPIC_Wait(MPIR_Request * request_ptr)
 
     MPIR_FUNC_ENTER;
 
-    if (request_ptr->kind == MPIR_REQUEST_KIND__SEND)
-        request_ptr->status.MPI_TAG = 0;
-
     mpi_errno = MPID_Wait(request_ptr, MPI_STATUS_IGNORE);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -541,8 +541,10 @@ int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status * statuses)
     if (numreq > MPIC_REQUEST_PTR_ARRAY_SIZE) {
         MPIR_CHKLMEM_MALLOC(request_ptrs, MPI_Request *, numreq * sizeof(MPI_Request), mpi_errno,
                             "request pointers", MPL_MEM_BUFFER);
-        MPIR_CHKLMEM_MALLOC(status_array, MPI_Status *, numreq * sizeof(MPI_Status), mpi_errno,
-                            "status objects", MPL_MEM_BUFFER);
+        if (statuses == MPI_STATUSES_IGNORE) {
+            MPIR_CHKLMEM_MALLOC(status_array, MPI_Status *, numreq * sizeof(MPI_Status), mpi_errno,
+                                "status objects", MPL_MEM_BUFFER);
+        }
     }
 
     for (i = 0; i < numreq; ++i) {

--- a/src/mpid/ch4/src/ch4_probe.h
+++ b/src/mpid/ch4/src/ch4_probe.h
@@ -92,7 +92,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Probe(int source,
     int mpi_errno, flag = 0;
     MPIR_FUNC_ENTER;
 
-    if (MPIDI_is_self_comm(comm)) {
+    if (MPIR_is_self_comm(comm)) {
         /* There better be another thread sending the self message */
         while (!flag) {
             mpi_errno = MPIDI_Self_iprobe(source, tag, comm, attr, &flag, status);
@@ -128,7 +128,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Mprobe(int source,
     int mpi_errno = MPI_SUCCESS, flag = 0;
     MPIR_FUNC_ENTER;
 
-    if (MPIDI_is_self_comm(comm)) {
+    if (MPIR_is_self_comm(comm)) {
         /* There better be another thread sending the self message */
         while (!flag) {
             mpi_errno = MPIDI_Self_improbe(source, tag, comm, attr, &flag, message, status);
@@ -163,7 +163,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Improbe(int source,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    if (MPIDI_is_self_comm(comm)) {
+    if (MPIR_is_self_comm(comm)) {
         mpi_errno = MPIDI_Self_improbe(source, tag, comm, attr, flag, message, status);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
@@ -195,7 +195,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Iprobe(int source,
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    if (MPIDI_is_self_comm(comm)) {
+    if (MPIR_is_self_comm(comm)) {
         mpi_errno = MPIDI_Self_iprobe(source, tag, comm, attr, flag, status);
         MPIR_ERR_CHECK(mpi_errno);
     } else {

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -208,7 +208,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Imrecv(void *buf, MPI_Aint count, MPI_Datatype
     MPIR_Assert(message->kind == MPIR_REQUEST_KIND__MPROBE);
     message->kind = MPIR_REQUEST_KIND__RECV;
 
-    if (message->comm && MPIDI_is_self_comm(message->comm)) {
+    if (message->comm && MPIR_is_self_comm(message->comm)) {
         mpi_errno = MPIDI_Self_imrecv(buf, count, datatype, message, rreqp);
     } else {
         *rreqp = message;
@@ -236,7 +236,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irecv(void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    if (MPIDI_is_self_comm(comm)) {
+    if (MPIR_is_self_comm(comm)) {
         mpi_errno = MPIDI_Self_irecv(buf, count, datatype, rank, tag, comm, attr, request);
     } else {
         MPIDI_av_entry_t *av = (rank == MPI_ANY_SOURCE ? NULL : MPIDIU_comm_rank_to_av(comm, rank));
@@ -258,7 +258,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Cancel_recv(MPIR_Request * rreq)
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    if (rreq->comm && MPIDI_is_self_comm(rreq->comm)) {
+    if (rreq->comm && MPIR_is_self_comm(rreq->comm)) {
         mpi_errno = MPIDI_Self_cancel(rreq);
     } else {
         mpi_errno = MPIDI_cancel_recv_safe(rreq);

--- a/src/mpid/ch4/src/ch4_self.h
+++ b/src/mpid/ch4/src/ch4_self.h
@@ -6,9 +6,6 @@
 #ifndef MPIDI_SELF_H_INCLUDED
 #define MPIDI_SELF_H_INCLUDED
 
-#define MPIDI_is_self_comm(comm) \
-    (comm->remote_size == 1 && comm->comm_kind == MPIR_COMM_KIND__INTRACOMM)
-
 int MPIDI_Self_init(void);
 int MPIDI_Self_finalize(void);
 int MPIDI_Self_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -53,7 +53,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend(const void *buf,
     MPIDI_av_entry_t *av = NULL;
     MPIR_FUNC_ENTER;
 
-    if (MPIDI_is_self_comm(comm)) {
+    if (MPIR_is_self_comm(comm)) {
         mpi_errno = MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, attr, request);
     } else {
         av = MPIDIU_comm_rank_to_av(comm, rank);
@@ -109,7 +109,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irsend(const void *buf,
     MPIDI_av_entry_t *av = NULL;
     MPIR_FUNC_ENTER;
 
-    if (MPIDI_is_self_comm(comm)) {
+    if (MPIR_is_self_comm(comm)) {
         mpi_errno = MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, attr, request);
     } else {
         av = MPIDIU_comm_rank_to_av(comm, rank);
@@ -155,7 +155,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Cancel_send(MPIR_Request * sreq)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    if (sreq->comm && MPIDI_is_self_comm(sreq->comm)) {
+    if (sreq->comm && MPIR_is_self_comm(sreq->comm)) {
         mpi_errno = MPIDI_Self_cancel(sreq);
     } else {
 #ifdef MPIDI_CH4_DIRECT_NETMOD


### PR DESCRIPTION
## Pull Request Description
Split from #6326. These are the commits that don't depend on the threadcomm feature but are revealed during threadcomm development.

* clean up duplicate code in binding scripts
* collective path are unnecessary touching the status field of lightweight send requests, running the multi-threading performance. This not much an issue in `MPI+Thread` since collective can't overlap. But it is in threadcomm since multiple threads will participate in the same collective.
* refactor self-comm check into a neat macro.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
