### PR TITLE
hydra: reuse the same proxy for spawn

### DIFF
--- a/src/pm/hydra/lib/hydra.h
+++ b/src/pm/hydra/lib/hydra.h
@@ -317,6 +317,8 @@ struct HYD_node {
     int active_processes;
 
     int node_id;
+    int control_fd;
+    int control_fd_refcnt;
 
     /* Username */
     char *user;

--- a/src/pm/hydra/lib/hydra.h
+++ b/src/pm/hydra/lib/hydra.h
@@ -565,7 +565,7 @@ void HYDU_sock_finalize(void);
 HYD_status HYDU_sock_get_iface_ip(char *iface, char **ip);
 HYD_status
 HYDU_sock_create_and_listen_portstr(char *iface, char *hostname, char *port_range,
-                                    char **port_str,
+                                    char **port_str, int *listenfd,
                                     HYD_status(*callback) (int fd, HYD_event_t events,
                                                            void *userp), void *userp);
 HYD_status HYDU_sock_cloexec(int fd);

--- a/src/pm/hydra/lib/pmiserv_common.h
+++ b/src/pm/hydra/lib/pmiserv_common.h
@@ -30,6 +30,7 @@ struct HYD_pmcd_pmi_kvs {
 /* init header proxy send to server upon connection */
 struct HYD_pmcd_init_hdr {
     char signature[4]; /* HYD\0 */ ;
+    int pgid;
     int proxy_id;
 };
 

--- a/src/pm/hydra/lib/tools/topo/topo.c
+++ b/src/pm/hydra/lib/tools/topo/topo.c
@@ -14,10 +14,9 @@ struct HYDT_topo_info HYDT_topo_info = {.topolib = NULL,.debug = -1 };
 
 static int ignore_binding = 0;
 
-HYD_status HYDT_topo_init(char *user_topolib, char *user_binding, char *user_mapping,
-                          char *user_membind)
+HYD_status HYDT_topo_init(char *user_topolib)
 {
-    const char *topolib = NULL, *binding = NULL, *mapping = NULL, *membind = NULL;
+    const char *topolib = NULL;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
@@ -33,6 +32,17 @@ HYD_status HYDT_topo_init(char *user_topolib, char *user_binding, char *user_map
     } else {
         HYDT_topo_info.topolib = NULL;
     }
+
+    HYDU_FUNC_EXIT();
+    return status;
+}
+
+HYD_status HYDT_topo_set(char *user_binding, char *user_mapping, char *user_membind)
+{
+    const char *binding = NULL, *mapping = NULL, *membind = NULL;
+    HYD_status status = HYD_SUCCESS;
+
+    HYDU_FUNC_ENTER();
 
     if (user_binding)
         binding = user_binding;
@@ -56,12 +66,15 @@ HYD_status HYDT_topo_init(char *user_topolib, char *user_binding, char *user_map
 
     /* Reaching here means that user specified some binding */
     setenv("HYDRA_USER_PROVIDED_BINDING", "1", 1);
-    /* Initialize the topology library requested by the user */
+
+    /* Apply the bindings requested by the user */
 #if defined HAVE_HWLOC
     if (!strcmp(HYDT_topo_info.topolib, "hwloc")) {
         status = HYDT_topo_hwloc_init(binding, mapping, membind);
         HYDU_ERR_POP(status, "unable to initialize hwloc\n");
     }
+#else
+    HYDU_ERR_POP(status, "dummy check to suppress label warnings.\n");
 #endif /* HAVE_HWLOC */
 
   fn_exit:

--- a/src/pm/hydra/lib/tools/topo/topo.c
+++ b/src/pm/hydra/lib/tools/topo/topo.c
@@ -10,11 +10,11 @@
 #include "hwloc/topo_hwloc.h"
 #endif /* HAVE_HWLOC */
 
-struct HYDT_topo_info HYDT_topo_info = {.topolib = NULL,.debug = -1 };
+struct HYDT_topo_info HYDT_topo_info;
 
 static int ignore_binding = 0;
 
-HYD_status HYDT_topo_init(char *user_topolib)
+HYD_status HYDT_topo_init(char *user_topolib, int topo_debug)
 {
     const char *topolib = NULL;
     HYD_status status = HYD_SUCCESS;
@@ -32,6 +32,8 @@ HYD_status HYDT_topo_init(char *user_topolib)
     } else {
         HYDT_topo_info.topolib = NULL;
     }
+
+    HYDT_topo_info.debug = topo_debug;
 
     HYDU_FUNC_EXIT();
     return status;

--- a/src/pm/hydra/lib/tools/topo/topo.h
+++ b/src/pm/hydra/lib/tools/topo/topo.h
@@ -35,14 +35,23 @@ extern struct HYDT_topo_info HYDT_topo_info;
  * \brief HYDT_topo_init - Initialize the topology library
  *
  * \param[in]  topolib   Topology library to use
- * \param[in]  binding   Binding pattern to use
- * \param[in]  mapping   Mapping pattern to use
  *
  * This function initializes the topology library requested by the
  * user. It also queries for the support provided by the library and
  * stores it for future calls.
  */
-HYD_status HYDT_topo_init(char *topolib, char *binding, char *mapping, char *membind);
+HYD_status HYDT_topo_init(char *topolib);
+
+/**
+ * \brief HYDT_topo_set - Set the topology bindings
+ *
+ * \param[in]  binding   Binding pattern to use
+ * \param[in]  mapping   Mapping pattern to use
+ * \param[in]  membind   Memory binding pattern to use
+ *
+ * This function applies the topology bindings.
+ */
+HYD_status HYDT_topo_set(char *binding, char *mapping, char *membind);
 
 
 /**

--- a/src/pm/hydra/lib/tools/topo/topo.h
+++ b/src/pm/hydra/lib/tools/topo/topo.h
@@ -34,13 +34,14 @@ extern struct HYDT_topo_info HYDT_topo_info;
 /**
  * \brief HYDT_topo_init - Initialize the topology library
  *
- * \param[in]  topolib   Topology library to use
+ * \param[in]  topolib        Topology library to use
+ * \param[in]  topo_debug     Enable debugging output
  *
  * This function initializes the topology library requested by the
  * user. It also queries for the support provided by the library and
  * stores it for future calls.
  */
-HYD_status HYDT_topo_init(char *topolib);
+HYD_status HYDT_topo_init(char *topolib, int topo_debug);
 
 /**
  * \brief HYDT_topo_set - Set the topology bindings

--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -77,6 +77,8 @@ HYD_status HYDU_alloc_node(struct HYD_node **node)
     (*node)->core_count = 0;
     (*node)->active_processes = 0;
     (*node)->node_id = -1;
+    (*node)->control_fd = -1;
+    (*node)->control_fd_refcnt = 0;
     (*node)->user = NULL;
     (*node)->local_binding = NULL;
     (*node)->next = NULL;

--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -13,13 +13,11 @@ void HYDU_init_user_global(struct HYD_user_global *user_global)
 
     user_global->binding = NULL;
     user_global->topolib = NULL;
-    user_global->topo_debug = -1;
 
     user_global->demux = NULL;
     user_global->iface = NULL;
 
     user_global->enablex = -1;
-    user_global->debug = -1;
     user_global->usize = HYD_USIZE_UNSET;
 
     user_global->auto_cleanup = -1;

--- a/src/pm/hydra/lib/utils/args.c
+++ b/src/pm/hydra/lib/utils/args.c
@@ -213,7 +213,8 @@ HYD_status HYDU_set_int(char *arg, int *var, int val)
 {
     HYD_status status = HYD_SUCCESS;
 
-    HYDU_ERR_CHKANDJUMP(status, *var != -1, HYD_INTERNAL_ERROR, "duplicate setting: %s\n", arg);
+    HYDU_ERR_CHKANDJUMP(status, *var != -1 &&
+                        *var != val, HYD_INTERNAL_ERROR, "duplicate setting: %s\n", arg);
 
     *var = val;
 

--- a/src/pm/hydra/mpiexec/get_parameters.c
+++ b/src/pm/hydra/mpiexec/get_parameters.c
@@ -182,12 +182,6 @@ static void set_default_values(void)
     if (HYD_server_info.enable_profiling == -1)
         HYD_server_info.enable_profiling = 0;
 
-    if (HYD_server_info.user_global.debug == -1)
-        HYD_server_info.user_global.debug = 0;
-
-    if (HYD_server_info.user_global.topo_debug == -1)
-        HYD_server_info.user_global.topo_debug = 0;
-
     if (HYD_server_info.user_global.auto_cleanup == -1)
         HYD_server_info.user_global.auto_cleanup = 1;
 
@@ -223,10 +217,10 @@ static HYD_status check_environment(void)
     char *tmp;
     HYD_status status = HYD_SUCCESS;
 
-    if (HYD_server_info.user_global.debug == -1)
+    if (!HYD_server_info.user_global.debug)
         ENV2BOOL("HYDRA_DEBUG", &HYD_server_info.user_global.debug);
 
-    if (HYD_server_info.user_global.topo_debug == -1)
+    if (!HYD_server_info.user_global.topo_debug)
         ENV2BOOL("HYDRA_TOPO_DEBUG", &HYD_server_info.user_global.topo_debug);
 
     /* don't clobber existing iface values from the command line */

--- a/src/pm/hydra/mpiexec/hydra_server.h
+++ b/src/pm/hydra/mpiexec/hydra_server.h
@@ -49,6 +49,9 @@ struct HYD_server_info_s {
     char *localhost;
     char *rankmap;
     time_t time_start;
+    /* for proxies to connect back */
+    char *control_port;
+    int control_listen_fd;
 
     bool is_singleton;
     int singleton_port;

--- a/src/pm/hydra/mpiexec/options.c
+++ b/src/pm/hydra/mpiexec/options.c
@@ -1136,21 +1136,8 @@ static void verbose_help_fn(void)
 
 static HYD_status verbose_fn(char *arg, char ***argv)
 {
-    HYD_status status = HYD_SUCCESS;
-
-    if (HYD_ui_mpich_info.reading_config_file && HYD_server_info.user_global.debug != -1) {
-        /* global variable already set; ignore */
-        goto fn_exit;
-    }
-
-    status = HYDU_set_int(arg, &HYD_server_info.user_global.debug, 1);
-    HYDU_ERR_POP(status, "error setting debug\n");
-
-  fn_exit:
-    return status;
-
-  fn_fail:
-    goto fn_exit;
+    HYD_server_info.user_global.debug = 1;
+    return HYD_SUCCESS;
 }
 
 static void info_help_fn(void)

--- a/src/pm/hydra/mpiexec/pmiserv.h
+++ b/src/pm/hydra/mpiexec/pmiserv.h
@@ -13,5 +13,6 @@ HYD_status HYD_pmcd_pmiserv_control_listen_cb(int fd, HYD_event_t events, void *
 HYD_status HYD_pmcd_pmiserv_cleanup_all_pgs(void);
 HYD_status HYD_pmcd_pmiserv_send_signal(struct HYD_proxy *proxy, int signum);
 HYD_status HYD_control_listen(void);
+HYD_status HYD_send_exec_info(struct HYD_proxy *proxy);
 
 #endif /* PMISERV_H_INCLUDED */

--- a/src/pm/hydra/mpiexec/pmiserv.h
+++ b/src/pm/hydra/mpiexec/pmiserv.h
@@ -12,5 +12,6 @@ HYD_status HYD_pmcd_pmiserv_proxy_init_cb(int fd, HYD_event_t events, void *user
 HYD_status HYD_pmcd_pmiserv_control_listen_cb(int fd, HYD_event_t events, void *userp);
 HYD_status HYD_pmcd_pmiserv_cleanup_all_pgs(void);
 HYD_status HYD_pmcd_pmiserv_send_signal(struct HYD_proxy *proxy, int signum);
+HYD_status HYD_control_listen(void);
 
 #endif /* PMISERV_H_INCLUDED */

--- a/src/pm/hydra/mpiexec/pmiserv_cb.c
+++ b/src/pm/hydra/mpiexec/pmiserv_cb.c
@@ -557,23 +557,10 @@ HYD_status HYD_pmcd_pmiserv_proxy_init_cb(int fd, HYD_event_t events, void *user
 
 HYD_status HYD_pmcd_pmiserv_control_listen_cb(int fd, HYD_event_t events, void *userp)
 {
-    int accept_fd = -1, pgid;
-    struct HYD_pg *pg;
-    struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
+    int accept_fd = -1;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
-
-    /* Get the PGID of the connection */
-    pgid = ((int) (size_t) userp);
-
-    /* Find the process group */
-    pg = PMISERV_pg_by_id(pgid);
-    if (!pg)
-        HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR, "could not find pg with ID %d\n", pgid);
-
-    pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) pg->pg_scratch;
-    pg_scratch->control_listen_fd = fd;
 
     /* We got a control socket connection */
     status = HYDU_sock_accept(fd, &accept_fd);

--- a/src/pm/hydra/mpiexec/pmiserv_cb.c
+++ b/src/pm/hydra/mpiexec/pmiserv_cb.c
@@ -504,6 +504,7 @@ HYD_status HYD_pmcd_pmiserv_proxy_init_cb(int fd, HYD_event_t events, void *user
         close(fd);
         goto fn_exit;
     }
+    HYDU_ASSERT(pgid == init_hdr.pgid, status);
     proxy_id = init_hdr.proxy_id;
 
     /* Find the process group */

--- a/src/pm/hydra/mpiexec/pmiserv_cb.c
+++ b/src/pm/hydra/mpiexec/pmiserv_cb.c
@@ -508,6 +508,8 @@ HYD_status HYD_pmcd_pmiserv_proxy_init_cb(int fd, HYD_event_t events, void *user
     proxy = &pg->proxy_list[proxy_id];
 
     /* This will be the control socket for this proxy */
+    HYDU_ASSERT(proxy->node->control_fd == -1, status);
+    proxy->node->control_fd = fd;
     proxy->control_fd = fd;
 
     /* Send out the executable information */

--- a/src/pm/hydra/mpiexec/pmiserv_pmci.c
+++ b/src/pm/hydra/mpiexec/pmiserv_pmci.c
@@ -99,7 +99,7 @@ HYD_status HYD_pmci_launch_procs(void)
                                                  HYD_server_info.localhost,
                                                  HYD_server_info.port_range, &control_port,
                                                  HYD_pmcd_pmiserv_control_listen_cb,
-                                                 (void *) (size_t) 0);
+                                                 (void *) (size_t) pgid);
     HYDU_ERR_POP(status, "unable to create PMI port\n");
     if (HYD_server_info.user_global.debug)
         HYDU_dump(stdout, "Got a control port string of %s\n", control_port);
@@ -124,7 +124,7 @@ HYD_status HYD_pmci_launch_procs(void)
         if (control_fd[i] != HYD_FD_UNSET) {
             pg->proxy_list[i].control_fd = control_fd[i];
 
-            status = HYDT_dmx_register_fd(1, &control_fd[i], HYD_POLLIN, (void *) (size_t) 0,
+            status = HYDT_dmx_register_fd(1, &control_fd[i], HYD_POLLIN, (void *) (size_t) pgid,
                                           HYD_pmcd_pmiserv_proxy_init_cb);
             HYDU_ERR_POP(status, "unable to register fd\n");
         }

--- a/src/pm/hydra/mpiexec/pmiserv_pmci.c
+++ b/src/pm/hydra/mpiexec/pmiserv_pmci.c
@@ -75,7 +75,6 @@ static HYD_status ui_cmd_cb(int fd, HYD_event_t events, void *userp)
 HYD_status HYD_pmci_launch_procs(void)
 {
     struct HYD_string_stash proxy_stash;
-    char *control_port = NULL;
     int node_count, i, *control_fd;
     HYD_status status = HYD_SUCCESS;
 
@@ -95,23 +94,10 @@ HYD_status HYD_pmci_launch_procs(void)
     status = HYD_pmiserv_epoch_init(pg);
     HYDU_ERR_POP(status, "unable to init epoch\n");
 
-    int listen_fd;
-    status = HYDU_sock_create_and_listen_portstr(HYD_server_info.user_global.iface,
-                                                 HYD_server_info.localhost,
-                                                 HYD_server_info.port_range, &control_port,
-                                                 &listen_fd,
-                                                 HYD_pmcd_pmiserv_control_listen_cb,
-                                                 (void *) (size_t) pgid);
+    status = HYD_control_listen();
     HYDU_ERR_POP(status, "unable to create PMI port\n");
 
-    struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
-    pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) PMISERV_pg_0->pg_scratch;
-    pg_scratch->control_listen_fd = listen_fd;
-
-    if (HYD_server_info.user_global.debug)
-        HYDU_dump(stdout, "Got a control port string of %s\n", control_port);
-
-    status = HYD_pmcd_pmi_fill_in_proxy_args(&proxy_stash, control_port, 0);
+    status = HYD_pmcd_pmi_fill_in_proxy_args(&proxy_stash, HYD_server_info.control_port, 0);
     HYDU_ERR_POP(status, "unable to fill in proxy arguments\n");
 
     status = HYD_pmcd_pmi_fill_in_exec_launch_info(pg);
@@ -140,7 +126,6 @@ HYD_status HYD_pmci_launch_procs(void)
     MPL_free(control_fd);
 
   fn_exit:
-    MPL_free(control_port);
     HYD_STRING_STASH_FREE(proxy_stash);
     HYDU_FUNC_EXIT();
     return status;

--- a/src/pm/hydra/mpiexec/pmiserv_pmci.c
+++ b/src/pm/hydra/mpiexec/pmiserv_pmci.c
@@ -131,7 +131,7 @@ HYD_status HYD_pmci_launch_procs(void)
         if (control_fd[i] != HYD_FD_UNSET) {
             pg->proxy_list[i].control_fd = control_fd[i];
 
-            status = HYDT_dmx_register_fd(1, &control_fd[i], HYD_POLLIN, (void *) (size_t) pgid,
+            status = HYDT_dmx_register_fd(1, &control_fd[i], HYD_POLLIN, NULL,
                                           HYD_pmcd_pmiserv_proxy_init_cb);
             HYDU_ERR_POP(status, "unable to register fd\n");
         }

--- a/src/pm/hydra/mpiexec/pmiserv_pmci.c
+++ b/src/pm/hydra/mpiexec/pmiserv_pmci.c
@@ -95,12 +95,19 @@ HYD_status HYD_pmci_launch_procs(void)
     status = HYD_pmiserv_epoch_init(pg);
     HYDU_ERR_POP(status, "unable to init epoch\n");
 
+    int listen_fd;
     status = HYDU_sock_create_and_listen_portstr(HYD_server_info.user_global.iface,
                                                  HYD_server_info.localhost,
                                                  HYD_server_info.port_range, &control_port,
+                                                 &listen_fd,
                                                  HYD_pmcd_pmiserv_control_listen_cb,
                                                  (void *) (size_t) pgid);
     HYDU_ERR_POP(status, "unable to create PMI port\n");
+
+    struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
+    pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) PMISERV_pg_0->pg_scratch;
+    pg_scratch->control_listen_fd = listen_fd;
+
     if (HYD_server_info.user_global.debug)
         HYDU_dump(stdout, "Got a control port string of %s\n", control_port);
 

--- a/src/pm/hydra/mpiexec/pmiserv_pmi.h
+++ b/src/pm/hydra/mpiexec/pmiserv_pmi.h
@@ -21,7 +21,6 @@ struct HYD_pmcd_pmi_pg_scratch {
         int epoch;
     } *ecount;
 
-    int control_listen_fd;
     int pmi_listen_fd;
 
     char *dead_processes;

--- a/src/pm/hydra/mpiexec/pmiserv_spawn.c
+++ b/src/pm/hydra/mpiexec/pmiserv_spawn.c
@@ -257,18 +257,34 @@ static HYD_status do_spawn(void)
     HYDU_ERR_POP(status, "error creating proxy list\n");
     HYDU_free_exec_list(exec_list);
 
-    status = HYD_control_listen();
-    HYDU_ERR_POP(status, "unable to create PMI port\n");
-
-    status = HYD_pmcd_pmi_fill_in_proxy_args(&proxy_stash, HYD_server_info.control_port, pg->pgid);
-    HYDU_ERR_POP(status, "unable to fill in proxy arguments\n");
-
     status = HYD_pmcd_pmi_fill_in_exec_launch_info(pg);
     HYDU_ERR_POP(status, "unable to fill in executable arguments\n");
 
-    status = HYDT_bsci_launch_procs(proxy_stash.strlist, pg->proxy_list, pg->proxy_count,
-                                    HYD_FALSE, NULL);
-    HYDU_ERR_POP(status, "launcher cannot launch processes\n");
+    struct HYD_proxy *filtered_proxy_list;
+    filtered_proxy_list = MPL_malloc(pg->proxy_count * sizeof(struct HYD_proxy), MPL_MEM_OTHER);
+    int rem_count = 0;
+    for (int i = 0; i < pg->proxy_count; i++) {
+        if (pg->proxy_list[i].node->control_fd != -1) {
+            pg->proxy_list[i].control_fd = pg->proxy_list[i].node->control_fd;
+            pg->proxy_list[i].node->control_fd_refcnt++;
+            status = HYD_send_exec_info(&pg->proxy_list[i]);
+        } else {
+            filtered_proxy_list[rem_count] = pg->proxy_list[i];
+            rem_count++;
+        }
+    }
+    if (rem_count > 0) {
+        HYDU_ASSERT(HYD_server_info.control_listen_fd >= 0, status);
+
+        status = HYD_pmcd_pmi_fill_in_proxy_args(&proxy_stash, HYD_server_info.control_port,
+                                                 pg->pgid);
+        HYDU_ERR_POP(status, "unable to fill in proxy arguments\n");
+
+        status = HYDT_bsci_launch_procs(proxy_stash.strlist, filtered_proxy_list, rem_count,
+                                        HYD_FALSE, NULL);
+        HYDU_ERR_POP(status, "launcher cannot launch processes\n");
+    }
+    MPL_free(filtered_proxy_list);
 
   fn_exit:
     HYD_STRING_STASH_FREE(proxy_stash);

--- a/src/pm/hydra/mpiexec/pmiserv_spawn.c
+++ b/src/pm/hydra/mpiexec/pmiserv_spawn.c
@@ -257,28 +257,11 @@ static HYD_status do_spawn(void)
     HYDU_ERR_POP(status, "error creating proxy list\n");
     HYDU_free_exec_list(exec_list);
 
-    int pgid = pg->pgid;
-
-    char *control_port;
-    int listen_fd;
-    status = HYDU_sock_create_and_listen_portstr(HYD_server_info.user_global.iface,
-                                                 HYD_server_info.localhost,
-                                                 HYD_server_info.port_range, &control_port,
-                                                 &listen_fd,
-                                                 HYD_pmcd_pmiserv_control_listen_cb,
-                                                 (void *) (size_t) pgid);
+    status = HYD_control_listen();
     HYDU_ERR_POP(status, "unable to create PMI port\n");
 
-    struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
-    pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) pg->pg_scratch;
-    pg_scratch->control_listen_fd = listen_fd;
-
-    if (HYD_server_info.user_global.debug)
-        HYDU_dump(stdout, "Got a control port string of %s\n", control_port);
-
-    status = HYD_pmcd_pmi_fill_in_proxy_args(&proxy_stash, control_port, pgid);
+    status = HYD_pmcd_pmi_fill_in_proxy_args(&proxy_stash, HYD_server_info.control_port, pg->pgid);
     HYDU_ERR_POP(status, "unable to fill in proxy arguments\n");
-    MPL_free(control_port);
 
     status = HYD_pmcd_pmi_fill_in_exec_launch_info(pg);
     HYDU_ERR_POP(status, "unable to fill in executable arguments\n");

--- a/src/pm/hydra/mpiexec/pmiserv_spawn.c
+++ b/src/pm/hydra/mpiexec/pmiserv_spawn.c
@@ -260,12 +260,19 @@ static HYD_status do_spawn(void)
     int pgid = pg->pgid;
 
     char *control_port;
+    int listen_fd;
     status = HYDU_sock_create_and_listen_portstr(HYD_server_info.user_global.iface,
                                                  HYD_server_info.localhost,
                                                  HYD_server_info.port_range, &control_port,
+                                                 &listen_fd,
                                                  HYD_pmcd_pmiserv_control_listen_cb,
                                                  (void *) (size_t) pgid);
     HYDU_ERR_POP(status, "unable to create PMI port\n");
+
+    struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
+    pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) pg->pg_scratch;
+    pg_scratch->control_listen_fd = listen_fd;
+
     if (HYD_server_info.user_global.debug)
         HYDU_dump(stdout, "Got a control port string of %s\n", control_port);
 

--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -89,6 +89,11 @@ HYD_status HYD_pmcd_pmi_fill_in_proxy_args(struct HYD_string_stash *proxy_stash,
         HYD_STRING_STASH(*proxy_stash, MPL_strdup(HYD_server_info.user_global.iface), status);
     }
 
+    if (HYD_server_info.user_global.topolib) {
+        HYD_STRING_STASH(*proxy_stash, MPL_strdup("--topolib"), status);
+        HYD_STRING_STASH(*proxy_stash, MPL_strdup(HYD_server_info.user_global.topolib), status);
+    }
+
     HYD_STRING_STASH(*proxy_stash, MPL_strdup("--pgid"), status);
     HYD_STRING_STASH(*proxy_stash, HYDU_int_to_str(pgid), status);
 
@@ -296,11 +301,6 @@ HYD_status HYD_pmcd_pmi_fill_in_exec_launch_info(struct HYD_pg *pg)
         if (HYD_server_info.user_global.membind) {
             HYD_STRING_STASH(exec_stash, MPL_strdup("--membind"), status);
             HYD_STRING_STASH(exec_stash, MPL_strdup(HYD_server_info.user_global.membind), status);
-        }
-
-        if (HYD_server_info.user_global.topolib) {
-            HYD_STRING_STASH(exec_stash, MPL_strdup("--topolib"), status);
-            HYD_STRING_STASH(exec_stash, MPL_strdup(HYD_server_info.user_global.topolib), status);
         }
 
         status = add_env_to_exec_stash(&exec_stash, "--global-inherited-env",

--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -456,8 +456,14 @@ static HYD_status gen_kvsname(char kvsname[], int pgid)
     }
     rnd = rand();
 
+#if 0
+    /* shorter kvsname for debugging */
+    MPL_snprintf_nowarn(kvsname, PMI_MAXKVSLEN, "kvs%d", pgid);
+#else
     MPL_snprintf_nowarn(kvsname, PMI_MAXKVSLEN, "kvs_%d_%d_%d_%s", (int) getpid(), pgid,
                         rnd, hostname);
+#endif
+
   fn_exit:
     HYDU_FUNC_EXIT();
     return status;

--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -444,14 +444,16 @@ static HYD_status gen_kvsname(char kvsname[], int pgid)
 
     char hostname[MAX_HOSTNAME_LEN - 40];       /* Remove space taken up by the integers and other
                                                  * characters below. */
-    unsigned int seed;
+    static unsigned int seed = 0;
     int rnd;
 
     if (gethostname(hostname, MAX_HOSTNAME_LEN - 40) < 0)
         HYDU_ERR_SETANDJUMP(status, HYD_SOCK_ERROR, "unable to get local hostname\n");
 
-    seed = (unsigned int) time(NULL);
-    srand(seed);
+    if (!seed) {
+        seed = (unsigned int) time(NULL);
+        srand(seed);
+    }
     rnd = rand();
 
     MPL_snprintf_nowarn(kvsname, PMI_MAXKVSLEN, "kvs_%d_%d_%d_%s", (int) getpid(), pgid,

--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -393,7 +393,6 @@ HYD_status HYD_pmcd_pmi_alloc_pg_scratch(struct HYD_pg *pg)
     pg_scratch->epoch = 0;
     pg_scratch->fence_count = 0;
 
-    pg_scratch->control_listen_fd = HYD_FD_UNSET;
     pg_scratch->pmi_listen_fd = HYD_FD_UNSET;
 
     pg_scratch->dead_processes = MPL_strdup("");

--- a/src/pm/hydra/mpiexec/uiu.c
+++ b/src/pm/hydra/mpiexec/uiu.c
@@ -36,6 +36,8 @@ void HYD_uiu_init_params(void)
     HYD_server_info.stderr_cb = NULL;
 
     HYD_server_info.node_list = NULL;
+    HYD_server_info.control_port = NULL;
+    HYD_server_info.control_listen_fd = -1;
 
 #if defined ENABLE_PROFILING
     HYD_server_info.enable_profiling = -1;
@@ -61,6 +63,12 @@ void HYD_uiu_free_params(void)
     MPL_free(HYD_ui_mpich_info.prepend_pattern);
     MPL_free(HYD_ui_mpich_info.outfile_pattern);
     MPL_free(HYD_ui_mpich_info.errfile_pattern);
+
+    MPL_free(HYD_server_info.control_port);
+    if (HYD_server_info.control_listen_fd != -1) {
+        close(HYD_server_info.control_listen_fd);
+        HYD_server_info.control_listen_fd = -1;
+    }
 
     for (run = stdoe_fd_list; run;) {
         close(run->fd);

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -109,6 +109,7 @@ int main(int argc, char **argv)
 
     struct HYD_pmcd_init_hdr init_hdr;
     strncpy(init_hdr.signature, "HYD", 4);
+    init_hdr.pgid = HYD_pmcd_pmip.local.pgid;
     init_hdr.proxy_id = HYD_pmcd_pmip.local.id;
     status = HYDU_sock_write(HYD_pmcd_pmip.upstream.control,
                              &init_hdr, sizeof(init_hdr), &sent, &closed, HYDU_SOCK_COMM_MSGWAIT);

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -40,6 +40,7 @@ struct HYD_pmcd_pmip_s {
 
 /* downstreams */
 struct pmip_downstream {
+    int idx;
     int pg_idx;
 
     int out;

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -108,6 +108,9 @@ struct pmip_pg {
     struct cache_elem *hash_get;
     int num_elems;
 
+    /* for barrier_in */
+    int barrier_count;
+
     /* environment */
     char *iface_ip_env_name;
     char *hostname;

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -118,7 +118,8 @@ struct pmip_pg {
 };
 
 extern struct HYD_pmcd_pmip_s HYD_pmcd_pmip;
-extern struct HYD_arg_match_table HYD_pmcd_pmip_match_table[];
+extern struct HYD_arg_match_table HYD_pmip_args_match_table[];
+extern struct HYD_arg_match_table HYD_pmip_procinfo_match_table[];
 
 void HYD_set_cur_pg(struct pmip_pg *pg);
 HYD_status HYD_pmcd_pmip_get_params(char **t_argv);

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -42,7 +42,7 @@ struct HYD_pmcd_pmip_s {
 
 /* downstreams */
 struct pmip_downstream {
-    struct pmip_pg *pg;
+    int pg_idx;
 
     int out;
     int err;
@@ -74,6 +74,7 @@ struct cache_elem {
 };
 
 struct pmip_pg {
+    int idx;                    /* index in global dynamic array PMIP_pgs */
     int pgid;
     int proxy_id;
 
@@ -128,6 +129,7 @@ void PMIP_pg_init(void);
 void PMIP_pg_finalize(void);
 struct pmip_pg *PMIP_new_pg(int pgid, int proxy_id);
 struct pmip_pg *PMIP_pg_0(void);
+struct pmip_pg *PMIP_pg_from_downstream(struct pmip_downstream *downstream);
 HYD_status PMIP_pg_alloc_downstreams(struct pmip_pg *pg, int num_procs);
 struct pmip_pg *PMIP_find_pg(int pgid, int proxy_id);
 

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -33,8 +33,6 @@ struct HYD_pmcd_pmip_s {
     struct {
         int id;
         int pgid;
-        char *iface_ip_env_name;
-        char *hostname;
 
         int retries;
     } local;
@@ -109,6 +107,10 @@ struct pmip_pg {
     struct cache_elem *cache_get;
     struct cache_elem *hash_get;
     int num_elems;
+
+    /* environment */
+    char *iface_ip_env_name;
+    char *hostname;
 };
 
 extern struct HYD_pmcd_pmip_s HYD_pmcd_pmip;
@@ -130,6 +132,7 @@ void PMIP_pg_finalize(void);
 struct pmip_pg *PMIP_new_pg(int pgid, int proxy_id);
 struct pmip_pg *PMIP_pg_0(void);
 struct pmip_pg *PMIP_pg_from_downstream(struct pmip_downstream *downstream);
+HYD_status PMIP_foreach_pg_do(HYD_status(*callback) (struct pmip_pg * pg));
 HYD_status PMIP_pg_alloc_downstreams(struct pmip_pg *pg, int num_procs);
 struct pmip_pg *PMIP_find_pg(int pgid, int proxy_id);
 

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -574,14 +574,9 @@ static HYD_status handle_launch_procs(struct pmip_pg *pg)
     status = procinfo(pg);
     HYDU_ERR_POP(status, "error parsing process info\n");
 
-    /* FIXME: split topo initialization from applying bindings.
-     *        The topolib should be passed as proxy commandline args
-     *        and initialized in main.
-     */
-    status = HYDT_topo_init(HYD_pmcd_pmip.user_global.topolib,
-                            HYD_pmcd_pmip.user_global.binding,
-                            HYD_pmcd_pmip.user_global.mapping, HYD_pmcd_pmip.user_global.membind);
-    HYDU_ERR_POP(status, "unable to initialize process topology\n");
+    status = HYDT_topo_set(HYD_pmcd_pmip.user_global.binding,
+                           HYD_pmcd_pmip.user_global.mapping, HYD_pmcd_pmip.user_global.membind);
+    HYDU_ERR_POP(status, "unable to set process topology\n");
 
     if (pg->is_singleton) {
         status = singleton_init(pg, HYD_pmcd_pmip.singleton_pid, HYD_pmcd_pmip.singleton_port);

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -159,7 +159,11 @@ static HYD_status handle_pmi_cmd(struct pmip_downstream *p, char *buf, int bufle
         HYDU_ERR_POP(status, "unable to parse PMI command\n");
 
         if (HYD_pmcd_pmip.user_global.debug) {
-            HYDU_dump(stdout, "got pmi command\n    ");
+            int pgid = -1;
+            if (p->pg_idx != -1) {
+                pgid = PMIP_pg_from_downstream(p)->pgid;
+            }
+            HYDU_dump(stdout, "got pmi command from downstream %d-%d:\n    ", pgid, p->idx);
             HYD_pmcd_pmi_dump(&pmi);
         }
 

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -774,9 +774,13 @@ static HYD_status launch_procs(struct pmip_pg *pg)
     }
 
     if (HYD_pmcd_pmip.user_global.pmi_port) {
+        int listen_fd;
         status = HYDU_sock_create_and_listen_portstr(HYD_pmcd_pmip.user_global.iface,
-                                                     NULL, NULL, &pmi_port, pmi_listen_cb, NULL);
+                                                     NULL, NULL, &pmi_port, &listen_fd,
+                                                     pmi_listen_cb, NULL);
         HYDU_ERR_POP(status, "unable to create PMI port\n");
+
+        /* FIXME: should we close(listen_fd) at some point? */
 
         status = HYDU_env_create(&env, "PMI_PORT", pmi_port);
         HYDU_ERR_POP(status, "unable to create env\n");

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -609,7 +609,7 @@ static HYD_status parse_exec_params(struct pmip_pg *pg, char **t_argv)
     init_pg_params(pg);
     do {
         /* Get the executable arguments  */
-        status = HYDU_parse_array(&argv, HYD_pmcd_pmip_match_table);
+        status = HYDU_parse_array(&argv, HYD_pmip_procinfo_match_table);
         HYDU_ERR_POP(status, "error parsing input array\n");
 
         /* No more arguments left */

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -846,7 +846,7 @@ static HYD_status launch_procs(struct pmip_pg *pg)
         }
 
         /* Set the interface hostname based on what the user provided */
-        if (HYD_pmcd_pmip.local.iface_ip_env_name) {
+        if (pg->iface_ip_env_name) {
             if (HYD_pmcd_pmip.user_global.iface) {
                 char *ip;
 
@@ -855,13 +855,11 @@ static HYD_status launch_procs(struct pmip_pg *pg)
                              HYD_pmcd_pmip.user_global.iface);
 
                 /* The user asked us to use a specific interface; let's find it */
-                status = HYDU_append_env_to_list(HYD_pmcd_pmip.local.iface_ip_env_name,
-                                                 ip, &force_env);
+                status = HYDU_append_env_to_list(pg->iface_ip_env_name, ip, &force_env);
                 HYDU_ERR_POP(status, "unable to add env to list\n");
-            } else if (HYD_pmcd_pmip.local.hostname) {
+            } else if (pg->hostname) {
                 /* The second choice is the hostname the user gave */
-                status = HYDU_append_env_to_list(HYD_pmcd_pmip.local.iface_ip_env_name,
-                                                 HYD_pmcd_pmip.local.hostname, &force_env);
+                status = HYDU_append_env_to_list(pg->iface_ip_env_name, pg->hostname, &force_env);
                 HYDU_ERR_POP(status, "unable to add env to list\n");
             }
         }

--- a/src/pm/hydra/proxy/pmip_pg.c
+++ b/src/pm/hydra/proxy/pmip_pg.c
@@ -129,6 +129,7 @@ HYD_status PMIP_pg_alloc_downstreams(struct pmip_pg * pg, int num_procs)
     HYDU_ASSERT(pg->downstreams, status);
 
     for (int i = 0; i < num_procs; i++) {
+        pg->downstreams[i].idx = i;
         pg->downstreams[i].pg_idx = pg->idx;
         pg->downstreams[i].pid = -1;
         pg->downstreams[i].exit_status = PMIP_EXIT_STATUS_UNSET;

--- a/src/pm/hydra/proxy/pmip_pg.c
+++ b/src/pm/hydra/proxy/pmip_pg.c
@@ -50,9 +50,12 @@ void PMIP_pg_finalize(void)
 
 struct pmip_pg *PMIP_new_pg(int pgid, int proxy_id)
 {
+    int idx = utarray_len(PMIP_pgs);
+
     utarray_extend_back(PMIP_pgs, MPL_MEM_OTHER);
     struct pmip_pg *pg = (void *) utarray_back(PMIP_pgs);
 
+    pg->idx = idx;
     pg->pgid = pgid;
     pg->proxy_id = proxy_id;
 
@@ -74,6 +77,11 @@ struct pmip_pg *PMIP_pg_0(void)
     } else {
         return NULL;
     }
+}
+
+struct pmip_pg *PMIP_pg_from_downstream(struct pmip_downstream *downstream)
+{
+    return (void *) utarray_eltptr(PMIP_pgs, downstream->pg_idx);
 }
 
 /* linear search.
@@ -101,7 +109,7 @@ HYD_status PMIP_pg_alloc_downstreams(struct pmip_pg * pg, int num_procs)
     HYDU_ASSERT(pg->downstreams, status);
 
     for (int i = 0; i < num_procs; i++) {
-        pg->downstreams[i].pg = pg;
+        pg->downstreams[i].pg_idx = pg->idx;
         pg->downstreams[i].pid = -1;
         pg->downstreams[i].exit_status = PMIP_EXIT_STATUS_UNSET;
         pg->downstreams[i].pmi_fd = HYD_FD_UNSET;

--- a/src/pm/hydra/proxy/pmip_pg.c
+++ b/src/pm/hydra/proxy/pmip_pg.c
@@ -15,6 +15,8 @@ static void pg_destructor(void *_elt)
     MPL_free(pg->kvsname);
     MPL_free(pg->pmi_process_mapping);
     MPL_free(pg->downstreams);
+    MPL_free(pg->iface_ip_env_name);
+    MPL_free(pg->hostname);
     HYDU_free_exec_list(pg->exec_list);
     HYD_pmcd_free_pmi_kvs_list(pg->kvs);
 
@@ -82,6 +84,24 @@ struct pmip_pg *PMIP_pg_0(void)
 struct pmip_pg *PMIP_pg_from_downstream(struct pmip_downstream *downstream)
 {
     return (void *) utarray_eltptr(PMIP_pgs, downstream->pg_idx);
+}
+
+/* iterate each pg */
+HYD_status PMIP_foreach_pg_do(HYD_status(*callback) (struct pmip_pg * pg))
+{
+    HYD_status status = HYD_SUCCESS;
+
+    int n = utarray_len(PMIP_pgs);
+    struct pmip_pg *arr = ut_type_array(PMIP_pgs, struct pmip_pg *);
+    for (int i = 0; i < n; i++) {
+        status = callback(&arr[i]);
+        HYDU_ERR_POP(status, "foreach_pg_do failed at i = %d / %d", i, n);
+    }
+
+  fn_exit:
+    return status;
+  fn_fail:
+    goto fn_exit;
 }
 
 /* linear search.

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -531,16 +531,15 @@ HYD_status fn_keyval_cache(struct pmip_pg *pg, struct PMIU_cmd *pmi)
 
 HYD_status fn_barrier_in(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 {
-    static int barrier_count = 0;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
-    barrier_count++;
-    if (barrier_count == PMIP_pg_from_downstream(p)->num_procs) {
-        barrier_count = 0;
+    struct pmip_pg *pg = PMIP_pg_from_downstream(p);
+    pg->barrier_count++;
+    if (pg->barrier_count == pg->num_procs) {
+        pg->barrier_count = 0;
 
-        struct pmip_pg *pg = PMIP_pg_from_downstream(p);
         cache_put_flush(pg);
 
         status = send_cmd_upstream(pg, pmi, p->pmi_fd);

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -335,7 +335,8 @@ HYD_status fn_get_my_kvsname(struct pmip_downstream *p, struct PMIU_cmd *pmi)
     HYDU_FUNC_ENTER();
 
     struct PMIU_cmd pmi_response;
-    pmi_errno = PMIU_msg_set_response_kvsname(pmi, &pmi_response, is_static, p->pg->kvsname);
+    pmi_errno = PMIU_msg_set_response_kvsname(pmi, &pmi_response, is_static,
+                                              PMIP_pg_from_downstream(p)->kvsname);
     HYDU_ASSERT(!pmi_errno, status);
 
     status = send_cmd_downstream(p->pmi_fd, &pmi_response);
@@ -357,7 +358,7 @@ HYD_status fn_get_usize(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 
     int universe_size;
     if (HYD_pmcd_pmip.user_global.usize == HYD_USIZE_SYSTEM) {
-        universe_size = p->pg->global_core_map.global_count;
+        universe_size = PMIP_pg_from_downstream(p)->global_core_map.global_count;
     } else if (HYD_pmcd_pmip.user_global.usize == HYD_USIZE_INFINITE) {
         universe_size = -1;
     } else {
@@ -382,7 +383,7 @@ HYD_status fn_get_usize(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 static const char *get_jobattr(struct pmip_downstream *p, const char *key)
 {
     if (strcmp(key, "PMI_process_mapping") == 0) {
-        return p->pg->pmi_process_mapping;
+        return PMIP_pg_from_downstream(p)->pmi_process_mapping;
     } else if (!strcmp(key, "PMI_hwloc_xmlfile")) {
         return HYD_pmip_get_hwloc_xmlfile();
     }
@@ -408,7 +409,7 @@ HYD_status fn_get(struct pmip_downstream * p, struct PMIU_cmd * pmi)
         }
     } else {
         struct cache_elem *elem = NULL;
-        HASH_FIND_STR(p->pg->hash_get, key, elem);
+        HASH_FIND_STR(PMIP_pg_from_downstream(p)->hash_get, key, elem);
         if (elem) {
             found = true;
             val = elem->val;
@@ -423,7 +424,7 @@ HYD_status fn_get(struct pmip_downstream * p, struct PMIU_cmd * pmi)
         HYDU_ERR_POP(status, "error sending PMI response\n");
     } else {
         /* if we can't find the key locally, ask upstream */
-        status = send_cmd_upstream(p->pg, pmi, p->pmi_fd);
+        status = send_cmd_upstream(PMIP_pg_from_downstream(p), pmi, p->pmi_fd);
     }
 
   fn_exit:
@@ -461,7 +462,7 @@ HYD_status fn_put(struct pmip_downstream *p, struct PMIU_cmd *pmi)
     }
 
     /* add to the cache */
-    struct pmip_pg *pg = p->pg;
+    struct pmip_pg *pg = PMIP_pg_from_downstream(p);
     int i = pg->cache_put.keyval_len++;
     pg->cache_put.tokens[i].key = MPL_strdup(key);
     if (val) {
@@ -536,12 +537,13 @@ HYD_status fn_barrier_in(struct pmip_downstream *p, struct PMIU_cmd *pmi)
     HYDU_FUNC_ENTER();
 
     barrier_count++;
-    if (barrier_count == p->pg->num_procs) {
+    if (barrier_count == PMIP_pg_from_downstream(p)->num_procs) {
         barrier_count = 0;
 
-        cache_put_flush(p->pg);
+        struct pmip_pg *pg = PMIP_pg_from_downstream(p);
+        cache_put_flush(pg);
 
-        status = send_cmd_upstream(p->pg, pmi, p->pmi_fd);
+        status = send_cmd_upstream(pg, pmi, p->pmi_fd);
         HYDU_ERR_POP(status, "error sending command upstream\n");
     }
 
@@ -580,7 +582,7 @@ HYD_status fn_finalize(struct pmip_downstream *p, struct PMIU_cmd *pmi)
     int pmi_errno;
     HYDU_FUNC_ENTER();
 
-    struct pmip_pg *pg = p->pg;
+    struct pmip_pg *pg = PMIP_pg_from_downstream(p);
 
     struct PMIU_cmd pmi_response;
     pmi_errno = PMIU_msg_set_response(pmi, &pmi_response, is_static);
@@ -633,7 +635,7 @@ HYD_status fn_info_putnodeattr(struct pmip_downstream *p, struct PMIU_cmd *pmi)
         goto fn_exit;
     }
 
-    status = HYD_pmcd_pmi_add_kvs(key, val, p->pg->kvs, &ret);
+    status = HYD_pmcd_pmi_add_kvs(key, val, PMIP_pg_from_downstream(p)->kvs, &ret);
     HYDU_ERR_POP(status, "unable to put data into kvs\n");
 
     pmi_errno = PMIU_msg_set_response(pmi, &pmi_response, is_static);
@@ -672,7 +674,7 @@ HYD_status fn_info_getnodeattr(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 
     /* FIXME: wrap it in e.g. HYD_pmcd_pmi_find_kvs */
     struct HYD_pmcd_pmi_kvs_pair *run;
-    for (run = p->pg->kvs->key_pair; run; run = run->next) {
+    for (run = PMIP_pg_from_downstream(p)->kvs->key_pair; run; run = run->next) {
         if (!strcmp(run->key, key)) {
             found = 1;
             break;

--- a/src/pm/hydra/proxy/pmip_pmi.h
+++ b/src/pm/hydra/proxy/pmip_pmi.h
@@ -16,7 +16,7 @@ struct HYD_pmcd_pmip_pmi_handle {
 };
 
 /* handlers for initialization via pmi port */
-HYD_status fn_fullinit(int fd, struct PMIU_cmd *pmi);
+HYD_status fn_fullinit(struct pmip_downstream *p, struct PMIU_cmd *pmi);
 
 /* handlers for client pmi commands */
 HYD_status fn_init(struct pmip_downstream *p, struct PMIU_cmd *pmi);

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -623,6 +623,7 @@ struct HYD_arg_match_table HYD_pmip_args_match_table[] = {
     {"launcher", launcher_fn, NULL},
     {"launcher-exec", launcher_exec_fn, NULL},
     {"demux", demux_fn, NULL},
+    {"topolib", topolib_fn, NULL},
     {"iface", iface_fn, NULL},
     {"retries", retries_fn, NULL},
     {"\0", NULL, NULL}
@@ -634,7 +635,6 @@ struct HYD_arg_match_table HYD_pmip_procinfo_match_table[] = {
     {"pmi-kvsname", pmi_kvsname_fn, NULL},
     {"pmi-spawner-kvsname", pmi_spawner_kvsname_fn, NULL},
     {"pmi-process-mapping", pmi_process_mapping_fn, NULL},
-    {"topolib", topolib_fn, NULL},
     {"binding", binding_fn, NULL},
     {"mapping", mapping_fn, NULL},
     {"membind", membind_fn, NULL},
@@ -699,6 +699,9 @@ HYD_status HYD_pmcd_pmip_get_params(char **t_argv)
                             HYD_pmcd_pmip.user_global.launcher_exec,
                             0 /* disable x */ , HYD_pmcd_pmip.user_global.debug);
     HYDU_ERR_POP(status, "proxy unable to initialize bootstrap server\n");
+
+    status = HYDT_topo_init(HYD_pmcd_pmip.user_global.topolib);
+    HYDU_ERR_POP(status, "proxy unable to initialize topology library\n");
 
     if (HYD_pmcd_pmip.local.id == -1) {
         /* We didn't get a proxy ID during launch; query the launcher

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -606,12 +606,13 @@ static HYD_status exec_args_fn(char *arg, char ***argv)
     goto fn_exit;
 }
 
-struct HYD_arg_match_table HYD_pmcd_pmip_match_table[] = {
+struct HYD_arg_match_table HYD_pmip_args_match_table[] = {
     /* Proxy parameters */
     {"control-port", control_port_fn, NULL},
     {"proxy-id", proxy_id_fn, NULL},
     {"pgid", pgid_fn, NULL},
     {"debug", debug_fn, NULL},
+    {"topo-debug", topo_debug_fn, NULL},
     {"usize", usize_fn, NULL},
     {"pmi-port", pmi_port_fn, NULL},
     {"gpus-per-proc", gpus_per_proc_fn, NULL},
@@ -623,10 +624,13 @@ struct HYD_arg_match_table HYD_pmcd_pmip_match_table[] = {
     {"launcher-exec", launcher_exec_fn, NULL},
     {"demux", demux_fn, NULL},
     {"iface", iface_fn, NULL},
-    {"auto-cleanup", auto_cleanup_fn, NULL},
     {"retries", retries_fn, NULL},
+    {"\0", NULL, NULL}
+};
 
+struct HYD_arg_match_table HYD_pmip_procinfo_match_table[] = {
     /* Executable parameters */
+    {"auto-cleanup", auto_cleanup_fn, NULL},
     {"pmi-kvsname", pmi_kvsname_fn, NULL},
     {"pmi-spawner-kvsname", pmi_spawner_kvsname_fn, NULL},
     {"pmi-process-mapping", pmi_process_mapping_fn, NULL},
@@ -634,7 +638,6 @@ struct HYD_arg_match_table HYD_pmcd_pmip_match_table[] = {
     {"binding", binding_fn, NULL},
     {"mapping", mapping_fn, NULL},
     {"membind", membind_fn, NULL},
-    {"topo-debug", topo_debug_fn, NULL},
     {"global-inherited-env", global_env_fn, NULL},
     {"global-system-env", global_env_fn, NULL},
     {"global-user-env", global_env_fn, NULL},
@@ -652,7 +655,8 @@ struct HYD_arg_match_table HYD_pmcd_pmip_match_table[] = {
     {"exec-local-env", exec_local_env_fn, NULL},
     {"exec-env-prop", exec_env_prop_fn, NULL},
     {"exec-wdir", exec_wdir_fn, NULL},
-    {"exec-args", exec_args_fn, NULL}
+    {"exec-args", exec_args_fn, NULL},
+    {"\0", NULL, NULL}
 };
 
 HYD_status HYD_pmcd_pmip_get_params(char **t_argv)
@@ -666,7 +670,7 @@ HYD_status HYD_pmcd_pmip_get_params(char **t_argv)
     argv++;
     do {
         /* Get the proxy arguments  */
-        status = HYDU_parse_array(&argv, HYD_pmcd_pmip_match_table);
+        status = HYDU_parse_array(&argv, HYD_pmip_args_match_table);
         HYDU_ERR_POP(status, "error parsing input array\n");
 
         /* No more arguments left */

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -713,8 +713,7 @@ HYD_status HYD_pmcd_pmip_get_params(char **t_argv)
         HYD_pmcd_pmip.local.retries = 0;
 
     HYDU_dbg_finalize();
-    snprintf(dbg_prefix, 2 * MAX_HOSTNAME_LEN, "proxy:%d:%d",
-             HYD_pmcd_pmip.local.pgid, HYD_pmcd_pmip.local.id);
+    snprintf(dbg_prefix, 2 * MAX_HOSTNAME_LEN, "proxy:%d", HYD_pmcd_pmip.local.id);
     status = HYDU_dbg_init((const char *) dbg_prefix);
     HYDU_ERR_POP(status, "unable to initialization debugging\n");
 

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -448,7 +448,7 @@ static HYD_status iface_ip_env_name_fn(char *arg, char ***argv)
 {
     HYD_status status = HYD_SUCCESS;
 
-    status = HYDU_set_str(arg, &HYD_pmcd_pmip.local.iface_ip_env_name, **argv);
+    status = HYDU_set_str(arg, &cur_pg->iface_ip_env_name, **argv);
 
     (*argv)++;
 
@@ -459,7 +459,7 @@ static HYD_status hostname_fn(char *arg, char ***argv)
 {
     HYD_status status = HYD_SUCCESS;
 
-    status = HYDU_set_str(arg, &HYD_pmcd_pmip.local.hostname, **argv);
+    status = HYDU_set_str(arg, &cur_pg->hostname, **argv);
 
     (*argv)++;
 

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -11,6 +11,10 @@
 
 #include "pmi_util.h"   /* from libpmi, for PMIU_verbose */
 
+/* NOTE: pg pointer can change on PMIP_new_pg since it is from a dynamic
+ *       array. It's ok here because we only use cur_pg during command
+ *       line parsing.
+ */
 static struct pmip_pg *cur_pg = NULL;
 
 void HYD_set_cur_pg(struct pmip_pg *pg)

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -307,7 +307,8 @@ static HYD_status topolib_fn(char *arg, char ***argv)
 
 static HYD_status topo_debug_fn(char *arg, char ***argv)
 {
-    return HYDU_set_int(arg, &HYDT_topo_info.debug, 1);
+    HYD_pmcd_pmip.user_global.topo_debug = 1;
+    return HYD_SUCCESS;
 }
 
 static HYD_status global_env_fn(char *arg, char ***argv)
@@ -688,19 +689,14 @@ HYD_status HYD_pmcd_pmip_get_params(char **t_argv)
     if (HYD_pmcd_pmip.user_global.demux == NULL)
         HYDU_ERR_SETANDJUMP(status, HYD_INTERNAL_ERROR, "demux engine not available\n");
 
-    if (HYD_pmcd_pmip.user_global.debug == -1)
-        HYD_pmcd_pmip.user_global.debug = 0;
-
-    if (HYDT_topo_info.debug == -1)
-        HYDT_topo_info.debug = 0;
-
     status = HYDT_bsci_init(HYD_pmcd_pmip.user_global.rmk,
                             HYD_pmcd_pmip.user_global.launcher,
                             HYD_pmcd_pmip.user_global.launcher_exec,
                             0 /* disable x */ , HYD_pmcd_pmip.user_global.debug);
     HYDU_ERR_POP(status, "proxy unable to initialize bootstrap server\n");
 
-    status = HYDT_topo_init(HYD_pmcd_pmip.user_global.topolib);
+    status = HYDT_topo_init(HYD_pmcd_pmip.user_global.topolib,
+                            HYD_pmcd_pmip.user_global.topo_debug);
     HYDU_ERR_POP(status, "proxy unable to initialize topology library\n");
 
     if (HYD_pmcd_pmip.local.id == -1) {

--- a/src/pmi/src/pmi_util.c
+++ b/src/pmi/src/pmi_util.c
@@ -71,6 +71,15 @@ void PMIU_SetServer(void)
     MPL_strncpy(PMIU_print_id, "server", PMIU_IDSIZE);
 }
 
+void PMIU_Set_rank_kvsname(int rank, const char *kvsname)
+{
+    if (strlen(kvsname) < PMIU_IDSIZE - 10) {
+        snprintf(PMIU_print_id, PMIU_IDSIZE, "%s-%d", kvsname, rank);
+    } else {
+        snprintf(PMIU_print_id, PMIU_IDSIZE, "cli-%d", rank);
+    }
+}
+
 /* Note that vfprintf is part of C89 */
 
 /* style: allow:fprintf:1 sig:0 */

--- a/src/pmi/src/pmi_util.h
+++ b/src/pmi/src/pmi_util.h
@@ -47,6 +47,7 @@
 
 /* prototypes for PMIU routines */
 void PMIU_Set_rank(int PMI_rank);
+void PMIU_Set_rank_kvsname(int rank, const char *kvsname);
 void PMIU_SetServer(void);
 void PMIU_printf(int print_flag, const char *fmt, ...);
 int PMIU_readline(int fd, char *buf, int max);

--- a/src/pmi/src/pmi_v1.c
+++ b/src/pmi/src/pmi_v1.c
@@ -364,6 +364,7 @@ PMI_API_PUBLIC int PMI_KVS_Get_my_name(char kvsname[], int length)
     pmi_errno = PMIU_msg_get_response_kvsname(&pmicmd, &tmp_kvsname);
 
     MPL_strncpy(kvsname, tmp_kvsname, length);
+    PMIU_Set_rank_kvsname(PMI_rank, tmp_kvsname);
 
   fn_exit:
     PMIU_cmd_free_buf(&pmicmd);

--- a/src/pmi/src/pmi_v2.c
+++ b/src/pmi/src/pmi_v2.c
@@ -267,6 +267,7 @@ PMI_API_PUBLIC int PMI2_Job_GetId(char jobid[], int jobid_size)
     PMIU_ERR_POP(pmi_errno);
 
     MPL_strncpy(jobid, jid, jobid_size);
+    PMIU_Set_rank_kvsname(PMI_rank, jid);
 
   fn_exit:
     PMIU_cmd_free_buf(&pmicmd);

--- a/test/mpi/session/testlist
+++ b/test/mpi/session/testlist
@@ -1,6 +1,6 @@
 session 4
 session_mult_init 4
 session_mult_init 4 arg=5
-session_re_init 4 mpiexecarg=-disable-auto-cleanup
+session_re_init 4
 session_psets 1
 session_self 1


### PR DESCRIPTION
## Pull Request Description
When we spawning processes, rather than launch separate proxy process, we can reuse the same proxy on each node to launch additional processes so long as the proxy can handle multiple `pg`s.

This is split from #5943

Fixes #2277 
Fixes #2913
Fixes #5903
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
