### PR TITLE
ch4/ofi: Ignore errors when closing fabric

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -893,8 +893,10 @@ int MPIDI_OFI_mpi_finalize_hook(void)
     for (int nic = MPIDI_OFI_global.num_nics - 1; nic >= 0; nic--) {
         for (int vci = MPIDI_OFI_global.num_vcis - 1; vci >= 0; vci--) {
             if (MPIDI_global.is_initialized || (vci == 0 && nic == 0)) {
-                mpi_errno = destroy_vci_context(vci, nic);
-                MPIR_ERR_CHECK(mpi_errno);
+                /* If the user has not freed all MPI objects, ofi might not shut down cleanly.
+                 * We intentionally ignore errors to avoid crashing in finalize. Debug builds
+                 * will warn about unfreed objects/memory. */
+                (void) destroy_vci_context(vci, nic);
             }
         }
     }


### PR DESCRIPTION
## Pull Request Description

If applications do not free all MPI resources, then ofi may not shutdown cleanly. Ignore fi_close errors to avoid crashing. Debug builds will warn users about any unfreed resources.

This is a draft PR based on the discussion from https://github.com/mpi-forum/mpi-issues/issues/711. In it, the user does not free an RMA window, which causes MPICH to crash during finalize. The user believes that this should not result in a crash, since they have satisfied the requirements of the MPI library by completing all communication. Whether it is required to free all RMA windows is still being debated. This change will prevent the crash from happening during finalize.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
