### PR TITLE
threadcomm: support comm dup and thread-local attributes

### DIFF
--- a/src/binding/c/comm_api.txt
+++ b/src/binding/c/comm_api.txt
@@ -23,6 +23,7 @@ MPI_Comm_create_group:
 MPI_Comm_dup:
     .desc: Duplicates an existing communicator
     .seealso: MPI_Comm_free, MPI_Keyval_create, MPI_Attr_put, MPI_Attr_delete, MPI_Comm_create_keyval, MPI_Comm_set_attr, MPI_Comm_delete_attr
+    .extra: threadcomm
 /*
     Notes:
       This routine is used to create a new communicator that has a new
@@ -60,7 +61,7 @@ MPI_Comm_dup_with_info:
 
 MPI_Comm_free:
     .desc: Marks the communicator object for deallocation
-    .extra: ignore_revoked_comm
+    .extra: ignore_revoked_comm, threadcomm
 /*
     Notes:
     This routine `frees` a communicator.  Because the communicator may still

--- a/src/binding/c/comm_api.txt
+++ b/src/binding/c/comm_api.txt
@@ -184,6 +184,12 @@ MPI_Comm_test_inter:
     .desc: Tests to see if a comm is an inter-communicator
     .skip: global_cs
 
+MPIX_Comm_test_threadcomm:
+    comm: COMMUNICATOR, [communicator]
+    flag: LOGICAL, direction=out, [true if comm is an inter-communicator]
+    .desc: Tests to see if a comm is a threadcomm
+    .skip: global_cs
+
 MPI_Intercomm_create_from_groups:
     .desc: Create an intercommuncator from local and remote groups
 

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -266,7 +266,8 @@ struct MPIR_Comm {
 };
 
 #define MPIR_is_self_comm(comm) \
-    ((comm)->remote_size == 1 && (comm)->comm_kind == MPIR_COMM_KIND__INTRACOMM)
+    ((comm)->remote_size == 1 && (comm)->comm_kind == MPIR_COMM_KIND__INTRACOMM && \
+     (!(comm)->threadcomm || (comm)->threadcomm->num_threads == 1))
 
 extern MPIR_Object_alloc_t MPIR_Comm_mem;
 

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -218,29 +218,41 @@ cvars:
         goto fn_fail;                                                   \
     }
 
-#define MPIR_ERRTEST_RANK(comm_ptr,rank,err)                            \
-    if ((rank) < 0 || (rank) >= (comm_ptr)->remote_size) {              \
-        err = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__, \
-                                   MPI_ERR_RANK, "**rank", "**rank %d %d", rank, \
-                                   (comm_ptr)->remote_size);            \
-        goto fn_fail;                                                   \
-    }
+#ifdef ENABLE_THREADCOMM
+#define MPIR_ERRTEST_RANK_internal(min,comm_ptr,rank,err) \
+    do { \
+        int comm_size = (comm_ptr)->remote_size; \
+        if (comm_ptr->threadcomm) { \
+            comm_size = comm_ptr->threadcomm->rank_offset_table[comm_size - 1]; \
+        } \
+        if ((rank) < (min) || (rank) >= comm_size) { \
+            err = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__, \
+                                    MPI_ERR_RANK, "**rank", "**rank %d %d", rank, \
+                                    comm_size); \
+            goto fn_fail; \
+        } \
+    } while (0)
+#else
+#define MPIR_ERRTEST_RANK_internal(min,comm_ptr,rank,err) \
+    do { \
+        int comm_size = (comm_ptr)->remote_size; \
+        if ((rank) < (min) || (rank) >= comm_size) { \
+            err = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__, \
+                                    MPI_ERR_RANK, "**rank", "**rank %d %d", rank, \
+                                    comm_size); \
+            goto fn_fail; \
+        } \
+    } while (0)
+#endif
 
-#define MPIR_ERRTEST_SEND_RANK(comm_ptr,rank,err)                       \
-    if ((rank) < MPI_PROC_NULL || (rank) >= (comm_ptr)->remote_size) {  \
-        err = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__, \
-                                   MPI_ERR_RANK, "**rank", "**rank %d %d", rank, \
-                                   (comm_ptr)->remote_size);            \
-        goto fn_fail;                                                   \
-    }
+#define MPIR_ERRTEST_RANK(comm_ptr,rank,err) \
+    MPIR_ERRTEST_RANK_internal(0, comm_ptr, rank, err)
 
-#define MPIR_ERRTEST_RECV_RANK(comm_ptr,rank,err)                       \
-    if ((rank) < MPI_ANY_SOURCE || (rank) >= (comm_ptr)->remote_size) { \
-        err = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__, \
-                                   MPI_ERR_RANK, "**rank", "**rank %d %d", rank, \
-                                   (comm_ptr)->remote_size);            \
-        goto fn_fail;                                                   \
-    }
+#define MPIR_ERRTEST_SEND_RANK(comm_ptr,rank,err) \
+    MPIR_ERRTEST_RANK_internal(MPI_PROC_NULL, comm_ptr, rank, err)
+
+#define MPIR_ERRTEST_RECV_RANK(comm_ptr,rank,err) \
+    MPIR_ERRTEST_RANK_internal(MPI_ANY_SOURCE, comm_ptr, rank, err)
 
 #define MPIR_ERRTEST_COUNT(count,err)                           \
     if ((count) < 0) {                                          \

--- a/src/include/mpir_threadcomm.h
+++ b/src/include/mpir_threadcomm.h
@@ -43,6 +43,7 @@ typedef struct MPIR_Threadcomm {
 typedef struct MPIR_threadcomm_tls_t {
     MPIR_Threadcomm *threadcomm;
     int tid;
+    MPIR_Attribute *attributes;
     /* postponed send request */
     MPIR_Request *pending_sreqs;
     /* posted message queue */

--- a/src/include/mpir_threadcomm.h
+++ b/src/include/mpir_threadcomm.h
@@ -19,8 +19,6 @@ typedef struct MPIR_Threadcomm {
     int num_threads;            /* number of threads in this rank */
     int *rank_offset_table;     /* offset table for inter-process rank to
                                  * threadcomm rank conversion */
-    /* for thread_id assignment */
-    MPL_atomic_int_t next_id;
     /* thread barrier - two-counter algorithm */
     MPL_atomic_int_t arrive_counter;
     MPL_atomic_int_t leave_counter;

--- a/src/include/mpir_threadcomm.h
+++ b/src/include/mpir_threadcomm.h
@@ -11,6 +11,11 @@
 typedef struct MPIR_Threadcomm {
     MPIR_OBJECT_HEADER;
     MPIR_Comm *comm;
+    enum {
+        MPIR_THREADCOMM_KIND__PERSIST,  /* created via MPIX_Threadcomm_init */
+        MPIR_THREADCOMM_KIND__DERIVED,  /* created inside a parallel region,
+                                         * must be freed before exit the parallel region */
+    } kind;
     int num_threads;            /* number of threads in this rank */
     int *rank_offset_table;     /* offset table for inter-process rank to
                                  * threadcomm rank conversion */
@@ -20,6 +25,8 @@ typedef struct MPIR_Threadcomm {
     MPL_atomic_int_t arrive_counter;
     MPL_atomic_int_t leave_counter;
     MPL_atomic_int_t barrier_flag;
+    /* bcast during comm_dup */
+    void *bcast_value;
 } MPIR_Threadcomm;
 
 #define MPIR_THREADCOMM_RANK_IS_INTERTHREAD(threadcomm, rank) \

--- a/src/include/mpir_threadcomm.h
+++ b/src/include/mpir_threadcomm.h
@@ -54,6 +54,9 @@ typedef struct MPIR_threadcomm_tls_t {
 extern UT_icd MPIR_threadcomm_icd;
 extern MPL_TLS UT_array *MPIR_threadcomm_array;
 
+/* We can optimize if we are not using MPI_THREAD_MULTIPLE */
+extern bool MPIR_threadcomm_was_thread_single;
+
 #define MPIR_THREADCOMM_TLS_ADD(threadcomm, p) \
     do { \
         if (MPIR_threadcomm_array == NULL) { \

--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -58,6 +58,12 @@ int MPIR_Comm_test_inter_impl(MPIR_Comm * comm_ptr, int *flag)
     return MPI_SUCCESS;
 }
 
+int MPIR_Comm_test_threadcomm_impl(MPIR_Comm * comm_ptr, int *flag)
+{
+    *flag = (comm_ptr->threadcomm != NULL);
+    return MPI_SUCCESS;
+}
+
 /* used in MPIR_Comm_group_impl and MPIR_Comm_create_group_impl */
 static int comm_create_local_group(MPIR_Comm * comm_ptr)
 {

--- a/src/mpi/init/mpi_init.h
+++ b/src/mpi/init/mpi_init.h
@@ -122,7 +122,7 @@ static inline void MPII_pre_init_memory_tracing(void)
 static inline void MPII_post_init_memory_tracing(void)
 {
 #ifdef USE_MEMORY_TRACING
-    MPL_trconfig(MPIR_Process.rank, MPIR_ThreadInfo.thread_provided == MPI_THREAD_MULTIPLE);
+    MPL_trconfig(MPIR_Process.rank, &MPIR_ThreadInfo.isThreaded);
 #endif
 }
 

--- a/src/mpi/threadcomm/threadcomm_impl.c
+++ b/src/mpi/threadcomm/threadcomm_impl.c
@@ -42,6 +42,7 @@ int MPIR_Threadcomm_init_impl(MPIR_Comm * comm, int num_threads, MPIR_Comm ** co
         rank_offset_table[i] = offset;
     }
 
+    threadcomm->kind = MPIR_THREADCOMM_KIND__PERSIST;
     threadcomm->comm = dup_comm;
     threadcomm->num_threads = num_threads;
     threadcomm->rank_offset_table = rank_offset_table;
@@ -66,6 +67,19 @@ int MPIR_Threadcomm_free_impl(MPIR_Comm * comm)
 
     MPIR_Assert(comm->threadcomm);
     MPIR_Threadcomm *threadcomm = comm->threadcomm;
+
+    if (threadcomm->kind == MPIR_THREADCOMM_KIND__DERIVED) {
+        /* duplicated threadcomm are freed inside the parallel region using MPI_Comm_free */
+        MPIR_threadcomm_tls_t *p = MPIR_threadcomm_get_tls(threadcomm);
+        MPIR_Assert(p);
+
+        mpi_errno = MPIR_Threadcomm_finish_impl(comm);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        if (p->tid > 0) {
+            goto fn_exit;
+        }
+    }
 
     /* make sure MPIR_Comm_free_impl do not invoke the threadcomm paths */
     comm->threadcomm = NULL;
@@ -166,6 +180,43 @@ int MPIR_Threadcomm_rank_impl(MPIR_Comm * comm, int *rank)
 
     *rank = MPIR_THREADCOMM_TID_TO_RANK(threadcomm, MPIR_threadcomm_get_tid(threadcomm));
     return MPI_SUCCESS;
+}
+
+int MPIR_Threadcomm_dup_impl(MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_Assert(comm->threadcomm);
+
+    MPIR_Threadcomm *threadcomm = comm->threadcomm;
+    int num_threads = threadcomm->num_threads;
+    MPIR_threadcomm_tls_t *p = MPIR_threadcomm_get_tls(threadcomm);
+    MPIR_Assert(p);
+
+    MPIR_Comm *newcomm = NULL;
+    if (p->tid == 0) {
+        mpi_errno = MPIR_Threadcomm_init_impl(comm, num_threads, &newcomm);
+        newcomm->threadcomm->kind = MPIR_THREADCOMM_KIND__DERIVED;
+        MPIR_ERR_CHECK(mpi_errno);
+        /* bcast to all threads */
+        threadcomm->bcast_value = newcomm;
+    }
+    mpi_errno = thread_barrier(threadcomm);
+    MPIR_ERR_CHECK(mpi_errno);
+    if (p->tid > 0) {
+        newcomm = threadcomm->bcast_value;
+    }
+
+    mpi_errno = MPIR_Threadcomm_start_impl(newcomm);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    *newcomm_ptr = newcomm;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    *newcomm_ptr = NULL;
+    goto fn_exit;
 }
 
 #else /* ! ENABLE_THREADCOMM */

--- a/src/mpi/threadcomm/threadcomm_impl.c
+++ b/src/mpi/threadcomm/threadcomm_impl.c
@@ -7,7 +7,9 @@
 
 #ifdef ENABLE_THREADCOMM
 
-MPL_TLS int MPIR_Threadcomm_thread_id;
+UT_icd MPIR_threadcomm_icd = { sizeof(MPIR_threadcomm_tls_t), NULL, NULL, NULL };
+
+MPL_TLS UT_array *MPIR_threadcomm_array = NULL;
 
 int MPIR_Threadcomm_init_impl(MPIR_Comm * comm, int num_threads, MPIR_Comm ** comm_out)
 {
@@ -119,11 +121,15 @@ int MPIR_Threadcomm_start_impl(MPIR_Comm * comm)
     MPIR_Assert(comm->threadcomm);
     MPIR_Threadcomm *threadcomm = comm->threadcomm;
 
-    MPIR_Threadcomm_thread_id = MPL_atomic_fetch_add_int(&threadcomm->next_id, 1);
+    MPIR_threadcomm_tls_t *p;
+    MPIR_THREADCOMM_TLS_ADD(threadcomm, p);
+
+    MPIR_Assert(p);
+    p->tid = MPL_atomic_fetch_add_int(&threadcomm->next_id, 1);
 
     /* Need reset next_id and a barrier to ensure next MPI_Threadcomm_start to work.
      * We can do this at either MPI_Threadcomm_start or MPI_Threadcomm_finish. */
-    if (MPIR_Threadcomm_thread_id == threadcomm->num_threads - 1) {
+    if (p->tid == threadcomm->num_threads - 1) {
         MPL_atomic_store_int(&threadcomm->next_id, 0);
     }
     mpi_errno = thread_barrier(threadcomm);
@@ -136,7 +142,10 @@ int MPIR_Threadcomm_start_impl(MPIR_Comm * comm)
 
 int MPIR_Threadcomm_finish_impl(MPIR_Comm * comm)
 {
-    /* NO-OP */
+    MPIR_Threadcomm *threadcomm = comm->threadcomm;
+    MPIR_Assert(threadcomm);
+
+    MPIR_THREADCOMM_TLS_DELETE(threadcomm);
     return MPI_SUCCESS;
 }
 
@@ -155,7 +164,7 @@ int MPIR_Threadcomm_rank_impl(MPIR_Comm * comm, int *rank)
     MPIR_Assert(comm->threadcomm);
     MPIR_Threadcomm *threadcomm = comm->threadcomm;
 
-    *rank = MPIR_THREADCOMM_TID_TO_RANK(threadcomm, MPIR_Threadcomm_thread_id);
+    *rank = MPIR_THREADCOMM_TID_TO_RANK(threadcomm, MPIR_threadcomm_get_tid(threadcomm));
     return MPI_SUCCESS;
 }
 

--- a/src/mpi/threadcomm/threadcomm_impl.c
+++ b/src/mpi/threadcomm/threadcomm_impl.c
@@ -156,11 +156,24 @@ int MPIR_Threadcomm_start_impl(MPIR_Comm * comm)
 
 int MPIR_Threadcomm_finish_impl(MPIR_Comm * comm)
 {
+    int mpi_errno = MPI_SUCCESS;
+
     MPIR_Threadcomm *threadcomm = comm->threadcomm;
     MPIR_Assert(threadcomm);
+    MPIR_threadcomm_tls_t *p = MPIR_threadcomm_get_tls(comm->threadcomm);
+    MPIR_Assert(p);
+
+    if (MPIR_Process.attr_free && p->attributes) {
+        mpi_errno = MPIR_Process.attr_free(comm->handle, &p->attributes);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
 
     MPIR_THREADCOMM_TLS_DELETE(threadcomm);
-    return MPI_SUCCESS;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 int MPIR_Threadcomm_size_impl(MPIR_Comm * comm, int *size)

--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -498,7 +498,7 @@ typedef union {
    does not alias any pointer prior to the call.
  */
 void MPL_trinit(void);
-void MPL_trconfig(int, int);
+void MPL_trconfig(int, int *);
 void *MPL_trmalloc(size_t, MPL_memory_class, int, const char[]);
 void MPL_trfree(void *, int, const char[]);
 int MPL_trvalid(const char[]);

--- a/test/mpi/impls/mpich/threads/threadcomm/Makefile.am
+++ b/test/mpi/impls/mpich/threads/threadcomm/Makefile.am
@@ -8,4 +8,5 @@ include $(top_srcdir)/Makefile_threads.mtest
 EXTRA_DIST = testlist
 
 noinst_PROGRAMS = \
-    threadcomm
+    threadcomm \
+    threadcomm_attr

--- a/test/mpi/impls/mpich/threads/threadcomm/testlist
+++ b/test/mpi/impls/mpich/threads/threadcomm/testlist
@@ -1,2 +1,4 @@
 threadcomm 1
 threadcomm 4
+threadcomm 4 arg=-restart=4
+threadcomm 4 arg=-commdup=1

--- a/test/mpi/impls/mpich/threads/threadcomm/testlist
+++ b/test/mpi/impls/mpich/threads/threadcomm/testlist
@@ -2,3 +2,4 @@ threadcomm 1
 threadcomm 4
 threadcomm 4 arg=-restart=4
 threadcomm 4 arg=-commdup=1
+threadcomm_attr 1

--- a/test/mpi/impls/mpich/threads/threadcomm/threadcomm.c
+++ b/test/mpi/impls/mpich/threads/threadcomm/threadcomm.c
@@ -28,10 +28,9 @@ int main(int argc, char *argv[])
 
     MTestArgList *head = MTestArgListCreate(argc, argv);
     nthreads = MTestArgListGetInt_with_default(head, "nthreads", 4);
+    MTestArgListDestroy(head);
 
-    int provided;
-    MTest_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
-    assert(provided == MPI_THREAD_MULTIPLE);
+    MTest_Init(NULL, NULL);
 
     MPI_Comm comm;
     MPIX_Threadcomm_init(MPI_COMM_WORLD, nthreads, &comm);

--- a/test/mpi/impls/mpich/threads/threadcomm/threadcomm.c
+++ b/test/mpi/impls/mpich/threads/threadcomm/threadcomm.c
@@ -6,19 +6,33 @@
 #include "mpitest.h"
 #include <assert.h>
 
+static int do_restart = 0;
+static int do_commdup = 0;
+
 static MTEST_THREAD_RETURN_TYPE test_thread(void *arg)
 {
     MPI_Comm comm = *(MPI_Comm *) arg;
-    MPIX_Threadcomm_start(comm);
 
-    int rank, size;
-    MPI_Comm_size(comm, &size);
-    MPI_Comm_rank(comm, &rank);
-    MTestPrintfMsg(1, "Rank %d / %d\n", rank, size);
+    for (int rep = 0; rep < 1 + do_restart; rep++) {
+        MPIX_Threadcomm_start(comm);
 
-    /* TODO: add message tests */
+        MPI_Comm use_comm = comm;
+        if (do_commdup) {
+            MPI_Comm_dup(comm, &use_comm);
+        }
 
-    MPIX_Threadcomm_finish(comm);
+        int rank, size;
+        MPI_Comm_size(use_comm, &size);
+        MPI_Comm_rank(use_comm, &rank);
+        MTestPrintfMsg(1, "Rank %d / %d\n", rank, size);
+
+        /* TODO: add message tests */
+
+        if (do_commdup) {
+            MPI_Comm_free(&use_comm);
+        }
+        MPIX_Threadcomm_finish(comm);
+    }
 }
 
 int main(int argc, char *argv[])
@@ -28,9 +42,14 @@ int main(int argc, char *argv[])
 
     MTestArgList *head = MTestArgListCreate(argc, argv);
     nthreads = MTestArgListGetInt_with_default(head, "nthreads", 4);
+    do_restart = MTestArgListGetInt_with_default(head, "restart", 0);
+    do_commdup = MTestArgListGetInt_with_default(head, "commdup", 0);
     MTestArgListDestroy(head);
 
     MTest_Init(NULL, NULL);
+
+    MTestPrintfMsg(1, "Test Threadcomm: nthreads=%d, restart=%d, commdup=%d\n",
+                   nthreads, do_restart, do_commdup);
 
     MPI_Comm comm;
     MPIX_Threadcomm_init(MPI_COMM_WORLD, nthreads, &comm);

--- a/test/mpi/impls/mpich/threads/threadcomm/threadcomm_attr.c
+++ b/test/mpi/impls/mpich/threads/threadcomm/threadcomm_attr.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpitest.h"
+#include <assert.h>
+
+#define NTHREADS 4
+
+MPI_Comm comm;
+int key = 0;
+
+struct perthread {
+    int errs;
+    int delete_fn_called;
+};
+static struct perthread data[NTHREADS];
+
+static int key_delete_fn(MPI_Comm comm, int keyval, void *attribute_val, void *extra_state)
+{
+    struct perthread *my_data = attribute_val;
+    my_data->delete_fn_called++;
+    return MPI_SUCCESS;
+}
+
+static MTEST_THREAD_RETURN_TYPE test_thread(void *arg)
+{
+    struct perthread *my_data = arg;
+    MPIX_Threadcomm_start(comm);
+
+    MPI_Comm_set_attr(comm, key, arg);
+
+    void *v;
+    int flag;
+    MPI_Comm_get_attr(comm, MPI_TAG_UB, &v, &flag);
+    if (!flag) {
+        my_data->errs++;
+        printf("Could not get TAG_UB\n");
+    } else {
+        int vval = *(int *) v;
+        if (vval < 32767) {
+            my_data->errs++;
+            printf("Got too-small value (%d) for TAG_UB\n", vval);
+        }
+    }
+
+    MPI_Comm_get_attr(comm, key, &v, &flag);
+    if (!flag) {
+        my_data->errs++;
+        printf("Could not get key\n");
+    } else {
+        if (v != arg) {
+            my_data->errs++;
+            printf("Retrieved incorrect key value\n");
+        }
+    }
+
+    MPIX_Threadcomm_finish(comm);
+}
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    MTest_Init(NULL, NULL);
+
+    MPI_Comm_create_keyval(MPI_NULL_COPY_FN, key_delete_fn, &key, NULL);
+
+    MPIX_Threadcomm_init(MPI_COMM_WORLD, NTHREADS, &comm);
+    for (int i = 0; i < NTHREADS; i++) {
+        MTest_Start_thread(test_thread, &data[i]);
+    }
+    MTest_Join_threads();
+    MPIX_Threadcomm_free(&comm);
+
+    for (int i = 0; i < NTHREADS; i++) {
+        if (data[i].delete_fn_called != 1) {
+            errs++;
+            printf("The delete function for thread %d was not called\n", i);
+        }
+        errs += data[i].errs;
+    }
+
+    MPI_Comm_free_keyval(&key);
+    MTest_Finalize(errs);
+    return errs;
+}


### PR DESCRIPTION
## Pull Request Description

A second split from #6326.

* Add support for MPI_Comm_dup of an active threadcomm. This addition results in two kinds of theadcomm. One created via `MPIX_Threadcomm_init` and is able to `MPIX_Threadcomm_start/finish` multiple times. This is very similar to persistent requests.
The other kind of threadcomm is created via duplicate -- and in future, `MPI_Comm_split` etc. -- from an active threadcomm. This results in an active threadcomm that has to be freed within the same parallel region.
* Add communicator attributes support. We need use thread local storage since each thread rank need to have their local attributes.
* Turn on `MPIR_ThreadInfo.isThreaded` inside `MPIX_Threadcomm_start/finish` region to ensure thread safety. Threadcomm is fully thread-aware so we are able to optimize and avoid thread contention to our best. But we need `isThreaded` on to enable the
 mutexes.
* Enhance the test to cover the new features.

## Test
```
$ MPITEST_VERBOSE=1 mpirun -l -n 2 ./threadcomm -nthreads=3 -commdup=1 -restart=2
[0] Test Threadcomm: nthreads=3, restart=2, commdup=1
[1] Test Threadcomm: nthreads=3, restart=2, commdup=1
[0] Rank 0 / 6
[0] Rank 1 / 6
[1] Rank 3 / 6
[1] Rank 5 / 6
[1] Rank 4 / 6
[0] Rank 2 / 6
[0] Rank 0 / 6
[0] Rank 2 / 6
[0] Rank 1 / 6
[1] Rank 3 / 6
[1] Rank 4 / 6
[1] Rank 5 / 6
[0] Rank 0 / 6
[0] Rank 2 / 6
[1] Rank 3 / 6
[1] Rank 4 / 6
[1] Rank 5 / 6
[0] Rank 1 / 6
[0]  No Errors[0]
```

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
