### PR TITLE
hydra: refactor kvs and fix duplicate keys

### DIFF
--- a/src/pm/hydra/lib/pmiserv_common.h
+++ b/src/pm/hydra/lib/pmiserv_common.h
@@ -16,18 +16,18 @@
 #define PMI_MAXVALLEN    (1024) /* max length of value in keyval space */
 #define PMI_MAXKVSLEN    (256)  /* max length of various names */
 
-struct HYD_pmcd_pmi_kvs_pair {
+struct HYD_kvs_pair {
     char key[PMI_MAXKEYLEN];
     char val[PMI_MAXVALLEN];
-    struct HYD_pmcd_pmi_kvs_pair *next;
+    struct HYD_kvs_pair *next;
 };
 
-struct HYD_pmcd_pmi_kvs {
-    struct HYD_pmcd_pmi_kvs_pair *key_pair;
+struct HYD_kvs {
+    struct HYD_kvs_pair *key_pair;
     /* iter fields used for HYD_pmiserv_bcast_keyvals */
-    struct HYD_pmcd_pmi_kvs_pair *iter_end;
-    struct HYD_pmcd_pmi_kvs_pair *iter_begin;
-    struct HYD_pmcd_pmi_kvs_pair *iter_cur;
+    struct HYD_kvs_pair *iter_end;
+    struct HYD_kvs_pair *iter_begin;
+    struct HYD_kvs_pair *iter_cur;
     bool iter_new_only;
 };
 
@@ -38,16 +38,13 @@ struct HYD_pmcd_init_hdr {
     int proxy_id;
 };
 
-HYD_status HYD_pmcd_pmi_allocate_kvs(struct HYD_pmcd_pmi_kvs **kvs);
-void HYD_pmcd_free_pmi_kvs_list(struct HYD_pmcd_pmi_kvs *kvs_list);
-HYD_status HYD_pmcd_pmi_kvs_find(struct HYD_pmcd_pmi_kvs *kvs_list,
-                                 const char *key, const char **val, int *found);
-HYD_status HYD_pmcd_pmi_add_kvs(const char *key, const char *val, struct HYD_pmcd_pmi_kvs *kvs,
-                                int *ret);
-void HYD_pmcd_pmi_kvs_iter_begin(struct HYD_pmcd_pmi_kvs *kvs_list, bool new_only);
-void HYD_pmcd_pmi_kvs_iter_end(struct HYD_pmcd_pmi_kvs *kvs_list);
-bool HYD_pmcd_pmi_kvs_iter_next(struct HYD_pmcd_pmi_kvs *kvs_list,
-                                const char **key, const char **val);
+HYD_status HYD_pmcd_pmi_allocate_kvs(struct HYD_kvs **kvs);
+void HYD_pmcd_free_pmi_kvs_list(struct HYD_kvs *kvs_list);
+HYD_status HYD_kvs_find(struct HYD_kvs *kvs_list, const char *key, const char **val, int *found);
+HYD_status HYD_pmcd_pmi_add_kvs(const char *key, const char *val, struct HYD_kvs *kvs, int *ret);
+void HYD_kvs_iter_begin(struct HYD_kvs *kvs_list, bool new_only);
+void HYD_kvs_iter_end(struct HYD_kvs *kvs_list);
+bool HYD_kvs_iter_next(struct HYD_kvs *kvs_list, const char **key, const char **val);
 
 /* ---- struct HYD_pmcd_hdr ---- */
 

--- a/src/pm/hydra/lib/pmiserv_common.h
+++ b/src/pm/hydra/lib/pmiserv_common.h
@@ -24,7 +24,11 @@ struct HYD_pmcd_pmi_kvs_pair {
 
 struct HYD_pmcd_pmi_kvs {
     struct HYD_pmcd_pmi_kvs_pair *key_pair;
-    struct HYD_pmcd_pmi_kvs_pair *tail;
+    /* iter fields used for HYD_pmiserv_bcast_keyvals */
+    struct HYD_pmcd_pmi_kvs_pair *iter_end;
+    struct HYD_pmcd_pmi_kvs_pair *iter_begin;
+    struct HYD_pmcd_pmi_kvs_pair *iter_cur;
+    bool iter_new_only;
 };
 
 /* init header proxy send to server upon connection */
@@ -36,8 +40,14 @@ struct HYD_pmcd_init_hdr {
 
 HYD_status HYD_pmcd_pmi_allocate_kvs(struct HYD_pmcd_pmi_kvs **kvs);
 void HYD_pmcd_free_pmi_kvs_list(struct HYD_pmcd_pmi_kvs *kvs_list);
+HYD_status HYD_pmcd_pmi_kvs_find(struct HYD_pmcd_pmi_kvs *kvs_list,
+                                 const char *key, const char **val, int *found);
 HYD_status HYD_pmcd_pmi_add_kvs(const char *key, const char *val, struct HYD_pmcd_pmi_kvs *kvs,
                                 int *ret);
+void HYD_pmcd_pmi_kvs_iter_begin(struct HYD_pmcd_pmi_kvs *kvs_list, bool new_only);
+void HYD_pmcd_pmi_kvs_iter_end(struct HYD_pmcd_pmi_kvs *kvs_list);
+bool HYD_pmcd_pmi_kvs_iter_next(struct HYD_pmcd_pmi_kvs *kvs_list,
+                                const char **key, const char **val);
 
 /* ---- struct HYD_pmcd_hdr ---- */
 

--- a/src/pm/hydra/mpiexec/pmiserv_kvs.c
+++ b/src/pm/hydra/mpiexec/pmiserv_kvs.c
@@ -56,14 +56,7 @@ HYD_status HYD_pmiserv_kvs_get(struct HYD_proxy *proxy, int process_fd, int pgid
         found = 1;
         val = pg_scratch->dead_processes;
     } else {
-        struct HYD_pmcd_pmi_kvs_pair *run;
-        for (run = pg_scratch->kvs->key_pair; run; run = run->next) {
-            if (strcmp(run->key, key) == 0) {
-                found = 1;
-                val = run->val;
-                break;
-            }
-        }
+        HYD_pmcd_pmi_kvs_find(pg_scratch->kvs, key, &val, &found);
     }
 
     if (!found && sync) {

--- a/src/pm/hydra/mpiexec/pmiserv_kvs.c
+++ b/src/pm/hydra/mpiexec/pmiserv_kvs.c
@@ -56,7 +56,7 @@ HYD_status HYD_pmiserv_kvs_get(struct HYD_proxy *proxy, int process_fd, int pgid
         found = 1;
         val = pg_scratch->dead_processes;
     } else {
-        HYD_pmcd_pmi_kvs_find(pg_scratch->kvs, key, &val, &found);
+        HYD_kvs_find(pg_scratch->kvs, key, &val, &found);
     }
 
     if (!found && sync) {

--- a/src/pm/hydra/mpiexec/pmiserv_pmi.c
+++ b/src/pm/hydra/mpiexec/pmiserv_pmi.c
@@ -30,54 +30,45 @@ HYD_status HYD_pmiserv_pmi_reply(struct HYD_proxy * proxy, int process_fd, struc
 
 HYD_status HYD_pmiserv_bcast_keyvals(struct HYD_proxy * proxy, int process_fd)
 {
-    int keyval_count, arg_count, j;
-    struct HYD_pmcd_pmi_kvs_pair *run;
-    struct HYD_pg *pg;
-    struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
     HYD_status status = HYD_SUCCESS;
-
     HYDU_FUNC_ENTER();
 
+    struct HYD_pg *pg;
+    struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
     pg = PMISERV_pg_by_id(proxy->pgid);
     pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) pg->pg_scratch;
 
-    /* find the number of keyvals */
-    keyval_count = 0;
-    for (run = pg_scratch->kvs->key_pair; run; run = run->next)
-        keyval_count++;
+    struct PMIU_cmd pmi;
+    int arg_count = 0, num_total = 0;
 
-    keyval_count -= pg_scratch->keyval_dist_count;
-
-    if (keyval_count) {
-        struct PMIU_cmd pmi;
-        PMIU_msg_set_query(&pmi, PMIU_WIRE_V1, PMIU_CMD_KVSCACHE, false /* not static */);
-        arg_count = 1;
-        for (run = pg_scratch->kvs->key_pair, j = 0; run; run = run->next, j++) {
-            if (j < pg_scratch->keyval_dist_count)
-                continue;
-
-            PMIU_cmd_add_str(&pmi, run->key, run->val);
-
-            arg_count++;
-            if (arg_count >= MAX_PMI_ARGS) {
-                pg_scratch->keyval_dist_count += (arg_count - 1);
-                for (int i = 0; i < pg->proxy_count; i++) {
-                    status = HYD_pmiserv_pmi_reply(&pg->proxy_list[i], process_fd, &pmi);
-                    HYDU_ERR_POP(status, "error writing PMI line\n");
-                }
-
+    const char *key, *val;
+    HYD_pmcd_pmi_kvs_iter_begin(pg_scratch->kvs, true);
+    while (true) {
+        bool has_next = HYD_pmcd_pmi_kvs_iter_next(pg_scratch->kvs, &key, &val);
+        if (has_next) {
+            if (arg_count == 0) {
                 PMIU_msg_set_query(&pmi, PMIU_WIRE_V1, PMIU_CMD_KVSCACHE, false /* not static */);
                 arg_count = 1;
             }
+            PMIU_cmd_add_str(&pmi, key, val);
+            arg_count++;
+            num_total++;
         }
 
-        if (arg_count > 1) {
-            pg_scratch->keyval_dist_count += (arg_count - 1);
+        if (arg_count >= MAX_PMI_ARGS || (!has_next && arg_count > 1)) {
             for (int i = 0; i < pg->proxy_count; i++) {
                 status = HYD_pmiserv_pmi_reply(&pg->proxy_list[i], process_fd, &pmi);
                 HYDU_ERR_POP(status, "error writing PMI line\n");
             }
+            arg_count = 0;
         }
+
+        if (!has_next) {
+            break;
+        }
+    }
+    HYD_pmcd_pmi_kvs_iter_end(pg_scratch->kvs);
+    if (num_total > 0) {
         PMIU_cmd_free_buf(&pmi);
     }
 

--- a/src/pm/hydra/mpiexec/pmiserv_pmi.c
+++ b/src/pm/hydra/mpiexec/pmiserv_pmi.c
@@ -42,9 +42,9 @@ HYD_status HYD_pmiserv_bcast_keyvals(struct HYD_proxy * proxy, int process_fd)
     int arg_count = 0, num_total = 0;
 
     const char *key, *val;
-    HYD_pmcd_pmi_kvs_iter_begin(pg_scratch->kvs, true);
+    HYD_kvs_iter_begin(pg_scratch->kvs, true);
     while (true) {
-        bool has_next = HYD_pmcd_pmi_kvs_iter_next(pg_scratch->kvs, &key, &val);
+        bool has_next = HYD_kvs_iter_next(pg_scratch->kvs, &key, &val);
         if (has_next) {
             if (arg_count == 0) {
                 PMIU_msg_set_query(&pmi, PMIU_WIRE_V1, PMIU_CMD_KVSCACHE, false /* not static */);
@@ -67,7 +67,7 @@ HYD_status HYD_pmiserv_bcast_keyvals(struct HYD_proxy * proxy, int process_fd)
             break;
         }
     }
-    HYD_pmcd_pmi_kvs_iter_end(pg_scratch->kvs);
+    HYD_kvs_iter_end(pg_scratch->kvs);
     if (num_total > 0) {
         PMIU_cmd_free_buf(&pmi);
     }

--- a/src/pm/hydra/mpiexec/pmiserv_pmi.h
+++ b/src/pm/hydra/mpiexec/pmiserv_pmi.h
@@ -27,7 +27,7 @@ struct HYD_pmcd_pmi_pg_scratch {
     int dead_process_count;
 
     char kvsname[PMI_MAXKVSLEN];
-    struct HYD_pmcd_pmi_kvs *kvs;
+    struct HYD_kvs *kvs;
     int keyval_dist_count;      /* Number of keyvals distributed */
 };
 

--- a/src/pm/hydra/mpiexec/pmiserv_spawn.c
+++ b/src/pm/hydra/mpiexec/pmiserv_spawn.c
@@ -17,8 +17,7 @@ static HYD_status allocate_spawn_pg(int spawner_pgid);
 static HYD_status fill_exec_params(struct HYD_exec *exec, const char *execname, int nprocs,
                                    int argcnt, const char **argv,
                                    int infonum, struct PMIU_token *infos);
-static HYD_status fill_preput_kvs(struct HYD_pmcd_pmi_kvs *kvs,
-                                  int preput_num, struct PMIU_token *infos);
+static HYD_status fill_preput_kvs(struct HYD_kvs *kvs, int preput_num, struct PMIU_token *infos);
 static HYD_status do_spawn(void);
 
 static char *get_exec_path(const char *execname, const char *path);
@@ -205,8 +204,7 @@ static HYD_status fill_exec_params(struct HYD_exec *exec, const char *execname, 
     goto fn_exit;
 }
 
-static HYD_status fill_preput_kvs(struct HYD_pmcd_pmi_kvs *kvs,
-                                  int preput_num, struct PMIU_token *infos)
+static HYD_status fill_preput_kvs(struct HYD_kvs *kvs, int preput_num, struct PMIU_token *infos)
 {
     HYD_status status = HYD_SUCCESS;
 

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -101,7 +101,7 @@ struct pmip_pg {
     struct HYD_exec *exec_list;
 
     /* This is for PMI-2 info-putnodeattr. Should it be per-node or per pg? */
-    struct HYD_pmcd_pmi_kvs *kvs;
+    struct HYD_kvs *kvs;
 
     /* PMI-1 caches server kvs locally */
     struct cache_put_elem cache_put;

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -676,7 +676,7 @@ HYD_status fn_info_getnodeattr(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 
     const char *val;
     int found;
-    HYD_pmcd_pmi_kvs_find(PMIP_pg_from_downstream(p)->kvs, key, &val, &found);
+    HYD_kvs_find(PMIP_pg_from_downstream(p)->kvs, key, &val, &found);
 
     if (!found && wait) {
         status = HYD_pmcd_pmi_v2_queue_req(p, pmi, key);

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -513,7 +513,8 @@ HYD_status fn_keyval_cache(struct pmip_pg *pg, struct PMIU_cmd *pmi)
     int i;
     for (i = 0; i < pg->num_elems; i++) {
         struct cache_elem *elem = pg->cache_get + i;
-        HASH_ADD_STR(pg->hash_get, key, elem, MPL_MEM_PM);
+        struct cache_elem *replaced;
+        HASH_REPLACE_STR(pg->hash_get, key, elem, replaced, MPL_MEM_PM);
     }
     for (; i < pg->num_elems + num_tokens; i++) {
         struct cache_elem *elem = pg->cache_get + i;
@@ -521,7 +522,8 @@ HYD_status fn_keyval_cache(struct pmip_pg *pg, struct PMIU_cmd *pmi)
         HYDU_ERR_CHKANDJUMP(status, NULL == elem->key, HYD_INTERNAL_ERROR, "%s", "");
         elem->val = MPL_strdup(tokens[i - pg->num_elems].val);
         HYDU_ERR_CHKANDJUMP(status, NULL == elem->val, HYD_INTERNAL_ERROR, "%s", "");
-        HASH_ADD_STR(pg->hash_get, key, elem, MPL_MEM_PM);
+        struct cache_elem *replaced;
+        HASH_REPLACE_STR(pg->hash_get, key, elem, replaced, MPL_MEM_PM);
     }
     pg->num_elems += num_tokens;
 

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -674,17 +674,9 @@ HYD_status fn_info_getnodeattr(struct pmip_downstream *p, struct PMIU_cmd *pmi)
     /* if a predefined value is not found, we let the code fall back
      * to regular search and return an error to the client */
 
+    const char *val;
     int found;
-    found = 0;
-
-    /* FIXME: wrap it in e.g. HYD_pmcd_pmi_find_kvs */
-    struct HYD_pmcd_pmi_kvs_pair *run;
-    for (run = PMIP_pg_from_downstream(p)->kvs->key_pair; run; run = run->next) {
-        if (!strcmp(run->key, key)) {
-            found = 1;
-            break;
-        }
-    }
+    HYD_pmcd_pmi_kvs_find(PMIP_pg_from_downstream(p)->kvs, key, &val, &found);
 
     if (!found && wait) {
         status = HYD_pmcd_pmi_v2_queue_req(p, pmi, key);
@@ -694,8 +686,7 @@ HYD_status fn_info_getnodeattr(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 
     struct PMIU_cmd pmi_response;
     if (found) {
-        pmi_errno =
-            PMIU_msg_set_response_getnodeattr(pmi, &pmi_response, is_static, run->val, true);
+        pmi_errno = PMIU_msg_set_response_getnodeattr(pmi, &pmi_response, is_static, val, true);
     } else {
         pmi_errno = PMIU_msg_set_response_fail(pmi, &pmi_response, is_static, 1, "not_found");
     }


### PR DESCRIPTION
## Pull Request Description
Refactor kvs to hide internals in lib/pmiserv_common.c.

Always add new keypair to the head, so that we always find the latest
key pair in the case of duplicate keys. Although PMI require users to
not put duplicate keys, this fix makes the behavior more expected.

Note: this fixes the session_re_init test. Session reinit skips
PMI_Finalize between sessions. The proper fix should introduce new API
e.g. PMI_KVS_Clear. For now, we'll simply make the later key overwirte
the previous duplicates.

Also rename the `HYD_pmcd_pmi_kvs_` prefix to `HYD_kvs_`

Fixes #6446

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
