### PR TITLE
hydra/mpiexec: detect missing executables

### DIFF
--- a/src/pm/hydra/mpiexec/mpiexec.c
+++ b/src/pm/hydra/mpiexec/mpiexec.c
@@ -53,6 +53,14 @@ int main(int argc, char **argv)
     status = HYD_uii_mpx_get_parameters(argv);
     HYDU_ERR_POP(status, "error parsing parameters\n");
 
+    /* Check if any exec argument is missing */
+    for (exec = HYD_uii_mpx_exec_list; exec; exec = exec->next) {
+        if (exec->exec[0] == NULL) {
+            HYDU_ERR_SETANDJUMP(status, HYD_INVALID_PARAM,
+                                "Missing executable. Try -h for usages.\n");
+        }
+    }
+
     /* The demux engine should be initialized before any sockets are
      * created, since it checks for STDIN's validity.  If STDIN was
      * closed and we opened a socket that got the same fd as STDIN,


### PR DESCRIPTION
## Pull Request Description

If the user invokes mpiexec without executables, currently it will segfault. Check for this case and provider proper error messages.

Fixes #6563  - `mpirun`

Related: #6520 - `mpirun -n 2`
EDIT: also #5598 - `mpirun -n`
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
