### PR TITLE
ch4/coll: Use type extent in fallback check for reduce/allreduce

### DIFF
--- a/src/mpid/ch4/shm/posix/posix_coll_release_gather.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_release_gather.h
@@ -78,12 +78,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
     MPIR_Datatype_is_contig(datatype, &is_contig);
-
-    if (is_contig) {
-        MPIR_Datatype_get_size_macro(datatype, type_size);
-    } else {
-        MPIR_Pack_size(1, datatype, &type_size);
-    }
+    MPIR_Datatype_get_size_macro(datatype, type_size);
 
     if (!is_contig || type_size >= MPIDI_POSIX_RELEASE_GATHER_BCAST_CELLSIZE) {
         /* Convert to MPI_BYTE datatype */
@@ -178,7 +173,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
     int i;
     MPI_Aint num_chunks, chunk_size_floor, chunk_size_ceil;
     MPI_Aint offset = 0;
-    int is_contig;
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
     MPI_Aint lb, true_extent, extent, type_size;
 
@@ -216,13 +210,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
     MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);
     extent = MPL_MAX(extent, true_extent);
 
-    MPIR_Datatype_is_contig(datatype, &is_contig);
-
-    if (is_contig) {
-        MPIR_Datatype_get_size_macro(datatype, type_size);
-    } else {
-        MPIR_Pack_size(1, datatype, &type_size);
-    }
+    MPIR_Datatype_get_size_macro(datatype, type_size);
 
     if (sendbuf == MPI_IN_PLACE) {
         sendbuf = recvbuf;
@@ -280,7 +268,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
     int i;
     MPI_Aint num_chunks, chunk_size_floor, chunk_size_ceil;
     MPI_Aint offset = 0;
-    int is_contig;
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
     MPI_Aint lb, true_extent, extent, type_size;
 
@@ -313,13 +300,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
     MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);
     extent = MPL_MAX(extent, true_extent);
 
-    MPIR_Datatype_is_contig(datatype, &is_contig);
-
-    if (is_contig) {
-        MPIR_Datatype_get_size_macro(datatype, type_size);
-    } else {
-        MPIR_Pack_size(1, datatype, &type_size);
-    }
+    MPIR_Datatype_get_size_macro(datatype, type_size);
 
     if (sendbuf == MPI_IN_PLACE) {
         sendbuf = recvbuf;

--- a/src/mpid/ch4/src/ch4_coll.h
+++ b/src/mpid/ch4/src/ch4_coll.h
@@ -409,9 +409,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *sendbuf, void *recvbuf, 
     is_commutative = MPIR_Op_is_commutative(op);
 
     /* FIXME: this fallback check assumes device algorithms are limited by release gather shm cell size */
-    MPI_Aint dt_size;
+    MPI_Aint dt_size, lb, extent, true_extent;
     MPIR_Datatype_get_size_macro(datatype, dt_size);
-    if (dt_size >=
+    MPIR_Type_get_extent_impl(datatype, &lb, &extent);
+    MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);
+    extent = MPL_MAX(extent, true_extent);
+    if (MPL_MAX(dt_size, extent) >=
         MPIR_CVAR_REDUCE_INTRANODE_BUFFER_TOTAL_SIZE / MPIR_CVAR_REDUCE_INTRANODE_NUM_CELLS) {
         goto fallback;
     }
@@ -1263,9 +1266,12 @@ MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *sendbuf, void *recvbuf,
     MPIR_FUNC_ENTER;
 
     /* FIXME: this fallback check assumes device algorithms are limited by release gather shm cell size */
-    MPI_Aint dt_size;
+    MPI_Aint dt_size, lb, extent, true_extent;
     MPIR_Datatype_get_size_macro(datatype, dt_size);
-    if (dt_size >=
+    MPIR_Type_get_extent_impl(datatype, &lb, &extent);
+    MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);
+    extent = MPL_MAX(extent, true_extent);
+    if (MPL_MAX(dt_size, extent) >=
         MPIR_CVAR_REDUCE_INTRANODE_BUFFER_TOTAL_SIZE / MPIR_CVAR_REDUCE_INTRANODE_NUM_CELLS) {
         goto fallback;
     }


### PR DESCRIPTION
## Pull Request Description

In release_gather implementations for reduce and allreduce, data is not
packed because we need to apply an operation to it. We need to fallback
when the extent is larger than the cell size. Fixes https://github.com/pmodels/mpich/issues/6550.

TODO: pack reduction data in terms of basic type when possible. This
should make most noncontig reductions more efficient and utilize
release_gather collectives in more scenarios.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
