### PR TITLE
ch3: fix MPIR_Get_node_id for intercomm

### DIFF
--- a/src/mpid/ch3/src/mpid_vc.c
+++ b/src/mpid/ch3/src/mpid_vc.c
@@ -804,7 +804,11 @@ char MPIU_hostname[MAX_HOSTNAME_LEN] = "_UNKNOWN_"; /* '_' is an illegal char fo
 
 int MPID_Get_node_id(MPIR_Comm *comm, int rank, int *id_p)
 {
-    *id_p = comm->dev.vcrt->vcr_table[rank]->node_id;
+    if (comm->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
+        *id_p = comm->dev.vcrt->vcr_table[rank]->node_id;
+    } else {
+        *id_p = comm->dev.local_vcrt->vcr_table[rank]->node_id;
+    }
     return MPI_SUCCESS;
 }
 


### PR DESCRIPTION
## Pull Request Description
Intercomm in ch3 uses comm->dev.local_vcrt rather than comm->dev.vcrt for local ranks.

Fixes #6515 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
