### PR TITLE
ch4: remove recusive lock usages

### DIFF
--- a/src/mpid/ch4/include/mpid_thread.h
+++ b/src/mpid/ch4/include/mpid_thread.h
@@ -20,18 +20,6 @@ typedef MPIDU_Thread_mutex_t MPID_Thread_mutex_t;
 #define MPID_THREAD_CS_YIELD       MPIDU_THREAD_CS_YIELD
 #define MPID_THREAD_ASSERT_IN_CS   MPIDU_THREAD_ASSERT_IN_CS
 
-/* In limited cases we need use recursive mutex. For example, during establishing anysource
- * receive, we need hold shm vci lock while setting up netmod request -- both may be the
- * same vci or different vci. Recursive locking allows us to proceed in both cases.
- * NOTE: use cautiously and comment on the reasoning of its usage.
- */
-
-#if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
-#define MPID_THREAD_CS_ENTER_REC_VCI(mutex)   MPIDUI_THREAD_CS_ENTER_REC(mutex)
-#else
-#define MPID_THREAD_CS_ENTER_REC_VCI(mutex)     /* NOOP */
-#endif
-
 #define MPID_Thread_init           MPIDU_Thread_init
 #define MPID_Thread_finalize       MPIDU_Thread_finalize
 #define MPID_Thread_mutex_create   MPIDU_Thread_mutex_create

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -169,13 +169,6 @@ int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret);
         }                                                       \
     } while (0)
 
-#define MPIDI_OFI_THREAD_CS_ENTER_REC_VCI_OPTIONAL(vci_)        \
-    do {                                                        \
-        if (!MPIDI_VCI_IS_EXPLICIT(vci_) && MPIDI_CH4_MT_MODEL != MPIDI_CH4_MT_LOCKLESS) {      \
-            MPID_THREAD_CS_ENTER_REC_VCI(MPIDI_VCI(vci_).lock);     \
-        }                                                       \
-    } while (0)
-
 #define MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vci_)         \
     do {                                                    \
         if (!MPIDI_VCI_IS_EXPLICIT(vci_) && MPIDI_CH4_MT_MODEL != MPIDI_CH4_MT_LOCKLESS) {  \

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -165,7 +165,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_safe(MPIR_Request * rreq)
      * usage it's often used inside a critical section (e.g. progress and anysource
      * receive). Therefore, we allow recursive lock usage here.
      */
-    MPID_THREAD_CS_ENTER_REC_VCI(MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
     mpi_errno = MPIDI_cancel_recv_unsafe(rreq);
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/common/thread/mpidu_thread_fallback.h
+++ b/src/mpid/common/thread/mpidu_thread_fallback.h
@@ -134,27 +134,6 @@ M*/
 /* ***************************************** */
 #if defined(MPICH_IS_THREADED)
 
-#define MPIDUI_THREAD_CS_ENTER_REC(mutex)                               \
-    do {                                                                \
-        if (MPIR_ThreadInfo.isThreaded) {                               \
-            int equal_ = 0;                                             \
-            MPL_thread_id_t self_, owner_;                              \
-            MPL_thread_self(&self_);                                    \
-            owner_ = mutex.owner;                                       \
-            MPL_thread_same(&self_, &owner_, &equal_);                  \
-            if (!equal_) {                                              \
-                int err_ = 0;                                           \
-                MPL_DBG_MSG_P(MPIR_DBG_THREAD,VERBOSE,"enter MPIDU_Thread_mutex_lock %p", &mutex); \
-                MPIDU_Thread_mutex_lock(&mutex, &err_, MPL_THREAD_PRIO_HIGH);\
-                MPL_DBG_MSG_P(MPIR_DBG_THREAD,VERBOSE,"exit MPIDU_Thread_mutex_lock %p", &mutex); \
-                MPIR_Assert(err_ == 0);                                 \
-                MPIR_Assert(mutex.count == 0);                          \
-                MPL_thread_self(&mutex.owner);                          \
-            }                                                           \
-            mutex.count++;                                              \
-        }                                                               \
-    } while (0)
-
 #define MPIDUI_THREAD_CS_ENTER(mutex)                                   \
     do {                                                                \
         if (MPIR_ThreadInfo.isThreaded) {                               \


### PR DESCRIPTION
## Pull Request Description
We used to allow shm and netmod to use different vcis. This is no longer the case. Thus recursive locking is no longer needed.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
