### PR TITLE
errhan: Add error message for canceling inactive persistent request

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -112,6 +112,7 @@ also the value at index %d
  deferred because of resource limits is not implemented
 **notgenreq:Attempt to complete a request with MPI_GREQUEST_COMPLETE that \
 was not started with MPI_GREQUEST_START
+**cancelinactive:Attempt to cancel an inactive persistent request
 **cancelunknown:Attempt to cancel an unknown type of request
 **permop:Cannot free permanent MPI_Op 
 **attrsentinal:Internal fields in an attribute have been overwritten; \

--- a/src/mpi/request/request_impl.c
+++ b/src/mpi/request/request_impl.c
@@ -82,7 +82,7 @@ int MPIR_Cancel_impl(MPIR_Request * request_ptr)
                     mpi_errno = MPID_Cancel_send(request_ptr->u.persist.real_request);
                     MPIR_ERR_CHECK(mpi_errno);
                 } else {
-                    MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_REQUEST, "**requestpersistactive");
+                    MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_REQUEST, "**cancelinactive");
                 }
                 break;
             }
@@ -93,7 +93,7 @@ int MPIR_Cancel_impl(MPIR_Request * request_ptr)
                     mpi_errno = MPID_Cancel_recv(request_ptr->u.persist.real_request);
                     MPIR_ERR_CHECK(mpi_errno);
                 } else {
-                    MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_REQUEST, "**requestpersistactive");
+                    MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_REQUEST, "**cancelinactive");
                 }
                 break;
             }


### PR DESCRIPTION
## Pull Request Description

Return an accurate error message to the user when they try to cancel an inactive persistent send or recv request. Closes pmodels/mpich#6542.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
