### PR TITLE
Fix bug in split_type test

### DIFF
--- a/test/mpi/f08/coll/split_typef08.f90
+++ b/test/mpi/f08/coll/split_typef08.f90
@@ -22,6 +22,7 @@
       call mtest_init( ierr )
 
       call mpi_comm_dup( MPI_COMM_WORLD, comm, ierr )
+      call mpi_comm_rank( comm, rank, ierr )
 
       call mpi_comm_split_type( comm, MPI_COMM_TYPE_SHARED, rank, &
       &     MPI_INFO_NULL, newcomm, ierr )


### PR DESCRIPTION
## Pull Request Description
A variable was used without initialization in the f08 tests.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
