### PR TITLE
test/coll: add test allred_float

### DIFF
--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -196,6 +196,16 @@ void MPIR_Datatype_get_flattened(MPI_Datatype type, void **flattened, int *flatt
         basic_type_ = MPI_DATATYPE_NULL;                            \
  } while (0)
 
+#define MPIR_Datatype_is_float(a, is_float) do { \
+    MPI_Datatype basic_type; \
+    MPIR_Datatype_get_basic_type(a, basic_type); \
+    if (basic_type == MPI_FLOAT || basic_type == MPI_DOUBLE) { \
+        is_float = true; \
+    } else { \
+        is_float = false; \
+    } \
+} while (0)
+
 #define MPIR_Datatype_get_ptr(a,ptr)   MPIR_Getb_ptr(Datatype,DATATYPE,a,0x000000ff,ptr)
 
 /* Note: Probably there is some clever way to build all of these from a macro.

--- a/src/mpi/coll/allreduce/allreduce_intra_recexch.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recexch.c
@@ -171,12 +171,6 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
 
 
     /* step2 */
-    if (!is_commutative && in_step2 && count > 0) {
-        /* sort the neighbor list so that receives can be posted in order */
-        for (phase = 0; phase < step2_nphases; phase++)
-            qsort(step2_nbrs[phase], k - 1, sizeof(int), MPII_Algo_compare_int);
-    }
-
     /* step2 sends and reduces */
     for (phase = 0; phase < step2_nphases && in_step2; phase++) {
         buf = 0;

--- a/test/mpi/coll/Makefile.am
+++ b/test/mpi/coll/Makefile.am
@@ -24,6 +24,7 @@ noinst_PROGRAMS =      \
     allred5            \
     allred6            \
     allred_derived     \
+    allred_float       \
     allredmany         \
     alltoall1          \
     alltoallv          \

--- a/test/mpi/coll/allred_float.c
+++ b/test/mpi/coll/allred_float.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpitest.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+/* MPI_Allreduce need produce identical results on all ranks. This is
+ * particular challenging for floating point datatypes since computer
+ * floating point arithmetic do not follow associative law. This means
+ * certain algorithms that works for integers need to be excluded for
+ * floating point.
+ *
+ * This test checks when an inapproprate algorithms is used for floating
+ * point reduction.
+ */
+
+/* single-precision float has roughly a precision of 7 decimal digits */
+#define BIG 1e6
+#define TINY 1e-2
+
+#define N 8
+
+float buf[N];
+
+static void init_buf(int rank, int pos1, int pos2)
+{
+    /* Mix a pair of (BIG, -BIG) and TINY, the sum of array will be the sum of
+     * all TINYs if we add (BIG, -BIG) first, but different results following
+     * different associativity. A valid algorithm need to produce consistent
+     * results on all ranks.
+     */
+    for (int i = 0; i < N; i++) {
+        if (rank == pos1) {
+            buf[i] = BIG;
+        } else if (rank == pos2) {
+            buf[i] = -BIG;
+        } else {
+            buf[i] = TINY;
+        }
+    }
+}
+
+int main(int argc, char **argv)
+{
+    int errs = 0;
+
+    MTest_Init(&argc, &argv);
+
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (size < 3) {
+        printf("At least 3 processes required. More (e.g. 10) is recommended.\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    for (int pos1 = 0; pos1 < size; pos1++) {
+        for (int pos2 = pos1 + 1; pos2 < size; pos2++) {
+            init_buf(rank, pos1, pos2);
+
+            MPI_Allreduce(MPI_IN_PLACE, buf, N, MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
+
+            float *check_buf;
+            if (rank == 0) {
+                check_buf = malloc(N * size * sizeof(float));
+            }
+            MPI_Gather(buf, N, MPI_FLOAT, check_buf, N, MPI_FLOAT, 0, MPI_COMM_WORLD);
+
+            if (rank == 0) {
+                MTestPrintfMsg(1, "BIG positions = (%d, %d), result = [", pos1, pos2);
+                for (int j = 0; j < N; j++) {
+                    MTestPrintfMsg(1, "%f ", buf[j]);
+                }
+                MTestPrintfMsg(1, "]\n");
+
+                for (int i = 0; i < size; i++) {
+                    for (int j = 0; j < N; j++) {
+                        if (memcmp(&check_buf[i * N + j], &buf[j], sizeof(float)) != 0) {
+                            if (errs < 10) {
+                                printf("(%d - %d) Result [%d] from rank %d mismatch: %f != %f\n",
+                                       pos1, pos2, j, i, check_buf[i * N + j], buf[j]);
+                            }
+                            errs++;
+                        }
+                    }
+                }
+                free(check_buf);
+            }
+        }
+    }
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/coll/testlist.in
+++ b/test/mpi/coll/testlist.in
@@ -10,6 +10,7 @@ allred5 10
 allred6 4
 allred6 7
 allred_derived 4
+allred_float 10
 reduce 5
 reduce 10
 reduce_local 2

--- a/test/mpi/maint/coll_cvars.txt
+++ b/test/mpi/maint/coll_cvars.txt
@@ -57,6 +57,7 @@ tests:
             allred5 5
             allred6 4
             allred6 7
+            allred_float 10
         persistent:
             p_allred 7
     alltoall:


### PR DESCRIPTION
## Pull Request Description

This test checks whether MPI_Allreduce produce identical results on all
ranks with floating point datatype.

The current `recexch` algorithm fails because it does reduction within the k-group as
```
((0 + (1 + [2])) + 3))
```
or
```
(((0 + [1]) + 2) + 3)
```
, where `[ ]` indicates the local rank positions. Thus, different ranks are doing the reduction with different associativity.

This is fixable.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
