### PR TITLE
datatype: MPI_Type_get_envelope to use MPI_ERR_TYPE

### DIFF
--- a/src/mpi/datatype/type_contents.c
+++ b/src/mpi/datatype/type_contents.c
@@ -44,7 +44,7 @@ int MPIR_Type_get_contents_impl(MPI_Datatype datatype, int max_integers, int max
 
     if (cp->nr_counts > 0) {
         mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                         __func__, __LINE__, MPI_ERR_OTHER,
+                                         __func__, __LINE__, MPI_ERR_TYPE,
                                          "**need_get_contents_c", 0);
         return mpi_errno;
     }
@@ -146,7 +146,7 @@ int MPIR_Type_get_envelope_impl(MPI_Datatype datatype,
 
     if (nr_counts > 0) {
         mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                         __func__, __LINE__, MPI_ERR_OTHER,
+                                         __func__, __LINE__, MPI_ERR_TYPE,
                                          "**need_get_envelope_c", 0);
         return mpi_errno;
     }


### PR DESCRIPTION
## Pull Request Description
When MPI_Type_get_envelope is used to query a datatype created using large count type-creation routines, we should return MPI_ERR_TYPE according to the standard.

Fixes #6548
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
