### PR TITLE
coll/csel: consolidate with CSEL_NODE_TYPE__OPERATOR__ANY

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -29,7 +29,6 @@ typedef enum MPIR_Comm_hierarchy_kind_t {
     MPIR_COMM_HIERARCHY_KIND__NODE_ROOTS = 2,   /* is the subcomm for node roots */
     MPIR_COMM_HIERARCHY_KIND__NODE = 3, /* is the subcomm for a node */
     MPIR_COMM_HIERARCHY_KIND__MULTI_LEADS = 4,  /* is the multi_leaders_comm for a node */
-    MPIR_COMM_HIERARCHY_KIND__SIZE      /* cardinality of this enum */
 } MPIR_Comm_hierarchy_kind_t;
 
 typedef enum {


### PR DESCRIPTION
## Pull Request Description
The csel tree is a decision tree. Rather than using different names to refer to the "else" branch, simplify them with a common name CSEL_NODE_TYPE__OPERATOR__ANY.

We are allowing the usage of "kind=any" in the json files, but it is equivallent to just use "any".

Reference: https://github.com/pmodels/mpich/pull/6572#discussion_r1242949990

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
