### PR TITLE
mpl/gpu: Implement fast memcpy for ze backend (PR #5)

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -958,6 +958,8 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **gpu_get_buffer_info: gpu_get_buffer_info failed
 **gpu_get_dev_count: gpu_get_dev_count failed
 **mpl_ze_init_device_fds: mpl_ze_init_device_fds failed
+**mpl_ze_mmap_device_ptr:  MPL_ze_mmap_device_pointer failed
+**mpl_gpu_fast_memcpy:  MPL_gpu_fast_memcpy failed
 
 ## GAVL tree related error messages
 **mpl_gavl_search: mpl_gavl_search failed

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -344,6 +344,11 @@ typedef struct MPIDIG_win_shared_info {
     void *shm_base_addr;
     uint32_t disp_unit;
     int ipc_mapped_device;
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    MPIDI_IPCI_type_t ipc_type;
+    MPIDI_GPU_ipc_handle_t ipc_handle;
+#endif
+    int mapped_type;            /* 0: gpu ipc mapped 1: gpu host mmapped 2: xpmem */
 } MPIDIG_win_shared_info_t;
 
 #define MPIDIG_ACCU_ORDER_RAR (1)

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -57,7 +57,7 @@ static void ipc_handle_free_hook(void *dptr)
                 MPIR_Assert(mpl_err == MPL_SUCCESS);
             }
 
-            mpl_err = MPL_gpu_ipc_handle_destroy(pbase);
+            mpl_err = MPL_gpu_ipc_handle_destroy(pbase, &gpu_attr);
             MPIR_Assert(mpl_err == MPL_SUCCESS);
         }
     }

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
@@ -10,12 +10,15 @@
 int MPIDI_GPU_get_ipc_attr(const void *vaddr, int rank, MPIR_Comm * comm,
                            MPIDI_IPCI_ipc_attr_t * ipc_attr);
 int MPIDI_GPU_ipc_get_map_dev(int remote_global_dev_id, int local_dev_id, MPI_Datatype datatype);
-int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int map_dev_id, void **vaddr);
-int MPIDI_GPU_ipc_handle_unmap(void *vaddr, MPIDI_GPU_ipc_handle_t handle);
+int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int map_dev_id, void **vaddr,
+                             bool do_mmap);
+int MPIDI_GPU_ipc_handle_unmap(void *vaddr, MPIDI_GPU_ipc_handle_t handle, int do_mmap);
 int MPIDI_GPU_init_local(void);
 int MPIDI_GPU_init_world(void);
 int MPIDI_GPU_mpi_finalize_hook(void);
 int MPIDI_GPU_ipc_handle_cache_insert(int rank, MPIR_Comm * comm, MPIDI_GPU_ipc_handle_t handle);
+int MPIDI_GPU_ipc_fast_memcpy(MPIDI_IPCI_ipc_handle_t ipc_handle, void *dest_vaddr,
+                              MPI_Aint src_data_sz, MPI_Datatype datatype);
 
 typedef struct {
     int max_dev_id;

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -159,6 +159,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPC_hdr * ipc_hdr,
     int mpi_errno = MPI_SUCCESS;
     void *src_buf = NULL;
     uintptr_t data_sz, recv_data_sz;
+    bool dt_contig;
 
     MPIR_FUNC_ENTER;
 
@@ -184,20 +185,34 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPC_hdr * ipc_hdr,
         MPIR_ERR_CHECK(mpi_errno);
         /* skip unmap */
     } else if (ipc_hdr->ipc_type == MPIDI_IPCI_TYPE__GPU) {
-        MPL_pointer_attr_t attr;
-        MPIR_GPU_query_pointer_attr(MPIDIG_REQUEST(rreq, buffer), &attr);
-        int dev_id = MPL_gpu_get_dev_id_from_attr(&attr);
-        int map_dev = MPIDI_GPU_ipc_get_map_dev(ipc_hdr->ipc_handle.gpu.global_dev_id, dev_id,
-                                                MPIDIG_REQUEST(rreq, datatype));
-        mpi_errno = MPIDI_GPU_ipc_handle_map(ipc_hdr->ipc_handle.gpu, map_dev, &src_buf);
-        MPIR_ERR_CHECK(mpi_errno);
-        /* copy */
-        /* TODO: get sender datatype and call MPIR_Typerep_op with mapped_device set to dev_id */
-        mpi_errno = MPIDI_IPCI_copy_data(ipc_hdr, rreq, src_buf, src_data_sz);
-        MPIR_ERR_CHECK(mpi_errno);
-        /* unmap */
-        mpi_errno = MPIDI_GPU_ipc_handle_unmap(src_buf, ipc_hdr->ipc_handle.gpu);
-        MPIR_ERR_CHECK(mpi_errno);
+        /* try fast memcpy first */
+        int fast_copy = 0;
+        if (src_data_sz <= MPIR_CVAR_CH4_IPC_GPU_FAST_COPY_MAX_SIZE) {
+            MPIDI_Datatype_check_contig(MPIDIG_REQUEST(rreq, datatype), dt_contig);
+            if (ipc_hdr->is_contig && dt_contig) {
+                mpi_errno =
+                    MPIDI_GPU_ipc_fast_memcpy(ipc_hdr->ipc_handle, MPIDIG_REQUEST(rreq, buffer),
+                                              src_data_sz, MPIDIG_REQUEST(rreq, datatype));
+                if (mpi_errno == MPI_SUCCESS)
+                    fast_copy = 1;
+            }
+        }
+        if (!fast_copy) {
+            MPL_pointer_attr_t attr;
+            MPIR_GPU_query_pointer_attr(MPIDIG_REQUEST(rreq, buffer), &attr);
+            int dev_id = MPL_gpu_get_dev_id_from_attr(&attr);
+            int map_dev = MPIDI_GPU_ipc_get_map_dev(ipc_hdr->ipc_handle.gpu.global_dev_id, dev_id,
+                                                    MPIDIG_REQUEST(rreq, datatype));
+            mpi_errno = MPIDI_GPU_ipc_handle_map(ipc_hdr->ipc_handle.gpu, map_dev, &src_buf, false);
+            MPIR_ERR_CHECK(mpi_errno);
+            /* copy */
+            /* TODO: get sender datatype and call MPIR_Typerep_op with mapped_device set to dev_id */
+            mpi_errno = MPIDI_IPCI_copy_data(ipc_hdr, rreq, src_buf, src_data_sz);
+            MPIR_ERR_CHECK(mpi_errno);
+            /* unmap */
+            mpi_errno = MPIDI_GPU_ipc_handle_unmap(src_buf, ipc_hdr->ipc_handle.gpu, 0);
+            MPIR_ERR_CHECK(mpi_errno);
+        }
     } else if (ipc_hdr->ipc_type == MPIDI_IPCI_TYPE__NONE) {
         /* no-op */
     } else {

--- a/src/mpid/ch4/shm/ipc/src/ipc_win.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_win.c
@@ -173,7 +173,7 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
                                                                    MPI_BYTE);
                         mpi_errno = MPIDI_GPU_ipc_handle_map(ipc_shared_table[i].ipc_handle.gpu,
                                                              map_dev_id,
-                                                             &shared_table[i].shm_base_addr);
+                                                             &shared_table[i].shm_base_addr, false);
                         MPIR_ERR_CHECK(mpi_errno);
                         shared_table[i].ipc_mapped_device = map_dev_id;
                     }

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -158,6 +158,7 @@ AC_ARG_ENABLE(fast,
 # only alwaysinline option is valid but still need break down multiple options
 # transferred from MPICH separated by commas
 enable_fast_alwaysinline=no
+enable_fast_avx_instr=no
 save_IFS="$IFS"
 IFS=","
 for option in $enable_fast ; do
@@ -167,6 +168,9 @@ for option in $enable_fast ; do
         ;;
         all|yes)
         enable_fast_alwaysinline=yes
+        ;;
+        avx)
+        enable_fast_avx_instr=yes
         ;;
         *) # do not change default value (no) for other fast options
         ;;
@@ -602,6 +606,7 @@ AC_MSG_NOTICE([Timer type selected is $timer_type])
 AC_CHECK_HEADERS(sched.h)
 AC_CHECK_HEADERS(unistd.h)
 AC_CHECK_HEADERS(sys/select.h)
+AC_CHECK_HEADERS(x86intrin.h)
 AC_CHECK_FUNCS(sched_yield yield usleep sleep select)
 
 if test "$ac_cv_func_usleep" = "yes" ; then
@@ -1135,6 +1140,64 @@ if test "X${pac_have_ze}" = "Xyes" ; then
     AC_CHECK_LIB(dl, dlopen, [], AC_MSG_ERROR([dlopen not found.  MPL ZE support requires libdl.]))
 fi
 AM_CONDITIONAL([MPL_HAVE_ZE],[test "X${pac_have_ze}" = "Xyes"])
+
+if test "$enable_fast_avx_instr" = "yes" ; then
+    AC_CACHE_CHECK([whether -mavx512f is supported], pac_cv_found_avx512f,
+                   [PAC_C_CHECK_COMPILER_OPTION([-mavx512f],pac_cv_found_avx512f=yes,pac_cv_found_avx512f=no)],
+                   pac_cv_found_avx512f=no,pac_cv_found_avx512f=yes)
+    if test "$pac_cv_found_avx512f" = "yes" ; then
+        PAC_APPEND_FLAG([-mavx512f],[CFLAGS])
+
+        AC_CACHE_CHECK([whether _mm512_storeu_si512 is supported], pac_cv_found___mm512_storeu_si512,[
+                        AC_RUN_IFELSE([AC_LANG_SOURCE([[
+                                       #include <x86intrin.h>
+
+                                       int main(int argc, char **argv) {
+                                           char source[1024], dest[1024];
+                                           for (int i = 0; i < 1024; i++) source[i] = 'a';
+
+                                           _mm512_storeu_si512((__m512i *) dest, _mm512_loadu_si512((__m512i const *) source));
+
+                                           if (dest[0] == source[0]) return 0;
+                                           else return 1;
+                                       }
+                                       ]])], pac_cv_found___mm512_storeu_si512="yes",
+                                       pac_cv_found___mm512_storeu_si512="no",
+                                       pac_cv_found___mm512_storeu_si512="unknown")
+                        ])
+    fi
+    if test "$pac_cv_found___mm512_storeu_si512" = "yes" ; then
+        AC_DEFINE(HAVE_MM512_STOREU_SI512,1,[Define if avx512f is available])
+    fi
+
+    AC_CACHE_CHECK([whether -mavx is supported], pac_cv_found_avx,
+                   [PAC_C_CHECK_COMPILER_OPTION([-mavx],pac_cv_found_avx=yes,pac_cv_found_avx=no)],
+                   pac_cv_found_avx=no,pac_cv_found_avx=yes)
+    if test "$pac_cv_found_avx" = "yes" ; then
+        PAC_APPEND_FLAG([-mavx],[CFLAGS])
+
+        AC_CACHE_CHECK([whether _mm256_storeu_si256 is supported], pac_cv_found___mm256_storeu_si256,[
+                        AC_RUN_IFELSE([AC_LANG_SOURCE([[
+                                       #include <x86intrin.h>
+
+                                       int main(int argc, char **argv) {
+                                           char source[1024], dest[1024];
+                                           for (int i = 0; i < 1024; i++) source[i] = 'a';
+
+                                           _mm256_storeu_si256((__m256i *) dest, _mm256_loadu_si256((__m256i const *) source));
+
+                                           if (dest[0] == source[0]) return 0;
+                                           else return 1;
+                                       }
+                                       ]])], pac_cv_found___mm256_storeu_si256="yes",
+                                       pac_cv_found___mm256_storeu_si256="no",
+                                       pac_cv_found___mm256_storeu_si256="unknown")
+                        ])
+    fi
+    if test "$pac_cv_found___mm256_storeu_si256" = "yes" ; then
+        AC_DEFINE(HAVE_MM256_STOREU_SI256,1,[Define if avx is available])
+    fi
+fi
 
 
 # Check HIP availability

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -76,7 +76,7 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr);
 
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle);
 /* Used in ipc_handle_free_hook. Needed for fd-based ipc mechanism. */
-int MPL_gpu_ipc_handle_destroy(const void *ptr);
+int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr);
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr);
 int MPL_gpu_ipc_handle_unmap(void *ptr);
 

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -105,6 +105,9 @@ int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env);
 
 int MPL_gpu_init_device_mappings(int max_devid, int max_subdev_id);
 
+int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
+                        MPL_pointer_attr_t * dest_attr, size_t size);
+
 typedef void (*MPL_gpu_hostfn) (void *data);
 int MPL_gpu_launch_hostfn(MPL_gpu_stream_t stream, MPL_gpu_hostfn fn, void *data);
 bool MPL_gpu_stream_is_valid(MPL_gpu_stream_t stream);

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -30,5 +30,14 @@ typedef volatile int MPL_gpu_event_t;
 int MPL_ze_init_device_fds(int *num_fds, int *device_fds);
 void MPL_ze_set_fds(int num_fds, int *fds);
 void MPL_ze_ipc_remove_cache_handle(void *dptr);
+int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, int local_dev_id,
+                             int use_shared_fd, MPL_gpu_ipc_mem_handle_t * ipc_handle);
+int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_handle, int dev_id,
+                          int is_mmap, size_t size, void **ptr);
+int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int shared_handle, int dev_id,
+                                size_t size, void **ptr);
+int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,
+                               MPL_gpu_device_handle_t device, void **mmaped_ptr);
+int MPL_ze_mmap_handle_unmap(void *ptr, int dev_id);
 
 #endif /* ifndef MPL_GPU_ZE_H_INCLUDED */

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -146,7 +146,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     goto fn_exit;
 }
 
-int MPL_gpu_ipc_handle_destroy(const void *ptr)
+int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
 {
     return MPL_SUCCESS;
 }

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -493,6 +493,12 @@ cudaError_t CUDARTAPI cudaFree(void *dptr)
     return result;
 }
 
+int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
+                        MPL_pointer_attr_t * dest_attr, size_t size)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
 int MPL_gpu_launch_hostfn(cudaStream_t stream, MPL_gpu_hostfn fn, void *data)
 {
     cudaError_t result;

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -37,7 +37,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_ipc_handle_destroy(const void *ptr)
+int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
 {
     abort();
     return MPL_ERR_GPU_INTERNAL;

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -131,6 +131,12 @@ int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr))
     return MPL_SUCCESS;
 }
 
+int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
+                        MPL_pointer_attr_t * dest_attr, size_t size)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
 int MPL_gpu_launch_hostfn(int stream, MPL_gpu_hostfn fn, void *data)
 {
     return -1;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -442,6 +442,12 @@ hipError_t hipFree(void *dptr)
     return result;
 }
 
+int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
+                        MPL_pointer_attr_t * dest_attr, size_t size)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
 /* ---- */
 struct stream_callback_wrapper {
     MPL_gpu_hostfn fn;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -138,7 +138,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     goto fn_exit;
 }
 
-int MPL_gpu_ipc_handle_destroy(const void *ptr)
+int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
 {
     return MPL_SUCCESS;
 }

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -961,11 +961,9 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_ha
     goto fn_exit;
 }
 
-int MPL_gpu_ipc_handle_destroy(const void *ptr)
+int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
 {
-    ze_result_t ret;
     int status, mpl_err = MPL_SUCCESS;
-    ze_device_handle_t device;
     MPL_ze_ipc_handle_entry_t *cache_entry = NULL;
     int dev_id;
     uint64_t mem_id;
@@ -989,23 +987,12 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr)
     }
 
     if (likely(MPL_gpu_info.specialized_cache)) {
-        ze_memory_allocation_properties_t ptr_attr = {
-            .stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES,
-            .pNext = NULL,
-            .type = 0,
-            .id = 0,
-            .pageSize = 0,
-        };
-
-        ret = zeMemGetAllocProperties(ze_context, ptr, &ptr_attr, &device);
-        ZE_ERR_CHECK(ret);
-
-        dev_id = device_to_dev_id(device);
+        dev_id = device_to_dev_id(gpu_attr->device);
         if (dev_id == -1) {
             goto fn_fail;
         }
 
-        mem_id = ptr_attr.id;
+        mem_id = gpu_attr->device_attr.prop.id;
         HASH_FIND(hh, ipc_cache_tracked[dev_id], &mem_id, sizeof(uint64_t), cache_entry);
 
         if (cache_entry != NULL) {


### PR DESCRIPTION
## Pull Request Description

Implements a fast memcpy for small GPU buffers. The file descriptor (fd) from an IPC handle is used to map device memory in the host in order to perform vector copies on the host. This is enabled for SHM point-to-point and RMA paths and is beneficial for small messages (< 1 KB)

Depends on #6526

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
