### PR TITLE
romio/lustre: Fix header include order

### DIFF
--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_rwcontig.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_rwcontig.c
@@ -3,11 +3,11 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#include "ad_lustre.h"
 #include <unistd.h>
 
 #include <stdlib.h>
 #include <malloc.h>
-#include "ad_lustre.h"
 
 #define LUSTRE_MEMALIGN (1<<12) /* to use page_shift */
 


### PR DESCRIPTION
## Pull Request Description

adio.h (included by ad_lustre.h) must be included before system headers so config settings are taken into account. Fixes an issue where aligned_alloc may be used with a declaration. See similar fixes in [a712b565] and [[4fcffbe6].

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
