### PR TITLE
mpl/gpu: bypass yaksa when copying contiguous GPU buffers (PR #6)

### DIFF
--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -56,6 +56,10 @@ int MPIR_Ilocalcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendty
                     MPIR_Typerep_req * typerep_req);
 int MPIR_Localcopy_stream(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                           void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, void *stream);
+int MPIR_Localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
+                       MPL_pointer_attr_t * sendattr, void *recvbuf, MPI_Aint recvcount,
+                       MPI_Datatype recvtype, MPL_pointer_attr_t * recvattr,
+                       MPL_gpu_engine_type_t enginetype, bool commit);
 
 /* Contiguous datatype calculates buffer address with `(char *) buf + dt_true_lb`.
  * However, dt_true_lb is treated as ptrdiff_t (signed), and when buf is MPI_BOTTOM

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -960,6 +960,9 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **mpl_ze_init_device_fds: mpl_ze_init_device_fds failed
 **mpl_ze_mmap_device_ptr:  MPL_ze_mmap_device_pointer failed
 **mpl_gpu_fast_memcpy:  MPL_gpu_fast_memcpy failed
+**mpl_gpu_get_dev_id_from_attr: MPL_gpu_get_dev_id_from_attr failed
+**mpl_gpu_imemcpy: MPL_gpu_imemcpy failed
+**mpl_gpu_test: MPL_gpu_test failed
 
 ## GAVL tree related error messages
 **mpl_gavl_search: mpl_gavl_search failed

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -47,6 +47,14 @@ typedef enum {
     MPL_GPU_TYPE_HIP,
 } MPL_gpu_type_t;
 
+typedef enum {
+    MPL_GPU_ENGINE_TYPE_COMPUTE = 0,
+    MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH,
+    MPL_GPU_ENGINE_TYPE_COPY_LOW_LATENCY,
+} MPL_gpu_engine_type_t;
+
+#define MPL_GPU_ENGINE_NUM_TYPES 3
+
 typedef struct {
     /* Input */
     int debug_summary;
@@ -107,6 +115,10 @@ int MPL_gpu_init_device_mappings(int max_devid, int max_subdev_id);
 
 int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
                         MPL_pointer_attr_t * dest_attr, size_t size);
+
+int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
+                    MPL_gpu_engine_type_t engine_type, MPL_gpu_request * req, bool commit);
+int MPL_gpu_test(MPL_gpu_request * req, int *completed);
 
 typedef void (*MPL_gpu_hostfn) (void *data);
 int MPL_gpu_launch_hostfn(MPL_gpu_stream_t stream, MPL_gpu_hostfn fn, void *data);

--- a/src/mpl/include/mpl_gpu_cuda.h
+++ b/src/mpl/include/mpl_gpu_cuda.h
@@ -12,6 +12,7 @@
 typedef cudaIpcMemHandle_t MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
 typedef struct cudaPointerAttributes MPL_gpu_device_attr;
+typedef int MPL_gpu_request;
 typedef cudaStream_t MPL_gpu_stream_t;
 
 /* Note: event variable need be allocated on a gpu registered host buffer for it to work */

--- a/src/mpl/include/mpl_gpu_fallback.h
+++ b/src/mpl/include/mpl_gpu_fallback.h
@@ -9,6 +9,7 @@
 typedef int MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
 typedef int MPL_gpu_device_attr;        /* dummy type */
+typedef int MPL_gpu_request;
 typedef int MPL_gpu_stream_t;
 
 typedef volatile int MPL_gpu_event_t;

--- a/src/mpl/include/mpl_gpu_hip.h
+++ b/src/mpl/include/mpl_gpu_hip.h
@@ -16,6 +16,7 @@
 typedef hipIpcMemHandle_t MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
 typedef struct hipPointerAttribute_t MPL_gpu_device_attr;
+typedef int MPL_gpu_request;
 typedef hipStream_t MPL_gpu_stream_t;
 
 typedef volatile int MPL_gpu_event_t;

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -16,6 +16,19 @@ typedef struct {
 typedef ze_ipc_mem_handle_t MPL_gpu_ipc_mem_handle_t;
 typedef ze_device_handle_t MPL_gpu_device_handle_t;
 typedef ze_alloc_attr_t MPL_gpu_device_attr;
+
+typedef struct MPL_cmdlist_pool {
+    ze_command_list_handle_t cmdList;
+    int dev;
+    int engine;
+    struct MPL_cmdlist_pool *next, *prev;
+} MPL_cmdlist_pool_t;
+
+typedef struct {
+    ze_event_handle_t event;
+    MPL_cmdlist_pool_t *cmdList;
+} MPL_gpu_request;
+
 /* FIXME: implement ze stream */
 typedef int MPL_gpu_stream_t;
 

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -499,6 +499,17 @@ int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
     return MPL_ERR_GPU_INTERNAL;
 }
 
+int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
+                    MPL_gpu_engine_type_t engine_type, MPL_gpu_request * req, bool commit)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
+int MPL_gpu_test(MPL_gpu_request * req, int *completed)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
 int MPL_gpu_launch_hostfn(cudaStream_t stream, MPL_gpu_hostfn fn, void *data)
 {
     cudaError_t result;

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -137,6 +137,17 @@ int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
     return MPL_ERR_GPU_INTERNAL;
 }
 
+int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
+                    MPL_gpu_engine_type_t engine_type, MPL_gpu_request * req, bool commit)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
+int MPL_gpu_test(MPL_gpu_request * req, int *completed)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
 int MPL_gpu_launch_hostfn(int stream, MPL_gpu_hostfn fn, void *data)
 {
     return -1;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -448,6 +448,17 @@ int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
     return MPL_ERR_GPU_INTERNAL;
 }
 
+int MPL_gpu_imemcpy(void *dest_ptr, void *src_ptr, size_t size, int dev,
+                    MPL_gpu_engine_type_t engine_type, MPL_gpu_request * req, bool commit)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
+int MPL_gpu_test(MPL_gpu_request * req, int *completed)
+{
+    return MPL_ERR_GPU_INTERNAL;
+}
+
 /* ---- */
 struct stream_callback_wrapper {
     MPL_gpu_hostfn fn;


### PR DESCRIPTION
## Pull Request Description

This PR adds GPU copy operations for contiguous buffers in MPL. When working with contiguous buffers, it is unnecessary to pack/unpack via Yaksa. Thus, by copying directly from within MPL, we eliminate these overheads from using Yaksa.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.