### PR TITLE
confdb: Improve f08 support test

### DIFF
--- a/confdb/aclocal_fc.m4
+++ b/confdb/aclocal_fc.m4
@@ -1092,6 +1092,7 @@ int foo_c(CFI_cdesc_t * a_desc, CFI_cdesc_t * b_desc)
 
 void test_assumed_rank_async_impl_c(CFI_cdesc_t * a_desc)
 {
+	CFI_is_contiguous(a_desc);
 	return;
 }
 ]])],[mv conftest.$OBJEXT conftest1.$OBJEXT],[f08_works=no])


### PR DESCRIPTION
## Pull Request Description

Add a call to CFI_is_contiguous, which is needed by the f08 binding. Some compilers provide this prototype, but not the symbol, so we need to disable f08 if the test fails to link.

Fixes pmodels/mpich#6505

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
