### PR TITLE
stream: shared reserved vcis needs locking

### DIFF
--- a/src/mpi/stream/stream_impl.c
+++ b/src/mpi/stream/stream_impl.c
@@ -16,13 +16,13 @@ static int allocate_vci(int *vci, bool is_gpu_stream)
     if (is_gpu_stream) {
         int mpi_errno = MPI_SUCCESS;
         if (!gpu_stream_vci) {
-            mpi_errno = MPID_Allocate_vci(&gpu_stream_vci);
+            mpi_errno = MPID_Allocate_vci(&gpu_stream_vci, true);       /* shared */
         }
         gpu_stream_count++;
         *vci = gpu_stream_vci;
         return mpi_errno;
     } else {
-        return MPID_Allocate_vci(vci);
+        return MPID_Allocate_vci(vci, false);   /* not shared */
     }
 }
 
@@ -44,7 +44,8 @@ static int deallocate_vci(int vci)
 #else
 static int allocate_vci(int *vci, bool is_gpu_stream)
 {
-    return MPID_Allocate_vci(vci);
+    /* TODO: need make sure the gpu enqueue path is thread-safe */
+    return MPID_Allocate_vci(vci, false);
 }
 
 static int deallocate_vci(int *vci)

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -532,7 +532,7 @@ int MPID_Init(int required, int *provided);
 
 int MPID_InitCompleted( void );
 
-int MPID_Allocate_vci(int *vci);
+int MPID_Allocate_vci(int *vci, bool is_shared);
 int MPID_Deallocate_vci(int vci);
 
 int MPID_Finalize(void);

--- a/src/mpid/ch3/src/mpid_init.c
+++ b/src/mpid/ch3/src/mpid_init.c
@@ -265,7 +265,7 @@ int MPID_InitCompleted( void )
     /* --END ERROR HANDLING-- */
 }
 
-int MPID_Allocate_vci(int *vci)
+int MPID_Allocate_vci(int *vci, bool is_shared)
 {
     int mpi_errno = MPI_SUCCESS;
     *vci = 0;

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -14,7 +14,7 @@
 
 int MPID_Init(int, int *);
 int MPID_InitCompleted(void);
-int MPID_Allocate_vci(int *vci);
+int MPID_Allocate_vci(int *vci, bool is_shared);
 int MPID_Deallocate_vci(int vci);
 MPL_STATIC_INLINE_PREFIX int MPID_Cancel_recv(MPIR_Request *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Cancel_send(MPIR_Request *) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -467,6 +467,7 @@ int MPID_Init(int requested, int *provided)
     MPIDI_global.n_vcis = MPIR_CVAR_CH4_NUM_VCIS;
     MPIDI_global.n_total_vcis = MPIDI_global.n_vcis + MPIR_CVAR_CH4_RESERVE_VCIS;
     MPIDI_global.n_reserved_vcis = 0;
+    MPIDI_global.share_reserved_vcis = false;
 
     MPIR_Assert(MPIDI_global.n_total_vcis <= MPIDI_CH4_MAX_VCIS);
     MPIR_Assert(MPIDI_global.n_total_vcis <= MPIR_REQUEST_NUM_POOLS);
@@ -577,7 +578,7 @@ int MPID_InitCompleted(void)
     goto fn_exit;
 }
 
-int MPID_Allocate_vci(int *vci)
+int MPID_Allocate_vci(int *vci, bool is_shared)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -599,6 +600,9 @@ int MPID_Allocate_vci(int *vci)
         }
     }
 #endif
+    if (is_shared) {
+        MPIDI_global.share_reserved_vcis = true;
+    }
     return mpi_errno;
 }
 

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -277,6 +277,7 @@ typedef struct MPIDI_CH4_Global_t {
     int n_vcis;                 /* num of vcis used for implicit hashing */
     int n_reserved_vcis;        /* num of reserved vcis */
     int n_total_vcis;           /* total num of vcis, must > n_vcis + n_reserved_vcis */
+    bool share_reserved_vcis;   /* default false, skip locking for explicit vcis */
     MPIDI_per_vci_t per_vci[MPIDI_CH4_MAX_VCIS];
 
     MPIDI_CH4_configurations_t settings;

--- a/src/mpid/ch4/src/ch4_vci.h
+++ b/src/mpid/ch4/src/ch4_vci.h
@@ -42,7 +42,7 @@
 /* vci above implicit vci pool are always explciitly allocated by user. It is
  * always under serial execution context and we can skip thread synchronizations.
  */
-#define MPIDI_VCI_IS_EXPLICIT(vci) (vci >= MPIDI_global.n_vcis)
+#define MPIDI_VCI_IS_EXPLICIT(vci) (!MPIDI_global.share_reserved_vcis && (vci) >= MPIDI_global.n_vcis)
 
 /* VCI hashing function (fast path) */
 


### PR DESCRIPTION
## Pull Request Description
Add the mechanism to allow reserved vcis to be shared. This is the case for gpu-backed streams. Shared vcis cannot skip locking.

GPU-backed stream will inccur threads callback from e.g. CUDA runtime threads, thus we may always need locking. We simply switch off a global flag and disable lock-skipping for all reserved vcis in this PR. This should be improved in the future. An alternative strategy is to add separte locking inside src/mpi/stream/stream_enqueue.c.

Also notes for GPU stream applications:
1. Use `MPI_THREAD_MULTIPLE`. At least GPU runtime will use background thread, thus require thread multiple.
2. Call `cudaStreamSynchronize` before `MPI_Finalize`. We need ensure all communications are complete before `MPI_Finalize`.

Fixes #6528 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
