### PR TITLE
ch4: allow different vcis per process

### DIFF
--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -44,6 +44,7 @@ Non Native API:
       NM : num_vcis, num_vcis_actual
   post_init : int
       NM : void
+     SHM : void
   progress : int
       NM*: vci, made_progress
      SHM*: vci, made_progress

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -40,6 +40,8 @@ Non Native API:
   mpi_finalize_hook : int
       NM : void
      SHM : void
+  init_vcis: int
+      NM : num_vcis, num_vcis_actual
   post_init : int
       NM : void
   progress : int
@@ -471,6 +473,8 @@ PARAM:
     message: MPIR_Request *
     message_p: MPIR_Request **
     newcomm_ptr: MPIR_Comm **
+    num_vcis: int
+    num_vcis_actual: int *
     op: MPI_Op
     op_p: MPIR_Op *
     origin_addr: const void *

--- a/src/mpid/ch4/include/mpidimpl.h
+++ b/src/mpid/ch4/include/mpidimpl.h
@@ -18,4 +18,7 @@
 #include "mpidpre.h"
 #include "mpidch4.h"
 
+int MPIDI_world_pre_init(void);
+int MPIDI_world_post_init(void);
+
 #endif /* MPIDIMPL_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -244,7 +244,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_pref_nic(MPIR_Comm * comm_ptr, int ra
  * Each nic will contain num_vcis vcis. Each corresponding to their respective vci index. */
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_ctx_index(int vci, int nic)
 {
-    return nic * MPIDI_OFI_global.num_vcis + vci;
+    return nic * MPIDI_CH4_MAX_VCIS + vci;
 }
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_cntr_incr(int vci, int nic)

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -732,6 +732,13 @@ int MPIDI_OFI_init_world(void)
     goto fn_exit;
 }
 
+int MPIDI_OFI_init_vcis(int num_vcis, int *num_vcis_actual)
+{
+    int mpi_errno = MPI_SUCCESS;
+    *num_vcis_actual = num_vcis;
+    return mpi_errno;
+}
+
 static int check_num_nics(void);
 static int setup_additional_vcis(void);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -732,7 +732,27 @@ int MPIDI_OFI_init_world(void)
     goto fn_exit;
 }
 
+static int check_num_nics(void);
+static int setup_additional_vcis(void);
+
 int MPIDI_OFI_post_init(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    /* All processes must have the same number of NICs */
+    mpi_errno = check_num_nics();
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = setup_additional_vcis();
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int check_num_nics(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -774,6 +794,16 @@ int MPIDI_OFI_post_init(void)
     for (int nic = 1; nic < MPIDI_OFI_global.num_nics; nic++) {
         set_sep_counters(nic);
     }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int setup_additional_vcis(void)
+{
+    int mpi_errno = MPI_SUCCESS;
 
     for (int vci = 0; vci < MPIDI_OFI_global.num_vcis; vci++) {
         for (int nic = 0; nic < MPIDI_OFI_global.num_nics; nic++) {

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -271,6 +271,13 @@ int MPIDI_UCX_init_world(void)
     goto fn_exit;
 }
 
+int MPIDI_UCX_init_vcis(int num_vcis, int *num_vcis_actual)
+{
+    int mpi_errno = MPI_SUCCESS;
+    *num_vcis_actual = num_vcis;
+    return mpi_errno;
+}
+
 /* static functions for MPIDI_UCX_post_init */
 static void flush_cb(void *request, ucs_status_t status)
 {

--- a/src/mpid/ch4/shm/posix/eager/include/posix_eager.h
+++ b/src/mpid/ch4/shm/posix/eager/include/posix_eager.h
@@ -11,6 +11,7 @@
 #define MPIDI_MAX_POSIX_EAGER_STRING_LEN 64
 
 typedef int (*MPIDI_POSIX_eager_init_t) (int rank, int size);
+typedef int (*MPIDI_POSIX_eager_post_init_t) (void);
 typedef int (*MPIDI_POSIX_eager_finalize_t) (void);
 
 typedef int (*MPIDI_POSIX_eager_send_t) (int grank, MPIDI_POSIX_am_header_t * msg_hdr,
@@ -35,6 +36,7 @@ typedef size_t(*MPIDI_POSIX_eager_buf_limit_t) (void);
 
 typedef struct {
     MPIDI_POSIX_eager_init_t init;
+    MPIDI_POSIX_eager_post_init_t post_init;
     MPIDI_POSIX_eager_finalize_t finalize;
 
     MPIDI_POSIX_eager_send_t send;
@@ -56,6 +58,7 @@ extern int MPIDI_num_posix_eager_fabrics;
 extern char MPIDI_POSIX_eager_strings[][MPIDI_MAX_POSIX_EAGER_STRING_LEN];
 
 int MPIDI_POSIX_eager_init(int rank, int size);
+int MPIDI_POSIX_eager_post_init(void);
 int MPIDI_POSIX_eager_finalize(void);
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr,

--- a/src/mpid/ch4/shm/posix/eager/iqueue/func_table.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/func_table.c
@@ -14,6 +14,7 @@
 
 MPIDI_POSIX_eager_funcs_t MPIDI_POSIX_eager_iqueue_funcs = {
     MPIDI_POSIX_iqueue_init,
+    MPIDI_POSIX_iqueue_post_init,
     MPIDI_POSIX_iqueue_finalize,
 
     MPIDI_POSIX_eager_send,

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
@@ -36,6 +36,42 @@ cvars:
 
 MPIDI_POSIX_eager_iqueue_global_t MPIDI_POSIX_eager_iqueue_global;
 
+static int init_transport(int vci_src, int vci_dst)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIDI_POSIX_eager_iqueue_transport_t *transport;
+    transport = MPIDI_POSIX_eager_iqueue_get_transport(vci_src, vci_dst);
+
+    transport->num_cells = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_NUM_CELLS;
+    transport->size_of_cell = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE;
+
+    mpi_errno = MPIDU_genq_shmem_pool_create(transport->size_of_cell, transport->num_cells,
+                                             MPIDI_POSIX_global.num_local,
+                                             MPIDI_POSIX_global.my_local_rank,
+                                             &transport->cell_pool);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    size_t size_of_terminals;
+    /* Create one terminal for each process with which we will be able to communicate. */
+    size_of_terminals = (size_t) MPIDI_POSIX_global.num_local * sizeof(MPIDU_genq_shmem_queue_u);
+
+    /* Create the shared memory regions that will be used for the iqueue cells and terminals. */
+    mpi_errno = MPIDU_Init_shm_alloc(size_of_terminals, (void *) &transport->terminals);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    transport->my_terminal = &transport->terminals[MPIDI_POSIX_global.my_local_rank];
+
+    mpi_errno = MPIDU_genq_shmem_queue_init(transport->my_terminal,
+                                            MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPSC);
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 int MPIDI_POSIX_iqueue_init(int rank, int size)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -46,43 +82,38 @@ int MPIDI_POSIX_iqueue_init(int rank, int size)
     MPIR_Assert((MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE & (MAX_ALIGNMENT - 1)) == 0);
     MPIR_Assert((sizeof(MPIDI_POSIX_eager_iqueue_cell_t) & (MAX_ALIGNMENT - 1)) == 0);
 
-    size_t size_of_terminals;
-    /* Create one terminal for each process with which we will be able to communicate. */
-    size_of_terminals = (size_t) MPIDI_POSIX_global.num_local * sizeof(MPIDU_genq_shmem_queue_u);
+    mpi_errno = init_transport(0, 0);
+    MPIR_ERR_CHECK(mpi_errno);
 
-    for (int vci_src = 0; vci_src < MPIDI_POSIX_global.num_vcis; vci_src++) {
-        for (int vci_dst = 0; vci_dst < MPIDI_POSIX_global.num_vcis; vci_dst++) {
-            MPIDI_POSIX_eager_iqueue_transport_t *transport;
-            transport = MPIDI_POSIX_eager_iqueue_get_transport(vci_src, vci_dst);
-
-            transport->num_cells = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_NUM_CELLS;
-            transport->size_of_cell = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE;
-
-            mpi_errno =
-                MPIDU_genq_shmem_pool_create(transport->size_of_cell, transport->num_cells,
-                                             MPIDI_POSIX_global.num_local,
-                                             MPIDI_POSIX_global.my_local_rank,
-                                             &transport->cell_pool);
-            MPIR_ERR_CHECK(mpi_errno);
-
-            /* Create the shared memory regions that will be used for the iqueue cells and terminals. */
-            mpi_errno = MPIDU_Init_shm_alloc(size_of_terminals, (void *) &transport->terminals);
-            MPIR_ERR_CHECK(mpi_errno);
-
-            transport->my_terminal = &transport->terminals[MPIDI_POSIX_global.my_local_rank];
-
-            mpi_errno = MPIDU_genq_shmem_queue_init(transport->my_terminal,
-                                                    MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPSC);
-            MPIR_ERR_CHECK(mpi_errno);
-        }
-    }
-
-    /* Run local procs barrier */
     mpi_errno = MPIDU_Init_shm_barrier();
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIDI_POSIX_iqueue_post_init(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    for (int vci_src = 0; vci_src < MPIDI_POSIX_global.num_vcis; vci_src++) {
+        for (int vci_dst = 0; vci_dst < MPIDI_POSIX_global.num_vcis; vci_dst++) {
+            if (vci_src == 0 && vci_dst == 0) {
+                continue;
+            }
+            mpi_errno = init_transport(vci_src, vci_dst);
+            MPIR_ERR_CHECK(mpi_errno);
+
+        }
+    }
+
+    mpi_errno = MPIDU_Init_shm_barrier();
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_noinline.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_noinline.h
@@ -10,10 +10,12 @@
 #include "iqueue_impl.h"
 
 int MPIDI_POSIX_iqueue_init(int rank, int size);
+int MPIDI_POSIX_iqueue_post_init(void);
 int MPIDI_POSIX_iqueue_finalize(void);
 
 #ifdef POSIX_EAGER_INLINE
 #define MPIDI_POSIX_eager_init MPIDI_POSIX_iqueue_init
+#define MPIDI_POSIX_eager_post_init MPIDI_POSIX_iqueue_post_init
 #define MPIDI_POSIX_eager_finalize MPIDI_POSIX_iqueue_finalize
 #endif
 

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
@@ -19,7 +19,8 @@ MPIDI_POSIX_eager_recv_begin(int vci, MPIDI_POSIX_eager_recv_transaction_t * tra
     MPIR_FUNC_ENTER;
 
     /* TODO: measure the latency overhead due to multiple vci */
-    for (int vci_src = 0; vci_src < MPIDI_POSIX_global.num_vcis; vci_src++) {
+    int max_vcis = MPIDI_POSIX_eager_iqueue_global.max_vcis;
+    for (int vci_src = 0; vci_src < max_vcis; vci_src++) {
         transport = MPIDI_POSIX_eager_iqueue_get_transport(vci_src, vci);
 
         MPIDU_genq_shmem_queue_dequeue(transport->cell_pool, transport->my_terminal,

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_types.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_types.h
@@ -34,6 +34,7 @@ typedef struct MPIDI_POSIX_eager_iqueue_transport {
 } MPIDI_POSIX_eager_iqueue_transport_t;
 
 typedef struct MPIDI_POSIX_eager_iqueue_global {
+    int max_vcis;
     /* 2d array indexed with [src_vci][dst_vci] */
     MPIDI_POSIX_eager_iqueue_transport_t transports[MPIDI_CH4_MAX_VCIS][MPIDI_CH4_MAX_VCIS];
 } MPIDI_POSIX_eager_iqueue_global_t;

--- a/src/mpid/ch4/shm/posix/eager/src/posix_eager_impl.c
+++ b/src/mpid/ch4/shm/posix/eager/src/posix_eager_impl.c
@@ -14,6 +14,11 @@ int MPIDI_POSIX_eager_init(int rank, int size)
     return MPIDI_POSIX_eager_func->init(rank, size);
 }
 
+int MPIDI_POSIX_eager_post_init(void)
+{
+    return MPIDI_POSIX_eager_func->post_init();
+}
+
 int MPIDI_POSIX_eager_finalize(void)
 {
     return MPIDI_POSIX_eager_func->finalize();

--- a/src/mpid/ch4/shm/posix/eager/stub/func_table.c
+++ b/src/mpid/ch4/shm/posix/eager/stub/func_table.c
@@ -15,6 +15,7 @@
 
 MPIDI_POSIX_eager_funcs_t MPIDI_POSIX_eager_stub_funcs = {
     MPIDI_POSIX_stub_init,
+    MPIDI_POSIX_stub_post_init,
     MPIDI_POSIX_stub_finalize,
 
     MPIDI_POSIX_eager_send,

--- a/src/mpid/ch4/shm/posix/eager/stub/stub_init.c
+++ b/src/mpid/ch4/shm/posix/eager/stub/stub_init.c
@@ -14,6 +14,12 @@ int MPIDI_POSIX_stub_init(int rank, int size)
     return MPI_SUCCESS;
 }
 
+int MPIDI_POSIX_stub_post_init(void)
+{
+    MPIR_Assert(0);
+    return MPI_SUCCESS;
+}
+
 int MPIDI_POSIX_stub_finalize()
 {
     MPIR_Assert(0);

--- a/src/mpid/ch4/shm/posix/eager/stub/stub_noinline.h
+++ b/src/mpid/ch4/shm/posix/eager/stub/stub_noinline.h
@@ -9,10 +9,12 @@
 #include "stub_impl.h"
 
 int MPIDI_POSIX_stub_init(int rank, int size);
+int MPIDI_POSIX_stub_post_init(void);
 int MPIDI_POSIX_stub_finalize(void);
 
 #ifdef POSIX_EAGER_INLINE
 #define MPIDI_POSIX_eager_init MPIDI_POSIX_stub_init
+#define MPIDI_POSIX_eager_post_init MPIDI_POSIX_stub_post_init
 #define MPIDI_POSIX_eager_finalize MPIDI_POSIX_stub_finalize
 #endif
 

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -236,6 +236,9 @@ int MPIDI_POSIX_post_init(void)
         MPIR_ERR_CHECK(mpi_errno);
     }
 
+    mpi_errno = MPIDI_POSIX_eager_post_init();
+    MPIR_ERR_CHECK(mpi_errno);
+
   fn_exit:
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -227,6 +227,11 @@ int MPIDI_POSIX_init_world(void)
     goto fn_exit;
 }
 
+int MPIDI_POSIX_post_init(void)
+{
+    return MPI_SUCCESS;
+}
+
 int MPIDI_POSIX_mpi_finalize_hook(void)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -124,11 +124,34 @@ static void *create_container(struct json_object *obj)
     return cnt;
 }
 
+static int init_vci(int vci)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIDU_genq_private_pool_create(MPIDI_POSIX_AM_HDR_POOL_CELL_SIZE,
+                                               MPIDI_POSIX_AM_HDR_POOL_NUM_CELLS_PER_CHUNK,
+                                               0 /* unlimited */ ,
+                                               host_alloc, host_free,
+                                               &MPIDI_POSIX_global.per_vci[vci].am_hdr_buf_pool);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPIDI_POSIX_global.per_vci[vci].postponed_queue = NULL;
+
+    MPIDI_POSIX_global.per_vci[vci].active_rreq =
+        MPL_calloc(MPIR_Process.local_size, sizeof(MPIR_Request *), MPL_MEM_SHM);
+    MPIR_ERR_CHKANDJUMP(!MPIDI_POSIX_global.per_vci[vci].active_rreq,
+                        mpi_errno, MPI_ERR_OTHER, "**nomem");
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 int MPIDI_POSIX_init_local(int *tag_bits /* unused */)
 {
     int mpi_errno = MPI_SUCCESS;
     int i, local_rank_0 = -1;
-    MPIR_CHKPMEM_DECL(MPIDI_CH4_MAX_VCIS);
 
     MPL_COMPILE_TIME_ASSERT(sizeof(MPIDI_POSIX_am_request_header_t)
                             < MPIDI_POSIX_AM_HDR_POOL_CELL_SIZE);
@@ -150,38 +173,9 @@ int MPIDI_POSIX_init_local(int *tag_bits /* unused */)
 
     MPIDI_POSIX_global.local_rank_0 = local_rank_0;
 
-    MPIDI_POSIX_global.num_vcis = MPIDI_global.n_total_vcis;
-    /* This is used to track messages that the eager submodule was not ready to send. */
-    for (int vci = 0; vci < MPIDI_global.n_total_vcis; vci++) {
-        mpi_errno = MPIDU_genq_private_pool_create(MPIDI_POSIX_AM_HDR_POOL_CELL_SIZE,
-                                                   MPIDI_POSIX_AM_HDR_POOL_NUM_CELLS_PER_CHUNK,
-                                                   0 /* unlimited */ ,
-                                                   host_alloc, host_free,
-                                                   &MPIDI_POSIX_global.
-                                                   per_vci[vci].am_hdr_buf_pool);
-        MPIR_ERR_CHECK(mpi_errno);
-
-        MPIDI_POSIX_global.per_vci[vci].postponed_queue = NULL;
-
-        MPIR_CHKPMEM_MALLOC(MPIDI_POSIX_global.per_vci[vci].active_rreq, MPIR_Request **,
-                            MPIR_Process.local_size * sizeof(MPIR_Request *), mpi_errno,
-                            "active recv req", MPL_MEM_SHM);
-
-        for (i = 0; i < MPIR_Process.local_size; i++) {
-            MPIDI_POSIX_global.per_vci[vci].active_rreq[i] = NULL;
-        }
-
-    }
-
     choose_posix_eager();
 
-    MPIR_CHKPMEM_COMMIT();
-
-  fn_exit:
     return mpi_errno;
-  fn_fail:
-    MPIR_CHKPMEM_REAP();
-    goto fn_exit;
 }
 
 static int posix_world_initialized;
@@ -211,6 +205,11 @@ int MPIDI_POSIX_init_world(void)
     int rank = MPIR_Process.rank;
     int size = MPIR_Process.size;
 
+    MPIDI_POSIX_global.num_vcis = 1;
+
+    mpi_errno = init_vci(0);
+    MPIR_ERR_CHECK(mpi_errno);
+
     mpi_errno = MPIDI_POSIX_eager_init(rank, size);
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -229,7 +228,18 @@ int MPIDI_POSIX_init_world(void)
 
 int MPIDI_POSIX_post_init(void)
 {
-    return MPI_SUCCESS;
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIDI_POSIX_global.num_vcis = MPIDI_global.n_total_vcis;
+    for (int i = 1; i < MPIDI_POSIX_global.num_vcis; i++) {
+        mpi_errno = init_vci(i);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 int MPIDI_POSIX_mpi_finalize_hook(void)
@@ -256,7 +266,7 @@ int MPIDI_POSIX_mpi_finalize_hook(void)
         utarray_free(shm_mutex_free_list);
     }
 
-    for (int vci = 0; vci < MPIDI_global.n_total_vcis; vci++) {
+    for (int vci = 0; vci < MPIDI_POSIX_global.num_vcis; vci++) {
         MPIDU_genq_private_pool_destroy(MPIDI_POSIX_global.per_vci[vci].am_hdr_buf_pool);
         MPL_free(MPIDI_POSIX_global.per_vci[vci].active_rreq);
     }

--- a/src/mpid/ch4/shm/src/shm_init.c
+++ b/src/mpid/ch4/shm/src/shm_init.c
@@ -43,6 +43,19 @@ int MPIDI_SHM_init_world(void)
     goto fn_exit;
 }
 
+int MPIDI_SHM_post_init(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIDI_POSIX_post_init();
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 int MPIDI_SHM_mpi_finalize_hook(void)
 {
     int ret;

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -147,14 +147,7 @@ int MPID_Comm_commit_pre_hook(MPIR_Comm * comm)
         MPIDI_COMM(comm, local_map).mode = MPIDI_RANK_MAP_NONE;
         MPIDIU_avt_add_ref(0);
 
-        mpi_errno = MPIDU_Init_shm_init();
-        MPIR_ERR_CHECK(mpi_errno);
-
-#ifndef MPIDI_CH4_DIRECT_NETMOD
-        mpi_errno = MPIDI_SHM_init_world();
-        MPIR_ERR_CHECK(mpi_errno);
-#endif
-        mpi_errno = MPIDI_NM_init_world();
+        mpi_errno = MPIDI_world_pre_init();
         MPIR_ERR_CHECK(mpi_errno);
     } else if (comm == MPIR_Process.comm_self) {
         MPIDI_COMM(comm, map).mode = MPIDI_RANK_MAP_OFFSET_INTRA;
@@ -225,10 +218,8 @@ int MPID_Comm_commit_post_hook(MPIR_Comm * comm)
     MPIR_FUNC_ENTER;
 
     if (comm == MPIR_Process.comm_world) {
-        mpi_errno = MPIDI_NM_post_init();
+        mpi_errno = MPIDI_world_post_init();
         MPIR_ERR_CHECK(mpi_errno);
-
-        MPIDI_global.is_initialized = 1;
     }
 
     mpi_errno = MPIDI_NM_mpi_comm_commit_post_hook(comm);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -499,6 +499,12 @@ int MPID_Init(int requested, int *provided)
     MPIDI_global.n_reserved_vcis = 0;
     MPIDI_global.share_reserved_vcis = false;
 
+    MPIDI_global.all_num_vcis = MPL_malloc(sizeof(int) * MPIR_Process.size, MPL_MEM_OTHER);
+    MPIR_Assert(MPIDI_global.all_num_vcis);
+    for (int i = 0; i < MPIR_Process.size; i++) {
+        MPIDI_global.all_num_vcis[i] = MPIDI_global.n_vcis;
+    }
+
     MPIR_Assert(MPIDI_global.n_total_vcis <= MPIDI_CH4_MAX_VCIS);
     MPIR_Assert(MPIDI_global.n_total_vcis <= MPIR_REQUEST_NUM_POOLS);
 
@@ -733,6 +739,8 @@ int MPID_Finalize(void)
         MPID_Thread_mutex_destroy(&MPIDI_VCI(i).lock, &err);
         MPIR_Assert(err == 0);
     }
+
+    MPL_free(MPIDI_global.all_num_vcis);
 
     memset(&MPIDI_global, 0, sizeof(MPIDI_global));
 

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -624,6 +624,43 @@ int MPID_InitCompleted(void)
     goto fn_exit;
 }
 
+/* This is called from MPIR_init_comm_world() -> MPID_Comm_commit_pre_hook() */
+int MPIDI_world_pre_init(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIDU_Init_shm_init();
+    MPIR_ERR_CHECK(mpi_errno);
+
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    mpi_errno = MPIDI_SHM_init_world();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
+    mpi_errno = MPIDI_NM_init_world();
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+/* This is called from MPIR_init_comm_world() -> MPID_Comm_commit_post_hook() */
+int MPIDI_world_post_init(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIDI_NM_post_init();
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPIDI_global.is_initialized = 1;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 int MPID_Allocate_vci(int *vci, bool is_shared)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -680,6 +680,10 @@ int MPIDI_world_post_init(void)
     MPIR_ERR_CHECK(mpi_errno);
 #endif
 
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    mpi_errno = MPIDI_SHM_post_init();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
     mpi_errno = MPIDI_NM_post_init();
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -280,6 +280,7 @@ typedef struct MPIDI_CH4_Global_t {
     int n_reserved_vcis;        /* num of reserved vcis */
     int n_total_vcis;           /* total num of vcis, must > n_vcis + n_reserved_vcis */
     bool share_reserved_vcis;   /* default false, skip locking for explicit vcis */
+    int *all_num_vcis;          /* allgathered n_vcis, needed for implicit hashing */
     MPIDI_per_vci_t per_vci[MPIDI_CH4_MAX_VCIS];
 
     MPIDI_CH4_configurations_t settings;

--- a/src/mpid/ch4/src/ch4_vci.h
+++ b/src/mpid/ch4/src/ch4_vci.h
@@ -58,6 +58,41 @@
 #define SRC_VCI_FROM_RECVER 2   /* Bit 2 marks SENDER/RECVER */
 #define DST_VCI_FROM_RECVER 3
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_hash_local_vci(int raw_vci)
+{
+    return raw_vci % MPIDI_global.n_vcis;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_hash_remote_vci(int raw_vci, MPIR_Comm * comm_ptr, int rank)
+{
+    if (raw_vci == 0) {
+        return 0;
+    } else if (rank < 0) {
+        /* MPI_ANY_SOURCE, MPI_PROC_NULL, return a dummy, won't be used */
+        return 0;
+    } else {
+        int grank = MPIDIU_rank_to_lpid(rank, comm_ptr);
+        MPIR_Assert(grank >= 0);
+        return raw_vci % MPIDI_global.all_num_vcis[grank];
+    }
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_hash_vci(int raw_vci, int flag,
+                                            MPIR_Comm * comm_ptr, int src_rank, int dst_rank)
+{
+    switch (flag & 0x3) {
+        case 0:
+        case 3:
+            return MPIDI_hash_local_vci(raw_vci);
+        case 1:
+            return MPIDI_hash_remote_vci(raw_vci, comm_ptr, dst_rank);
+        case 2:
+            return MPIDI_hash_remote_vci(raw_vci, comm_ptr, src_rank);
+    }
+    MPIR_Assert(0);
+    return 0;
+}
+
 #if MPIDI_CH4_VCI_METHOD == MPICH_VCI__ZERO
 
 /* Always and only use vci 0, equivalent to NUM_VCIS==1 */
@@ -73,7 +108,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_vci(int flag, MPIR_Comm * comm_ptr,
 MPL_STATIC_INLINE_PREFIX int MPIDI_get_vci(int flag, MPIR_Comm * comm_ptr,
                                            int src_rank, int dst_rank, int tag)
 {
-    return comm_ptr->seq % MPIDI_global.n_vcis;
+    return MPIDI_hash_vci(comm_ptr->seq, flag, comm_ptr, src_rank, dst_rank);
 }
 
 #elif MPIDI_CH4_VCI_METHOD == MPICH_VCI__TAG
@@ -89,11 +124,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_vci(int flag, MPIR_Comm * comm_ptr,
     if (!(flag & 0x1)) {
         /* src */
         vci = (tag == MPI_ANY_TAG) ? 0 : ((tag >> 10) & 0x1f);
+        return MPIDI_hash_vci(vci, flag, comm_ptr, src_rank, dst_rank);
     } else {
         /* dst */
         vci = (tag == MPI_ANY_TAG) ? 0 : ((tag >> 5) & 0x1f);
+        return MPIDI_hash_vci(vci, flag, comm_ptr, src_rank, dst_rank);
     }
-    return vci % MPIDI_global.n_vcis;
 }
 
 #elif MPIDI_CH4_VCI_METHOD == MPICH_VCI__IMPLICIT
@@ -101,26 +137,26 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_vci(int flag, MPIR_Comm * comm_ptr,
 /* Map comm to vci_idx */
 MPL_STATIC_INLINE_PREFIX int MPIDI_map_contextid_to_vci(MPIR_Context_id_t context_id)
 {
-    return (MPIR_CONTEXT_READ_FIELD(PREFIX, context_id)) % MPIDI_global.n_vcis;
+    return MPIR_CONTEXT_READ_FIELD(PREFIX, context_id);
 }
 
 /* Map comm and rank to vci_idx */
 MPL_STATIC_INLINE_PREFIX int MPIDI_map_contextid_rank_to_vci(MPIR_Context_id_t context_id, int rank)
 {
-    return (MPIR_CONTEXT_READ_FIELD(PREFIX, context_id) + rank) % MPIDI_global.n_vcis;
+    return MPIR_CONTEXT_READ_FIELD(PREFIX, context_id) + rank;
 }
 
 /* Map comm and tag to vci_idx */
 MPL_STATIC_INLINE_PREFIX int MPIDI_map_contextid_tag_to_vci(MPIR_Context_id_t context_id, int tag)
 {
-    return (MPIR_CONTEXT_READ_FIELD(PREFIX, context_id) + tag) % MPIDI_global.n_vcis;;
+    return MPIR_CONTEXT_READ_FIELD(PREFIX, context_id) + tag;
 }
 
 /* Map comm, rank, and tag to vci_idx */
 MPL_STATIC_INLINE_PREFIX int MPIDI_map_contextid_rank_tag_to_vci(MPIR_Context_id_t context_id,
                                                                  int rank, int tag)
 {
-    return (MPIR_CONTEXT_READ_FIELD(PREFIX, context_id) + rank + tag) % MPIDI_global.n_vcis;;
+    return MPIR_CONTEXT_READ_FIELD(PREFIX, context_id) + rank + tag;
 }
 
 static bool is_vci_restricted_to_zero(MPIR_Comm * comm)
@@ -253,13 +289,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_vci(int flag, MPIR_Comm * comm_ptr,
         ctxid_in_effect = comm_ptr->recvcontext_id;
     }
 
+    int vci;
     if (!(flag & 0x1)) {
         /* src */
-        return MPIDI_get_sender_vci(comm_ptr, ctxid_in_effect, src_rank, dst_rank, tag);
+        vci = MPIDI_get_sender_vci(comm_ptr, ctxid_in_effect, src_rank, dst_rank, tag);
     } else {
         /* dst */
-        return MPIDI_get_receiver_vci(comm_ptr, ctxid_in_effect, src_rank, dst_rank, tag);
+        vci = MPIDI_get_receiver_vci(comm_ptr, ctxid_in_effect, src_rank, dst_rank, tag);
     }
+    return MPIDI_hash_vci(vci, flag, comm_ptr, src_rank, dst_rank);
 }
 
 #elif MPIDI_CH4_VCI_METHOD == MPICH_VCI__EXPLICIT


### PR DESCRIPTION
## Pull Request Description
VCIs are finite resources. Different processes may need different number of vcis; or the process may run out of vcis. Thus we may need to adjust number of vcis according to netmod initialization and allgather each process' number of vcis.

The fixes the tests on `psm2` provider when we run tests with big number of processes and multiple vcis, resulting running out of vcis.

[skp warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
