### PR TITLE
hydra/mpiexec: check empty command line and fail early

### DIFF
--- a/src/pm/hydra/mpiexec/mpiexec.c
+++ b/src/pm/hydra/mpiexec/mpiexec.c
@@ -44,6 +44,11 @@ int main(int argc, char **argv)
 
     PMISERV_pg_init();
 
+    if (argc == 1) {
+        HYDU_ERR_SETANDJUMP(status, HYD_INVALID_PARAM,
+                            "No executable provided. Try -h for usages.\n");
+    }
+
     /* Get user preferences */
     status = HYD_uii_mpx_get_parameters(argv);
     HYDU_ERR_POP(status, "error parsing parameters\n");


### PR DESCRIPTION

## Pull Request Description
Check empty command line and fail early rather than resulting in mysterious seg faults.

Fixes #6519 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
