### PR TITLE
comm: Free inactive persistent requests at destruction

### DIFF
--- a/maint/gen_coll.py
+++ b/maint/gen_coll.py
@@ -439,6 +439,7 @@ def dump_mpir_impl_persistent(name):
     G.out.append("MPIR_ERR_CHKANDJUMP(!req, mpi_errno, MPI_ERR_OTHER, \"**nomem\");")
     G.out.append("MPIR_Comm_add_ref(comm_ptr);")
     G.out.append("req->comm = comm_ptr;")
+    G.out.append("MPIR_Comm_save_inactive_request(comm_ptr, req);")
     G.out.append("req->u.persist_coll.sched_type = MPIR_SCHED_INVALID;")
     G.out.append("req->u.persist_coll.real_request = NULL;")
 

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -259,6 +259,8 @@ struct MPIR_Comm {
         } multiplex;
     } stream_comm;
 
+    MPIR_Request *persistent_requests;
+
     /* Other, device-specific information */
 #ifdef MPID_DEV_COMM_DECL
      MPID_DEV_COMM_DECL
@@ -373,6 +375,9 @@ int MPIR_Comm_split_filesystem(MPI_Comm comm, int key, const char *dirname, MPI_
 
 #define MPIR_Comm_rank(comm_ptr) ((comm_ptr)->rank)
 #define MPIR_Comm_size(comm_ptr) ((comm_ptr)->local_size)
+
+int MPIR_Comm_save_inactive_request(MPIR_Comm * comm, MPIR_Request * request);
+int MPIR_Comm_free_inactive_requests(MPIR_Comm * comm);
 
 /* Comm hint registration.
  *

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -231,6 +231,7 @@ struct MPIR_Request {
 #endif                          /* HAVE_DEBUGGER_SUPPORT */
 
     struct MPIR_Request *next, *prev;
+    UT_hash_handle hh;
 
     /* Other, device-specific information */
 #ifdef MPID_DEV_REQUEST_DECL
@@ -534,6 +535,9 @@ static inline void MPIR_Request_free_with_safety(MPIR_Request * req, int need_sa
         /* FIXME: We need a way to call these routines ONLY when the
          * related ref count has become zero. */
         if (req->comm != NULL) {
+            if (MPIR_Request_is_persistent(req)) {
+                HASH_DEL(req->comm->persistent_requests, req);
+            }
             MPIR_Comm_release(req->comm);
         }
 

--- a/src/mpi/comm/builtin_comms.c
+++ b/src/mpi/comm/builtin_comms.c
@@ -127,6 +127,8 @@ static int finalize_builtin_comm(MPIR_Comm * comm)
         comm->errhandler = NULL;
     }
 
+    MPIR_Comm_free_inactive_requests(comm);
+
     mpi_errno = MPIR_Comm_release_always(comm);
 
   fn_exit:

--- a/src/mpi/spawn/spawn_impl.c
+++ b/src/mpi/spawn/spawn_impl.c
@@ -239,6 +239,8 @@ int MPIR_Comm_disconnect_impl(MPIR_Comm * comm_ptr)
                 goto fn_fail;
             }
             /* --END ERROR HANDLING-- */
+
+            MPIR_Comm_free_inactive_requests(comm_ptr);
         }
         MPID_Progress_end(&progress_state);
     }

--- a/src/mpid/ch4/src/ch4_persist.c
+++ b/src/mpid/ch4/src/ch4_persist.c
@@ -28,6 +28,7 @@ static int psend_init(MPIDI_ptype ptype,
 
     MPIR_Comm_add_ref(comm);
     sreq->comm = comm;
+    MPIR_Comm_save_inactive_request(comm, sreq);
 
     MPIDI_PREQUEST(sreq, p_type) = ptype;
     MPIDI_PREQUEST(sreq, buffer) = (void *) buf;
@@ -145,6 +146,7 @@ int MPID_Recv_init(void *buf,
     *request = rreq;
     rreq->comm = comm;
     MPIR_Comm_add_ref(comm);
+    MPIR_Comm_save_inactive_request(comm, rreq);
 
     MPIDI_PREQUEST(rreq, buffer) = (void *) buf;
     MPIDI_PREQUEST(rreq, count) = count;

--- a/src/mpid/ch4/src/mpidig_part.c
+++ b/src/mpid/ch4/src/mpidig_part.c
@@ -22,6 +22,7 @@ static int part_req_create(void *buf, int partitions, MPI_Aint count,
 
     MPIR_Comm_add_ref(comm);
     req->comm = comm;
+    MPIR_Comm_save_inactive_request(comm, req);
 
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
 

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -217,6 +217,7 @@
 /comm/icm
 /comm/icsplit
 /comm/idup_with_info
+/comm/inactive_reqs
 /comm/probe_intercomm
 /comm/testlist
 /confdb

--- a/test/mpi/comm/Makefile.am
+++ b/test/mpi/comm/Makefile.am
@@ -44,4 +44,5 @@ noinst_PROGRAMS =     \
     comm_idup_comm2   \
     comm_create_group_idup \
     comm_info \
-    comm_info2
+    comm_info2 \
+    inactive_reqs

--- a/test/mpi/comm/inactive_reqs.c
+++ b/test/mpi/comm/inactive_reqs.c
@@ -1,0 +1,51 @@
+#include <stdlib.h>
+#include "mpitest.h"
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm comm;
+    MPI_Comm_dup(MPI_COMM_WORLD, &comm);
+
+    int rank;
+    int size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int dst = (rank + 1) % size;
+    int src = rank - 1 < 0 ? size - 1 : rank - 1;
+
+    /* started and freed request on MPI_COMM_WORLD */
+    MPI_Request request;
+    MPI_Send_init(NULL, 0, MPI_INT, dst, 0, MPI_COMM_WORLD, &request);
+    MPI_Start(&request);
+    MPI_Request_free(&request);
+
+    /* inactive request on MPI_COMM_SELF */
+    MPI_Send_init(NULL, 0, MPI_INT, 0, 0, MPI_COMM_SELF, &request);
+
+    /* freed request on user comm */
+    MPI_Send_init(NULL, 0, MPI_INT, dst, 0, comm, &request);
+    MPI_Request_free(&request);
+
+    /* started and completed request on MPI_COMM_WORLD */
+    MPI_Recv_init(NULL, 0, MPI_INT, src, 0, MPI_COMM_WORLD, &request);
+    MPI_Start(&request);
+    MPI_Wait(&request, MPI_STATUS_IGNORE);
+
+    /* inactive request on MPI_COMM_SELF */
+    MPI_Recv_init(NULL, 0, MPI_INT, 0, 0, MPI_COMM_SELF, &request);
+
+    /* inactive request on user comm */
+    MPI_Recv_init(NULL, 0, MPI_INT, src, 0, comm, &request);
+
+    /* inactive collective request on user comm */
+    MPI_Barrier_init(comm, MPI_INFO_NULL, &request);
+
+    MPI_Comm_disconnect(&comm);
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/comm/testlist.in
+++ b/test/mpi/comm/testlist.in
@@ -48,3 +48,4 @@ idup_with_info 8
 comm_info 6
 comm_info2 1
 comm_create_group_idup 4
+inactive_reqs 1


### PR DESCRIPTION
## Pull Request Description

See mpi-forum/mpi-issues#710 which proposes that MPI can/should free inactive requests at communicator destruction time (disconnect/finalize) since the user is not _required_ to do so.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
