### PR TITLE
ch4/rma: make MPIDI_WINATTR_MR_PREFERRED default

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -501,7 +501,8 @@ typedef enum {
                                          * its internal optimization. */
     MPIDI_WINATTR_NM_DYNAMIC_MR = 32,   /* whether the memory region is registered dynamically. Valid only for
                                          * dynamic window. Set by netmod. */
-    MPIDI_WINATTR_MR_PREFERRED = 64,    /* message rate preferred flag. Default 0, set by user hint. */
+    MPIDI_WINATTR_MR_PREFERRED = 64,    /* message rate preferred flag. Default unless user set
+                                         * latency preference. */
     MPIDI_WINATTR_LAST_BIT
 } MPIDI_winattr_bit_t;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -311,9 +311,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_cmpl_hook(MPIR_Win * win)
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
         int vci = MPIDI_WIN(win, am_vci);
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
         mpi_errno = MPIDI_OFI_win_do_progress(win, vci);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -331,9 +329,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
         int vci = MPIDI_WIN(win, am_vci);
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
         mpi_errno = MPIDI_OFI_win_do_progress(win, vci);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -352,9 +348,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank ATTRIBUTE((u
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
         int vci = MPIDI_WIN(win, am_vci);
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
         mpi_errno = MPIDI_OFI_win_do_progress(win, vci);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -373,9 +367,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank ATTRIB
     if (MPIDI_OFI_ENABLE_RMA) {
         /* network completion */
         int vci = MPIDI_WIN(win, am_vci);
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
         mpi_errno = MPIDI_OFI_win_do_progress(win, vci);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpid/ch4/netmod/ucx/ucx_win.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.h
@@ -156,9 +156,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_cmpl_hook(MPIR_Win * win)
     if (MPIDI_UCX_WIN(win).info_table && MPIDI_UCX_win_need_flush(win)) {
         ucs_status_t ucp_status;
         int vci = MPIDI_WIN(win, am_vci);
-        MPIDI_UCX_THREAD_CS_ENTER_VCI(vci);
         ucp_status = MPIDI_UCX_flush(vci);
-        MPIDI_UCX_THREAD_CS_EXIT_VCI(vci);
         MPIDI_UCX_CHK_STATUS(ucp_status);
         MPIDI_UCX_win_unset_sync(win);
     }
@@ -181,9 +179,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_win_local_cmpl_hook(MPIR_Win * win)
         /* currently, UCP does not support local flush, so we have to call
          * a global flush. This is not good for performance - but OK for now */
         int vci = MPIDI_WIN(win, am_vci);
-        MPIDI_UCX_THREAD_CS_ENTER_VCI(vci);
         ucp_status = MPIDI_UCX_flush(vci);
-        MPIDI_UCX_THREAD_CS_EXIT_VCI(vci);
         MPIDI_UCX_CHK_STATUS(ucp_status);
 
         /* TODO: should set to FLUSH after replace with real local flush. */
@@ -211,9 +207,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_cmpl_hook(int rank, MPIR_Win * 
         int vci_target = MPIDI_WIN_TARGET_VCI(win, rank);
         ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vci, vci_target);
         /* only flush the endpoint */
-        MPIDI_UCX_THREAD_CS_ENTER_VCI(vci);
         ucp_status = ucp_ep_flush(ep);
-        MPIDI_UCX_THREAD_CS_EXIT_VCI(vci);
         MPIDI_UCX_CHK_STATUS(ucp_status);
         MPIDI_UCX_WIN(win).target_sync[rank].need_sync = MPIDI_UCX_WIN_SYNC_UNSET;
     }
@@ -239,9 +233,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_rma_target_local_cmpl_hook(int rank, MPIR_
         ucp_ep_h ep = MPIDI_UCX_WIN_TO_EP(win, rank, vci, vci_target);
         /* currently, UCP does not support local flush, so we have to call
          * a global flush. This is not good for performance - but OK for now */
-        MPIDI_UCX_THREAD_CS_ENTER_VCI(vci);
         ucp_status = ucp_ep_flush(ep);
-        MPIDI_UCX_THREAD_CS_EXIT_VCI(vci);
         MPIDI_UCX_CHK_STATUS(ucp_status);
 
         /* TODO: should set to FLUSH after replace with real local flush. */

--- a/src/mpid/ch4/src/mpidig_win.c
+++ b/src/mpid/ch4/src/mpidig_win.c
@@ -134,10 +134,12 @@ static void update_winattr_after_set_info(MPIR_Win * win)
     else
         MPIDI_WIN(win, winattr) &= ~((unsigned) MPIDI_WINATTR_ACCU_SAME_OP_NO_OP);
 
-    if (MPIDIG_WIN(win, info_args).perf_preference & (1 << MPIDIG_RMA_MR_PREFERRED))
-        MPIDI_WIN(win, winattr) |= MPIDI_WINATTR_MR_PREFERRED;
-    else
+    if ((MPIDIG_WIN(win, info_args).perf_preference & (1 << MPIDIG_RMA_LAT_PREFERRED)) &&
+        !(MPIDIG_WIN(win, info_args).perf_preference & (1 << MPIDIG_RMA_MR_PREFERRED))) {
         MPIDI_WIN(win, winattr) &= ~((unsigned) MPIDI_WINATTR_MR_PREFERRED);
+    } else {
+        MPIDI_WIN(win, winattr) |= MPIDI_WINATTR_MR_PREFERRED;
+    }
 }
 
 #define INFO_GET_BOOL(info, key, var) do { \

--- a/src/mpid/ch4/src/mpidig_win.h
+++ b/src/mpid/ch4/src/mpidig_win.h
@@ -176,6 +176,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_complete(MPIR_Win * win)
     group = MPIDIG_WIN(win, sync).sc.group;
     MPIR_Assert(group != NULL);
 
+    int vci = MPIDI_WIN(win, am_vci);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    need_unlock = 1;
+
     /* Ensure op completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_win_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
@@ -184,10 +188,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_complete(MPIR_Win * win)
     mpi_errno = MPIDI_SHM_rma_win_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
-
-    int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
-    need_unlock = 1;
 
     msg.win_id = MPIDIG_WIN(win, win_id);
     msg.origin_rank = win->comm_ptr->rank;
@@ -421,6 +421,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
     /* NOTE: lock blocking waits till granted */
     MPIR_Assert(slock->locked == 1);
 
+    int vci = MPIDI_WIN(win, am_vci);
+    int vci_target = MPIDI_WIN_TARGET_VCI(win, rank);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    need_unlock = 1;
+
     /* Ensure op completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_target_cmpl_hook(rank, win);
     MPIR_ERR_CHECK(mpi_errno);
@@ -429,11 +434,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
     mpi_errno = MPIDI_SHM_rma_target_cmpl_hook(rank, win);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
-
-    int vci = MPIDI_WIN(win, am_vci);
-    int vci_target = MPIDI_WIN_TARGET_VCI(win, rank);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
-    need_unlock = 1;
 
     /* Ensure completion of AM operations */
     MPIDIU_PROGRESS_DO_WHILE(MPIR_cc_get(target_ptr->remote_cmpl_cnts) != 0 ||
@@ -487,6 +487,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_fence(int massert, MPIR_Win * win)
 
     MPIDIG_FENCE_EPOCH_CHECK(win, mpi_errno, goto fn_fail);
 
+    int vci = MPIDI_WIN(win, am_vci);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    need_unlock = 1;
+
     /* Ensure op completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_win_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
@@ -495,10 +499,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_fence(int massert, MPIR_Win * win)
     mpi_errno = MPIDI_SHM_rma_win_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
-
-    int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
-    need_unlock = 1;
 
     /* Ensure completion of AM operations */
     MPIDIU_PROGRESS_DO_WHILE(MPIR_cc_get(MPIDIG_WIN(win, local_cmpl_cnts)) != 0 ||
@@ -588,6 +588,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush(int rank, MPIR_Win * win)
     /* Check window lock epoch. */
     MPIDIG_EPOCH_CHECK_PASSIVE(win, mpi_errno, return mpi_errno);
 
+    int vci = MPIDI_WIN(win, am_vci);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    need_unlock = 1;
+
     /* Ensure op completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_target_cmpl_hook(rank, win);
     MPIR_ERR_CHECK(mpi_errno);
@@ -596,10 +600,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush(int rank, MPIR_Win * win)
     mpi_errno = MPIDI_SHM_rma_target_cmpl_hook(rank, win);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
-
-    int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
-    need_unlock = 1;
 
     /* Ensure completion of AM operations issued to the target.
      * If target object is not created (e.g., when all operations issued
@@ -634,6 +634,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local_all(MPIR_Win * win)
 
     MPIDIG_EPOCH_CHECK_PASSIVE(win, mpi_errno, goto fn_fail);
 
+    int vci = MPIDI_WIN(win, am_vci);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    need_unlock = 1;
+
     /* Ensure op local completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_win_local_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
@@ -642,10 +646,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local_all(MPIR_Win * win)
     mpi_errno = MPIDI_SHM_rma_win_local_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
-
-    int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
-    need_unlock = 1;
 
     /* Ensure completion of AM operations */
 
@@ -677,6 +677,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock_all(MPIR_Win * win)
     /* NOTE: lockall blocking waits till all locks granted */
     MPIR_Assert(MPIDIG_WIN(win, sync).lockall.allLocked == win->comm_ptr->local_size);
 
+    int vci = MPIDI_WIN(win, am_vci);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    need_unlock = 1;
+
     /* Ensure op completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_win_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
@@ -685,10 +689,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock_all(MPIR_Win * win)
     mpi_errno = MPIDI_SHM_rma_win_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
-
-    int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
-    need_unlock = 1;
 
     /* Ensure completion of AM operations */
 
@@ -740,6 +740,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local(int rank, MPIR_Win * win
     /* Check window lock epoch. */
     MPIDIG_EPOCH_CHECK_PASSIVE(win, mpi_errno, return mpi_errno);
 
+    int vci = MPIDI_WIN(win, am_vci);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    need_unlock = 1;
+
     /* Ensure op local completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_target_local_cmpl_hook(rank, win);
     MPIR_ERR_CHECK(mpi_errno);
@@ -749,9 +753,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local(int rank, MPIR_Win * win
     MPIR_ERR_CHECK(mpi_errno);
 #endif
 
-    int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
-    need_unlock = 1;
     /* Ensure completion of AM operations issued to the target.
      * If target object is not created (e.g., when all operations issued
      * to the target were via shm and in lockall), we also need trigger
@@ -799,6 +800,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_all(MPIR_Win * win)
 
     MPIDIG_EPOCH_CHECK_PASSIVE(win, mpi_errno, goto fn_fail);
 
+    int vci = MPIDI_WIN(win, am_vci);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    need_unlock = 1;
+
     /* Ensure op completion in netmod and shmmod */
     mpi_errno = MPIDI_NM_rma_win_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
@@ -807,10 +812,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_all(MPIR_Win * win)
     mpi_errno = MPIDI_SHM_rma_win_cmpl_hook(win);
     MPIR_ERR_CHECK(mpi_errno);
 #endif
-
-    int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
-    need_unlock = 1;
 
     /* Ensure completion of AM operations */
 


### PR DESCRIPTION
## Pull Request Description
In MPIDI_POSIX_do_{put,get} we use nonblocking typerep api if MPIDI_WINATTR_MR_PREFERRED is set. Since rma put/get is always nonblocking, we should always do nonblocking typerep api.

The nonblocking typerep api has no effect if the buffer is host memory, but for GPU, it can significantly improve the performance.

Thus, we make MPIDI_WINATTR_MR_PREFERRED default. User can use window hint "perf_preference" "lat" to switch to use block typerep API.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
