### PR TITLE
ch4/coll: Fix reduce composition alpha with non-zero root

### DIFF
--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -576,7 +576,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_alpha(const void *se
     MPI_Aint true_lb = 0;
     MPI_Aint true_extent = 0;
     MPI_Aint extent = 0;
-    const void *inter_sendbuf;
+    const void *intra_sendbuf, *inter_sendbuf;
     void *ori_recvbuf = recvbuf;
 
     MPIR_CHKLMEM_DECL(1);
@@ -594,14 +594,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_alpha(const void *se
         recvbuf = (void *) ((char *) recvbuf - true_lb);
     }
 
+    /* non-zero root needs to send from recvbuf if using MPI_IN_PLACE  */
+    intra_sendbuf = (sendbuf == MPI_IN_PLACE && root != 0) ? recvbuf : sendbuf;
+
     /* intranode reduce on all nodes */
     if (comm->node_comm != NULL) {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-        coll_ret = MPIDI_SHM_mpi_reduce(sendbuf, recvbuf, count, datatype, op, 0, comm->node_comm,
-                                        errflag);
+        coll_ret =
+            MPIDI_SHM_mpi_reduce(intra_sendbuf, recvbuf, count, datatype, op, 0, comm->node_comm,
+                                 errflag);
 #else
-        coll_ret = MPIDI_NM_mpi_reduce(sendbuf, recvbuf, count, datatype, op, 0, comm->node_comm,
-                                       errflag);
+        coll_ret =
+            MPIDI_NM_mpi_reduce(intra_sendbuf, recvbuf, count, datatype, op, 0, comm->node_comm,
+                                errflag);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
 
         MPIR_ERR_COLL_CHECKANDCONT(coll_ret, errflag, mpi_errno);


### PR DESCRIPTION
## Pull Request Description

We need to handle the case where a non-zero root uses
MPI_IN_PLACE. Otherwise we could try reading from a bad address and
crash. Fixes https://github.com/pmodels/mpich/issues/6540.

NOTE: For single node reduce operation with non-zero root, this
composition incurs an unnecessary extra copy.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
