### PR TITLE
mpi/coll: Check if json tuning file is opened successfully

### DIFF
--- a/src/mpi/coll/src/csel.c
+++ b/src/mpi/coll/src/csel.c
@@ -577,9 +577,14 @@ int MPIR_Csel_create_from_buf(const char *json,
 int MPIR_Csel_create_from_file(const char *json_file,
                                void *(*create_container) (struct json_object *), void **csel_)
 {
+    int mpi_errno = MPI_SUCCESS;
+
     MPIR_Assert(strcmp(json_file, ""));
 
     int fd = open(json_file, O_RDONLY);
+    MPIR_ERR_CHKANDJUMP1(fd == -1, mpi_errno, MPI_ERR_INTERN, "**opencolltuningfile",
+                         "**opencolltuningfile %s", json_file);
+
     struct stat st;
     stat(json_file, &st);
     char *json = mmap(NULL, st.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
@@ -587,7 +592,8 @@ int MPIR_Csel_create_from_file(const char *json_file,
 
     MPIR_Csel_create_from_buf(json, create_container, csel_);
 
-    return 0;
+  fn_fail:
+    return mpi_errno;
 }
 
 static csel_node_s *prune_tree(csel_node_s * root, MPIR_Comm * comm_ptr)

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -239,6 +239,9 @@ A memory object id was expected but a non-memory object id was passed instead
 **partitioninvalid %d: Invalid partition, value is %d 
 **partitioninvalid %d %d: Invalid partition range, values are %d %d
 
+**opencolltuningfile: Unable to open collective tuning file
+**opencolltuningfile %s: Unable to open collective tuning file %s.\nCheck the file or unset MPIR_CVAR_COLL_SELECTION_TUNING_JSON_FILE to use the default settings.
+
 # -- FIXME: Some (but not all) of the messages below this line have been used
 #---- The messages below this line haven't been used yet.
 #


### PR DESCRIPTION
## Pull Request Description

If MPIR_CVAR_COLL_SELECTION_TUNING_JSON_FILE is set but the file is not successfully opened, we should return an error so the user can fix the environment.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
