### PR TITLE
mpir_pmi: allow runtime pmi selection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1621,7 +1621,6 @@ AM_CONDITIONAL([PRIMARY_PM_GFORKER],[test "X$first_pm_name" = "Xgforker"])
 AM_CONDITIONAL([PRIMARY_PM_REMSHELL],[test "X$first_pm_name" = "Xremshell"])
 
 # ---- $with_pmilib ----
-
 pmisrcdir=""
 AC_SUBST([pmisrcdir])
 pmilib=""
@@ -1699,6 +1698,39 @@ case "$with_pmilib" in
     AC_MSG_ERROR([pmilib $with_pmilib not supported.])
     ;;
 esac
+
+
+# ---- define ENABLE_PMI[12X] ----
+enable_pmi1="no"
+enable_pmi2="no"
+enable_pmix="no"
+if test "$with_pmi" = "pmi2" ; then
+    enable_pmi2="yes"
+elif test "$with_pmi" = "pmix" ; then
+    enable_pmix="yes"
+elif test "$with_pmilib" = "mpich" -o "$with_pmilib" = "install"; then
+    # mpich's libpmi support both PMI1 and PMI2
+    enable_pmi1="yes"
+    enable_pmi2="yes"
+else
+    # detect
+    AC_CHECK_FUNC([PMI_Init], [enable_pmi1="yes"])
+    AC_CHECK_FUNC([PMI2_Init], [enable_pmi2="yes"])
+    AC_CHECK_FUNC([PMIx_Init], [enable_pmix="yes"])
+    if test "$enable_pmi1" != "yes" -a "$enable_pmi2" != "yes" -a "$enable_pmix" != "yes"; then
+        AC_MSG_ERROR([Neither PMI, nor PMI2, nor PMIx is enabled.])
+    fi
+fi
+
+if test "$enable_pmi1" = "yes"; then
+    AC_DEFINE([ENABLE_PMI1], 1, [Define to enable PMI1 protocol])
+fi
+if test "$enable_pmi2" = "yes"; then
+    AC_DEFINE([ENABLE_PMI2], 1, [Define to enable PMI2 protocol])
+fi
+if test "$enable_pmix" = "yes"; then
+    AC_DEFINE([ENABLE_PMIX], 1, [Define to enable PMIX protocol])
+fi
 
 # ---------------------------------------------------------------------------
 # Check for whether the compiler defines a symbol that contains the

--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -55,7 +55,7 @@ int MPIR_pmi_set_threaded(int is_threaded);
 int MPIR_pmi_max_key_size(void);
 int MPIR_pmi_max_val_size(void);
 const char *MPIR_pmi_job_id(void);
-char *MPIR_pmi_get_hwloc_xmlfile(void);
+char *MPIR_pmi_get_jobattr(const char *key);    /* key must use "PMI_" prefix */
 
 /* PMI wrapper utilities */
 
@@ -97,7 +97,6 @@ int MPIR_pmi_unpublish(const char name[]);
 
 /* Other misc functions */
 int MPIR_pmi_get_universe_size(int *universe_size);
-char *MPIR_pmi_get_failed_procs(void);
 
 struct MPIR_Info;               /* forward declare (mpir_info.h) */
 int MPIR_pmi_spawn_multiple(int count, char *commands[], char **argvs[],

--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -8,27 +8,23 @@
 
 #include "mpichconf.h"
 
-#if !defined USE_PMI1_API && !defined USE_PMI2_API && !defined USE_PMIX_API
-#define USE_PMI1_API
-#endif
-
+#ifdef ENABLE_PMI1
 #if defined(USE_PMI1_SLURM)
 #include <slurm/pmi.h>
-
-#elif defined(USE_PMI2_SLURM)
-#include <slurm/pmi2.h>
-
-#elif defined(USE_PMI2_CRAY)
-#include <pmi2.h>
-
-#elif defined(USE_PMI1_API)
+#else
 #include <pmi.h>
+#endif
+#endif
 
-#elif defined(USE_PMI2_API)
+#ifdef ENABLE_PMI2
+#if defined(USE_PMI2_SLURM)
+#include <slurm/pmi2.h>
+#else
 #include <pmi2.h>
-#define PMI_keyval_t PMI2_keyval_t
+#endif
+#endif
 
-#elif defined(USE_PMIX_API)
+#ifdef ENABLE_PMIX
 #include <pmix.h>
 #endif
 

--- a/src/mpi/comm/ulfm_impl.c
+++ b/src/mpi/comm/ulfm_impl.c
@@ -73,7 +73,7 @@ int MPIR_Comm_get_failed_impl(MPIR_Comm * comm_ptr, MPIR_Group ** failed_group_p
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    char *failed_procs_string = MPIR_pmi_get_failed_procs();
+    char *failed_procs_string = MPIR_pmi_get_jobattr("PMI_dead_processes");
 
     if (!failed_procs_string) {
         *failed_group_ptr = MPIR_Group_empty;

--- a/src/mpid/ch3/src/ch3u_handle_connection.c
+++ b/src/mpid/ch3/src/ch3u_handle_connection.c
@@ -471,7 +471,7 @@ int MPIDI_CH3U_Check_for_failed_procs(void)
 
     MPIR_FUNC_ENTER;
 
-    MPIDI_failed_procs_string = MPIR_pmi_get_failed_procs();
+    MPIDI_failed_procs_string = MPIR_pmi_get_jobattr("PMI_dead_processes");
 
     if (*MPIDI_failed_procs_string == '\0') {
         /* there are no failed processes */

--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -141,7 +141,7 @@ int MPIDI_check_for_failed_procs(void)
      * with the rank, then we need to create the failed group from
      * something bigger than comm_world. */
 
-    char *failed_procs_string = MPIR_pmi_get_failed_procs();
+    char *failed_procs_string = MPIR_pmi_get_jobattr("PMI_dead_processes");
 
     if (failed_procs_string) {
         MPL_free(failed_procs_string);

--- a/src/pmi/include/pmi2.h
+++ b/src/pmi/include/pmi2.h
@@ -6,8 +6,10 @@
 #ifndef PMI2_H_INCLUDED
 #define PMI2_H_INCLUDED
 
+#ifndef PMI_VERSION
 #define PMI_VERSION    2
 #define PMI_SUBVERSION 0
+#endif
 
 #define PMI2_MAX_KEYLEN 64
 #define PMI2_MAX_VALLEN 1024

--- a/src/util/mpir_hwtopo.c
+++ b/src/util/mpir_hwtopo.c
@@ -200,7 +200,7 @@ int MPII_hwtopo_init(void)
 #ifdef HAVE_HWLOC
     bindset = hwloc_bitmap_alloc();
     hwloc_topology_init(&hwloc_topology);
-    char *xmlfile = MPIR_pmi_get_hwloc_xmlfile();
+    char *xmlfile = MPIR_pmi_get_jobattr("PMI_hwloc_xmlfile");
     if (xmlfile != NULL) {
         int rc;
         rc = hwloc_topology_set_xml(hwloc_topology, xmlfile);

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -115,36 +115,28 @@ static int pmi_max_val_size;
 
 static char *pmi_kvs_name;
 
-#if defined(ENABLE_PMIX)
-static pmix_proc_t pmix_proc;
-static pmix_proc_t pmix_wcproc;
-#endif
-
 static char *hwloc_topology_xmlfile;
 
-static void MPIR_pmi_finalize_on_exit(void)
-{
-    switch (MPIR_CVAR_PMI_VERSION) {
-#ifdef ENABLE_PMI1
-        case MPIR_CVAR_PMI_VERSION_1:
-            PMI_Finalize();
-            break;
-#endif
-#ifdef ENABLE_PMI2
-        case MPIR_CVAR_PMI_VERSION_2:
-            PMI2_Finalize();
-            break;
-#endif
-#ifdef ENABLE_PMI3
-        case MPIR_CVAR_PMI_VERSION_x:
-            PMIx_Finalize(NULL, 0);
-            break;
-#endif
-        default:
-            MPIR_Assert(0);
-            break;
-    };
-}
+#include "mpir_pmi1.inc"
+#include "mpir_pmi2.inc"
+#include "mpir_pmix.inc"
+
+#define SWITCH_PMI(call_pmi1, call_pmi2, call_pmix) \
+    switch (MPIR_CVAR_PMI_VERSION) { \
+        case MPIR_CVAR_PMI_VERSION_1: \
+            call_pmi1; \
+            break; \
+        case MPIR_CVAR_PMI_VERSION_2: \
+            call_pmi2; \
+            break; \
+        case MPIR_CVAR_PMI_VERSION_x: \
+            call_pmix; \
+            break; \
+        default: \
+            MPIR_Assert(0); \
+            break; \
+    }
+
 
 static int check_MPIR_CVAR_PMI_VERSION(void)
 {
@@ -178,144 +170,14 @@ static int check_MPIR_CVAR_PMI_VERSION(void)
     return MPI_SUCCESS;
 }
 
-/* -- MPIR_pmi_init -- */
-static int pmi1_init(int *has_parent, int *rank, int *size, int *appnum)
+static void MPIR_pmi_finalize_on_exit(void)
 {
-#ifdef ENABLE_PMI1
-    int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
-
-    pmi_errno = PMI_Init(has_parent);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_init", "**pmi_init %d", pmi_errno);
-    pmi_errno = PMI_Get_rank(rank);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_get_rank", "**pmi_get_rank %d", pmi_errno);
-    pmi_errno = PMI_Get_size(size);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_get_size", "**pmi_get_size %d", pmi_errno);
-    pmi_errno = PMI_Get_appnum(appnum);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_get_appnum", "**pmi_get_appnum %d", pmi_errno);
-
-    int pmi_max_kvs_name_length;
-    pmi_errno = PMI_KVS_Get_name_length_max(&pmi_max_kvs_name_length);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_kvs_get_name_length_max",
-                         "**pmi_kvs_get_name_length_max %d", pmi_errno);
-    pmi_kvs_name = (char *) MPL_malloc(pmi_max_kvs_name_length, MPL_MEM_OTHER);
-    pmi_errno = PMI_KVS_Get_my_name(pmi_kvs_name, pmi_max_kvs_name_length);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_kvs_get_my_name", "**pmi_kvs_get_my_name %d", pmi_errno);
-
-    pmi_errno = PMI_KVS_Get_key_length_max(&pmi_max_key_size);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_kvs_get_key_length_max",
-                         "**pmi_kvs_get_key_length_max %d", pmi_errno);
-    pmi_errno = PMI_KVS_Get_value_length_max(&pmi_max_val_size);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_kvs_get_value_length_max",
-                         "**pmi_kvs_get_value_length_max %d", pmi_errno);
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-#else
-    return MPI_ERR_INTERN;
-#endif
-}
-
-static int pmi2_init(int *has_parent, int *rank, int *size, int *appnum)
-{
-#ifdef ENABLE_PMI2
-    int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
-
-    pmi_max_key_size = PMI2_MAX_KEYLEN;
-    pmi_max_val_size = PMI2_MAX_VALLEN;
-
-    pmi_errno = PMI2_Init(has_parent, size, rank, appnum);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_init", "**pmi_init %d", pmi_errno);
-
-    pmi_kvs_name = (char *) MPL_malloc(PMI2_MAX_VALLEN, MPL_MEM_OTHER);
-    pmi_errno = PMI2_Job_GetId(pmi_kvs_name, PMI2_MAX_VALLEN);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_job_getid", "**pmi_job_getid %d", pmi_errno);
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-#else
-    return MPI_ERR_INTERN;
-#endif
-}
-
-static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
-{
-#ifdef ENABLE_PMI2
-    int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
-
-    pmi_max_key_size = PMIX_MAX_KEYLEN;
-    pmi_max_val_size = 1024;    /* this is what PMI2_MAX_VALLEN currently set to */
-
-    pmix_value_t *pvalue = NULL;
-
-    /* Since we only call PMIx_Finalize once at `atexit` handler, we need prevent
-     * calling PMIx_Init multiple times. */
-    static int pmix_init_count = 0;
-    pmix_init_count++;
-    if (pmix_init_count == 1) {
-        pmi_errno = PMIx_Init(&pmix_proc, NULL, 0);
-        if (pmi_errno == PMIX_ERR_UNREACH) {
-            /* no pmi server, assume we are a singleton */
-            goto singleton_out;
-        }
-        MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                             "**pmix_init", "**pmix_init %d", pmi_errno);
-
-        PMIX_PROC_CONSTRUCT(&pmix_wcproc);
-        MPL_strncpy(pmix_wcproc.nspace, pmix_proc.nspace, PMIX_MAX_NSLEN);
-        pmix_wcproc.rank = PMIX_RANK_WILDCARD;
-    }
-
-    *rank = pmix_proc.rank;
-
-    pmi_errno = PMIx_Get(&pmix_wcproc, PMIX_JOB_SIZE, NULL, 0, &pvalue);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_get", "**pmix_get %d", pmi_errno);
-    *size = pvalue->data.uint32;
-    PMIX_VALUE_RELEASE(pvalue);
-
-    /* PMIX_JOBID seems to be more supported than PMIX_NSPACE */
-    /* TODO: fallback in case the key is not supported */
-    pmi_errno = PMIx_Get(&pmix_wcproc, PMIX_JOBID, NULL, 0, &pvalue);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_get", "**pmix_get %d", pmi_errno);
-    pmi_kvs_name = MPL_strdup(pvalue->data.string);
-    PMIX_VALUE_RELEASE(pvalue);
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-  singleton_out:
-    *rank = 0;
-    *size = 1;
-    *appnum = 0;
-    *has_parent = 0;
-    goto fn_exit;
-#else
-    return MPI_ERR_INTERN;
-#endif
+    SWITCH_PMI(pmi1_exit(), pmi2_exit(), pmix_exit());
 }
 
 int MPIR_pmi_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
     static bool pmi_connected = false;
 
     mpi_errno = check_MPIR_CVAR_PMI_VERSION();
@@ -326,20 +188,9 @@ int MPIR_pmi_init(void)
     MPL_env2int("PMI_SUBVERSION", &pmi_subversion);
 
     int has_parent, rank, size, appnum;
-    switch (MPIR_CVAR_PMI_VERSION) {
-        case MPIR_CVAR_PMI_VERSION_1:
-            mpi_errno = pmi1_init(&has_parent, &rank, &size, &appnum);
-            break;
-        case MPIR_CVAR_PMI_VERSION_2:
-            mpi_errno = pmi2_init(&has_parent, &rank, &size, &appnum);
-            break;
-        case MPIR_CVAR_PMI_VERSION_x:
-            mpi_errno = pmix_init(&has_parent, &rank, &size, &appnum);
-            break;
-        default:
-            MPIR_Assert(0);
-            break;
-    };
+    SWITCH_PMI(mpi_errno = pmi1_init(&has_parent, &rank, &size, &appnum),
+               mpi_errno = pmi2_init(&has_parent, &rank, &size, &appnum),
+               mpi_errno = pmix_init(&has_parent, &rank, &size, &appnum));
     MPIR_ERR_CHECK(mpi_errno);
 
     unsigned world_id = 0;
@@ -392,13 +243,8 @@ void MPIR_pmi_finalize(void)
 
 void MPIR_pmi_abort(int exit_code, const char *error_msg)
 {
-#ifdef USE_PMI1_API
-    PMI_Abort(exit_code, error_msg);
-#elif defined(USE_PMI2_API)
-    PMI2_Abort(TRUE, error_msg);
-#elif defined(USE_PMIX_API)
-    PMIx_Abort(exit_code, error_msg, NULL, 0);
-#endif
+    SWITCH_PMI(pmi1_abort(exit_code, error_msg),
+               pmi2_abort(exit_code, error_msg), pmix_abort(exit_code, error_msg));
 }
 
 /* This function is currently unused in MPICH because we always call
@@ -406,9 +252,11 @@ void MPIR_pmi_abort(int exit_code, const char *error_msg)
  */
 int MPIR_pmi_set_threaded(int is_threaded)
 {
-#if defined(USE_PMI2_API) && !defined(USE_PMI2_SLURM) && !defined(USE_PMI2_CRAY)
-    PMI2_Set_threaded(is_threaded);
+    if (MPIR_CVAR_PMI_VERSION == MPIR_CVAR_PMI_VERSION_2) {
+#if ENABLE_PMI2
+        PMI2_Set_threaded(is_threaded);
 #endif
+    }
     return MPI_SUCCESS;
 }
 
@@ -432,76 +280,21 @@ const char *MPIR_pmi_job_id(void)
 int MPIR_pmi_kvs_put(const char *key, const char *val)
 {
     int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
 
-#ifdef USE_PMI1_API
-    pmi_errno = PMI_KVS_Put(pmi_kvs_name, key, val);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_kvs_put", "**pmi_kvs_put %d", pmi_errno);
-    pmi_errno = PMI_KVS_Commit(pmi_kvs_name);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_kvs_commit", "**pmi_kvs_commit %d", pmi_errno);
-#elif defined(USE_PMI2_API)
-    pmi_errno = PMI2_KVS_Put(key, val);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_kvsput", "**pmi_kvsput %d", pmi_errno);
-#elif defined(USE_PMIX_API)
-    pmix_value_t value;
-    value.type = PMIX_STRING;
-    value.data.string = (char *) val;
-    pmi_errno = PMIx_Put(PMIX_GLOBAL, key, &value);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_put", "**pmix_put %d", pmi_errno);
-    pmi_errno = PMIx_Commit();
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_commit", "**pmix_commit %d", pmi_errno);
-#endif
-
-  fn_exit:
+    SWITCH_PMI(mpi_errno = pmi1_put(key, val),
+               mpi_errno = pmi2_put(key, val), mpi_errno = pmix_put(key, val));
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 /* NOTE: src is a hint, use src = -1 if not known */
 int MPIR_pmi_kvs_get(int src, const char *key, char *val, int val_size)
 {
     int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
 
-#ifdef USE_PMI1_API
-    /* src is not used in PMI1 */
-    pmi_errno = PMI_KVS_Get(pmi_kvs_name, key, val, val_size);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_kvs_get", "**pmi_kvs_get %d", pmi_errno);
-#elif defined(USE_PMI2_API)
-    if (src < 0)
-        src = PMI2_ID_NULL;
-    int out_len;
-    pmi_errno = PMI2_KVS_Get(pmi_kvs_name, src, key, val, val_size, &out_len);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_kvsget", "**pmi_kvsget %d", pmi_errno);
-#elif defined(USE_PMIX_API)
-    pmix_value_t *pvalue;
-    if (src < 0) {
-        pmi_errno = PMIx_Get(NULL, key, NULL, 0, &pvalue);
-    } else {
-        pmix_proc_t proc;
-        PMIX_PROC_CONSTRUCT(&proc);
-        proc.rank = src;
-
-        pmi_errno = PMIx_Get(&proc, key, NULL, 0, &pvalue);
-    }
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_get", "**pmix_get %d", pmi_errno);
-    strncpy(val, pvalue->data.string, val_size);
-    PMIX_VALUE_RELEASE(pvalue);
-#endif
-
-  fn_exit:
+    SWITCH_PMI(mpi_errno = pmi1_get(src, key, val, val_size),
+               mpi_errno = pmi2_get(src, key, val, val_size),
+               mpi_errno = pmix_get(src, key, val, val_size));
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 char *MPIR_pmi_get_jobattr(const char *key)
@@ -512,51 +305,14 @@ char *MPIR_pmi_get_jobattr(const char *key)
         goto fn_exit;
     }
 
-    /* try to get hwloc topology file */
-    int pmi_errno;
-#ifdef USE_PMI1_API
-    pmi_errno = PMI_KVS_Get(pmi_kvs_name, key, valbuf, pmi_max_val_size);
-    if (pmi_errno != PMI_SUCCESS) {
+    bool found = false;
+    SWITCH_PMI(found = pmi1_get_jobattr(key, valbuf),
+               found = pmi2_get_jobattr(key, valbuf), found = pmix_get_jobattr(key, valbuf));
+
+    if (!found) {
         MPL_free(valbuf);
         valbuf = NULL;
-        goto fn_exit;
     }
-
-    /* we either get "unavailable" or a valid filename */
-    if (strcmp(valbuf, "unavailable") == 0) {
-        MPL_free(valbuf);
-        valbuf = NULL;
-        goto fn_exit;
-    }
-#elif defined USE_PMI2_API
-    if (strcmp(key, "PMI_dead_processes") == 0) {
-        int out_len;
-        pmi_errno = PMI2_KVS_Get(pmi_jobid, PMI2_ID_NULL, key, valbuf, pmi_max_val_size, &out_len);
-        if (pmi_errno != PMI2_SUCCESS || out_len == 0) {
-            MPL_free(valbuf);
-            valbuf = NULL;
-            goto fn_exit;
-        }
-    } else {
-        int found;
-        int pmi_errno = PMI2_Info_GetJobAttr(key, valbuf, pmi_max_val_size, &found);
-        if (pmi_errno != PMI2_SUCCESS || !found) {
-            MPL_free(valbuf);
-            valbuf = NULL;
-            goto fn_exit;
-        }
-    }
-
-#elif defined USE_PMIX_API
-    pmix_value_t *pvalue;
-    pmi_errno = PMIx_Get(NULL, key, NULL, 0, &pvalue);
-    if (pmi_errno != PMIX_SUCCESS) {
-        goto fn_exit;
-    }
-    strncpy(valbuf, pvalue->data.string, pmi_max_val_size);
-    PMIX_VALUE_RELEASE(pvalue);
-
-#endif
 
   fn_exit:
     return valbuf;
@@ -567,71 +323,16 @@ char *MPIR_pmi_get_jobattr(const char *key)
 int MPIR_pmi_barrier(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
-
-#ifdef USE_PMI1_API
-    pmi_errno = PMI_Barrier();
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_barrier", "**pmi_barrier %d", pmi_errno);
-#elif defined(USE_PMI2_API)
-    pmi_errno = PMI2_KVS_Fence();
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_kvsfence", "**pmi_kvsfence %d", pmi_errno);
-    /* Get a non-existent key, it only returns after every process called fence */
-    int out_len;
-    PMI2_KVS_Get(pmi_kvs_name, PMI2_ID_NULL, "-NONEXIST-KEY", NULL, 0, &out_len);
-#elif defined(USE_PMIX_API)
-    pmix_info_t *info;
-    PMIX_INFO_CREATE(info, 1);
-    int flag = 1;
-    PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
-
-    /* use global wildcard proc set */
-    pmi_errno = PMIx_Fence(&pmix_wcproc, 1, info, 1);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_fence", "**pmix_fence %d", pmi_errno);
-    PMIX_INFO_FREE(info, 1);
-#endif
-
-  fn_exit:
+    SWITCH_PMI(mpi_errno = pmi1_barrier(), mpi_errno = pmi2_barrier(), mpi_errno = pmix_barrier());
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 int MPIR_pmi_barrier_local(void)
 {
-#if defined(USE_PMIX_API)
     int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
-    int local_size = MPIR_Process.local_size;
-    pmix_proc_t *procs = MPL_malloc(local_size * sizeof(pmix_proc_t), MPL_MEM_OTHER);
-    for (int i = 0; i < local_size; i++) {
-        PMIX_PROC_CONSTRUCT(&procs[i]);
-        strncpy(procs[i].nspace, pmix_proc.nspace, PMIX_MAX_NSLEN);
-        procs[i].rank = MPIR_Process.node_local_map[i];
-    }
-
-    pmix_info_t *info;
-    int flag = 1;
-    PMIX_INFO_CREATE(info, 1);
-    PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
-
-    pmi_errno = PMIx_Fence(procs, local_size, info, 1);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**pmix_fence",
-                         "**pmix_fence %d", pmi_errno);
-
-    PMIX_INFO_FREE(info, 1);
-    MPL_free(procs);
-
-  fn_exit:
+    SWITCH_PMI(mpi_errno = pmi1_barrier_local(),
+               mpi_errno = pmi2_barrier_local(), mpi_errno = pmix_barrier_local());
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-#else
-    /* If local barrier is not supported (PMI1 and PMI2), simply fallback */
-    return MPIR_pmi_barrier();
-#endif
 }
 
 /* declare static functions used in bcast/allgather */
@@ -642,57 +343,19 @@ static void decode(int size, const char *src, char *dest);
 static int optimized_put(const char *key, const char *val, int is_local)
 {
     int mpi_errno = MPI_SUCCESS;
-#if defined(USE_PMI1_API)
-    mpi_errno = MPIR_pmi_kvs_put(key, val);
-    MPIR_ERR_CHECK(mpi_errno);
-#elif defined(USE_PMI2_API)
-    if (!is_local) {
-        mpi_errno = MPIR_pmi_kvs_put(key, val);
-    } else {
-        int pmi_errno = PMI2_Info_PutNodeAttr(key, val);
-        MPIR_ERR_CHKANDJUMP(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                            "**pmi_putnodeattr");
-    }
-#elif defined(USE_PMIX_API)
-    int pmi_errno;
-    pmix_value_t value;
-    value.type = PMIX_STRING;
-    value.data.string = (char *) val;
-    pmi_errno = PMIx_Put(is_local ? PMIX_LOCAL : PMIX_GLOBAL, key, &value);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_put", "**pmix_put %d", pmi_errno);
-    pmi_errno = PMIx_Commit();
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_commit", "**pmix_commit %d", pmi_errno);
-#endif
-
-  fn_exit:
+    SWITCH_PMI(mpi_errno = pmi1_optimized_put(key, val, is_local),
+               mpi_errno = pmi2_optimized_put(key, val, is_local),
+               mpi_errno = pmix_optimized_put(key, val, is_local));
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 static int optimized_get(int src, const char *key, char *val, int valsize, int is_local)
 {
-#if defined(USE_PMI1_API)
-    return MPIR_pmi_kvs_get(src, key, val, valsize);
-#elif defined(USE_PMI2_API)
-    if (is_local) {
-        int mpi_errno = MPI_SUCCESS;
-        int found;
-        int pmi_errno = PMI2_Info_GetNodeAttr(key, val, valsize, &found, TRUE);
-        if (pmi_errno != PMI2_SUCCESS) {
-            MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**pmi_getnodeattr");
-        } else if (!found) {
-            MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**pmi_getnodeattr");
-        }
-        return mpi_errno;
-    } else {
-        return MPIR_pmi_kvs_get(src, key, val, valsize);
-    }
-#else
-    return MPIR_pmi_kvs_get(src, key, val, valsize);
-#endif
+    int mpi_errno = MPI_SUCCESS;
+    SWITCH_PMI(mpi_errno = pmi1_optimized_get(src, key, val, valsize, is_local),
+               mpi_errno = pmi2_optimized_get(src, key, val, valsize, is_local),
+               mpi_errno = pmix_optimized_get(src, key, val, valsize, is_local));
+    return mpi_errno;
 }
 
 /* higher-level binary put/get:
@@ -700,10 +363,9 @@ static int optimized_get(int src, const char *key, char *val, int valsize, int i
  * 2. chops long values into multiple segments
  * 3. uses optimized_put/get for the case of node-level access
  */
-static int put_ex(const char *key, const void *buf, int bufsize, int is_local)
+static int put_ex_segs(const char *key, const void *buf, int bufsize, int is_local)
 {
     int mpi_errno = MPI_SUCCESS;
-#if defined(USE_PMI1_API) || defined(USE_PMI2_API)
     char *val = MPL_malloc(pmi_max_val_size, MPL_MEM_OTHER);
     /* reserve some spaces for '\0' and maybe newlines
      * (depends on pmi implementations, and may not be sufficient) */
@@ -732,37 +394,19 @@ static int put_ex(const char *key, const void *buf, int bufsize, int is_local)
             MPIR_ERR_CHECK(mpi_errno);
         }
     }
-#elif defined(USE_PMIX_API)
-    int pmi_errno;
-    pmix_value_t value;
-    value.type = PMIX_BYTE_OBJECT;
-    value.data.bo.bytes = (char *) buf;
-    value.data.bo.size = bufsize;
-    pmi_errno = PMIx_Put(is_local ? PMIX_LOCAL : PMIX_GLOBAL, key, &value);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_put", "**pmix_put %d", pmi_errno);
-    pmi_errno = PMIx_Commit();
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_commit", "**pmix_commit %d", pmi_errno);
-#endif
 
   fn_exit:
-#if defined(USE_PMI1_API) || defined(USE_PMI2_API)
     MPL_free(val);
-#endif
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
-static int get_ex(int src, const char *key, void *buf, int *p_size, int is_local)
+static int get_ex_segs(int src, const char *key, void *buf, int *p_size, int is_local)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_Assert(p_size);
-    MPIR_Assert(*p_size > 0);
     int bufsize = *p_size;
-#if defined(USE_PMI1_API) || defined(USE_PMI2_API)
     char *val = MPL_malloc(pmi_max_val_size, MPL_MEM_OTHER);
     int segsize = (pmi_max_val_size - 1) / 2;
 
@@ -799,41 +443,35 @@ static int get_ex(int src, const char *key, void *buf, int *p_size, int is_local
 
     *p_size = got_size;
 
-#elif defined(USE_PMIX_API)
-    int pmi_errno;
-    pmix_value_t *pvalue;
-    if (src < 0) {
-        pmi_errno = PMIx_Get(NULL, key, NULL, 0, &pvalue);
-    } else {
-        pmix_proc_t proc;
-        PMIX_PROC_CONSTRUCT(&proc);
-        proc.rank = src;
-
-        pmi_errno = PMIx_Get(&proc, key, NULL, 0, &pvalue);
-    }
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_get", "**pmix_get %d", pmi_errno);
-    MPIR_Assert(pvalue->type == PMIX_BYTE_OBJECT);
-    MPIR_Assert(pvalue->data.bo.size <= bufsize);
-
-    memcpy(buf, pvalue->data.bo.bytes, pvalue->data.bo.size);
-    *p_size = pvalue->data.bo.size;
-
-    PMIX_VALUE_RELEASE(pvalue);
-#endif
-
   fn_exit:
-#if defined(USE_PMI1_API) || defined(USE_PMI2_API)
     MPL_free(val);
-#endif
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
 
+static int put_ex(const char *key, const void *buf, int bufsize, int is_local)
+{
+    int mpi_errno = MPI_SUCCESS;
+    SWITCH_PMI(mpi_errno = put_ex_segs(key, buf, bufsize, is_local),
+               mpi_errno = put_ex_segs(key, buf, bufsize, is_local),
+               mpi_errno = pmix_put_binary(key, buf, bufsize, is_local));
+    return mpi_errno;
+}
+
+static int get_ex(int src, const char *key, void *buf, int *p_size, int is_local)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Assert(p_size);
+    MPIR_Assert(*p_size > 0);
+    SWITCH_PMI(mpi_errno = get_ex_segs(src, key, buf, p_size, is_local),
+               mpi_errno = get_ex_segs(src, key, buf, p_size, is_local),
+               mpi_errno = pmix_get_binary(src, key, buf, p_size, is_local));
+    return mpi_errno;
+}
+
 static int optional_bcast_barrier(MPIR_PMI_DOMAIN domain)
 {
-#if defined(USE_PMI1_API)
     /* unless bcast is skipped altogether */
     if (domain == MPIR_PMI_DOMAIN_ALL && MPIR_Process.size == 1) {
         return MPI_SUCCESS;
@@ -842,23 +480,12 @@ static int optional_bcast_barrier(MPIR_PMI_DOMAIN domain)
     } else if (domain == MPIR_PMI_DOMAIN_LOCAL && MPIR_Process.size == MPIR_Process.num_nodes) {
         return MPI_SUCCESS;
     }
-#elif defined(USE_PMI2_API)
-    if (domain == MPIR_PMI_DOMAIN_ALL && MPIR_Process.size == 1) {
-        return MPI_SUCCESS;
-    } else if (domain == MPIR_PMI_DOMAIN_NODE_ROOTS && MPIR_Process.num_nodes == 1) {
-        return MPI_SUCCESS;
-    } else if (domain == MPIR_PMI_DOMAIN_LOCAL) {
-        /* PMI2 local uses Put/GetNodeAttr, no need for barrier */
-        return MPI_SUCCESS;
-    }
-#elif defined(USE_PMIX_API)
-    if (domain == MPIR_PMI_DOMAIN_LOCAL) {
-        return MPIR_pmi_barrier_local();
-    } else {
-        return MPIR_pmi_barrier();
-    }
-#endif
-    return MPIR_pmi_barrier();
+
+    int mpi_errno = MPI_SUCCESS;
+    SWITCH_PMI(mpi_errno = pmi1_optional_bcast_barrier(domain),
+               mpi_errno = pmi2_optional_bcast_barrier(domain),
+               mpi_errno = pmix_optional_bcast_barrier(domain));
+    return mpi_errno;
 }
 
 int MPIR_pmi_bcast(void *buf, int bufsize, MPIR_PMI_DOMAIN domain)
@@ -960,12 +587,11 @@ int MPIR_pmi_allgather(const void *sendbuf, int sendsize, void *recvbuf, int rec
         mpi_errno = put_ex(key, sendbuf, sendsize, 0);
         MPIR_ERR_CHECK(mpi_errno);
     }
-#ifndef USE_PMIX_API
-    /* PMIx will wait, so barrier unnecessary */
-    mpi_errno = MPIR_pmi_barrier();
-    MPIR_ERR_CHECK(mpi_errno);
-#endif
-
+    if (MPIR_CVAR_PMI_VERSION != MPIR_CVAR_PMI_VERSION_x) {
+        /* PMIx will wait, so barrier unnecessary */
+        mpi_errno = MPIR_pmi_barrier();
+        MPIR_ERR_CHECK(mpi_errno);
+    }
     if (in_domain) {
         int domain_size = MPIR_Process.size;
         if (domain == MPIR_PMI_DOMAIN_NODE_ROOTS) {
@@ -1059,58 +685,11 @@ int MPIR_pmi_allgather_shm(const void *sendbuf, int sendsize, void *shm_buf, int
 int MPIR_pmi_get_universe_size(int *universe_size)
 {
     int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
-
-#ifdef USE_PMI1_API
-    pmi_errno = PMI_Get_universe_size(universe_size);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_get_universe_size", "**pmi_get_universe_size %d", pmi_errno);
-#elif defined(USE_PMI2_API)
-    char val[PMI2_MAX_VALLEN];
-    int found = 0;
-    char *endptr;
-
-    pmi_errno = PMI2_Info_GetJobAttr("universeSize", val, sizeof(val), &found);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_getjobattr", "**pmi_getjobattr %d", pmi_errno);
-    if (!found) {
-        *universe_size = MPIR_UNIVERSE_SIZE_NOT_AVAILABLE;
-    } else {
-        *universe_size = strtol(val, &endptr, 0);
-        MPIR_ERR_CHKINTERNAL(endptr - val != strlen(val), mpi_errno, "can't parse universe size");
-    }
-#elif defined(USE_PMIX_API)
-    pmix_value_t *pvalue = NULL;
-
-    pmi_errno = PMIx_Get(&pmix_wcproc, PMIX_UNIV_SIZE, NULL, 0, &pvalue);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_get", "**pmix_get %d", pmi_errno);
-    *universe_size = pvalue->data.uint32;
-    PMIX_VALUE_RELEASE(pvalue);
-#endif
-  fn_exit:
+    SWITCH_PMI(mpi_errno = pmi1_get_universe_size(universe_size),
+               mpi_errno = pmi2_get_universe_size(universe_size),
+               mpi_errno = pmix_get_universe_size(universe_size));
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
-
-/* static functions only for MPIR_pmi_spawn_multiple */
-static int pmi2_spawn_slurm(int count, char *commands[], char **argvs[],
-                            const int maxprocs[], MPIR_Info * info_ptrs[],
-                            int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals,
-                            int *pmi_errcodes);
-static int pmi1_spawn(int count, char *commands[], char **argvs[],
-                      const int maxprocs[], MPIR_Info * info_ptrs[],
-                      int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals,
-                      int *pmi_errcodes);
-static int pmi2_spawn(int count, char *commands[], char **argvs[],
-                      const int maxprocs[], MPIR_Info * info_ptrs[],
-                      int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals,
-                      int *pmi_errcodes);
-static int pmix_spawn(int count, char *commands[], char **argvs[],
-                      const int maxprocs[], MPIR_Info * info_ptrs[],
-                      int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals,
-                      int *pmi_errcodes);
 
 /* NOTE: MPIR_pmi_spawn_multiple is to be called by a single root spawning process */
 int MPIR_pmi_spawn_multiple(int count, char *commands[], char **argvs[],
@@ -1127,23 +706,12 @@ int MPIR_pmi_spawn_multiple(int count, char *commands[], char **argvs[],
     mpi_errno = pmi2_spawn_slurm(count, commands, argvs, maxprocs, info_ptrs,
                                  num_preput_keyval, preput_keyvals, pmi_errcodes);
 #else
-    switch (MPIR_CVAR_PMI_VERSION) {
-        case MPIR_CVAR_PMI_VERSION_1:
-            mpi_errno = pmi1_spawn(count, commands, argvs, maxprocs, info_ptrs,
-                                   num_preput_keyval, preput_keyvals, pmi_errcodes);
-            break;
-        case MPIR_CVAR_PMI_VERSION_2:
-            mpi_errno = pmi2_spawn(count, commands, argvs, maxprocs, info_ptrs,
-                                   num_preput_keyval, preput_keyvals, pmi_errcodes);
-            break;
-        case MPIR_CVAR_PMI_VERSION_x:
-            mpi_errno = pmix_spawn(count, commands, argvs, maxprocs, info_ptrs,
-                                   num_preput_keyval, preput_keyvals, pmi_errcodes);
-            break;
-        default:
-            MPIR_Assert(0);
-            break;
-    };
+    SWITCH_PMI(mpi_errno = pmi1_spawn(count, commands, argvs, maxprocs, info_ptrs,
+                                      num_preput_keyval, preput_keyvals, pmi_errcodes),
+               mpi_errno = pmi2_spawn(count, commands, argvs, maxprocs, info_ptrs,
+                                      num_preput_keyval, preput_keyvals, pmi_errcodes),
+               mpi_errno = pmix_spawn(count, commands, argvs, maxprocs, info_ptrs,
+                                      num_preput_keyval, preput_keyvals, pmi_errcodes));
 #endif
     return mpi_errno;
 }
@@ -1151,80 +719,24 @@ int MPIR_pmi_spawn_multiple(int count, char *commands[], char **argvs[],
 int MPIR_pmi_publish(const char name[], const char port[])
 {
     int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
-
-#ifdef USE_PMI2_API
-    /* release the global CS for PMI calls */
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-    pmi_errno = PMI2_Nameserv_publish(name, NULL, port);
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-#elif defined(USE_PMIX_API)
-    pmix_info_t *info;
-    PMIX_INFO_CREATE(info, 1);
-    MPL_strncpy(info[0].key, name, PMIX_MAX_KEYLEN);
-    info[0].value.type = PMIX_STRING;
-    info[0].value.data.string = MPL_direct_strdup(port);
-    pmi_errno = PMIx_Publish(info, 1);
-    PMIX_INFO_FREE(info, 1);
-#else
-    pmi_errno = PMI_Publish_name(name, port);
-#endif
-    MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_NAME, "**namepubnotpub",
-                         "**namepubnotpub %s", name);
-
-  fn_fail:
+    SWITCH_PMI(mpi_errno = pmi1_publish(name, port),
+               mpi_errno = pmi2_publish(name, port), mpi_errno = pmix_publish(name, port));
     return mpi_errno;
 }
 
 int MPIR_pmi_lookup(const char name[], char port[])
 {
     int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
-
-#ifdef USE_PMI2_API
-    /* release the global CS for PMI calls */
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-    pmi_errno = PMI2_Nameserv_lookup(name, NULL, port, MPI_MAX_PORT_NAME);
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-#elif defined(USE_PMIX_API)
-    pmix_pdata_t *pdata;
-    PMIX_PDATA_CREATE(pdata, 1);
-    MPL_strncpy(pdata[0].key, name, PMIX_MAX_KEYLEN);
-    pmi_errno = PMIx_Lookup(pdata, 1, NULL, 0);
-    if (pmi_errno == PMIX_SUCCESS) {
-        MPL_strncpy(port, pdata[0].value.data.string, MPI_MAX_PORT_NAME);
-    }
-    PMIX_PDATA_FREE(pdata, 1);
-#else
-    pmi_errno = PMI_Lookup_name(name, port);
-#endif
-    MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_NAME, "**namepubnotfound",
-                         "**namepubnotfound %s", name);
-
-  fn_fail:
+    SWITCH_PMI(mpi_errno = pmi1_lookup(name, port),
+               mpi_errno = pmi2_lookup(name, port), mpi_errno = pmix_lookup(name, port));
     return mpi_errno;
 }
 
 int MPIR_pmi_unpublish(const char name[])
 {
     int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
-
-#ifdef USE_PMI2_API
-    /* release the global CS for PMI calls */
-    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-    pmi_errno = PMI2_Nameserv_unpublish(name, NULL);
-    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-#elif defined(USE_PMIX_API)
-    char *keys[2] = { (char *) name, NULL };
-    PMIx_Unpublish(keys, NULL, 0);
-#else
-    pmi_errno = PMI_Unpublish_name(name);
-#endif
-    MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_SERVICE, "**namepubnotunpub",
-                         "**namepubnotunpub %s", name);
-
-  fn_fail:
+    SWITCH_PMI(mpi_errno = pmi1_unpublish(name),
+               mpi_errno = pmi2_unpublish(name), mpi_errno = pmix_unpublish(name));
     return mpi_errno;
 }
 
@@ -1237,14 +749,7 @@ static int build_nodemap_nolocal(int *nodemap, int sz, int *num_nodes);
 static int build_nodemap_roundrobin(int num_cliques, int *nodemap, int sz, int *num_nodes);
 static int build_nodemap_byblock(int num_cliques, int *nodemap, int sz, int *num_nodes);
 
-#ifdef USE_PMI1_API
-static int build_nodemap_pmi1(int *nodemap, int sz);
-static int build_nodemap_fallback(int *nodemap, int sz);
-#elif defined(USE_PMI2_API)
-static int build_nodemap_pmi2(int *nodemap, int sz);
-#elif defined(USE_PMIX_API)
-static int build_nodemap_pmix(int *nodemap, int sz);
-#endif
+static int pmi_build_nodemap(int *nodemap, int sz);
 
 /* TODO: if the process manager promises persistent node_id across multiple spawns,
  *       we can use the node id to check intranode processes across comm worlds.
@@ -1262,13 +767,7 @@ static int build_nodemap(int *nodemap, int sz, int *num_nodes)
         mpi_errno = build_nodemap_nolocal(nodemap, sz, num_nodes);
         goto fn_exit;
     }
-#ifdef USE_PMI1_API
-    mpi_errno = build_nodemap_pmi1(nodemap, sz);
-#elif defined(USE_PMI2_API)
-    mpi_errno = build_nodemap_pmi2(nodemap, sz);
-#elif defined(USE_PMIX_API)
-    mpi_errno = build_nodemap_pmix(nodemap, sz);
-#endif
+    mpi_errno = pmi_build_nodemap(nodemap, sz);
     MPIR_ERR_CHECK(mpi_errno);
 
     if (do_normalize_nodemap) {
@@ -1382,97 +881,29 @@ static int build_nodemap_byblock(int num_cliques, int *nodemap, int sz, int *num
     return MPI_SUCCESS;
 }
 
-#ifdef USE_PMI1_API
-
-/* build nodemap based on allgather hostnames */
-/* FIXME: migrate the function */
-static int build_nodemap_fallback(int *nodemap, int sz)
-{
-    return MPIR_NODEMAP_build_nodemap_fallback(sz, MPIR_Process.rank, nodemap);
-}
-
-/* build nodemap using PMI1 process_mapping or fallback with hostnames */
-static int build_nodemap_pmi1(int *nodemap, int sz)
+static int pmi_build_nodemap(int *nodemap, int sz)
 {
     int mpi_errno = MPI_SUCCESS;
-    int did_map = 0;
-    if (pmi_version == 1 && pmi_subversion == 1) {
+    if (MPIR_CVAR_PMI_VERSION == MPIR_CVAR_PMI_VERSION_x) {
+        mpi_errno = pmix_build_nodemap(nodemap, sz);
+    } else {
         char *process_mapping = MPIR_pmi_get_jobattr("PMI_process_mapping");
         if (process_mapping) {
             int mpl_err = MPL_rankmap_str_to_array(process_mapping, sz, nodemap);
             MPIR_ERR_CHKINTERNAL(mpl_err, mpi_errno,
                                  "unable to populate node ids from PMI_process_mapping");
-            did_map = 1;
             MPL_free(process_mapping);
+        } else {
+            /* build nodemap based on allgather hostnames */
+            /* FIXME: migrate the function */
+            mpi_errno = MPIR_NODEMAP_build_nodemap_fallback(sz, MPIR_Process.rank, nodemap);
         }
     }
-    if (!did_map) {
-        mpi_errno = build_nodemap_fallback(nodemap, sz);
-    }
   fn_exit:
     return mpi_errno;
   fn_fail:
     goto fn_exit;
 }
-
-#elif defined USE_PMI2_API
-
-/* build nodemap using PMI2 process_mapping or error */
-static int build_nodemap_pmi2(int *nodemap, int sz)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    char *process_mapping = MPIR_pmi_get_jobattr("PMI_process_mapping");
-    MPIR_ERR_CHKINTERNAL(!process_mapping, mpi_errno, "PMI_process_mapping attribute not found");
-
-    int mpl_err;
-    mpl_err = MPL_rankmap_str_to_array(process_mapping, sz, nodemap);
-    MPIR_ERR_CHKINTERNAL(mpl_err, mpi_errno,
-                         "unable to populate node ids from PMI_process_mapping");
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-#elif defined USE_PMIX_API
-
-/* build nodemap using PMIx_Resolve_nodes */
-int build_nodemap_pmix(int *nodemap, int sz)
-{
-    int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
-    char *nodelist = NULL, *node = NULL;
-    pmix_proc_t *procs = NULL;
-    size_t nprocs, node_id = 0;
-
-    pmi_errno = PMIx_Resolve_nodes(pmix_proc.nspace, &nodelist);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_resolve_nodes", "**pmix_resolve_nodes %d", pmi_errno);
-    MPIR_Assert(nodelist);
-
-    node = strtok(nodelist, ",");
-    while (node) {
-        pmi_errno = PMIx_Resolve_peers(node, pmix_proc.nspace, &procs, &nprocs);
-        MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                             "**pmix_resolve_peers", "**pmix_resolve_peers %d", pmi_errno);
-        for (int i = 0; i < nprocs; i++) {
-            nodemap[procs[i].rank] = node_id;
-        }
-        node_id++;
-        node = strtok(NULL, ",");
-    }
-    /* PMIx latest adds pmix_free. We should switch to that at some point */
-    MPL_external_free(nodelist);
-    PMIX_PROC_FREE(procs, nprocs);
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-#endif
 
 /* allocate and populate MPIR_Process.node_local_map and MPIR_Process.node_root_map */
 static int build_locality(void)
@@ -1641,185 +1072,4 @@ static void free_pmi_keyvals(INFO_TYPE ** kv, int size, int *counts)
         MPL_free(kv);
         MPL_free(counts);
     }
-}
-
-static int pmi2_spawn_slurm(int count, char *commands[], char **argvs[],
-                            const int maxprocs[], MPIR_Info * info_ptrs[],
-                            int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals,
-                            int *pmi_errcodes)
-{
-#ifdef USE_PMI2_SLURM
-    int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
-
-    int *info_keyval_sizes = NULL;
-    INFO_TYPE **info_keyval_vectors = NULL;
-    mpi_errno = get_info_kv_vectors(count, info_ptrs, &info_keyval_vectors, &info_keyval_sizes);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    const INFO_TYPE **preput_vector = NULL;
-    INFO_TYPE *preput_vector_array = NULL;
-
-    if (num_preput_keyval > 0) {
-        preput_vector = MPL_malloc(num_preput_keyval * sizeof(INFO_TYPE *), MPL_MEM_BUFFER);
-        MPIR_ERR_CHKANDJUMP(!preput_vector, mpi_errno, MPI_ERR_OTHER, "**nomem");
-        preput_vector_array = MPL_malloc(num_preput_keyval * sizeof(INFO_TYPE), MPL_MEM_BUFFER);
-        MPIR_ERR_CHKANDJUMP(!preput_vector_array, mpi_errno, MPI_ERR_OTHER, "**nomem");
-        for (int i = 0; i < num_preput_keyval; i++) {
-            INFO_TYPE_KEY(preput_vector_array[i]) = (char *) preput_keyvals[i].key;
-            INFO_TYPE_VAL(preput_vector_array[i]) = preput_keyvals[i].val;
-            preput_vector[i] = &preput_vector_array[i];
-        }
-    }
-
-    int *argcs = MPL_malloc(count * sizeof(int), MPL_MEM_DYNAMIC);
-    MPIR_Assert(argcs);
-
-    /* compute argcs array */
-    for (int i = 0; i < count; ++i) {
-        argcs[i] = 0;
-        if (argvs != NULL && argvs[i] != NULL) {
-            while (argvs[i][argcs[i]]) {
-                ++argcs[i];
-            }
-        }
-    }
-
-    pmi_errno = PMI2_Job_Spawn(count, (const char **) commands,
-                               argcs, (const char ***) argvs, maxprocs,
-                               info_keyval_sizes, (const MPID_Info **) info_keyval_vectors,
-                               num_preput_keyval, (const MPID_Info **) preput_vector,
-                               NULL, 0, pmi_errcodes);
-    MPL_free(argcs);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_spawn_multiple", "**pmi_spawn_multiple %d", pmi_errno);
-
-  fn_exit:
-    free_pmi_keyvals(info_keyval_vectors, count, info_keyval_sizes);
-    if (num_preput_keyval > 0) {
-        MPL_free(preput_vector_array);
-        MPL_free(preput_vector);
-    }
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-#else
-    return MPI_ERR_INTERN;
-#endif
-}
-
-static int pmi1_spawn(int count, char *commands[], char **argvs[],
-                      const int maxprocs[], MPIR_Info * info_ptrs[],
-                      int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals,
-                      int *pmi_errcodes)
-{
-#ifdef ENABLE_PMI1
-    int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
-
-    int *info_keyval_sizes = NULL;
-    INFO_TYPE **info_keyval_vectors = NULL;
-    mpi_errno = get_info_kv_vectors(count, info_ptrs, &info_keyval_vectors, &info_keyval_sizes);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    INFO_TYPE *preput_vector = NULL;
-
-    if (num_preput_keyval > 0) {
-        preput_vector = MPL_malloc(num_preput_keyval * sizeof(INFO_TYPE), MPL_MEM_BUFFER);
-        MPIR_ERR_CHKANDJUMP(!preput_vector, mpi_errno, MPI_ERR_OTHER, "**nomem");
-        for (int i = 0; i < num_preput_keyval; i++) {
-            INFO_TYPE_KEY(preput_vector[i]) = preput_keyvals[i].key;
-            INFO_TYPE_VAL(preput_vector[i]) = preput_keyvals[i].val;
-        }
-    }
-
-    pmi_errno = PMI_Spawn_multiple(count, (const char **) commands, (const char ***) argvs,
-                                   maxprocs,
-                                   info_keyval_sizes, (const PMI_keyval_t **) info_keyval_vectors,
-                                   num_preput_keyval, (const PMI_keyval_t *) preput_vector,
-                                   pmi_errcodes);
-
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_spawn_multiple", "**pmi_spawn_multiple %d", pmi_errno);
-
-  fn_exit:
-    free_pmi_keyvals(info_keyval_vectors, count, info_keyval_sizes);
-    if (num_preput_keyval > 0) {
-        MPL_free(preput_vector);
-    }
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-#else
-    return MPI_ERR_INTERN;
-#endif
-}
-
-static int pmi2_spawn(int count, char *commands[], char **argvs[],
-                      const int maxprocs[], MPIR_Info * info_ptrs[],
-                      int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals,
-                      int *pmi_errcodes)
-{
-#ifdef ENABLE_PMI2
-    int mpi_errno = MPI_SUCCESS;
-    int pmi_errno;
-
-    int *info_keyval_sizes = NULL;
-    INFO_TYPE **info_keyval_vectors = NULL;
-    mpi_errno = get_info_kv_vectors(count, info_ptrs, &info_keyval_vectors, &info_keyval_sizes);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    INFO_TYPE *preput_vector = NULL;
-
-    if (num_preput_keyval > 0) {
-        preput_vector = MPL_malloc(num_preput_keyval * sizeof(INFO_TYPE), MPL_MEM_BUFFER);
-        MPIR_ERR_CHKANDJUMP(!preput_vector, mpi_errno, MPI_ERR_OTHER, "**nomem");
-        for (int i = 0; i < num_preput_keyval; i++) {
-            INFO_TYPE_KEY(preput_vector[i]) = preput_keyvals[i].key;
-            INFO_TYPE_VAL(preput_vector[i]) = preput_keyvals[i].val;
-        }
-    }
-
-    int *argcs = MPL_malloc(count * sizeof(int), MPL_MEM_DYNAMIC);
-    MPIR_Assert(argcs);
-
-    /* compute argcs array */
-    for (int i = 0; i < count; ++i) {
-        argcs[i] = 0;
-        if (argvs != NULL && argvs[i] != NULL) {
-            while (argvs[i][argcs[i]]) {
-                ++argcs[i];
-            }
-        }
-    }
-
-    pmi_errno = PMI2_Job_Spawn(count, (const char **) commands,
-                               argcs, (const char ***) argvs, maxprocs,
-                               info_keyval_sizes, (const PMI2_keyval_t **) info_keyval_vectors,
-                               num_preput_keyval, (const PMI2_keyval_t *) preput_vector,
-                               NULL, 0, pmi_errcodes);
-    MPL_free(argcs);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmi_spawn_multiple", "**pmi_spawn_multiple %d", pmi_errno);
-
-  fn_exit:
-    free_pmi_keyvals(info_keyval_vectors, count, info_keyval_sizes);
-    if (num_preput_keyval > 0) {
-        MPL_free(preput_vector);
-    }
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-#else
-    return MPI_ERR_INTERN;
-#endif
-}
-
-static int pmix_spawn(int count, char *commands[], char **argvs[],
-                      const int maxprocs[], MPIR_Info * info_ptrs[],
-                      int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals,
-                      int *pmi_errcodes)
-{
-    /* not supported yet */
-    return MPI_ERR_INTERN;
 }

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -730,9 +730,12 @@ static int optional_bcast_barrier(MPIR_PMI_DOMAIN domain)
         /* PMI2 local uses Put/GetNodeAttr, no need for barrier */
         return MPI_SUCCESS;
     }
-#elif defined(USE_PMIx_API)
-    /* PMIx will block/wait, so barrier unnecessary */
-    return MPI_SUCCESS;
+#elif defined(USE_PMIX_API)
+    if (domain == MPIR_PMI_DOMAIN_LOCAL) {
+        return MPIR_pmi_barrier_local();
+    } else {
+        return MPIR_pmi_barrier();
+    }
 #endif
     return MPIR_pmi_barrier();
 }

--- a/src/util/mpir_pmi1.inc
+++ b/src/util/mpir_pmi1.inc
@@ -1,0 +1,319 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifdef ENABLE_PMI1
+
+static int pmi1_init(int *has_parent, int *rank, int *size, int *appnum)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    pmi_errno = PMI_Init(has_parent);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_init", "**pmi_init %d", pmi_errno);
+    pmi_errno = PMI_Get_rank(rank);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_get_rank", "**pmi_get_rank %d", pmi_errno);
+    pmi_errno = PMI_Get_size(size);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_get_size", "**pmi_get_size %d", pmi_errno);
+    pmi_errno = PMI_Get_appnum(appnum);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_get_appnum", "**pmi_get_appnum %d", pmi_errno);
+
+    int pmi_max_kvs_name_length;
+    pmi_errno = PMI_KVS_Get_name_length_max(&pmi_max_kvs_name_length);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_kvs_get_name_length_max",
+                         "**pmi_kvs_get_name_length_max %d", pmi_errno);
+    pmi_kvs_name = (char *) MPL_malloc(pmi_max_kvs_name_length, MPL_MEM_OTHER);
+    pmi_errno = PMI_KVS_Get_my_name(pmi_kvs_name, pmi_max_kvs_name_length);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_kvs_get_my_name", "**pmi_kvs_get_my_name %d", pmi_errno);
+
+    pmi_errno = PMI_KVS_Get_key_length_max(&pmi_max_key_size);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_kvs_get_key_length_max",
+                         "**pmi_kvs_get_key_length_max %d", pmi_errno);
+    pmi_errno = PMI_KVS_Get_value_length_max(&pmi_max_val_size);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_kvs_get_value_length_max",
+                         "**pmi_kvs_get_value_length_max %d", pmi_errno);
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static void pmi1_exit(void)
+{
+    PMI_Finalize();
+}
+
+static void pmi1_abort(int exit_code, const char *error_msg)
+{
+    PMI_Abort(exit_code, error_msg);
+}
+
+static int pmi1_put(const char *key, const char *val)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    pmi_errno = PMI_KVS_Put(pmi_kvs_name, key, val);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_kvs_put", "**pmi_kvs_put %d", pmi_errno);
+    pmi_errno = PMI_KVS_Commit(pmi_kvs_name);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_kvs_commit", "**pmi_kvs_commit %d", pmi_errno);
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmi1_get(int src, const char *key, char *val, int val_size)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    /* src is not used in PMI1 */
+    pmi_errno = PMI_KVS_Get(pmi_kvs_name, key, val, val_size);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_kvs_get", "**pmi_kvs_get %d", pmi_errno);
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static bool pmi1_get_jobattr(const char *key, char *valbuf)
+{
+    int pmi_errno = PMI_KVS_Get(pmi_kvs_name, key, valbuf, pmi_max_val_size);
+    if (pmi_errno != PMI_SUCCESS) {
+        return false;
+    }
+
+    /* we either get "unavailable" or a valid filename */
+    if (strcmp(valbuf, "unavailable") == 0) {
+        return false;
+    }
+
+    return true;
+}
+
+static int pmi1_barrier(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    pmi_errno = PMI_Barrier();
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_barrier", "**pmi_barrier %d", pmi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmi1_barrier_local(void)
+{
+    return pmi1_barrier();
+}
+
+static int pmi1_optimized_put(const char *key, const char *val, int is_local)
+{
+    return pmi1_put(key, val);
+}
+
+static int pmi1_optimized_get(int src, const char *key, char *val, int valsize, int is_local)
+{
+    return pmi1_get(src, key, val, valsize);
+}
+
+static int pmi1_optional_bcast_barrier(MPIR_PMI_DOMAIN domain)
+{
+    return pmi1_barrier();
+}
+
+static int pmi1_get_universe_size(int *universe_size)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    pmi_errno = PMI_Get_universe_size(universe_size);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_get_universe_size", "**pmi_get_universe_size %d", pmi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmi1_spawn(int count, char *commands[], char **argvs[], const int maxprocs[], MPIR_Info * info_ptrs[], int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+    INFO_TYPE *preput_vector = NULL;
+
+    int *info_keyval_sizes = NULL;
+    INFO_TYPE **info_keyval_vectors = NULL;
+    mpi_errno = get_info_kv_vectors(count, info_ptrs, &info_keyval_vectors, &info_keyval_sizes);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    if (num_preput_keyval > 0) {
+        preput_vector = MPL_malloc(num_preput_keyval * sizeof(INFO_TYPE), MPL_MEM_BUFFER);
+        MPIR_ERR_CHKANDJUMP(!preput_vector, mpi_errno, MPI_ERR_OTHER, "**nomem");
+        for (int i = 0; i < num_preput_keyval; i++) {
+            INFO_TYPE_KEY(preput_vector[i]) = preput_keyvals[i].key;
+            INFO_TYPE_VAL(preput_vector[i]) = preput_keyvals[i].val;
+        }
+    }
+
+    pmi_errno = PMI_Spawn_multiple(count, (const char **) commands, (const char ***) argvs,
+                                   maxprocs,
+                                   info_keyval_sizes, (const PMI_keyval_t **) info_keyval_vectors,
+                                   num_preput_keyval, (const PMI_keyval_t *) preput_vector,
+                                   pmi_errcodes);
+
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_spawn_multiple", "**pmi_spawn_multiple %d", pmi_errno);
+
+  fn_exit:
+    free_pmi_keyvals(info_keyval_vectors, count, info_keyval_sizes);
+    if (num_preput_keyval > 0) {
+        MPL_free(preput_vector);
+    }
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmi1_publish(const char name[], const char port[])
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+    pmi_errno = PMI_Publish_name(name, port);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_NAME, "**namepubnotpub",
+                         "**namepubnotpub %s", name);
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmi1_lookup(const char name[], char port[])
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+    pmi_errno = PMI_Lookup_name(name, port);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_NAME, "**namepubnotfound",
+                         "**namepubnotfound %s", name);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmi1_unpublish(const char name[])
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+    pmi_errno = PMI_Unpublish_name(name);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_SERVICE, "**namepubnotunpub",
+                         "**namepubnotunpub %s", name);
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+#else  /* ENABLE_PMI1 */
+
+static int pmi1_init(int *has_parent, int *rank, int *size, int *appnum)
+{
+    return MPI_ERR_INTERN;
+}
+
+static void pmi1_exit(void)
+{
+    MPIR_Assert(0);
+}
+
+static void pmi1_abort(int exit_code, const char *error_msg)
+{
+    MPIR_Assert(0);
+}
+
+static int pmi1_put(const char *key, const char *val)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi1_get(int src, const char *key, char *val, int val_size)
+{
+    return MPI_ERR_INTERN;
+}
+
+static bool pmi1_get_jobattr(const char *key, char *valbuf)
+{
+    MPIR_Assert(0);
+    return false;
+}
+
+static int pmi1_barrier(void)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi1_barrier_local(void)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi1_optimized_put(const char *key, const char *val, int is_local)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi1_optimized_get(int src, const char *key, char *val, int valsize, int is_local)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi1_optional_bcast_barrier(MPIR_PMI_DOMAIN domain)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi1_get_universe_size(int *universe_size)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi1_spawn(int count, char *commands[], char **argvs[], const int maxprocs[], MPIR_Info * info_ptrs[], int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi1_publish(const char name[], const char port[])
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi1_lookup(const char name[], char port[])
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi1_unpublish(const char name[])
+{
+    return MPI_ERR_INTERN;
+}
+
+#endif /* ENABLE_PMI1 */

--- a/src/util/mpir_pmi2.inc
+++ b/src/util/mpir_pmi2.inc
@@ -1,0 +1,431 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifdef ENABLE_PMI2
+
+static int pmi2_init(int *has_parent, int *rank, int *size, int *appnum)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    pmi_max_key_size = PMI2_MAX_KEYLEN;
+    pmi_max_val_size = PMI2_MAX_VALLEN;
+
+    pmi_errno = PMI2_Init(has_parent, size, rank, appnum);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_init", "**pmi_init %d", pmi_errno);
+
+    pmi_kvs_name = (char *) MPL_malloc(PMI2_MAX_VALLEN, MPL_MEM_OTHER);
+    pmi_errno = PMI2_Job_GetId(pmi_kvs_name, PMI2_MAX_VALLEN);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_job_getid", "**pmi_job_getid %d", pmi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static void pmi2_exit(void)
+{
+    PMI2_Finalize();
+}
+
+static void pmi2_abort(int exit_code, const char *error_msg)
+{
+    PMI2_Abort(TRUE, error_msg);
+}
+
+static int pmi2_put(const char *key, const char *val)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    pmi_errno = PMI2_KVS_Put(key, val);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_kvsput", "**pmi_kvsput %d", pmi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmi2_get(int src, const char *key, char *val, int val_size)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    if (src < 0)
+        src = PMI2_ID_NULL;
+    int out_len;
+    pmi_errno = PMI2_KVS_Get(pmi_kvs_name, src, key, val, val_size, &out_len);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_kvsget", "**pmi_kvsget %d", pmi_errno);
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static bool pmi2_get_jobattr(const char *key, char *valbuf)
+{
+    if (strcmp(key, "PMI_dead_processes") == 0) {
+        int out_len;
+        int pmi_errno = PMI2_KVS_Get(pmi_kvs_name, PMI2_ID_NULL, key, valbuf, pmi_max_val_size, &out_len);
+        if (pmi_errno != PMI2_SUCCESS || out_len == 0) {
+            return false;
+        }
+    } else {
+        int found;
+        int pmi_errno = PMI2_Info_GetJobAttr(key, valbuf, pmi_max_val_size, &found);
+        if (pmi_errno != PMI2_SUCCESS || !found) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static int pmi2_barrier(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    pmi_errno = PMI2_KVS_Fence();
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_kvsfence", "**pmi_kvsfence %d", pmi_errno);
+    /* Get a non-existent key, it only returns after every process called fence */
+    int out_len;
+    PMI2_KVS_Get(pmi_kvs_name, PMI2_ID_NULL, "-NONEXIST-KEY", NULL, 0, &out_len);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmi2_barrier_local(void)
+{
+    return pmi2_barrier();
+}
+
+static int pmi2_optimized_put(const char *key, const char *val, int is_local)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    if (!is_local) {
+        mpi_errno = pmi2_put(key, val);
+    } else {
+        int pmi_errno = PMI2_Info_PutNodeAttr(key, val);
+        MPIR_ERR_CHKANDJUMP(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                            "**pmi_putnodeattr");
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmi2_optimized_get(int src, const char *key, char *val, int valsize, int is_local)
+{
+    if (is_local) {
+        int mpi_errno = MPI_SUCCESS;
+        int found;
+        int pmi_errno = PMI2_Info_GetNodeAttr(key, val, valsize, &found, TRUE);
+        if (pmi_errno != PMI2_SUCCESS) {
+            MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**pmi_getnodeattr");
+        } else if (!found) {
+            MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**pmi_getnodeattr");
+        }
+        return mpi_errno;
+    } else {
+        return pmi2_get(src, key, val, valsize);
+    }
+}
+
+static int pmi2_optional_bcast_barrier(MPIR_PMI_DOMAIN domain)
+{
+    if (domain == MPIR_PMI_DOMAIN_LOCAL) {
+        /* PMI2 local uses Put/GetNodeAttr, no need for barrier */
+        return MPI_SUCCESS;
+    } else {
+        return pmi2_barrier();
+    }
+}
+
+static int pmi2_get_universe_size(int *universe_size)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+    char val[PMI2_MAX_VALLEN];
+    int found = 0;
+    char *endptr;
+
+    pmi_errno = PMI2_Info_GetJobAttr("universeSize", val, sizeof(val), &found);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_getjobattr", "**pmi_getjobattr %d", pmi_errno);
+    if (!found) {
+        *universe_size = MPIR_UNIVERSE_SIZE_NOT_AVAILABLE;
+    } else {
+        *universe_size = strtol(val, &endptr, 0);
+        MPIR_ERR_CHKINTERNAL(endptr - val != strlen(val), mpi_errno, "can't parse universe size");
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmi2_spawn(int count, char *commands[], char **argvs[], const int maxprocs[], MPIR_Info * info_ptrs[], int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+    INFO_TYPE *preput_vector = NULL;
+
+    int *info_keyval_sizes = NULL;
+    INFO_TYPE **info_keyval_vectors = NULL;
+    mpi_errno = get_info_kv_vectors(count, info_ptrs, &info_keyval_vectors, &info_keyval_sizes);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    if (num_preput_keyval > 0) {
+        preput_vector = MPL_malloc(num_preput_keyval * sizeof(INFO_TYPE), MPL_MEM_BUFFER);
+        MPIR_ERR_CHKANDJUMP(!preput_vector, mpi_errno, MPI_ERR_OTHER, "**nomem");
+        for (int i = 0; i < num_preput_keyval; i++) {
+            INFO_TYPE_KEY(preput_vector[i]) = preput_keyvals[i].key;
+            INFO_TYPE_VAL(preput_vector[i]) = preput_keyvals[i].val;
+        }
+    }
+
+    int *argcs = MPL_malloc(count * sizeof(int), MPL_MEM_DYNAMIC);
+    MPIR_Assert(argcs);
+
+    /* compute argcs array */
+    for (int i = 0; i < count; ++i) {
+        argcs[i] = 0;
+        if (argvs != NULL && argvs[i] != NULL) {
+            while (argvs[i][argcs[i]]) {
+                ++argcs[i];
+            }
+        }
+    }
+
+    pmi_errno = PMI2_Job_Spawn(count, (const char **) commands,
+                               argcs, (const char ***) argvs, maxprocs,
+                               info_keyval_sizes, (const PMI2_keyval_t **) info_keyval_vectors,
+                               num_preput_keyval, (const PMI2_keyval_t *) preput_vector,
+                               NULL, 0, pmi_errcodes);
+    MPL_free(argcs);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_spawn_multiple", "**pmi_spawn_multiple %d", pmi_errno);
+
+  fn_exit:
+    free_pmi_keyvals(info_keyval_vectors, count, info_keyval_sizes);
+    if (num_preput_keyval > 0) {
+        MPL_free(preput_vector);
+    }
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmi2_publish(const char name[], const char port[])
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+    /* release the global CS for PMI calls */
+    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    pmi_errno = PMI2_Nameserv_publish(name, NULL, port);
+    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_NAME, "**namepubnotpub",
+                         "**namepubnotpub %s", name);
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmi2_lookup(const char name[], char port[])
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+    /* release the global CS for PMI calls */
+    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    pmi_errno = PMI2_Nameserv_lookup(name, NULL, port, MPI_MAX_PORT_NAME);
+    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_NAME, "**namepubnotfound",
+                         "**namepubnotfound %s", name);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmi2_unpublish(const char name[])
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+    /* release the global CS for PMI calls */
+    MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    pmi_errno = PMI2_Nameserv_unpublish(name, NULL);
+    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_SERVICE, "**namepubnotunpub",
+                         "**namepubnotunpub %s", name);
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+#else  /* ENABLE_PMI2 */
+
+static int pmi2_init(int *has_parent, int *rank, int *size, int *appnum)
+{
+    return MPI_ERR_INTERN;
+}
+
+static void pmi2_exit(void)
+{
+    MPIR_Assert(0);
+}
+
+static void pmi2_abort(int exit_code, const char *error_msg)
+{
+    MPIR_Assert(0);
+}
+
+static int pmi2_put(const char *key, const char *val)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi2_get(int src, const char *key, char *val, int val_size)
+{
+    return MPI_ERR_INTERN;
+}
+
+static bool pmi2_get_jobattr(const char *key, char *valbuf)
+{
+    MPIR_Assert(0);
+    return false;
+}
+
+static int pmi2_barrier(void)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi2_barrier_local(void)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi2_optimized_put(const char *key, const char *val, int is_local)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi2_optimized_get(int src, const char *key, char *val, int valsize, int is_local)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi2_optional_bcast_barrier(MPIR_PMI_DOMAIN domain)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi2_get_universe_size(int *universe_size)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi2_spawn(int count, char *commands[], char **argvs[], const int maxprocs[], MPIR_Info * info_ptrs[], int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi2_publish(const char name[], const char port[])
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi2_lookup(const char name[], char port[])
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi2_unpublish(const char name[])
+{
+    return MPI_ERR_INTERN;
+}
+
+#endif /* ENABLE_PMI2 */
+
+#ifdef USE_PMI2_SLURM
+static int pmi2_spawn_slurm(int count, char *commands[], char **argvs[],
+                            const int maxprocs[], MPIR_Info * info_ptrs[],
+                            int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals,
+                            int *pmi_errcodes)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    int *info_keyval_sizes = NULL;
+    INFO_TYPE **info_keyval_vectors = NULL;
+    mpi_errno = get_info_kv_vectors(count, info_ptrs, &info_keyval_vectors, &info_keyval_sizes);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    const INFO_TYPE **preput_vector = NULL;
+    INFO_TYPE *preput_vector_array = NULL;
+
+    if (num_preput_keyval > 0) {
+        preput_vector = MPL_malloc(num_preput_keyval * sizeof(INFO_TYPE *), MPL_MEM_BUFFER);
+        MPIR_ERR_CHKANDJUMP(!preput_vector, mpi_errno, MPI_ERR_OTHER, "**nomem");
+        preput_vector_array = MPL_malloc(num_preput_keyval * sizeof(INFO_TYPE), MPL_MEM_BUFFER);
+        MPIR_ERR_CHKANDJUMP(!preput_vector_array, mpi_errno, MPI_ERR_OTHER, "**nomem");
+        for (int i = 0; i < num_preput_keyval; i++) {
+            INFO_TYPE_KEY(preput_vector_array[i]) = (char *) preput_keyvals[i].key;
+            INFO_TYPE_VAL(preput_vector_array[i]) = preput_keyvals[i].val;
+            preput_vector[i] = &preput_vector_array[i];
+        }
+    }
+
+    int *argcs = MPL_malloc(count * sizeof(int), MPL_MEM_DYNAMIC);
+    MPIR_Assert(argcs);
+
+    /* compute argcs array */
+    for (int i = 0; i < count; ++i) {
+        argcs[i] = 0;
+        if (argvs != NULL && argvs[i] != NULL) {
+            while (argvs[i][argcs[i]]) {
+                ++argcs[i];
+            }
+        }
+    }
+
+    pmi_errno = PMI2_Job_Spawn(count, (const char **) commands,
+                               argcs, (const char ***) argvs, maxprocs,
+                               info_keyval_sizes, (const struct MPID_Info **) info_keyval_vectors,
+                               num_preput_keyval, (const struct MPID_Info **) preput_vector,
+                               NULL, 0, pmi_errcodes);
+    MPL_free(argcs);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_spawn_multiple", "**pmi_spawn_multiple %d", pmi_errno);
+
+  fn_exit:
+    free_pmi_keyvals(info_keyval_vectors, count, info_keyval_sizes);
+    if (num_preput_keyval > 0) {
+        MPL_free(preput_vector_array);
+        MPL_free(preput_vector);
+    }
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+#endif

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -1,0 +1,481 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifdef ENABLE_PMIX
+
+static pmix_proc_t pmix_proc;
+static pmix_proc_t pmix_wcproc;
+
+static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    pmi_max_key_size = PMIX_MAX_KEYLEN;
+    pmi_max_val_size = 1024;    /* this is what PMI2_MAX_VALLEN currently set to */
+
+    pmix_value_t *pvalue = NULL;
+
+    /* Since we only call PMIx_Finalize once at `atexit` handler, we need prevent
+     * calling PMIx_Init multiple times. */
+    static int pmix_init_count = 0;
+    pmix_init_count++;
+    if (pmix_init_count == 1) {
+        pmi_errno = PMIx_Init(&pmix_proc, NULL, 0);
+        if (pmi_errno == PMIX_ERR_UNREACH) {
+            /* no pmi server, assume we are a singleton */
+            goto singleton_out;
+        }
+        MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                             "**pmix_init", "**pmix_init %d", pmi_errno);
+
+        PMIX_PROC_CONSTRUCT(&pmix_wcproc);
+        MPL_strncpy(pmix_wcproc.nspace, pmix_proc.nspace, PMIX_MAX_NSLEN);
+        pmix_wcproc.rank = PMIX_RANK_WILDCARD;
+    }
+
+    *rank = pmix_proc.rank;
+
+    pmi_errno = PMIx_Get(&pmix_wcproc, PMIX_JOB_SIZE, NULL, 0, &pvalue);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_get", "**pmix_get %d", pmi_errno);
+    *size = pvalue->data.uint32;
+    PMIX_VALUE_RELEASE(pvalue);
+
+    /* PMIX_JOBID seems to be more supported than PMIX_NSPACE */
+    /* TODO: fallback in case the key is not supported */
+    pmi_errno = PMIx_Get(&pmix_wcproc, PMIX_JOBID, NULL, 0, &pvalue);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_get", "**pmix_get %d", pmi_errno);
+    pmi_kvs_name = MPL_strdup(pvalue->data.string);
+    PMIX_VALUE_RELEASE(pvalue);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+  singleton_out:
+    *rank = 0;
+    *size = 1;
+    *appnum = 0;
+    *has_parent = 0;
+    pmi_kvs_name = MPL_strdup("0");
+    goto fn_exit;
+}
+
+static void pmix_exit(void)
+{
+    PMIx_Finalize(NULL, 0);
+}
+
+static void pmix_abort(int exit_code, const char *error_msg)
+{
+    PMIx_Abort(exit_code, error_msg, NULL, 0);
+}
+
+static int pmix_put(const char *key, const char *val)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    pmix_value_t value;
+    value.type = PMIX_STRING;
+    value.data.string = (char *) val;
+    pmi_errno = PMIx_Put(PMIX_GLOBAL, key, &value);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_put", "**pmix_put %d", pmi_errno);
+    pmi_errno = PMIx_Commit();
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_commit", "**pmix_commit %d", pmi_errno);
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmix_get(int src, const char *key, char *val, int val_size)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    pmix_value_t *pvalue;
+    if (src < 0) {
+        pmi_errno = PMIx_Get(NULL, key, NULL, 0, &pvalue);
+    } else {
+        pmix_proc_t proc;
+        PMIX_PROC_CONSTRUCT(&proc);
+        proc.rank = src;
+
+        pmi_errno = PMIx_Get(&proc, key, NULL, 0, &pvalue);
+    }
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_get", "**pmix_get %d", pmi_errno);
+    strncpy(val, pvalue->data.string, val_size);
+    PMIX_VALUE_RELEASE(pvalue);
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static bool pmix_get_jobattr(const char *key, char *valbuf)
+{
+    pmix_value_t *pvalue;
+    int pmi_errno = PMIx_Get(NULL, key, NULL, 0, &pvalue);
+    if (pmi_errno != PMIX_SUCCESS) {
+        return false;
+    }
+    strncpy(valbuf, pvalue->data.string, pmi_max_val_size);
+    PMIX_VALUE_RELEASE(pvalue);
+    return true;
+}
+
+static int pmix_barrier(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    pmix_info_t *info;
+    PMIX_INFO_CREATE(info, 1);
+    int flag = 1;
+    PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
+
+    /* use global wildcard proc set */
+    pmi_errno = PMIx_Fence(&pmix_wcproc, 1, info, 1);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_fence", "**pmix_fence %d", pmi_errno);
+    PMIX_INFO_FREE(info, 1);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmix_barrier_local(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    int local_size = MPIR_Process.local_size;
+    pmix_proc_t *procs = MPL_malloc(local_size * sizeof(pmix_proc_t), MPL_MEM_OTHER);
+    for (int i = 0; i < local_size; i++) {
+        PMIX_PROC_CONSTRUCT(&procs[i]);
+        strncpy(procs[i].nspace, pmix_proc.nspace, PMIX_MAX_NSLEN);
+        procs[i].rank = MPIR_Process.node_local_map[i];
+    }
+
+    pmix_info_t *info;
+    int flag = 1;
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
+
+    pmi_errno = PMIx_Fence(procs, local_size, info, 1);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**pmix_fence",
+                         "**pmix_fence %d", pmi_errno);
+
+    PMIX_INFO_FREE(info, 1);
+    MPL_free(procs);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmix_optimized_put(const char *key, const char *val, int is_local)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    int pmi_errno;
+    pmix_value_t value;
+    value.type = PMIX_STRING;
+    value.data.string = (char *) val;
+    pmi_errno = PMIx_Put(is_local ? PMIX_LOCAL : PMIX_GLOBAL, key, &value);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_put", "**pmix_put %d", pmi_errno);
+    pmi_errno = PMIx_Commit();
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_commit", "**pmix_commit %d", pmi_errno);
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmix_optimized_get(int src, const char *key, char *val, int valsize, int is_local)
+{
+    return pmix_get(src, key, val, valsize);
+}
+
+static int pmix_put_binary(const char *key, const char *buf, int bufsize, int is_local)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    pmix_value_t value;
+    value.type = PMIX_BYTE_OBJECT;
+    value.data.bo.bytes = (char *) buf;
+    value.data.bo.size = bufsize;
+    pmi_errno = PMIx_Put(is_local ? PMIX_LOCAL : PMIX_GLOBAL, key, &value);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_put", "**pmix_put %d", pmi_errno);
+    pmi_errno = PMIx_Commit();
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_commit", "**pmix_commit %d", pmi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmix_get_binary(int src, const char *key, char *buf, int *p_size, int is_local)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    int bufsize = *p_size;
+    pmix_value_t *pvalue;
+    if (src < 0) {
+        pmi_errno = PMIx_Get(NULL, key, NULL, 0, &pvalue);
+    } else {
+        pmix_proc_t proc;
+        PMIX_PROC_CONSTRUCT(&proc);
+        proc.rank = src;
+
+        pmi_errno = PMIx_Get(&proc, key, NULL, 0, &pvalue);
+    }
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_get", "**pmix_get %d", pmi_errno);
+    MPIR_Assert(pvalue->type == PMIX_BYTE_OBJECT);
+    MPIR_Assert(pvalue->data.bo.size <= bufsize);
+
+    memcpy(buf, pvalue->data.bo.bytes, pvalue->data.bo.size);
+    *p_size = pvalue->data.bo.size;
+
+    PMIX_VALUE_RELEASE(pvalue);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmix_optional_bcast_barrier(MPIR_PMI_DOMAIN domain)
+{
+    if (domain == MPIR_PMI_DOMAIN_LOCAL) {
+        pmix_barrier_local();
+    } else {
+        return pmix_barrier();
+    }
+}
+
+static int pmix_get_universe_size(int *universe_size)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+    pmix_value_t *pvalue = NULL;
+
+    pmi_errno = PMIx_Get(&pmix_wcproc, PMIX_UNIV_SIZE, NULL, 0, &pvalue);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_get", "**pmix_get %d", pmi_errno);
+    *universe_size = pvalue->data.uint32;
+    PMIX_VALUE_RELEASE(pvalue);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmix_spawn(int count, char *commands[], char **argvs[], const int maxprocs[], MPIR_Info * info_ptrs[], int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+{
+    /* not supported yet */
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_publish(const char name[], const char port[])
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+    pmix_info_t *info;
+    PMIX_INFO_CREATE(info, 1);
+    MPL_strncpy(info[0].key, name, PMIX_MAX_KEYLEN);
+    info[0].value.type = PMIX_STRING;
+    info[0].value.data.string = MPL_direct_strdup(port);
+    pmi_errno = PMIx_Publish(info, 1);
+    PMIX_INFO_FREE(info, 1);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_NAME, "**namepubnotpub",
+                         "**namepubnotpub %s", name);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmix_lookup(const char name[], char port[])
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+    pmix_pdata_t *pdata;
+    PMIX_PDATA_CREATE(pdata, 1);
+    MPL_strncpy(pdata[0].key, name, PMIX_MAX_KEYLEN);
+    pmi_errno = PMIx_Lookup(pdata, 1, NULL, 0);
+    if (pmi_errno == PMIX_SUCCESS) {
+        MPL_strncpy(port, pdata[0].value.data.string, MPI_MAX_PORT_NAME);
+    }
+    PMIX_PDATA_FREE(pdata, 1);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_NAME, "**namepubnotfound",
+                         "**namepubnotfound %s", name);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pmix_unpublish(const char name[])
+{
+    char *keys[2] = { (char *) name, NULL };
+    PMIx_Unpublish(keys, NULL, 0);
+    return MPI_SUCCESS;
+}
+
+#else  /* ENABLE_PMIX */
+
+static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
+{
+    return MPI_ERR_INTERN;
+}
+
+static void pmix_exit(void)
+{
+    MPIR_Assert(0);
+}
+
+static void pmix_abort(int exit_code, const char *error_msg)
+{
+    MPIR_Assert(0);
+}
+
+static int pmix_put(const char *key, const char *val)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_get(int src, const char *key, char *val, int val_size)
+{
+    return MPI_ERR_INTERN;
+}
+
+static bool pmix_get_jobattr(const char *key, char *valbuf)
+{
+    MPIR_Assert(0);
+    return false;
+}
+
+static int pmix_barrier(void)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_barrier_local(void)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_optimized_put(const char *key, const char *val, int is_local)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_optimized_get(int src, const char *key, char *val, int valsize, int is_local)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_put_binary(const char *key, const char *buf, int bufsize, int is_local)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_get_binary(int src, const char *key, char *buf, int *p_size, int is_local)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_optional_bcast_barrier(MPIR_PMI_DOMAIN domain)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_get_universe_size(int *universe_size)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_spawn(int count, char *commands[], char **argvs[], const int maxprocs[], MPIR_Info * info_ptrs[], int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_publish(const char name[], const char port[])
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_lookup(const char name[], char port[])
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_unpublish(const char name[])
+{
+    return MPI_ERR_INTERN;
+}
+
+#endif /* ENABLE_PMIX */
+
+/* build nodemap using PMIx_Resolve_nodes */
+static int pmix_build_nodemap(int *nodemap, int sz)
+{
+#ifndef ENABLE_PMIX
+    return MPI_ERR_INTERN;
+#else
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+    char *nodelist = NULL, *node = NULL;
+    pmix_proc_t *procs = NULL;
+    size_t nprocs, node_id = 0;
+
+    pmi_errno = PMIx_Resolve_nodes(pmix_proc.nspace, &nodelist);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_resolve_nodes", "**pmix_resolve_nodes %d", pmi_errno);
+    MPIR_Assert(nodelist);
+
+    node = strtok(nodelist, ",");
+    while (node) {
+        pmi_errno = PMIx_Resolve_peers(node, pmix_proc.nspace, &procs, &nprocs);
+        MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                             "**pmix_resolve_peers", "**pmix_resolve_peers %d", pmi_errno);
+        for (int i = 0; i < nprocs; i++) {
+            nodemap[procs[i].rank] = node_id;
+        }
+        node_id++;
+        node = strtok(NULL, ",");
+    }
+    /* PMIx latest adds pmix_free. We should switch to that at some point */
+    MPL_external_free(nodelist);
+    PMIX_PROC_FREE(procs, nprocs);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+#endif
+}
+


### PR DESCRIPTION
## Pull Request Description
Instead of selecting a PMI API version at configure time, detect all available PMI versions, and enable multiple APIs if they are supported. Use `MPIR_CVAR_PMI_VERSION` environment variable to select a runtime PMI protocol.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
