### PR TITLE
config: use more specific `-Werror=type-safety`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3524,7 +3524,7 @@ PAC_SET_MPI_DATATYPE_ALIAS(MPI_C_COMPLEX, MPI_C_FLOAT_COMPLEX)
 # does not help, since only the latest type_tag definition is used. Type tags are defined in mpi.h,
 # therefore, they must be also be activated/deavtivated there
 PAC_PUSH_FLAG([CFLAGS])
-PAC_C_CHECK_COMPILER_OPTION([-Werror],[CFLAGS="$CFLAGS -Werror"])
+PAC_C_CHECK_COMPILER_OPTION([-Werror=type-safety],[CFLAGS="$CFLAGS -Werror=type-safety"])
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
     typedef int TEST_Datatype;
     #define TEST_INT ((TEST_Datatype)0x44)


### PR DESCRIPTION
## Pull Request Description

See https://github.com/pmodels/mpich/issues/6496#issuecomment-1620486871. This change is fundamentally a workaround for [spack](https://spack.readthedocs.io/), specifically [this PR](https://github.com/spack/spack/pull/30882). However, making the `-Werror` flag more specific would help apply a more targeted workaround in spack.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
