### PR TITLE
mpit: add global config file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -322,6 +322,22 @@ m4_include([subsys_include.m4])
 
 dnl ----------------------------------------------------------------------------
 dnl setup top-level argument handling
+
+AC_ARG_WITH(configfile,
+        AS_HELP_STRING([--with-configfile], [Set global config file. The default is /etc/mpich.conf.])
+,,with_configfile="/etc/mpich.conf")
+if test "$with_configfile" != "no" ; then
+    case "$with_configfile" in
+        "yes|default")
+            configfile="/etc/mpich.conf"
+            ;;
+        *)
+            configfile="$with_configfile"
+            ;;
+    esac
+    AC_DEFINE_UNQUOTED(USE_CONFIGFILE, ["$configfile"], [define to use global config file])
+fi
+
 AC_ARG_ENABLE(echo,
 	AS_HELP_STRING([--enable-echo], [Turn on strong echoing. The default is enable=no.]),
 	set -x)

--- a/maint/extractcvars
+++ b/maint/extractcvars
@@ -252,6 +252,10 @@ int ${fn_ns}_init(void)
     MPIR_T_cvar_value_t defaultval;
 
     int debug = 0;
+    rc = MPL_env2bool("MPICH_DEBUG_CVARS", &debug);
+    MPIR_ERR_CHKANDJUMP1((-1 == rc),mpi_errno,MPI_ERR_OTHER,"**envvarparse","**envvarparse %s","MPICH_DEBUG_CVARS");
+    rc = MPL_env2bool("MPIR_PARAM_DEBUG_CVARS", &debug);
+    MPIR_ERR_CHKANDJUMP1((-1 == rc),mpi_errno,MPI_ERR_OTHER,"**envvarparse","**envvarparse %s","MPIR_PARAM_DEBUG_CVARS");
     rc = MPL_env2bool("MPIR_CVAR_DEBUG_CVARS", &debug);
     MPIR_ERR_CHKANDJUMP1((-1 == rc),mpi_errno,MPI_ERR_OTHER,"**envvarparse","**envvarparse %s","MPIR_CVAR_DEBUG_CVARS");
 

--- a/src/mpi_t/mpit_initthread.c
+++ b/src/mpi_t/mpit_initthread.c
@@ -5,6 +5,73 @@
 
 #include "mpiimpl.h"
 
+static bool debug_config_files = false;
+
+/*
+ * Read and set all the variables from the passed file
+ */
+static void read_files(const char fname[])
+{
+    int lineno = 0;
+    char storage[1024], *line;
+    FILE *f;
+
+    if (!(f = fopen(fname, "r"))) {
+        if (debug_config_files) {
+            fprintf(stderr, "Couldn't open %s: %m\n", fname);
+        }
+        return;
+    }
+
+    while ((line = fgets(storage, sizeof(storage), f))) {
+        char key[128], val[512], *spot;
+        bool force = false, already;
+
+        lineno++;
+
+        if ('\n' == line[0] || '#' == line[0])
+            continue;
+        if ('\0' == line[0])
+            break;
+
+        if (2 > sscanf(line, "%127[^=]=%511s", key, val)) {
+            fprintf(stderr, "Error parsing config file %s line %d: %s\n", fname, lineno, line);
+            goto err;
+        }
+        // If KEY:force=VALUE, then write prior values
+        if ((spot = strstr(key, ":force"))) {
+            force = true;
+            *spot = '\0';
+        }
+
+        already = getenv(key);
+        if (setenv(key, val, force)) {
+            fprintf(stderr, "Error setting %s from config file %s to %s\n", key, fname, val);
+            goto err;
+        }
+
+        if (debug_config_files && (!already || force)) {
+            fprintf(stderr, "Set %s=%s from %s:%d\n", key, val, fname, lineno);
+        }
+    }
+  err:
+    fclose(f);
+}
+
+/*
+ * Read global config files that have MPICH_ environment variables for us to
+ * use
+ */
+static void read_config_files(void)
+{
+    char *fname, *env;
+
+    if (getenv("MPICH_DEBUG_CONFIG_FILES"))
+        debug_config_files = true;
+
+    read_files("/etc/mpich.conf");
+}
+
 static inline void MPIR_T_enum_env_init(void)
 {
     static const UT_icd enum_table_entry_icd = { sizeof(MPIR_T_enum_t), NULL, NULL, NULL };
@@ -35,6 +102,8 @@ int MPIR_T_env_initialized = FALSE;
 int MPIR_T_env_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
+
+    read_config_files();
 
     if (!MPIR_T_env_initialized) {
         MPIR_T_env_initialized = TRUE;

--- a/src/mpi_t/mpit_initthread.c
+++ b/src/mpi_t/mpit_initthread.c
@@ -81,10 +81,13 @@ int MPIR_T_env_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    const char *config_filename = "/etc/mpich.conf";
+    const char *config_filename = NULL;
+#ifdef USE_CONFIGFILE
+    config_filename = USE_CONFIGFILE;
     if (!read_config_files(config_filename)) {
         config_filename = NULL;
     }
+#endif
 
     if (!MPIR_T_env_initialized) {
         MPIR_T_env_initialized = TRUE;

--- a/src/mpi_t/mpit_initthread.c
+++ b/src/mpi_t/mpit_initthread.c
@@ -5,27 +5,23 @@
 
 #include "mpiimpl.h"
 
-static bool debug_config_files = false;
-
 /*
- * Read and set all the variables from the passed file
+ * Read global config files that have MPICH_ environment variables for us to
+ * use
  */
-static void read_files(const char fname[])
+static int read_config_files(const char *fname)
 {
     int lineno = 0;
     char storage[1024], *line;
     FILE *f;
 
     if (!(f = fopen(fname, "r"))) {
-        if (debug_config_files) {
-            fprintf(stderr, "Couldn't open %s: %m\n", fname);
-        }
-        return;
+        return FALSE;
     }
 
     while ((line = fgets(storage, sizeof(storage), f))) {
         char key[128], val[512], *spot;
-        bool force = false, already;
+        bool force = false;
 
         lineno++;
 
@@ -38,38 +34,20 @@ static void read_files(const char fname[])
             fprintf(stderr, "Error parsing config file %s line %d: %s\n", fname, lineno, line);
             goto err;
         }
-        // If KEY:force=VALUE, then write prior values
+        /* If KEY:force=VALUE, then write prior values */
         if ((spot = strstr(key, ":force"))) {
             force = true;
             *spot = '\0';
         }
 
-        already = getenv(key);
         if (setenv(key, val, force)) {
             fprintf(stderr, "Error setting %s from config file %s to %s\n", key, fname, val);
             goto err;
         }
-
-        if (debug_config_files && (!already || force)) {
-            fprintf(stderr, "Set %s=%s from %s:%d\n", key, val, fname, lineno);
-        }
     }
   err:
     fclose(f);
-}
-
-/*
- * Read global config files that have MPICH_ environment variables for us to
- * use
- */
-static void read_config_files(void)
-{
-    char *fname, *env;
-
-    if (getenv("MPICH_DEBUG_CONFIG_FILES"))
-        debug_config_files = true;
-
-    read_files("/etc/mpich.conf");
+    return TRUE;
 }
 
 static inline void MPIR_T_enum_env_init(void)
@@ -103,7 +81,10 @@ int MPIR_T_env_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    read_config_files();
+    const char *config_filename = "/etc/mpich.conf";
+    if (!read_config_files(config_filename)) {
+        config_filename = NULL;
+    }
 
     if (!MPIR_T_env_initialized) {
         MPIR_T_env_initialized = TRUE;
@@ -111,6 +92,9 @@ int MPIR_T_env_init(void)
         MPIR_T_cat_env_init();
         mpi_errno = MPIR_T_cvar_env_init();
         MPIR_T_pvar_env_init();
+        if (MPIR_CVAR_DEBUG_SUMMARY && config_filename) {
+            printf("Global config file: %s\n", config_filename);
+        }
     }
     return mpi_errno;
 }


### PR DESCRIPTION
## Pull Request Description
Add a mechanism to set a global config file to be loaded at init time. The config file has a ":force" syntax to allow system admin to set variables that are difficult for user to overwrite.

Fixes #6501 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
