### PR TITLE
threadcomm: add coll implementation

### DIFF
--- a/src/binding/c/coll_api.txt
+++ b/src/binding/c/coll_api.txt
@@ -2,6 +2,7 @@
 
 MPI_Allgather:
     .desc: Gathers data from all tasks and distribute the combined data to all tasks
+    .extra: threadcomm
 /*
     Notes:
      The MPI standard (1.0 and 1.1) says that
@@ -34,6 +35,7 @@ MPI_Allgather_init:
 
 MPI_Allgatherv:
     .desc: Gathers data from all tasks and deliver the combined data to all tasks
+    .extra: threadcomm
 /*
     Notes:
      The MPI standard (1.0 and 1.1) says that
@@ -88,6 +90,7 @@ MPI_Allreduce_init:
 
 MPI_Alltoall:
     .desc: Sends data from all to all processes
+    .extra: threadcomm
 { -- early_return --
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && recvcount == 0) {
         goto fn_exit;
@@ -99,18 +102,21 @@ MPI_Alltoall_init:
 
 MPI_Alltoallv:
     .desc: Sends data from all to all processes; each process may send a different amount of data and provide displacements for the input and output data.
+    .extra: threadcomm
 
 MPI_Alltoallv_init:
     .desc: Create a persistent request for alltoallv.
 
 MPI_Alltoallw:
     .desc: Generalized all-to-all communication allowing different datatypes, counts, and displacements for each partner
+    .extra: threadcomm
 
 MPI_Alltoallw_init:
     .desc: Create a persistent request for alltoallw.
 
 MPI_Barrier:
     .desc: Blocks until all processes in the communicator have reached this routine.
+    .extra: threadcomm
 /*
     Notes:
     Blocks the caller until all processes in the communicator have called it;
@@ -128,6 +134,7 @@ MPI_Barrier_init:
 
 MPI_Bcast:
     .desc: Broadcasts a message from the process with rank "root" to all other processes of the communicator
+    .extra: threadcomm
 { -- early_return --
     if (count == 0 || MPIR_is_self_comm(comm_ptr)) {
         goto fn_exit;
@@ -140,7 +147,7 @@ MPI_Bcast_init:
 MPI_Exscan:
     .desc: Computes the exclusive scan (partial reductions) of data on a collection of processes
     .docnotes: collops
-    .extra: errtest_comm_intra
+    .extra: errtest_comm_intra, threadcomm
 /*
     Notes:
       'MPI_Exscan' is like 'MPI_Scan', except that the contribution from the
@@ -158,6 +165,7 @@ MPI_Exscan_init:
 
 MPI_Gather:
     .desc: Gathers together values from a group of processes
+    .extra: threadcomm
 { -- early_return --
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         if ((MPIR_Comm_rank(comm_ptr) == root && recvcount == 0) || (MPIR_Comm_rank(comm_ptr) != root && sendcount == 0)) {
@@ -171,6 +179,7 @@ MPI_Gather_init:
 
 MPI_Gatherv:
     .desc: Gathers into specified locations from all processes in a group
+    .extra: threadcomm
 
 MPI_Gatherv_init:
     .desc: Create a persistent request for gatherv.
@@ -413,6 +422,7 @@ MPI_Neighbor_alltoallw_init:
 MPI_Reduce:
     .desc: Reduces values on all processes to a single value
     .docnotes: collops
+    .extra: threadcomm
 { -- early_return --
     if (count == 0 && comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         goto fn_exit;
@@ -446,6 +456,7 @@ MPI_Reduce_local:
 MPI_Reduce_scatter:
     .desc: Combines values and scatters the results
     .docnotes: collops
+    .extra: threadcomm
 { -- early_return --
     if (MPIR_is_self_comm(comm_ptr)) {
         if (sendbuf != MPI_IN_PLACE) {
@@ -461,6 +472,7 @@ MPI_Reduce_scatter_init:
 MPI_Reduce_scatter_block:
     .desc: Combines values and scatters the results
     .docnotes: collops
+    .extra: threadcomm
 { -- early_return --
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && (recvcount == 0 || MPIR_is_self_comm(comm_ptr))) {
         if (sendbuf != MPI_IN_PLACE) {
@@ -476,7 +488,7 @@ MPI_Reduce_scatter_block_init:
 MPI_Scan:
     .desc: Computes the scan (partial reductions) of data on a collection of processes
     .docnotes: collops
-    .extra: errtest_comm_intra
+    .extra: errtest_comm_intra, threadcomm
 { -- early_return --
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && count == 0) {
         goto fn_exit;
@@ -488,6 +500,7 @@ MPI_Scan_init:
 
 MPI_Scatter:
     .desc: Sends data from one process to all other processes in a communicator
+    .extra: threadcomm
 { -- early_return --
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         if ((MPIR_Comm_rank(comm_ptr) == root && sendcount == 0) || (MPIR_Comm_rank(comm_ptr) != root && recvcount == 0)) {
@@ -501,6 +514,7 @@ MPI_Scatter_init:
 
 MPI_Scatterv:
     .desc: Scatters a buffer in parts to all processes in a communicator
+    .extra: threadcomm
 
 MPI_Scatterv_init:
     .desc: Create a persistent request for scatterv.

--- a/src/binding/c/coll_api.txt
+++ b/src/binding/c/coll_api.txt
@@ -73,6 +73,7 @@ MPI_Allgatherv_init:
 MPI_Allreduce:
     .desc: Combines values from all processes and distributes the result back to all processes
     .docnotes: collops
+    .extra: threadcomm
 { -- early_return --
     if (MPIR_is_self_comm(comm_ptr)) {
         if (sendbuf != MPI_IN_PLACE) {

--- a/src/include/mpir_threadcomm.h
+++ b/src/include/mpir_threadcomm.h
@@ -110,6 +110,28 @@ MPL_STATIC_INLINE_PREFIX
 }
 
 #ifdef ENABLE_THREADCOMM
+#define MPIR_THREADCOMM_RANK_SIZE(comm, rank_, size_) do { \
+        MPIR_Threadcomm *threadcomm = (comm)->threadcomm; \
+        if (threadcomm) { \
+            int intracomm_size = (comm)->local_size; \
+            size_ = threadcomm->rank_offset_table[intracomm_size - 1]; \
+            rank_ = MPIR_THREADCOMM_TID_TO_RANK(threadcomm, MPIR_threadcomm_get_tid(threadcomm)); \
+        } else { \
+            rank_ = (comm)->rank; \
+            size_ = (comm)->local_size; \
+        } \
+    } while (0)
+
+#else
+#define MPIR_THREADCOMM_RANK_SIZE(comm, rank_, size_) do { \
+        MPIR_Assert((comm)->threadcomm == NULL); \
+        rank_ = (comm)->rank; \
+        size_ = (comm)->local_size; \
+    } while (0)
+
+#endif
+
+#ifdef ENABLE_THREADCOMM
 typedef struct MPIR_threadcomm_tls_t {
     MPIR_Threadcomm *threadcomm;
     int tid;

--- a/src/include/mpir_threadcomm.h
+++ b/src/include/mpir_threadcomm.h
@@ -62,7 +62,8 @@ typedef struct MPIR_Threadcomm {
     MPL_atomic_int_t barrier_flag;
     /* bcast during comm_dup */
     void *bcast_value;
-
+    /* thread barrier - dissemination */
+    void *in_counters;
 #if MPIR_THREADCOMM_TRANSPORT == MPIR_THREADCOMM_USE_FBOX
     MPIR_threadcomm_fbox_t *mailboxes;
 #elif MPIR_THREADCOMM_TRANSPORT == MPIR_THREADCOMM_USE_QUEUE

--- a/src/mpi/coll/allgather/allgather_intra_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_brucks.c
@@ -34,8 +34,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
     if (((sendcount == 0) && (sendbuf != MPI_IN_PLACE)) || (recvcount == 0))
         goto fn_exit;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
     MPIR_Datatype_get_size_macro(recvtype, recvtype_sz);

--- a/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
@@ -36,8 +36,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
     void *tmp_buf;
     MPIR_CHKLMEM_DECL(1);
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     total_count = 0;
     for (i = 0; i < comm_size; i++)

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
@@ -4,6 +4,7 @@
  */
 
 #include "mpiimpl.h"
+#include "mpir_threadcomm.h"
 
 /*
  * Algorithm: Recursive Doubling
@@ -31,8 +32,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
     MPI_Aint true_extent, true_lb, extent;
     void *tmp_buf;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     is_commutative = MPIR_Op_is_commutative(op);
 
@@ -53,7 +53,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
     }
 
     /* get nearest power-of-two less than or equal to comm_size */
-    pof2 = comm_ptr->coll.pof2;
+    pof2 = MPL_pof2(comm_size);
 
     rem = comm_size - pof2;
 

--- a/src/mpi/coll/alltoall/alltoall_intra_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_brucks.c
@@ -37,8 +37,7 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
     void *tmp_buf;
     MPIR_CHKLMEM_DECL(6);
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     MPIR_Assert(sendbuf != MPI_IN_PLACE);

--- a/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
@@ -38,8 +38,7 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
 
     MPIR_CHKLMEM_DECL(2);
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Get extent of recv type, but send type is only valid if (sendbuf!=MPI_IN_PLACE) */
     MPIR_Datatype_get_extent_macro(recvtype, recv_extent);

--- a/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
@@ -36,8 +36,7 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
     MPI_Aint type_size;
     MPIR_CHKLMEM_DECL(2);
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     /* When MPI_IN_PLACE, we use pair-wise sendrecv_replace in order to conserve memory usage,

--- a/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
+++ b/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
@@ -21,8 +21,7 @@ int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t errfla
     int size, rank, src, dst, mask, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
 
-    size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, size);
 
     mask = 0x1;
     while (mask < size) {

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -33,8 +33,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
     void *tmp_buf = NULL;
     MPIR_CHKLMEM_DECL(1);
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     if (HANDLE_IS_BUILTIN(datatype))
         is_contig = 1;

--- a/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
@@ -59,8 +59,7 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
     void *partial_scan, *tmp_buf;
     MPIR_CHKLMEM_DECL(2);
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     is_commutative = MPIR_Op_is_commutative(op);
 

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -58,8 +58,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
     MPIR_CHKLMEM_DECL(1);
 
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Use binomial tree algorithm. */
 

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -15,6 +15,39 @@
    sends/receives by setting the context offset MPIR_CONTEXT_COLL_OFFSET.
  */
 
+#ifdef ENABLE_THREADCOMM
+#define DO_MPID_ISEND(buf, count, datatype, dest, tag, comm_ptr, attr, req) \
+    do { \
+        if (comm_ptr->threadcomm) { \
+            mpi_errno = MPIR_Threadcomm_isend_attr(buf, count, datatype, dest, tag, \
+                                                   comm_ptr->threadcomm, attr, req); \
+        } else { \
+            mpi_errno = MPID_Isend(buf, count, datatype, dest, tag, comm_ptr, attr, req); \
+        } \
+    } while (0)
+
+#define DO_MPID_IRECV(buf, count, datatype, source, tag, comm_ptr, attr, req) \
+    do { \
+        if (comm_ptr->threadcomm) { \
+            mpi_errno = MPIR_Threadcomm_irecv_attr(buf, count, datatype, source, tag, \
+                                                   comm_ptr->threadcomm, attr, req, true); \
+        } else { \
+            mpi_errno = MPID_Irecv(buf, count, datatype, source, tag, comm_ptr, attr, req); \
+        } \
+    } while (0)
+
+#else
+#define DO_MPID_ISEND(buf, count, datatype, dest, tag, comm_ptr, attr, req) \
+    do { \
+        mpi_errno = MPID_Isend(buf, count, datatype, dest, tag, comm_ptr, attr, req); \
+    } while (0)
+
+#define DO_MPID_IRECV(buf, count, datatype, source, tag, comm_ptr, attr, req) \
+    do { \
+        mpi_errno = MPID_Irecv(buf, count, datatype, source, tag, comm_ptr, attr, req); \
+    } while (0)
+#endif
+
 int MPIC_Probe(int source, int tag, MPI_Comm comm, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -114,7 +147,7 @@ int MPIC_Send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, 
     MPIR_PT2PT_ATTR_SET_CONTEXT_OFFSET(attr, MPIR_CONTEXT_COLL_OFFSET);
     MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
 
-    mpi_errno = MPID_Send(buf, count, datatype, dest, tag, comm_ptr, attr, &request_ptr);
+    DO_MPID_ISEND(buf, count, datatype, dest, tag, comm_ptr, attr, &request_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     if (request_ptr) {
         mpi_errno = MPIC_Wait(request_ptr);
@@ -159,7 +192,7 @@ int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int 
     if (status == MPI_STATUS_IGNORE)
         status = &mystatus;
 
-    mpi_errno = MPID_Recv(buf, count, datatype, source, tag, comm_ptr, attr, status, &request_ptr);
+    DO_MPID_IRECV(buf, count, datatype, source, tag, comm_ptr, attr, &request_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     if (request_ptr) {
         mpi_errno = MPIC_Wait(request_ptr);
@@ -168,12 +201,6 @@ int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int 
         *status = request_ptr->status;
         mpi_errno = status->MPI_ERROR;
         MPIR_Request_free(request_ptr);
-    } else {
-        mpi_errno = MPIR_Process_status(status);
-    }
-
-    if (MPI_SUCCESS == MPIR_ERR_GET_CLASS(status->MPI_ERROR)) {
-        MPIR_Assert(status->MPI_TAG == tag);
     }
 
   fn_exit:
@@ -210,7 +237,7 @@ int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
     MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
     MPIR_PT2PT_ATTR_SET_SYNCFLAG(attr);
 
-    mpi_errno = MPID_Send(buf, count, datatype, dest, tag, comm_ptr, attr, &request_ptr);
+    DO_MPID_ISEND(buf, count, datatype, dest, tag, comm_ptr, attr, &request_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     if (request_ptr) {
         mpi_errno = MPIC_Wait(request_ptr);
@@ -260,8 +287,7 @@ int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype
                             "**nomemreq");
         MPIR_Status_set_procnull(&recv_req_ptr->status);
     } else {
-        mpi_errno = MPID_Irecv(recvbuf, recvcount, recvtype, source, recvtag,
-                               comm_ptr, attr, &recv_req_ptr);
+        DO_MPID_IRECV(recvbuf, recvcount, recvtype, source, recvtag, comm_ptr, attr, &recv_req_ptr);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -272,8 +298,7 @@ int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype
                             "**nomemreq");
     } else {
         MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
-        mpi_errno = MPID_Isend(sendbuf, sendcount, sendtype, dest, sendtag,
-                               comm_ptr, attr, &send_req_ptr);
+        DO_MPID_ISEND(sendbuf, sendcount, sendtype, dest, sendtag, comm_ptr, attr, &send_req_ptr);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -363,7 +388,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
         MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
         MPIR_Status_set_procnull(&rreq->status);
     } else {
-        mpi_errno = MPID_Irecv(buf, count, datatype, source, recvtag, comm_ptr, attr, &rreq);
+        DO_MPID_IRECV(buf, count, datatype, source, recvtag, comm_ptr, attr, &rreq);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -373,8 +398,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
         MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     } else {
         MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
-        mpi_errno = MPID_Isend(tmpbuf, actual_pack_bytes, MPI_PACKED, dest,
-                               sendtag, comm_ptr, attr, &sreq);
+        DO_MPID_ISEND(tmpbuf, actual_pack_bytes, MPI_PACKED, dest, sendtag, comm_ptr, attr, &sreq);
         MPIR_ERR_CHECK(mpi_errno);
         if (mpi_errno != MPI_SUCCESS) {
             /* --BEGIN ERROR HANDLING-- */
@@ -440,7 +464,7 @@ int MPIC_Isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
     MPIR_PT2PT_ATTR_SET_CONTEXT_OFFSET(attr, MPIR_CONTEXT_COLL_OFFSET);
     MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
 
-    mpi_errno = MPID_Isend(buf, count, datatype, dest, tag, comm_ptr, attr, request_ptr);
+    DO_MPID_ISEND(buf, count, datatype, dest, tag, comm_ptr, attr, request_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -475,7 +499,7 @@ int MPIC_Issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest
     MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
     MPIR_PT2PT_ATTR_SET_SYNCFLAG(attr);
 
-    mpi_errno = MPID_Isend(buf, count, datatype, dest, tag, comm_ptr, attr, request_ptr);
+    DO_MPID_ISEND(buf, count, datatype, dest, tag, comm_ptr, attr, request_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -509,7 +533,7 @@ int MPIC_Irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source,
 
     MPIR_PT2PT_ATTR_SET_CONTEXT_OFFSET(attr, MPIR_CONTEXT_COLL_OFFSET);
 
-    mpi_errno = MPID_Irecv(buf, count, datatype, source, tag, comm_ptr, attr, request_ptr);
+    DO_MPID_IRECV(buf, count, datatype, source, tag, comm_ptr, attr, request_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpi/coll/reduce/reduce_intra_binomial.c
+++ b/src/mpi/coll/reduce/reduce_intra_binomial.c
@@ -24,8 +24,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
     void *tmp_buf;
     MPIR_CHKLMEM_DECL(2);
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Create a temporary buffer */
 

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -51,8 +51,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
     int pof2, old_i, newrank;
     MPIR_CHKLMEM_DECL(5);
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     {
@@ -102,7 +101,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
 
     MPIR_ERR_CHECK(mpi_errno);
 
-    pof2 = comm_ptr->coll.pof2;
+    pof2 = MPL_pof2(comm_size);
 
     rem = comm_size - pof2;
 

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -53,8 +53,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
     int pof2, old_i, newrank;
     MPIR_CHKLMEM_DECL(5);
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     {
@@ -102,7 +101,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
 
     MPIR_ERR_CHECK(mpi_errno);
 
-    pof2 = comm_ptr->coll.pof2;
+    pof2 = MPL_pof2(comm_size);
 
     rem = comm_size - pof2;
 

--- a/src/mpi/coll/scan/scan_intra_recursive_doubling.c
+++ b/src/mpi/coll/scan/scan_intra_recursive_doubling.c
@@ -55,8 +55,7 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
     void *partial_scan, *tmp_buf;
     MPIR_CHKLMEM_DECL(2);
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     is_commutative = MPIR_Op_is_commutative(op);
 

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -42,8 +42,7 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
     int mpi_errno_ret = MPI_SUCCESS;
     MPIR_CHKLMEM_DECL(4);
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     if (rank == root)
         MPIR_Datatype_get_extent_macro(sendtype, extent);

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -30,14 +30,12 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcount
     MPI_Status *starray;
     MPIR_CHKLMEM_DECL(2);
 
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* If I'm the root, then scatter */
     if (((comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) && (root == rank)) ||
         ((comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) && (root == MPI_ROOT))) {
-        if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM)
-            comm_size = comm_ptr->local_size;
-        else
+        if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM)
             comm_size = comm_ptr->remote_size;
 
         MPIR_Datatype_get_extent_macro(sendtype, extent);

--- a/src/mpi/threadcomm/Makefile.mk
+++ b/src/mpi/threadcomm/Makefile.mk
@@ -5,4 +5,5 @@
 
 mpi_core_sources +=   \
     src/mpi/threadcomm/threadcomm_impl.c \
-    src/mpi/threadcomm/threadcomm_pt2pt_impl.c
+    src/mpi/threadcomm/threadcomm_pt2pt_impl.c \
+    src/mpi/threadcomm/threadcomm_coll_impl.c

--- a/src/mpi/threadcomm/threadcomm_coll_impl.c
+++ b/src/mpi/threadcomm/threadcomm_coll_impl.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+
+#ifdef ENABLE_THREADCOMM
+
+int MPIR_Threadcomm_allreduce_impl(const void *sendbuf, void *recvbuf,
+                                   MPI_Aint count, MPI_Datatype datatype,
+                                   MPI_Op op, MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIR_Allreduce_intra_recursive_doubling(sendbuf, recvbuf, count, datatype, op,
+                                                        comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+#endif

--- a/src/mpi/threadcomm/threadcomm_coll_impl.c
+++ b/src/mpi/threadcomm/threadcomm_coll_impl.c
@@ -7,6 +7,149 @@
 
 #ifdef ENABLE_THREADCOMM
 
+int MPIR_Threadcomm_barrier_impl(MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIR_Barrier_intra_dissemination(comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+int MPIR_Threadcomm_bcast_impl(void *buffer, MPI_Aint count, MPI_Datatype datatype,
+                               int root, MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIR_Bcast_intra_binomial(buffer, count, datatype, root, comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+int MPIR_Threadcomm_gather_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                int root, MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIR_Gather_intra_binomial(sendbuf, sendcount, sendtype,
+                                           recvbuf, recvcount, recvtype, root, comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+int MPIR_Threadcomm_gatherv_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                 void *recvbuf, const MPI_Aint * recvcounts,
+                                 const MPI_Aint * displs, MPI_Datatype recvtype,
+                                 int root, MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIR_Gatherv_allcomm_linear(sendbuf, sendcount, sendtype,
+                                            recvbuf, recvcounts, displs, recvtype, root,
+                                            comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+int MPIR_Threadcomm_scatter_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                 int root, MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIR_Scatter_intra_binomial(sendbuf, sendcount, sendtype,
+                                            recvbuf, recvcount, recvtype, root,
+                                            comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+int MPIR_Threadcomm_scatterv_impl(const void *sendbuf, const MPI_Aint * sendcounts,
+                                  const MPI_Aint * displs, MPI_Datatype sendtype,
+                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                  int root, MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIR_Scatterv_allcomm_linear(sendbuf, sendcounts, displs, sendtype,
+                                             recvbuf, recvcount, recvtype, root,
+                                             comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+int MPIR_Threadcomm_allgather_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                   void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                   MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIR_Allgather_intra_brucks(sendbuf, sendcount, sendtype,
+                                            recvbuf, recvcount, recvtype, comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+int MPIR_Threadcomm_allgatherv_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                    void *recvbuf, const MPI_Aint * recvcounts,
+                                    const MPI_Aint * displs, MPI_Datatype recvtype,
+                                    MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIR_Allgatherv_intra_brucks(sendbuf, sendcount, sendtype,
+                                             recvbuf, recvcounts, displs, recvtype,
+                                             comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+int MPIR_Threadcomm_alltoall_impl(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                                  MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_Assert(sendbuf != MPI_IN_PLACE);
+    mpi_errno = MPIR_Alltoall_intra_brucks(sendbuf, sendcount, sendtype,
+                                           recvbuf, recvcount, recvtype, comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+int MPIR_Threadcomm_alltoallv_impl(const void *sendbuf, const MPI_Aint * sendcounts,
+                                   const MPI_Aint * sdispls, MPI_Datatype sendtype,
+                                   void *recvbuf, const MPI_Aint * recvcounts,
+                                   const MPI_Aint * rdispls, MPI_Datatype recvtype,
+                                   MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_Assert(sendbuf != MPI_IN_PLACE);
+    mpi_errno = MPIR_Alltoallv_intra_scattered(sendbuf, sendcounts, sdispls, sendtype,
+                                               recvbuf, recvcounts, rdispls, recvtype,
+                                               comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+int MPIR_Threadcomm_alltoallw_impl(const void *sendbuf, const MPI_Aint * sendcounts,
+                                   const MPI_Aint * sdispls, const MPI_Datatype * sendtypes,
+                                   void *recvbuf, const MPI_Aint * recvcounts,
+                                   const MPI_Aint * rdispls, const MPI_Datatype * recvtypes,
+                                   MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_Assert(sendbuf != MPI_IN_PLACE);
+    mpi_errno = MPIR_Alltoallw_intra_scattered(sendbuf, sendcounts, sdispls, sendtypes,
+                                               recvbuf, recvcounts, rdispls, recvtypes,
+                                               comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
 int MPIR_Threadcomm_allreduce_impl(const void *sendbuf, void *recvbuf,
                                    MPI_Aint count, MPI_Datatype datatype,
                                    MPI_Op op, MPIR_Comm * comm)
@@ -15,6 +158,67 @@ int MPIR_Threadcomm_allreduce_impl(const void *sendbuf, void *recvbuf,
 
     mpi_errno = MPIR_Allreduce_intra_recursive_doubling(sendbuf, recvbuf, count, datatype, op,
                                                         comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+int MPIR_Threadcomm_reduce_impl(const void *sendbuf, void *recvbuf,
+                                MPI_Aint count, MPI_Datatype datatype,
+                                MPI_Op op, int root, MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIR_Reduce_intra_binomial(sendbuf, recvbuf, count, datatype, op, root,
+                                           comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+int MPIR_Threadcomm_reduce_scatter_impl(const void *sendbuf, void *recvbuf,
+                                        const MPI_Aint * recvcounts, MPI_Datatype datatype,
+                                        MPI_Op op, MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_Assert(MPIR_Op_is_commutative(op));
+    mpi_errno = MPIR_Reduce_scatter_intra_recursive_halving(sendbuf, recvbuf, recvcounts,
+                                                            datatype, op, comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+int MPIR_Threadcomm_reduce_scatter_block_impl(const void *sendbuf, void *recvbuf,
+                                              MPI_Aint recvcount, MPI_Datatype datatype,
+                                              MPI_Op op, MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_Assert(MPIR_Op_is_commutative(op));
+    mpi_errno = MPIR_Reduce_scatter_block_intra_recursive_halving(sendbuf, recvbuf, recvcount,
+                                                                  datatype, op,
+                                                                  comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+int MPIR_Threadcomm_scan_impl(const void *sendbuf, void *recvbuf,
+                              MPI_Aint count, MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIR_Scan_intra_recursive_doubling(sendbuf, recvbuf, count, datatype, op,
+                                                   comm, MPIR_ERR_NONE);
+
+    return mpi_errno;
+}
+
+int MPIR_Threadcomm_exscan_impl(const void *sendbuf, void *recvbuf,
+                                MPI_Aint count, MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIR_Exscan_intra_recursive_doubling(sendbuf, recvbuf, count, datatype, op,
+                                                     comm, MPIR_ERR_NONE);
 
     return mpi_errno;
 }

--- a/src/mpi/threadcomm/threadcomm_impl.c
+++ b/src/mpi/threadcomm/threadcomm_impl.c
@@ -56,6 +56,9 @@ int MPIR_Threadcomm_init_impl(MPIR_Comm * comm, int num_threads, MPIR_Comm ** co
     MPL_atomic_relaxed_store_int(&threadcomm->leave_counter, num_threads);
     MPL_atomic_relaxed_store_int(&threadcomm->barrier_flag, 0);
 
+    threadcomm->in_counters = MPL_calloc(num_threads * num_threads, MPL_CACHELINE_SIZE,
+                                         MPL_MEM_OTHER);
+
 #if MPIR_THREADCOMM_TRANSPORT == MPIR_THREADCOMM_USE_FBOX
     threadcomm->mailboxes = MPL_calloc(num_threads * num_threads, MPIR_THREADCOMM_FBOX_SIZE,
                                        MPL_MEM_OTHER);
@@ -114,6 +117,8 @@ int MPIR_Threadcomm_free_impl(MPIR_Comm * comm)
 
     mpi_errno = MPIR_Comm_free_impl(comm);
     MPIR_ERR_CHECK(mpi_errno);
+
+    MPL_free(threadcomm->in_counters);
 
     MPL_free(threadcomm->rank_offset_table);
 

--- a/src/mpi/threadcomm/threadcomm_impl.c
+++ b/src/mpi/threadcomm/threadcomm_impl.c
@@ -285,7 +285,11 @@ int MPIR_Threadcomm_dup_impl(MPIR_Comm * comm, MPIR_Comm ** newcomm_ptr)
 
     MPIR_Comm *newcomm = NULL;
     if (p->tid == 0) {
-        mpi_errno = MPIR_Threadcomm_init_impl(comm, num_threads, &newcomm);
+        MPIR_Comm tmp_comm;
+        memcpy(&tmp_comm, comm, sizeof(MPIR_Comm));
+        tmp_comm.threadcomm = NULL;
+
+        mpi_errno = MPIR_Threadcomm_init_impl(&tmp_comm, num_threads, &newcomm);
         newcomm->threadcomm->kind = MPIR_THREADCOMM_KIND__DERIVED;
         MPIR_ERR_CHECK(mpi_errno);
         /* bcast to all threads */

--- a/test/mpi/impls/mpich/threads/threadcomm/Makefile.am
+++ b/test/mpi/impls/mpich/threads/threadcomm/Makefile.am
@@ -9,4 +9,5 @@ EXTRA_DIST = testlist
 
 noinst_PROGRAMS = \
     threadcomm \
-    threadcomm_attr
+    threadcomm_attr \
+    threadcomm_coll

--- a/test/mpi/impls/mpich/threads/threadcomm/testlist
+++ b/test/mpi/impls/mpich/threads/threadcomm/testlist
@@ -3,3 +3,5 @@ threadcomm 4
 threadcomm 4 arg=-restart=4
 threadcomm 4 arg=-commdup=1
 threadcomm_attr 1
+threadcomm_coll 1
+threadcomm_coll 4

--- a/test/mpi/impls/mpich/threads/threadcomm/threadcomm_coll.c
+++ b/test/mpi/impls/mpich/threads/threadcomm/threadcomm_coll.c
@@ -1,0 +1,788 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpitest.h"
+#include <assert.h>
+
+#define NTHREADS 4
+
+static void test_barrier(MPI_Comm comm);
+static void test_bcast(MPI_Comm comm);
+static void test_gather(MPI_Comm comm);
+static void test_gatherv(MPI_Comm comm);
+static void test_scatter(MPI_Comm comm);
+static void test_scatterv(MPI_Comm comm);
+static void test_allgather(MPI_Comm comm);
+static void test_allgatherv(MPI_Comm comm);
+static void test_alltoall(MPI_Comm comm);
+static void test_alltoallv(MPI_Comm comm);
+static void test_alltoallw(MPI_Comm comm);
+static void test_reduce(MPI_Comm comm);
+static void test_allreduce(MPI_Comm comm);
+static void test_reduce_scatter(MPI_Comm comm);
+static void test_reduce_scatter_block(MPI_Comm comm);
+static void test_scan(MPI_Comm comm);
+static void test_exscan(MPI_Comm comm);
+
+static void test_bcast_c(MPI_Comm comm);
+static void test_gather_c(MPI_Comm comm);
+static void test_gatherv_c(MPI_Comm comm);
+static void test_scatter_c(MPI_Comm comm);
+static void test_scatterv_c(MPI_Comm comm);
+static void test_allgather_c(MPI_Comm comm);
+static void test_allgatherv_c(MPI_Comm comm);
+static void test_alltoall_c(MPI_Comm comm);
+static void test_alltoallv_c(MPI_Comm comm);
+static void test_alltoallw_c(MPI_Comm comm);
+static void test_reduce_c(MPI_Comm comm);
+static void test_allreduce_c(MPI_Comm comm);
+static void test_reduce_scatter_c(MPI_Comm comm);
+static void test_reduce_scatter_block_c(MPI_Comm comm);
+static void test_scan_c(MPI_Comm comm);
+static void test_exscan_c(MPI_Comm comm);
+
+static MTEST_THREAD_RETURN_TYPE test_thread(void *arg)
+{
+    MPI_Comm comm = *(MPI_Comm *) arg;
+
+    MPIX_Threadcomm_start(comm);
+
+    test_barrier(comm);
+    test_bcast(comm);
+    test_gather(comm);
+    test_gatherv(comm);
+    test_scatter(comm);
+    test_scatterv(comm);
+    test_allgather(comm);
+    test_allgatherv(comm);
+    test_alltoall(comm);
+    test_alltoallv(comm);
+    test_alltoallw(comm);
+    test_reduce(comm);
+    test_allreduce(comm);
+    test_reduce_scatter(comm);
+    test_reduce_scatter_block(comm);
+    test_scan(comm);
+    test_exscan(comm);
+
+    test_bcast_c(comm);
+    test_gather_c(comm);
+    test_gatherv_c(comm);
+    test_scatter_c(comm);
+    test_scatterv_c(comm);
+    test_allgather_c(comm);
+    test_allgatherv_c(comm);
+    test_alltoall_c(comm);
+    test_alltoallv_c(comm);
+    test_alltoallw_c(comm);
+    test_reduce_c(comm);
+    test_allreduce_c(comm);
+    test_reduce_scatter_c(comm);
+    test_reduce_scatter_block_c(comm);
+    test_scan_c(comm);
+    test_exscan_c(comm);
+
+    MPIX_Threadcomm_finish(comm);
+}
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+
+    MTest_Init(NULL, NULL);
+
+    MPI_Comm comm;
+    MPIX_Threadcomm_init(MPI_COMM_WORLD, NTHREADS, &comm);
+    for (int i = 0; i < NTHREADS; i++) {
+        MTest_Start_thread(test_thread, &comm);
+    }
+    MTest_Join_threads();
+    MPIX_Threadcomm_free(&comm);
+
+    MTest_Finalize(errs);
+    return errs;
+}
+
+static void test_barrier(MPI_Comm comm)
+{
+    MPI_Barrier(comm);
+}
+
+static void test_bcast(MPI_Comm comm)
+{
+    int root = 0;
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int n = 0;
+    if (rank == root) {
+        n = 42;
+    }
+    MPI_Bcast(&n, 1, MPI_INT, root, comm);
+
+    if (n != 42) {
+        printf("[%d] test_bcast: expect %d, got %d\n", rank, 42, n);
+    }
+}
+
+static void test_gather(MPI_Comm comm)
+{
+    int root = 0;
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int allranks[size];         /* variable length array */
+
+    MPI_Gather(&rank, 1, MPI_INT, allranks, 1, MPI_INT, root, comm);
+
+    if (rank == root) {
+        for (int i = 0; i < size; i++) {
+            if (allranks[i] != i) {
+                printf("[%d] test_gather: expect allranks[%d] %d, got %d\n",
+                       rank, i, i, allranks[i]);
+            }
+        }
+    }
+}
+
+static void test_gatherv(MPI_Comm comm)
+{
+    int root = 0;
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int allranks[size], counts[size], displs[size];
+
+    if (rank == root) {
+        for (int i = 0; i < size; i++) {
+            counts[i] = 1;
+            displs[i] = i;
+        }
+    } else {
+        /* set to invalid values */
+        for (int i = 0; i < size; i++) {
+            counts[i] = -1;
+            displs[i] = -1;
+        }
+    }
+
+    MPI_Gatherv(&rank, 1, MPI_INT, allranks, counts, displs, MPI_INT, root, comm);
+
+    if (rank == root) {
+        for (int i = 0; i < size; i++) {
+            if (allranks[i] != i) {
+                printf("[%d] test_gather: expect allranks[%d] %d, got %d\n",
+                       rank, i, i, allranks[i]);
+            }
+        }
+    }
+}
+
+static void test_scatter(MPI_Comm comm)
+{
+    int root = 0;
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int data_out[size];
+    if (rank == root) {
+        for (int i = 0; i < size; i++) {
+            data_out[i] = i;
+        }
+    }
+
+    int data_in;
+    MPI_Scatter(data_out, 1, MPI_INT, &data_in, 1, MPI_INT, root, comm);
+
+    if (data_in != rank) {
+        printf("[%d] test_scatter: expect %d, got %d\n", rank, rank, data_in);
+    }
+}
+
+static void test_scatterv(MPI_Comm comm)
+{
+    int root = 0;
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int data_out[size], counts[size], displs[size];
+
+    if (rank == root) {
+        for (int i = 0; i < size; i++) {
+            data_out[i] = i;
+            counts[i] = 1;
+            displs[i] = i;
+        }
+    } else {
+        /* set to invalid values */
+        for (int i = 0; i < size; i++) {
+            counts[i] = -1;
+            displs[i] = -1;
+        }
+    }
+
+    int data_in;
+    MPI_Scatterv(&data_out, counts, displs, MPI_INT, &data_in, 1, MPI_INT, root, comm);
+
+    if (data_in != rank) {
+        printf("[%d] test_scatterv: expect %d, got %d\n", rank, rank, data_in);
+    }
+}
+
+static void test_allgather(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int allranks[size];
+
+    MPI_Allgather(&rank, 1, MPI_INT, allranks, 1, MPI_INT, comm);
+
+    for (int i = 0; i < size; i++) {
+        if (allranks[i] != i) {
+            printf("[%d] test_gather: expect allranks[%d] %d, got %d\n", rank, i, i, allranks[i]);
+        }
+    }
+}
+
+static void test_allgatherv(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int allranks[size], counts[size], displs[size];
+
+    for (int i = 0; i < size; i++) {
+        counts[i] = 1;
+        displs[i] = i;
+    }
+
+    MPI_Allgatherv(&rank, 1, MPI_INT, allranks, counts, displs, MPI_INT, comm);
+
+    for (int i = 0; i < size; i++) {
+        if (allranks[i] != i) {
+            printf("[%d] test_gatherv: expect allranks[%d] %d, got %d\n", rank, i, i, allranks[i]);
+        }
+    }
+}
+
+static void test_alltoall(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int data_out[size], data_in[size];
+    for (int i = 0; i < size; i++) {
+        data_out[i] = i * 1000 + rank;
+        data_in[i] = -1;
+    }
+
+    MPI_Alltoall(data_out, 1, MPI_INT, data_in, 1, MPI_INT, comm);
+
+    for (int i = 0; i < size; i++) {
+        if (data_in[i] != rank * 1000 + i) {
+            printf("[%d] test_alltoall: expect %d, got %d\n", rank, rank * 1000 + i, data_in[i]);
+        }
+    }
+}
+
+static void test_alltoallv(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int data_out[size], data_in[size];
+    int counts[size], displs[size];
+    for (int i = 0; i < size; i++) {
+        data_out[i] = i * 1000 + rank;
+        data_in[i] = -1;
+        counts[i] = 1;
+        displs[i] = i;
+    }
+
+    MPI_Alltoallv(data_out, counts, displs, MPI_INT, data_in, counts, displs, MPI_INT, comm);
+
+    for (int i = 0; i < size; i++) {
+        if (data_in[i] != rank * 1000 + i) {
+            printf("[%d] test_alltoallv: expect %d, got %d\n", rank, rank * 1000 + i, data_in[i]);
+        }
+    }
+}
+
+static void test_alltoallw(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int data_out[size], data_in[size];
+    int counts[size], displs[size];
+    MPI_Datatype types[size];
+    for (int i = 0; i < size; i++) {
+        data_out[i] = i * 1000 + rank;
+        data_in[i] = -1;
+        counts[i] = 1;
+        displs[i] = i * sizeof(int);
+        types[i] = MPI_INT;
+    }
+
+    MPI_Alltoallw(data_out, counts, displs, types, data_in, counts, displs, types, comm);
+
+    for (int i = 0; i < size; i++) {
+        if (data_in[i] != rank * 1000 + i) {
+            printf("[%d] test_alltoallw: expect %d, got %d\n", rank, rank * 1000 + i, data_in[i]);
+        }
+    }
+}
+
+static void test_reduce(MPI_Comm comm)
+{
+    int root = 0;
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int sum;
+    MPI_Reduce(&rank, &sum, 1, MPI_INT, MPI_SUM, root, comm);
+
+    if (rank == root) {
+        if (sum != size * (size - 1) / 2) {
+            printf("[%d] test_reduce: expect %d, got %d\n", rank, size * (size - 1) / 2, sum);
+        }
+    }
+}
+
+static void test_allreduce(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int sum;
+    MPI_Allreduce(&rank, &sum, 1, MPI_INT, MPI_SUM, comm);
+
+    if (sum != size * (size - 1) / 2) {
+        printf("[%d] test_allreduce: expect %d, got %d\n", rank, size * (size - 1) / 2, sum);
+    }
+}
+
+static void test_reduce_scatter(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int data_out[size];
+    int counts[size];
+    for (int i = 0; i < size; i++) {
+        data_out[i] = i;
+        counts[i] = 1;
+    }
+
+    int data_in;
+    MPI_Reduce_scatter(data_out, &data_in, counts, MPI_INT, MPI_SUM, comm);
+
+    if (data_in != rank * size) {
+        printf("[%d] test_reduce_scatter_block: expect %d, got %d\n", rank, rank * size, data_in);
+    }
+}
+
+static void test_reduce_scatter_block(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int data_out[size];
+    for (int i = 0; i < size; i++) {
+        data_out[i] = i;
+    }
+
+    int data_in;
+    MPI_Reduce_scatter_block(data_out, &data_in, 1, MPI_INT, MPI_SUM, comm);
+
+    if (data_in != rank * size) {
+        printf("[%d] test_reduce_scatter_block: expect %d, got %d\n", rank, rank * size, data_in);
+    }
+}
+
+static void test_scan(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int sum;
+    MPI_Scan(&rank, &sum, 1, MPI_INT, MPI_SUM, comm);
+
+    if (sum != rank * (rank + 1) / 2) {
+        printf("[%d] test_scan: expect %d, got %d\n", rank, rank * (rank - 1) / 2, sum);
+    }
+}
+
+static void test_exscan(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int sum;
+    MPI_Exscan(&rank, &sum, 1, MPI_INT, MPI_SUM, comm);
+
+    if (rank > 0) {
+        if (sum != (rank - 1) * rank / 2) {
+            printf("[%d] test_exscan: expect %d, got %d\n", rank, (rank - 1) * rank / 2, sum);
+        }
+    }
+}
+
+static void test_bcast_c(MPI_Comm comm)
+{
+    int root = 0;
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int n = 0;
+    if (rank == root) {
+        n = 42;
+    }
+    MPI_Bcast_c(&n, 1, MPI_INT, root, comm);
+
+    if (n != 42) {
+        printf("[%d] test_bcast: expect %d, got %d\n", rank, 42, n);
+    }
+}
+
+static void test_gather_c(MPI_Comm comm)
+{
+    int root = 0;
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int allranks[size];         /* variable length array */
+
+    MPI_Gather_c(&rank, 1, MPI_INT, allranks, 1, MPI_INT, root, comm);
+
+    if (rank == root) {
+        for (int i = 0; i < size; i++) {
+            if (allranks[i] != i) {
+                printf("[%d] test_gather: expect allranks[%d] %d, got %d\n",
+                       rank, i, i, allranks[i]);
+            }
+        }
+    }
+}
+
+static void test_gatherv_c(MPI_Comm comm)
+{
+    int root = 0;
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int allranks[size];
+    MPI_Count counts[size], displs[size];
+
+    if (rank == root) {
+        for (int i = 0; i < size; i++) {
+            counts[i] = 1;
+            displs[i] = i;
+        }
+    } else {
+        /* set to invalid values */
+        for (int i = 0; i < size; i++) {
+            counts[i] = -1;
+            displs[i] = -1;
+        }
+    }
+
+    MPI_Gatherv_c(&rank, 1, MPI_INT, allranks, counts, displs, MPI_INT, root, comm);
+
+    if (rank == root) {
+        for (int i = 0; i < size; i++) {
+            if (allranks[i] != i) {
+                printf("[%d] test_gather: expect allranks[%d] %d, got %d\n",
+                       rank, i, i, allranks[i]);
+            }
+        }
+    }
+}
+
+static void test_scatter_c(MPI_Comm comm)
+{
+    int root = 0;
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int data_out[size];
+    if (rank == root) {
+        for (int i = 0; i < size; i++) {
+            data_out[i] = i;
+        }
+    }
+
+    int data_in;
+    MPI_Scatter_c(data_out, 1, MPI_INT, &data_in, 1, MPI_INT, root, comm);
+
+    if (data_in != rank) {
+        printf("[%d] test_scatter: expect %d, got %d\n", rank, rank, data_in);
+    }
+}
+
+static void test_scatterv_c(MPI_Comm comm)
+{
+    int root = 0;
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int data_out[size];
+    MPI_Count counts[size], displs[size];
+
+    if (rank == root) {
+        for (int i = 0; i < size; i++) {
+            data_out[i] = i;
+            counts[i] = 1;
+            displs[i] = i;
+        }
+    } else {
+        /* set to invalid values */
+        for (int i = 0; i < size; i++) {
+            counts[i] = -1;
+            displs[i] = -1;
+        }
+    }
+
+    int data_in;
+    MPI_Scatterv_c(&data_out, counts, displs, MPI_INT, &data_in, 1, MPI_INT, root, comm);
+
+    if (data_in != rank) {
+        printf("[%d] test_scatterv: expect %d, got %d\n", rank, rank, data_in);
+    }
+}
+
+static void test_allgather_c(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int allranks[size];
+
+    MPI_Allgather_c(&rank, 1, MPI_INT, allranks, 1, MPI_INT, comm);
+
+    for (int i = 0; i < size; i++) {
+        if (allranks[i] != i) {
+            printf("[%d] test_gather: expect allranks[%d] %d, got %d\n", rank, i, i, allranks[i]);
+        }
+    }
+}
+
+static void test_allgatherv_c(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int allranks[size];
+    MPI_Count counts[size], displs[size];
+
+    for (int i = 0; i < size; i++) {
+        counts[i] = 1;
+        displs[i] = i;
+    }
+
+    MPI_Allgatherv_c(&rank, 1, MPI_INT, allranks, counts, displs, MPI_INT, comm);
+
+    for (int i = 0; i < size; i++) {
+        if (allranks[i] != i) {
+            printf("[%d] test_gatherv: expect allranks[%d] %d, got %d\n", rank, i, i, allranks[i]);
+        }
+    }
+}
+
+static void test_alltoall_c(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int data_out[size], data_in[size];
+    for (int i = 0; i < size; i++) {
+        data_out[i] = i * 1000 + rank;
+        data_in[i] = -1;
+    }
+
+    MPI_Alltoall_c(data_out, 1, MPI_INT, data_in, 1, MPI_INT, comm);
+
+    for (int i = 0; i < size; i++) {
+        if (data_in[i] != rank * 1000 + i) {
+            printf("[%d] test_alltoall: expect %d, got %d\n", rank, rank * 1000 + i, data_in[i]);
+        }
+    }
+}
+
+static void test_alltoallv_c(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int data_out[size], data_in[size];
+    MPI_Count counts[size], displs[size];
+    for (int i = 0; i < size; i++) {
+        data_out[i] = i * 1000 + rank;
+        data_in[i] = -1;
+        counts[i] = 1;
+        displs[i] = i;
+    }
+
+    MPI_Alltoallv_c(data_out, counts, displs, MPI_INT, data_in, counts, displs, MPI_INT, comm);
+
+    for (int i = 0; i < size; i++) {
+        if (data_in[i] != rank * 1000 + i) {
+            printf("[%d] test_alltoallv: expect %d, got %d\n", rank, rank * 1000 + i, data_in[i]);
+        }
+    }
+}
+
+static void test_alltoallw_c(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int data_out[size], data_in[size];
+    MPI_Count counts[size], displs[size];
+    MPI_Datatype types[size];
+    for (int i = 0; i < size; i++) {
+        data_out[i] = i * 1000 + rank;
+        data_in[i] = -1;
+        counts[i] = 1;
+        displs[i] = i * sizeof(int);
+        types[i] = MPI_INT;
+    }
+
+    MPI_Alltoallw_c(data_out, counts, displs, types, data_in, counts, displs, types, comm);
+
+    for (int i = 0; i < size; i++) {
+        if (data_in[i] != rank * 1000 + i) {
+            printf("[%d] test_alltoallw: expect %d, got %d\n", rank, rank * 1000 + i, data_in[i]);
+        }
+    }
+}
+
+static void test_reduce_c(MPI_Comm comm)
+{
+    int root = 0;
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int sum;
+    MPI_Reduce_c(&rank, &sum, 1, MPI_INT, MPI_SUM, root, comm);
+
+    if (rank == root) {
+        if (sum != size * (size - 1) / 2) {
+            printf("[%d] test_reduce: expect %d, got %d\n", rank, size * (size - 1) / 2, sum);
+        }
+    }
+}
+
+static void test_allreduce_c(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int sum;
+    MPI_Allreduce_c(&rank, &sum, 1, MPI_INT, MPI_SUM, comm);
+
+    if (sum != size * (size - 1) / 2) {
+        printf("[%d] test_allreduce: expect %d, got %d\n", rank, size * (size - 1) / 2, sum);
+    }
+}
+
+static void test_reduce_scatter_c(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int data_out[size];
+    MPI_Count counts[size];
+    for (int i = 0; i < size; i++) {
+        data_out[i] = i;
+        counts[i] = 1;
+    }
+
+    int data_in;
+    MPI_Reduce_scatter_c(data_out, &data_in, counts, MPI_INT, MPI_SUM, comm);
+
+    if (data_in != rank * size) {
+        printf("[%d] test_reduce_scatter_block: expect %d, got %d\n", rank, rank * size, data_in);
+    }
+}
+
+static void test_reduce_scatter_block_c(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int data_out[size];
+    for (int i = 0; i < size; i++) {
+        data_out[i] = i;
+    }
+
+    int data_in;
+    MPI_Reduce_scatter_block_c(data_out, &data_in, 1, MPI_INT, MPI_SUM, comm);
+
+    if (data_in != rank * size) {
+        printf("[%d] test_reduce_scatter_block: expect %d, got %d\n", rank, rank * size, data_in);
+    }
+}
+
+static void test_scan_c(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int sum;
+    MPI_Scan_c(&rank, &sum, 1, MPI_INT, MPI_SUM, comm);
+
+    if (sum != rank * (rank + 1) / 2) {
+        printf("[%d] test_scan: expect %d, got %d\n", rank, rank * (rank - 1) / 2, sum);
+    }
+}
+
+static void test_exscan_c(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int sum;
+    MPI_Exscan_c(&rank, &sum, 1, MPI_INT, MPI_SUM, comm);
+
+    if (rank > 0) {
+        if (sum != (rank - 1) * rank / 2) {
+            printf("[%d] test_exscan: expect %d, got %d\n", rank, (rank - 1) * rank / 2, sum);
+        }
+    }
+}


### PR DESCRIPTION
## Pull Request Description
This is the last split from #6326. This PR adds collective support for threadcomm.

Shortcoming and remaining work (for future, as needed):
* Only a single algorithm is used for threadcomm collectives. While it is trivial (but tedious) to add more algorithms, the plan is to seek a general hierarchical collective framework.
* Hierarchical collectives and thread-specific collective algorithms
* Nonblock collectives
    * The simplest is probably to implement schedule on thread-local storage. Straight-forward, but massive code duplication
    * Alternatively, always do hierarchical algorithms. The inter-thread part can be implemented can adopt thread-specific algorithm, and the inter-process part can be dubbed to existing inter-process communicator. More effort, but the thread-specific algorithm is needed work anyway.
* RMA
    * Simply dub the interprocess op to upper comm and interthread ops should be trivial. Not difficult, but tedious.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
