### PR TITLE
mpl/gpu/ze: add support for implicit scaling (PR #7)

### DIFF
--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -200,7 +200,9 @@ int MPIDI_GPU_get_ipc_attr(const void *vaddr, int rank, MPIR_Comm * comm,
     MPIR_ERR_CHECK(mpi_errno);
 
     if (handle_obj == NULL) {
-        mpl_err = MPL_gpu_ipc_handle_create(pbase, &ipc_attr->ipc_handle.gpu.ipc_handle);
+        mpl_err =
+            MPL_gpu_ipc_handle_create(pbase, &ipc_attr->gpu_attr.device_attr,
+                                      &ipc_attr->ipc_handle.gpu.ipc_handle);
         MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                             "**gpu_ipc_handle_create");
         ipc_attr->ipc_handle.gpu.handle_status = MPIDI_GPU_IPC_HANDLE_REMAP_REQUIRED;

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -302,7 +302,7 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int map_dev_id, void
         if (do_mmap) {
 #ifdef MPL_HAVE_ZE
             mpl_err =
-                MPL_ze_ipc_handle_mmap_host(handle.ipc_handle, 1, map_dev_id, handle.len, &pbase);
+                MPL_ze_ipc_handle_mmap_host(&handle.ipc_handle, 1, map_dev_id, handle.len, &pbase);
             MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                                 "**gpu_ipc_handle_map");
             *vaddr = (void *) ((uintptr_t) pbase + handle.offset);
@@ -311,7 +311,7 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int map_dev_id, void
             goto fn_fail;
 #endif
         } else {
-            mpl_err = MPL_gpu_ipc_handle_map(handle.ipc_handle, map_dev_id, &pbase);
+            mpl_err = MPL_gpu_ipc_handle_map(&handle.ipc_handle, map_dev_id, &pbase);
             MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                                 "**gpu_ipc_handle_map");
 

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -82,7 +82,8 @@ static inline int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t
 int MPL_gpu_query_support(MPL_gpu_type_t * type);
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr);
 
-int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle);
+int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
+                              MPL_gpu_ipc_mem_handle_t * ipc_handle);
 /* Used in ipc_handle_free_hook. Needed for fd-based ipc mechanism. */
 int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr);
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr);

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -83,10 +83,10 @@ int MPL_gpu_query_support(MPL_gpu_type_t * type);
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr);
 
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
-                              MPL_gpu_ipc_mem_handle_t * ipc_handle);
+                              MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle);
 /* Used in ipc_handle_free_hook. Needed for fd-based ipc mechanism. */
 int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr);
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr);
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle, int dev_id, void **ptr);
 int MPL_gpu_ipc_handle_unmap(void *ptr);
 
 int MPL_gpu_malloc_host(void **ptr, size_t size);

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -13,7 +13,19 @@ typedef struct {
     ze_device_handle_t device;
 } ze_alloc_attr_t;
 
-typedef ze_ipc_mem_handle_t MPL_gpu_ipc_mem_handle_t;
+typedef struct {
+    int fds[2];
+    uint32_t nfds;
+    pid_t pid;
+    int dev_id;
+    uint64_t mem_id;
+} fd_pid_t;
+
+typedef struct _MPL_gpu_ipc_mem_handle_t {
+    ze_ipc_mem_handle_t ipc_handles[2];
+    fd_pid_t data;
+} MPL_gpu_ipc_mem_handle_t;
+
 typedef ze_device_handle_t MPL_gpu_device_handle_t;
 typedef ze_alloc_attr_t MPL_gpu_device_attr;
 
@@ -45,10 +57,10 @@ void MPL_ze_set_fds(int num_fds, int *fds);
 void MPL_ze_ipc_remove_cache_handle(void *dptr);
 int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, int local_dev_id,
                              int use_shared_fd, MPL_gpu_ipc_mem_handle_t * ipc_handle);
-int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_handle, int dev_id,
+int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * ipc_handle, int is_shared_handle, int dev_id,
                           int is_mmap, size_t size, void **ptr);
-int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int shared_handle, int dev_id,
-                                size_t size, void **ptr);
+int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t * ipc_handle, int shared_handle,
+                                int dev_id, size_t size, void **ptr);
 int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,
                                MPL_gpu_device_handle_t device, void **mmaped_ptr);
 int MPL_ze_mmap_handle_unmap(void *ptr, int dev_id);

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -131,7 +131,8 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     goto fn_exit;
 }
 
-int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
+int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
+                              MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     int mpl_err = MPL_SUCCESS;
     cudaError_t ret;

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -152,7 +152,7 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
     return MPL_SUCCESS;
 }
 
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * ipc_handle, int dev_id, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;
     cudaError_t ret;
@@ -160,7 +160,7 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
 
     cudaGetDevice(&prev_devid);
     cudaSetDevice(dev_id);
-    ret = cudaIpcOpenMemHandle(ptr, ipc_handle, cudaIpcMemLazyEnablePeerAccess);
+    ret = cudaIpcOpenMemHandle(ptr, *ipc_handle, cudaIpcMemLazyEnablePeerAccess);
     CUDA_ERR_CHECK(ret);
 
   fn_exit:

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -31,7 +31,8 @@ int MPL_gpu_init_device_mappings(int max_devid, int max_subdev_id)
     return MPL_SUCCESS;
 }
 
-int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
+int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
+                              MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     abort();
     return MPL_ERR_GPU_INTERNAL;

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -44,7 +44,7 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
     return MPL_ERR_GPU_INTERNAL;
 }
 
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * ipc_handle, int dev_id, void **ptr)
 {
     abort();
     return MPL_ERR_GPU_INTERNAL;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -144,7 +144,7 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
     return MPL_SUCCESS;
 }
 
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * ipc_handle, int dev_id, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;
     hipError_t ret;
@@ -152,7 +152,7 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
 
     hipGetDevice(&prev_devid);
     hipSetDevice(dev_id);
-    ret = hipIpcOpenMemHandle(ptr, ipc_handle, hipIpcMemLazyEnablePeerAccess);
+    ret = hipIpcOpenMemHandle(ptr, *ipc_handle, hipIpcMemLazyEnablePeerAccess);
     HIP_ERR_CHECK(ret);
 
   fn_exit:

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -123,7 +123,8 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     goto fn_exit;
 }
 
-int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_ipc_mem_handle_t * ipc_handle)
+int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
+                              MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     int mpl_err = MPL_SUCCESS;
     hipError_t ret;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -153,14 +153,6 @@ typedef struct {
 
 static MPL_ze_mem_id_entry_t *mem_id_cache = NULL;
 
-typedef struct {
-    int fds[2];
-    uint32_t nfds;
-    pid_t pid;
-    int dev_id;
-    uint64_t mem_id;
-} fd_pid_t;
-
 typedef struct gpu_free_hook {
     void (*free_hook) (void *dptr);
     struct gpu_free_hook *next;
@@ -1344,7 +1336,7 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
     goto fn_exit;
 }
 
-int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void **ptr)
+int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle, int dev_id, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;
     MPL_ze_mapped_buffer_entry_t *cache_entry = NULL;
@@ -1353,7 +1345,7 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
     unsigned keylen = 0;
 
     fd_pid_t h;
-    memcpy(&h, &ipc_handle, sizeof(fd_pid_t));
+    h = mpl_ipc_handle->data;
 
     if (likely(MPL_gpu_info.specialized_cache)) {
         /* Check if ipc-mapped buffer is already cached */
@@ -1369,7 +1361,7 @@ int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int dev_id, void
     if (cache_entry && cache_entry->ipc_buf) {
         *ptr = cache_entry->ipc_buf;
     } else {
-        mpl_err = MPL_ze_ipc_handle_map(ipc_handle, true, dev_id, false, 0, ptr);
+        mpl_err = MPL_ze_ipc_handle_map(mpl_ipc_handle, true, dev_id, false, 0, ptr);
         if (mpl_err != MPL_SUCCESS) {
             goto fn_fail;
         }
@@ -2043,7 +2035,7 @@ void MPL_ze_ipc_remove_cache_handle(void *dptr)
 }
 
 int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, int local_dev_id,
-                             int use_shared_fd, MPL_gpu_ipc_mem_handle_t * ipc_handle)
+                             int use_shared_fd, MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle)
 {
     int mpl_err = MPL_SUCCESS;
     ze_result_t ret;
@@ -2120,8 +2112,10 @@ int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, in
     h.pid = mypid;
     h.mem_id = mem_id;
 
-    memset(ipc_handle, 0, sizeof(MPL_gpu_ipc_mem_handle_t));
-    memcpy(ipc_handle, &h, sizeof(fd_pid_t));
+    for (int i = 0; i < nfds; i++) {
+        memcpy(&mpl_ipc_handle->ipc_handles[i], &ze_ipc_handle[i], sizeof(ze_ipc_mem_handle_t));
+    }
+    mpl_ipc_handle->data = h;
 
   fn_exit:
     return mpl_err;
@@ -2130,8 +2124,8 @@ int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, in
     goto fn_exit;
 }
 
-int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_handle, int dev_id,
-                          int is_mmap, size_t size, void **ptr)
+int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle, int is_shared_handle,
+                          int dev_id, int is_mmap, size_t size, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;
     ze_result_t ret;
@@ -2140,7 +2134,7 @@ int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_han
     MPL_gpu_device_handle_t dev_handle;
 
     fd_pid_t h;
-    memcpy(&h, &ipc_handle, sizeof(fd_pid_t));
+    h = mpl_ipc_handle->data;
     nfds = h.nfds;
 
     if (shared_device_fds != NULL) {
@@ -2188,7 +2182,7 @@ int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_han
             goto fn_fail;
         }
         for (int i = 0; i < nfds; i++) {
-            memset(&ze_ipc_handle[i], 0, sizeof(ze_ipc_mem_handle_t));
+            memcpy(&ze_ipc_handle[i], &mpl_ipc_handle->ipc_handles[i], sizeof(ze_ipc_mem_handle_t));
             memcpy(&ze_ipc_handle[i], &fds[i], sizeof(int));
         }
 
@@ -2207,7 +2201,7 @@ int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_han
 }
 
 /* given an remote IPC handle, mmap it to host */
-int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shared_handle,
+int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle, int is_shared_handle,
                                 int dev_id, size_t size, void **ptr)
 {
     int mpl_err = MPL_SUCCESS;
@@ -2217,7 +2211,7 @@ int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shar
     MPL_ze_mapped_buffer_lookup_t lookup_entry;
 
     fd_pid_t h;
-    memcpy(&h, &ipc_handle, sizeof(fd_pid_t));
+    h = mpl_ipc_handle->data;
 
     if (likely(MPL_gpu_info.specialized_cache)) {
         /* Check if ipc-mapped buffer is already cached */
@@ -2253,7 +2247,7 @@ int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t ipc_handle, int is_shar
     }
 
     if (*ptr == NULL) {
-        mpl_err = MPL_ze_ipc_handle_map(ipc_handle, is_shared_handle, dev_id, true, size, ptr);
+        mpl_err = MPL_ze_ipc_handle_map(mpl_ipc_handle, is_shared_handle, dev_id, true, size, ptr);
         if (mpl_err != MPL_SUCCESS) {
             goto fn_fail;
         }


### PR DESCRIPTION
## Pull Request Description

This PR adds support for implicit scaling for Intel GPUs. Additionally, this PR adds various bug fixes related to IPC and caching of IPC handles.

Intel GPUs may have multiple physical tiles (denoted in Level Zero API as a `subdevice`) each of which may have their own compute engine, copy engines, and/or memory. Explicit scaling is a mode where these tiles are considered separate devices; when querying devices, you would have a root device (the entire GPU), and multiple subdevices (the individual tiles). Each of these devices are distinct and can be targets for allocation.

Implicit scaling removes the notion of subdevices and only exposes a root device. The driver automatically distributes work and memory across the tiles. Thus, an allocation against the root device could represent multiple allocations distributed between the tiles. During regular access to this memory (i.e. via Level Zero APIs, direct access inside kernels, etc.), the driver automatically handles dereferencing so this split memory allocation is transparent to the user. However, since IPC is backed by file descriptors, and a root device allocation could be represented by multiple allocations internally, there must be a file descriptor, and thus an IPC handle, for each of these allocations. The regular `zeMemGetIpcHandle` and `zeMemOpenIpcHandle` cannot handle this, so we must use the driver extensions `zexMemGetIpcHandle` and `zexMemOpenIpcHandles`.

Depends on #6569

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
