### PR TITLE
coll: add coll_attr and comm subgroups

### DIFF
--- a/maint/extracterrmsgs
+++ b/maint/extracterrmsgs
@@ -719,7 +719,7 @@ sub ProcessFile
 		    !($args[$errClassLoc] =~ /^MPIDI_CH3I_SOCK_ERR_/) &&
 		    !($args[$errClassLoc] =~ /^MPIX_ERR_/) &&
 		    !($args[$errClassLoc] =~ /^errclass/) &&
-                    !($args[$errClassLoc] =~ /^errflag/) &&
+                    !($args[$errClassLoc] =~ /^(errflag|coll_attr)/) &&
                     !($args[$errClassLoc] =~ /^\*errflag/)) {
 		    $bad_syntax_in_file{$filename} = 1;
 		    print STDERR "Invalid argument $args[$errClassLoc] for the MPI Error class in $routineName in $filename\n";

--- a/maint/gen_coll.py
+++ b/maint/gen_coll.py
@@ -652,7 +652,7 @@ def get_algo_args(args, algo, kind):
     elif algo['func-commkind'].startswith('i'):
         algo_args += ", *sched_p"
     elif not algo['func-commkind'].startswith('neighbor_'):
-        algo_args += ", errflag"
+        algo_args += ", coll_attr"
 
     return algo_args
 
@@ -666,7 +666,7 @@ def get_algo_params(params, algo):
     elif algo['func-commkind'].startswith('i'):
         algo_params += ", MPIR_Sched_t s"
     elif not algo['func-commkind'].startswith('neighbor_'):
-        algo_params += ", MPIR_Errflag_t errflag"
+        algo_params += ", int coll_attr"
 
     return algo_params
 
@@ -683,7 +683,7 @@ def get_func_params(params, name, kind):
     func_params = params
     if kind == "blocking":
         if not name.startswith('neighbor_'):
-            func_params += ", MPIR_Errflag_t errflag"
+            func_params += ", int coll_attr"
     elif kind == "nonblocking":
         func_params += ", MPIR_Request ** request"
     elif kind == "persistent":
@@ -703,7 +703,7 @@ def get_func_args(args, name, kind):
     func_args = args
     if kind == "blocking":
         if not name.startswith('neighbor_'):
-            func_args += ", errflag"
+            func_args += ", coll_attr"
     elif kind == "nonblocking":
         func_args += ", request"
     elif kind == "persistent":

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -1691,7 +1691,7 @@ def push_impl_decl(func, impl_name=None):
         if func['dir'] == 'coll':
             # block collective use an extra errflag
             if not RE.match(r'MPI_(I.*|Neighbor.*|.*_init)$', func['name']):
-                params = params + ", MPIR_Errflag_t errflag"
+                params = params + ", int coll_attr"
     else:
         params="void"
 

--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -9,6 +9,14 @@
 #include "coll_impl.h"
 #include "coll_algos.h"
 
+/* Define bit values for collective attributes. */
+
+/* NOTE: the two-bit errflag must be compatible with pt2pt attribute, ref. mpir_pt2pt.h */
+#define MPIR_COLL_ATTR_GET_ERRFLAG(attr) ((attr) & 0x6)
+#define MPIR_ERR_NONE 0
+#define MPIR_ERR_PROC_FAILED 2
+#define MPIR_ERR_OTHER 4
+
 /* During init, not all algorithms are safe to use. For example, the csel
  * may not have been initialized. We define a set of fallback routines that
  * are safe to use during init. They are all intra algorithms.
@@ -28,23 +36,23 @@ int MPIC_Wait(MPIR_Request * request_ptr);
 int MPIC_Probe(int source, int tag, MPI_Comm comm, MPI_Status * status);
 
 int MPIC_Send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-              MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag);
+              MPIR_Comm * comm_ptr, int coll_attr);
 int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int tag,
               MPIR_Comm * comm_ptr, MPI_Status * status);
 int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag);
+               MPIR_Comm * comm_ptr, int coll_attr);
 int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                   int dest, int sendtag, void *recvbuf, MPI_Aint recvcount,
                   MPI_Datatype recvtype, int source, int recvtag,
-                  MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t errflag);
+                  MPIR_Comm * comm_ptr, MPI_Status * status, int coll_attr);
 int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
                           int dest, int sendtag,
                           int source, int recvtag,
-                          MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t errflag);
+                          MPIR_Comm * comm_ptr, MPI_Status * status, int coll_attr);
 int MPIC_Isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-               MPIR_Comm * comm_ptr, MPIR_Request ** request, MPIR_Errflag_t errflag);
+               MPIR_Comm * comm_ptr, MPIR_Request ** request, int coll_attr);
 int MPIC_Issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-                MPIR_Comm * comm_ptr, MPIR_Request ** request, MPIR_Errflag_t errflag);
+                MPIR_Comm * comm_ptr, MPIR_Request ** request, int coll_attr);
 int MPIC_Irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source,
                int tag, MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status * statuses);
@@ -52,7 +60,7 @@ int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status * statuses);
 int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,
                       MPI_Op op);
 
-int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag);
+int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, int coll_attr);
 
 /* TSP auto */
 int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf, MPI_Aint count,

--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -11,11 +11,31 @@
 
 /* Define bit values for collective attributes. */
 
-/* NOTE: the two-bit errflag must be compatible with pt2pt attribute, ref. mpir_pt2pt.h */
+/* NOTE: the low 8 bits must be the same as pt2pt attr, ref. mpir_pt2pt.h */
 #define MPIR_COLL_ATTR_GET_ERRFLAG(attr) ((attr) & 0x6)
 #define MPIR_ERR_NONE 0
 #define MPIR_ERR_PROC_FAILED 2
 #define MPIR_ERR_OTHER 4
+
+#define MPIR_ATTR_COLL_CONTEXT 1
+#define MPIR_ATTR_SYNCFLAG 8
+
+/* Subgroup is the index to comm->subgroups[], and resulting in group collectives.
+ * NOTE: cross reference MPIR_MAX_SUBGROUPS */
+#define MPIR_COLL_ATTR_GET_SUBGROUP(attr) (((attr) & 0xf00) >> 8)
+#define MPIR_COLL_ATTR_SUBGROUP(idx) (((idx) & 0xf) << 8)
+
+#define MPIR_COLL_INTRA_RANK_SIZE(comm, coll_attr, rank_, size_) \
+    do { \
+        int grp = MPIR_COLL_ATTR_GET_SUBGROUP(coll_attr); \
+        if (grp == 0) { \
+            rank_ = (comm)->rank; \
+            size_ = (comm)->local_size; \
+        } else { \
+            rank_ = (comm)->subgroups[grp].rank; \
+            size_ = (comm)->subgroups[grp].size; \
+        } \
+    } while (0)
 
 /* During init, not all algorithms are safe to use. For example, the csel
  * may not have been initialized. We define a set of fallback routines that

--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -42,6 +42,7 @@
  * are safe to use during init. They are all intra algorithms.
  */
 #define MPIR_Barrier_fallback    MPIR_Barrier_intra_dissemination
+#define MPIR_Bcast_fallback      MPIR_Bcast_intra_binomial
 #define MPIR_Allgather_fallback  MPIR_Allgather_intra_brucks
 #define MPIR_Allgatherv_fallback MPIR_Allgatherv_intra_brucks
 #define MPIR_Allreduce_fallback  MPIR_Allreduce_intra_recursive_doubling

--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -38,7 +38,7 @@ int MPIC_Probe(int source, int tag, MPI_Comm comm, MPI_Status * status);
 int MPIC_Send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
               MPIR_Comm * comm_ptr, int coll_attr);
 int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int tag,
-              MPIR_Comm * comm_ptr, MPI_Status * status);
+              MPIR_Comm * comm_ptr, int coll_attr, MPI_Status * status);
 int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
                MPIR_Comm * comm_ptr, int coll_attr);
 int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
@@ -54,7 +54,7 @@ int MPIC_Isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
 int MPIC_Issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
                 MPIR_Comm * comm_ptr, MPIR_Request ** request, int coll_attr);
 int MPIC_Irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source,
-               int tag, MPIR_Comm * comm_ptr, MPIR_Request ** request);
+               int tag, MPIR_Comm * comm_ptr, int coll_attr, MPIR_Request ** request);
 int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status * statuses);
 
 int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -187,7 +187,6 @@ struct MPIR_Comm {
     int *internode_table;       /* internode_table[i] gives the rank in
                                  * node_roots_comm of rank i in this comm.
                                  * It is of size 'local_size'. */
-    int node_count;             /* number of nodes this comm is spread over */
     int num_local;              /* number of procs in this comm on local node */
     int num_external;           /* number of nodes this comm is spread over */
 

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -188,6 +188,8 @@ struct MPIR_Comm {
                                  * node_roots_comm of rank i in this comm.
                                  * It is of size 'local_size'. */
     int node_count;             /* number of nodes this comm is spread over */
+    int num_local;              /* number of procs in this comm on local node */
+    int num_external;           /* number of nodes this comm is spread over */
 
     int is_low_group;           /* For intercomms only, this boolean is
                                  * set for all members of one of the

--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -19,9 +19,9 @@
  * used to signal such.  More details can be found further down in the
  * code with the bitmasking logic */
 typedef enum {
-    MPIR_ERR_NONE = MPI_SUCCESS,
-    MPIR_ERR_PROC_FAILED = MPIX_ERR_PROC_FAILED,
-    MPIR_ERR_OTHER = MPI_ERR_OTHER
+    MPIR_ERR_NONE = 0,
+    MPIR_ERR_PROC_FAILED = 0x2,
+    MPIR_ERR_OTHER = 0x4
 } MPIR_Errflag_t;
 
 /*E

--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -14,16 +14,6 @@
 #define MPIR_FINALIZE_CALLBACK_DEFAULT_PRIO 0
 #define MPIR_FINALIZE_CALLBACK_MAX_PRIO 10
 
-/* Define a typedef for the errflag value used by many internal
- * functions.  If an error needs to be returned, these values can be
- * used to signal such.  More details can be found further down in the
- * code with the bitmasking logic */
-typedef enum {
-    MPIR_ERR_NONE = 0,
-    MPIR_ERR_PROC_FAILED = 0x2,
-    MPIR_ERR_OTHER = 0x4
-} MPIR_Errflag_t;
-
 /*E
   MPIR_Lang_t - Known language bindings for MPI
 

--- a/src/include/mpir_pt2pt.h
+++ b/src/include/mpir_pt2pt.h
@@ -16,6 +16,8 @@
  * 24-31: reserved (must be 0)
  */
 /* NOTE: All explicit vci (allocated) must be greater than 0 */
+/* NOTE: MPIR_ERR_XXX flags defined in mpir_misc.h and must be
+ *       consistent, i.e. 0x2 and 0x4 respectively. */
 
 #define MPIR_PT2PT_ATTR_SRC_VCI_SHIFT 8
 #define MPIR_PT2PT_ATTR_DST_VCI_SHIFT 16
@@ -33,19 +35,11 @@
 #define MPIR_PT2PT_ATTR_SET_CONTEXT_OFFSET(attr, context_offset) (attr) |= (context_offset)
 
 /* bit 1-2: errflag */
-#define MPIR_PT2PT_ATTR_GET_ERRFLAG(attr) \
-    ((!((attr) & 0x6)) ? MPIR_ERR_NONE : \
-        (((attr) & 0x2) ? MPIX_ERR_PROC_FAILED : MPI_ERR_OTHER))
+#define MPIR_PT2PT_ATTR_GET_ERRFLAG(attr) ((attr) & 0x6)
 
 #define MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag) \
     do { \
-        if (errflag) { \
-            if (errflag == MPIR_ERR_PROC_FAILED) { \
-                (attr) |= 0x2; \
-            } else { \
-                (attr) |= 0x4; \
-            } \
-        } \
+        (attr) |= (errflag); \
     } while (0)
 
 /* bit 3: syncflag */

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -179,7 +179,7 @@ struct MPIR_Request {
             struct MPIR_Grequest_fns *greq_fns;
         } ureq;                 /* kind : MPIR_REQUEST_KIND__GREQUEST */
         struct {
-            MPIR_Errflag_t errflag;
+            int coll_attr;
             MPII_Coll_req_t coll;
         } nbc;                  /* kind : MPIR_REQUEST_KIND__COLL */
         struct {
@@ -429,7 +429,7 @@ static inline MPIR_Request *MPIR_Request_create_from_pool(MPIR_Request_kind_t ki
 
     switch (kind) {
         case MPIR_REQUEST_KIND__COLL:
-            req->u.nbc.errflag = MPIR_ERR_NONE;
+            req->u.nbc.coll_attr = 0;
             req->u.nbc.coll.host_sendbuf = NULL;
             req->u.nbc.coll.host_recvbuf = NULL;
             req->u.nbc.coll.datatype = MPI_DATATYPE_NULL;

--- a/src/include/mpir_threadcomm.h
+++ b/src/include/mpir_threadcomm.h
@@ -111,23 +111,22 @@ MPL_STATIC_INLINE_PREFIX
 }
 
 #ifdef ENABLE_THREADCOMM
-#define MPIR_THREADCOMM_RANK_SIZE(comm, rank_, size_) do { \
+#define MPIR_THREADCOMM_RANK_SIZE(comm, coll_attr, rank_, size_) do { \
         MPIR_Threadcomm *threadcomm = (comm)->threadcomm; \
         if (threadcomm) { \
+            MPIR_Assert(MPIR_COLL_ATTR_GET_SUBGROUP(coll_attr) == 0); /* for now */ \
             int intracomm_size = (comm)->local_size; \
             size_ = threadcomm->rank_offset_table[intracomm_size - 1]; \
             rank_ = MPIR_THREADCOMM_TID_TO_RANK(threadcomm, MPIR_threadcomm_get_tid(threadcomm)); \
         } else { \
-            rank_ = (comm)->rank; \
-            size_ = (comm)->local_size; \
+            MPIR_COLL_INTRA_RANK_SIZE(comm, coll_attr, rank_, size_); \
         } \
     } while (0)
 
 #else
-#define MPIR_THREADCOMM_RANK_SIZE(comm, rank_, size_) do { \
+#define MPIR_THREADCOMM_RANK_SIZE(comm, coll_attr, rank_, size_) do { \
         MPIR_Assert((comm)->threadcomm == NULL); \
-        rank_ = (comm)->rank; \
-        size_ = (comm)->local_size; \
+        MPIR_COLL_INTRA_RANK_SIZE(comm, coll_attr, rank_, size_); \
     } while (0)
 
 #endif

--- a/src/mpi/coll/algorithms/treealgo/treeutil.c
+++ b/src/mpi/coll/algorithms/treealgo/treeutil.c
@@ -1129,7 +1129,7 @@ int MPII_Treeutil_tree_topology_wave_init(MPIR_Comm * comm, int k, int root, boo
     heap_vector minHeaps;
     heap_vector_init(&minHeaps);
 
-    /* To build hierarchy of ranks, swiches and groups */
+    /* To build hierarchy of ranks, switches and groups */
     int dim = MPIR_Process.coords_dims - 1;
     for (dim = MPIR_Process.coords_dims - 1; dim >= 0; --dim)
         tree_ut_hierarchy_init(&hierarchy[dim]);

--- a/src/mpi/coll/algorithms/treealgo/treeutil.c
+++ b/src/mpi/coll/algorithms/treealgo/treeutil.c
@@ -756,9 +756,9 @@ int MPII_Treeutil_tree_topology_aware_k_init(MPIR_Comm * comm, int k, int root, 
             } else {
                 /* rank level - build a tree on the ranks */
                 /* Do an allgather to know the current num_children on each rank */
-                MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+                int coll_attr = MPIR_ERR_NONE;
                 MPIR_Allgather_impl(&(ct->num_children), 1, MPI_INT, num_childrens, 1, MPI_INT,
-                                    comm, errflag);
+                                    comm, coll_attr);
                 if (mpi_errno) {
                     goto fn_fail;
                 }

--- a/src/mpi/coll/allgather/allgather_allcomm_nb.c
+++ b/src/mpi/coll/allgather/allgather_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Allgather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                              MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
+++ b/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
@@ -15,7 +15,7 @@
 int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, local_size, remote_size, mpi_errno = MPI_SUCCESS, root;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -48,8 +48,8 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
 
     if (sendcount != 0) {
         mpi_errno = MPIR_Gather(sendbuf, sendcount, sendtype, tmp_buf, sendcount * sendtype_sz,
-                                MPI_BYTE, 0, newcomm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                MPI_BYTE, 0, newcomm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* first broadcast from left to right group, then from right to
@@ -59,32 +59,32 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
         if (sendcount != 0) {
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Bcast(tmp_buf, sendcount * sendtype_sz * local_size,
-                                   MPI_BYTE, root, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                   MPI_BYTE, root, comm_ptr, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         /* receive bcast from right */
         if (recvcount != 0) {
             root = 0;
             mpi_errno = MPIR_Bcast(recvbuf, recvcount * remote_size,
-                                   recvtype, root, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                   recvtype, root, comm_ptr, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     } else {
         /* receive bcast from left */
         if (recvcount != 0) {
             root = 0;
             mpi_errno = MPIR_Bcast(recvbuf, recvcount * remote_size,
-                                   recvtype, root, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                   recvtype, root, comm_ptr, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         /* bcast to left */
         if (sendcount != 0) {
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Bcast(tmp_buf, sendcount * sendtype_sz * local_size,
-                                   MPI_BYTE, root, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                   MPI_BYTE, root, comm_ptr, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/allgather/allgather_intra_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_brucks.c
@@ -34,7 +34,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
     if (((sendcount == 0) && (sendbuf != MPI_IN_PLACE)) || (recvcount == 0))
         goto fn_exit;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
     MPIR_Datatype_get_size_macro(recvtype, recvtype_sz);

--- a/src/mpi/coll/allgather/allgather_intra_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_brucks.c
@@ -19,7 +19,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
                                 MPI_Datatype sendtype,
                                 void *recvbuf,
                                 MPI_Aint recvcount,
-                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
@@ -67,8 +67,8 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
                                   MPIR_ALLGATHER_TAG,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   curr_cnt * recvtype_sz, MPI_BYTE,
-                                  src, MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  src, MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         curr_cnt *= 2;
         pof2 *= 2;
     }
@@ -84,8 +84,8 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
                                   dst, MPIR_ALLGATHER_TAG,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   rem * recvcount * recvtype_sz, MPI_BYTE,
-                                  src, MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  src, MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* Rotate blocks in tmp_buf down by (rank) blocks and store
@@ -101,7 +101,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
                                    (comm_size - rank) * recvcount * recvtype_sz,
                                    rank * recvcount * recvtype_sz, MPI_BYTE, recvbuf,
                                    rank * recvcount, recvtype);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/allgather/allgather_intra_k_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_k_brucks.c
@@ -23,7 +23,7 @@ int
 MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
                               MPI_Datatype sendtype, void *recvbuf,
                               MPI_Aint recvcount, MPI_Datatype recvtype, MPIR_Comm * comm, int k,
-                              MPIR_Errflag_t errflag)
+                              int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -143,7 +143,7 @@ MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
             mpi_errno = MPIC_Irecv((char *) tmp_recvbuf + j * recvcount * delta * recvtype_extent,
                                    count, recvtype, src, MPIR_ALLGATHER_TAG, comm,
                                    &reqs[num_reqs++]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST,
                                                      "Phase#%d:, k:%d Recv at:%p for count:%d", i,
@@ -154,8 +154,8 @@ MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
             /* Send from the start of recv till `count` amount of data. */
             mpi_errno =
                 MPIC_Isend(tmp_recvbuf, count, recvtype, dst, MPIR_ALLGATHER_TAG, comm,
-                           &reqs[num_reqs++], errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                           &reqs[num_reqs++], coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST,
                                                      "Phase#%d:, k:%d Send from:%p for count:%d",
@@ -163,7 +163,7 @@ MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
 
         }
         mpi_errno = MPIC_Waitall(num_reqs, reqs, MPI_STATUSES_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         delta *= k;
     }
 

--- a/src/mpi/coll/allgather/allgather_intra_k_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_k_brucks.c
@@ -142,7 +142,7 @@ MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
             /* Receive at the exact location. */
             mpi_errno = MPIC_Irecv((char *) tmp_recvbuf + j * recvcount * delta * recvtype_extent,
                                    count, recvtype, src, MPIR_ALLGATHER_TAG, comm,
-                                   &reqs[num_reqs++]);
+                                   coll_attr, &reqs[num_reqs++]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST,

--- a/src/mpi/coll/allgather/allgather_intra_recexch.c
+++ b/src/mpi/coll/allgather/allgather_intra_recexch.c
@@ -19,8 +19,7 @@
 int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
                                  MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                  MPI_Datatype recvtype, MPIR_Comm * comm,
-                                 int recexch_type, int k, int single_phase_recv,
-                                 MPIR_Errflag_t errflag)
+                                 int recexch_type, int k, int single_phase_recv, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
     int is_inplace, i, j;
@@ -107,10 +106,10 @@ int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
                            (char *) recvbuf + rank * recv_extent * recvcount, recvcount, recvtype);
         if (mpi_errno) {
             /* for communication errors, just record the error but continue */
-            errflag =
+            coll_attr =
                 MPIX_ERR_PROC_FAILED ==
                 MPIR_ERR_GET_CLASS(mpi_errno) ? MPIR_ERR_PROC_FAILED : MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, errflag, "**fail");
+            MPIR_ERR_SET(mpi_errno, coll_attr, "**fail");
             MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
         }
     }
@@ -124,8 +123,8 @@ int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
             buf_to_send = (void *) sendbuf;
         mpi_errno =
             MPIC_Send(buf_to_send, recvcount, recvtype, step1_sendto, MPIR_ALLGATHER_TAG, comm,
-                      errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                      coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         if (step1_nrecvs) {
             num_rreq = 0;
@@ -134,7 +133,7 @@ int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
                 mpi_errno = MPIC_Irecv(((char *) recvbuf + recv_offset), recvcount, recvtype,
                                        step1_recvfrom[i], MPIR_ALLGATHER_TAG, comm,
                                        &recv_reqs[num_rreq++]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
             mpi_errno = MPIC_Waitall(num_rreq, recv_reqs, MPI_STATUSES_IGNORE);
             if (mpi_errno && mpi_errno != MPI_ERR_IN_STATUS)
@@ -167,8 +166,8 @@ int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
                                   recvtype, partner, MPIR_ALLGATHER_TAG,
                                   ((char *) recvbuf + recv_offset), recv_count * recvcount,
                                   recvtype, partner, MPIR_ALLGATHER_TAG, comm, MPI_STATUS_IGNORE,
-                                  errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
     }
@@ -199,7 +198,7 @@ int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
                 mpi_errno =
                     MPIC_Irecv(((char *) recvbuf + recv_offset), count * recvcount, recvtype, nbr,
                                MPIR_ALLGATHER_TAG, comm, &recv_reqs[num_rreq++]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
             if (recexch_type == MPIR_ALLGATHER_RECEXCH_TYPE_DISTANCE_HALVING)
                 recv_phase--;
@@ -217,8 +216,9 @@ int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
             MPII_Recexchalgo_get_count_and_offset(rank_for_offset, j, k, nranks, &count, &offset);
             send_offset = offset * recv_extent * recvcount;
             mpi_errno = MPIC_Isend(((char *) recvbuf + send_offset), count * recvcount, recvtype,
-                                   nbr, MPIR_ALLGATHER_TAG, comm, &send_reqs[num_sreq++], errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                   nbr, MPIR_ALLGATHER_TAG, comm, &send_reqs[num_sreq++],
+                                   coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
         /* wait on prev recvs */
         MPIC_Waitall((k - 1), recv_reqs, MPI_STATUSES_IGNORE);
@@ -244,8 +244,8 @@ int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
                     mpi_errno =
                         MPIC_Isend(((char *) recvbuf + send_offset), count * recvcount,
                                    recvtype, nbr, MPIR_ALLGATHER_TAG, comm,
-                                   &send_reqs[num_sreq++], errflag);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                   &send_reqs[num_sreq++], coll_attr);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
                 /* wait on prev recvs */
                 mpi_errno = MPIC_Waitall((k - 1), recv_reqs + (k - 1), MPI_STATUSES_IGNORE);
@@ -268,13 +268,13 @@ int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
         mpi_errno =
             MPIC_Recv(recvbuf, recvcount * nranks, recvtype, step1_sendto, MPIR_ALLGATHER_TAG,
                       comm, MPI_STATUS_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     for (i = 0; i < step1_nrecvs; i++) {
         mpi_errno = MPIC_Isend(recvbuf, recvcount * nranks, recvtype, step1_recvfrom[i],
-                               MPIR_ALLGATHER_TAG, comm, &recv_reqs[num_rreq++], errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                               MPIR_ALLGATHER_TAG, comm, &recv_reqs[num_rreq++], coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     mpi_errno = MPIC_Waitall(num_rreq, recv_reqs, MPI_STATUSES_IGNORE);
@@ -296,8 +296,8 @@ int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
   fn_exit:
     if (mpi_errno_ret)
         mpi_errno = mpi_errno_ret;
-    else if (errflag != MPIR_ERR_NONE)
-        MPIR_ERR_SET(mpi_errno, errflag, "**coll_fail");
+    else if (coll_attr != MPIR_ERR_NONE)
+        MPIR_ERR_SET(mpi_errno, coll_attr, "**coll_fail");
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpi/coll/allgather/allgather_intra_recexch.c
+++ b/src/mpi/coll/allgather/allgather_intra_recexch.c
@@ -115,7 +115,7 @@ int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
         }
     }
 
-    if (step1_sendto != -1) {   /* non-participating rank sends the data to a partcipating rank */
+    if (step1_sendto != -1) {   /* non-participating rank sends the data to a participating rank */
         void *buf_to_send;
         send_offset = rank * recv_extent * recvcount;
         if (is_inplace)

--- a/src/mpi/coll/allgather/allgather_intra_recexch.c
+++ b/src/mpi/coll/allgather/allgather_intra_recexch.c
@@ -132,7 +132,7 @@ int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
                 recv_offset = step1_recvfrom[i] * recv_extent * recvcount;
                 mpi_errno = MPIC_Irecv(((char *) recvbuf + recv_offset), recvcount, recvtype,
                                        step1_recvfrom[i], MPIR_ALLGATHER_TAG, comm,
-                                       &recv_reqs[num_rreq++]);
+                                       coll_attr, &recv_reqs[num_rreq++]);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
             mpi_errno = MPIC_Waitall(num_rreq, recv_reqs, MPI_STATUSES_IGNORE);
@@ -197,7 +197,7 @@ int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
                 recv_offset = offset * recv_extent * recvcount;
                 mpi_errno =
                     MPIC_Irecv(((char *) recvbuf + recv_offset), count * recvcount, recvtype, nbr,
-                               MPIR_ALLGATHER_TAG, comm, &recv_reqs[num_rreq++]);
+                               MPIR_ALLGATHER_TAG, comm, coll_attr, &recv_reqs[num_rreq++]);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
             if (recexch_type == MPIR_ALLGATHER_RECEXCH_TYPE_DISTANCE_HALVING)
@@ -267,7 +267,7 @@ int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
     if (step1_sendto != -1) {
         mpi_errno =
             MPIC_Recv(recvbuf, recvcount * nranks, recvtype, step1_sendto, MPIR_ALLGATHER_TAG,
-                      comm, MPI_STATUS_IGNORE);
+                      comm, coll_attr, MPI_STATUS_IGNORE);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
@@ -23,7 +23,7 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
                                             void *recvbuf,
                                             MPI_Aint recvcount,
                                             MPI_Datatype recvtype,
-                                            MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                            MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
@@ -82,8 +82,8 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
                                       ((char *) recvbuf + recv_offset),
                                       (comm_size - dst_tree_root) * recvcount,
                                       recvtype, dst,
-                                      MPIR_ALLGATHER_TAG, comm_ptr, &status, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      MPIR_ALLGATHER_TAG, comm_ptr, &status, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             if (mpi_errno) {
                 last_recv_cnt = 0;
             } else {
@@ -140,8 +140,8 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
                     && (dst >= tree_root + nprocs_completed)) {
                     mpi_errno = MPIC_Send(((char *) recvbuf + offset),
                                           last_recv_cnt,
-                                          recvtype, dst, MPIR_ALLGATHER_TAG, comm_ptr, errflag);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                          recvtype, dst, MPIR_ALLGATHER_TAG, comm_ptr, coll_attr);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
                 /* recv only if this proc. doesn't have data and sender
                  * has data */
@@ -151,7 +151,7 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
                     mpi_errno = MPIC_Recv(((char *) recvbuf + offset),
                                           (comm_size - (my_tree_root + mask)) * recvcount,
                                           recvtype, dst, MPIR_ALLGATHER_TAG, comm_ptr, &status);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     /* nprocs_completed is also equal to the
                      * no. of processes whose data we don't have */
                     if (mpi_errno) {

--- a/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
@@ -150,7 +150,8 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
                          (rank >= tree_root + nprocs_completed)) {
                     mpi_errno = MPIC_Recv(((char *) recvbuf + offset),
                                           (comm_size - (my_tree_root + mask)) * recvcount,
-                                          recvtype, dst, MPIR_ALLGATHER_TAG, comm_ptr, &status);
+                                          recvtype, dst, MPIR_ALLGATHER_TAG, comm_ptr, coll_attr,
+                                          &status);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     /* nprocs_completed is also equal to the
                      * no. of processes whose data we don't have */

--- a/src/mpi/coll/allgather/allgather_intra_ring.c
+++ b/src/mpi/coll/allgather/allgather_intra_ring.c
@@ -25,7 +25,7 @@ int MPIR_Allgather_intra_ring(const void *sendbuf,
                               MPI_Datatype sendtype,
                               void *recvbuf,
                               MPI_Aint recvcount,
-                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
@@ -64,8 +64,8 @@ int MPIR_Allgather_intra_ring(const void *sendbuf,
                                   ((char *) recvbuf +
                                    jnext * recvcount * recvtype_extent),
                                   recvcount, recvtype, left,
-                                  MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         j = jnext;
         jnext = (comm_size + jnext - 1) % comm_size;
     }

--- a/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
+++ b/src/mpi/coll/allgatherv/allgatherv_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Allgatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
-                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/allgatherv/allgatherv_inter_remote_gather_local_bcast.c
+++ b/src/mpi/coll/allgatherv/allgatherv_inter_remote_gather_local_bcast.c
@@ -19,7 +19,7 @@ int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, MPI_Ain
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     const MPI_Aint * recvcounts, const MPI_Aint
                                                     * displs, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int coll_attr)
 {
     int remote_size, mpi_errno, root, rank;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -35,24 +35,24 @@ int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, MPI_Ain
         /* gatherv from right group */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Gatherv(sendbuf, sendcount, sendtype, recvbuf,
-                                 recvcounts, displs, recvtype, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                 recvcounts, displs, recvtype, root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         /* gatherv to right group */
         root = 0;
         mpi_errno = MPIR_Gatherv(sendbuf, sendcount, sendtype, recvbuf,
-                                 recvcounts, displs, recvtype, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                 recvcounts, displs, recvtype, root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         /* gatherv to left group  */
         root = 0;
         mpi_errno = MPIR_Gatherv(sendbuf, sendcount, sendtype, recvbuf,
-                                 recvcounts, displs, recvtype, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                 recvcounts, displs, recvtype, root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         /* gatherv from left group */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Gatherv(sendbuf, sendcount, sendtype, recvbuf,
-                                 recvcounts, displs, recvtype, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                 recvcounts, displs, recvtype, root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* now do an intracommunicator broadcast within each group. we use
@@ -72,8 +72,8 @@ int MPIR_Allgatherv_inter_remote_gather_local_bcast(const void *sendbuf, MPI_Ain
     mpi_errno = MPIR_Type_commit_impl(&newtype);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPIR_Bcast_allcomm_auto(recvbuf, 1, newtype, 0, newcomm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    mpi_errno = MPIR_Bcast_allcomm_auto(recvbuf, 1, newtype, 0, newcomm_ptr, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     MPIR_Type_free_impl(&newtype);
 

--- a/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
@@ -34,7 +34,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
     void *tmp_buf;
     MPIR_CHKLMEM_DECL(1);
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
     total_count = 0;
     for (i = 0; i < comm_size; i++)

--- a/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
@@ -22,8 +22,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
                                  void *recvbuf,
                                  const MPI_Aint * recvcounts,
                                  const MPI_Aint * displs,
-                                 MPI_Datatype recvtype,
-                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, rank, j, i;
     int mpi_errno = MPI_SUCCESS;
@@ -77,8 +76,8 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
                                   MPIR_ALLGATHERV_TAG,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   (total_count - curr_cnt) * recvtype_sz, MPI_BYTE,
-                                  src, MPIR_ALLGATHERV_TAG, comm_ptr, &status, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  src, MPIR_ALLGATHERV_TAG, comm_ptr, &status, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         if (mpi_errno) {
             recv_cnt = 0;
         } else {
@@ -104,8 +103,8 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
                                   dst, MPIR_ALLGATHERV_TAG,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
                                   (total_count - curr_cnt) * recvtype_sz, MPI_BYTE,
-                                  src, MPIR_ALLGATHERV_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  src, MPIR_ALLGATHERV_TAG, comm_ptr, MPI_STATUS_IGNORE, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* Rotate blocks in tmp_buf down by (rank) blocks and store

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -194,7 +194,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
 
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset * recvtype_sz),
                                           (total_count - offset) * recvtype_sz, MPI_BYTE,
-                                          dst, MPIR_ALLGATHERV_TAG, comm_ptr, &status);
+                                          dst, MPIR_ALLGATHERV_TAG, comm_ptr, coll_attr, &status);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     if (mpi_errno) {
                         last_recv_cnt = 0;

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -25,7 +25,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                                              const MPI_Aint * recvcounts,
                                              const MPI_Aint * displs,
                                              MPI_Datatype recvtype,
-                                             MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                             MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, rank, j, i;
     int mpi_errno = MPI_SUCCESS;
@@ -113,8 +113,8 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                                       MPIR_ALLGATHERV_TAG,
                                       ((char *) tmp_buf + recv_offset * recvtype_sz),
                                       (total_count - recv_offset) * recvtype_sz, MPI_BYTE, dst,
-                                      MPIR_ALLGATHERV_TAG, comm_ptr, &status, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      MPIR_ALLGATHERV_TAG, comm_ptr, &status, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             if (mpi_errno) {
                 last_recv_cnt = 0;
             } else {
@@ -176,8 +176,8 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
 
                     mpi_errno = MPIC_Send(((char *) tmp_buf + offset * recvtype_sz),
                                           last_recv_cnt * recvtype_sz,
-                                          MPI_BYTE, dst, MPIR_ALLGATHERV_TAG, comm_ptr, errflag);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                          MPI_BYTE, dst, MPIR_ALLGATHERV_TAG, comm_ptr, coll_attr);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     /* last_recv_cnt was set in the previous
                      * receive. that's the amount of data to be
                      * sent now. */
@@ -195,7 +195,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset * recvtype_sz),
                                           (total_count - offset) * recvtype_sz, MPI_BYTE,
                                           dst, MPIR_ALLGATHERV_TAG, comm_ptr, &status);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     if (mpi_errno) {
                         last_recv_cnt = 0;
                     } else

--- a/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
@@ -109,8 +109,8 @@ int MPIR_Allgatherv_intra_ring(const void *sendbuf,
             /* Don't do anything. This case is possible if two
              * consecutive processes contribute 0 bytes each. */
         } else if (!sendnow) {  /* If there's no data to send, just do a recv call */
-            mpi_errno =
-                MPIC_Recv(rbuf, recvnow, recvtype, left, MPIR_ALLGATHERV_TAG, comm_ptr, &status);
+            mpi_errno = MPIC_Recv(rbuf, recvnow, recvtype, left, MPIR_ALLGATHERV_TAG, comm_ptr,
+                                  coll_attr, &status);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             torecv -= recvnow;
         } else if (!recvnow) {  /* If there's no data to receive, just do a send call */

--- a/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
@@ -28,7 +28,7 @@ int MPIR_Allgatherv_intra_ring(const void *sendbuf,
                                void *recvbuf,
                                const MPI_Aint * recvcounts,
                                const MPI_Aint * displs,
-                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, rank, i, left, right;
     int mpi_errno = MPI_SUCCESS;
@@ -111,18 +111,18 @@ int MPIR_Allgatherv_intra_ring(const void *sendbuf,
         } else if (!sendnow) {  /* If there's no data to send, just do a recv call */
             mpi_errno =
                 MPIC_Recv(rbuf, recvnow, recvtype, left, MPIR_ALLGATHERV_TAG, comm_ptr, &status);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             torecv -= recvnow;
         } else if (!recvnow) {  /* If there's no data to receive, just do a send call */
             mpi_errno =
-                MPIC_Send(sbuf, sendnow, recvtype, right, MPIR_ALLGATHERV_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIC_Send(sbuf, sendnow, recvtype, right, MPIR_ALLGATHERV_TAG, comm_ptr, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             tosend -= sendnow;
         } else {        /* There's data to be sent and received */
             mpi_errno = MPIC_Sendrecv(sbuf, sendnow, recvtype, right, MPIR_ALLGATHERV_TAG,
                                       rbuf, recvnow, recvtype, left, MPIR_ALLGATHERV_TAG,
-                                      comm_ptr, &status, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      comm_ptr, &status, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             tosend -= sendnow;
             torecv -= recvnow;
         }

--- a/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
+++ b/src/mpi/coll/allreduce/allreduce_allcomm_nb.c
@@ -6,8 +6,7 @@
 #include "mpiimpl.h"
 
 int MPIR_Allreduce_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
-                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                              MPIR_Errflag_t errflag)
+                              MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
+++ b/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
@@ -15,7 +15,7 @@
 
 int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                               MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -40,20 +40,20 @@ int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbu
     newcomm_ptr = comm_ptr->local_comm;
 
     /* Do a local reduce on this intracommunicator */
-    mpi_errno = MPIR_Reduce(sendbuf, tmp_buf, count, datatype, op, 0, newcomm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    mpi_errno = MPIR_Reduce(sendbuf, tmp_buf, count, datatype, op, 0, newcomm_ptr, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     /* Do a exchange between local and remote rank 0 on this intercommunicator */
     if (comm_ptr->rank == 0) {
         mpi_errno = MPIC_Sendrecv(tmp_buf, count, datatype, 0, MPIR_REDUCE_TAG,
                                   recvbuf, count, datatype, 0, MPIR_REDUCE_TAG,
-                                  comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  comm_ptr, MPI_STATUS_IGNORE, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* Do a local broadcast on this intracommunicator */
-    mpi_errno = MPIR_Bcast(recvbuf, count, datatype, 0, newcomm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    mpi_errno = MPIR_Bcast(recvbuf, count, datatype, 0, newcomm_ptr, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
@@ -15,7 +15,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                                                     MPI_Aint count,
                                                     MPI_Datatype datatype,
                                                     MPI_Op op, MPIR_Comm * comm, int k,
-                                                    int single_phase_recv, MPIR_Errflag_t errflag)
+                                                    int single_phase_recv, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
     int rank, nranks, nbr;
@@ -106,17 +106,17 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
     if (!in_step2) {    /* even */
         /* non-participating rank sends the data to a participating rank */
         mpi_errno = MPIC_Send(recvbuf, count,
-                              datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                              datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {    /* odd */
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
             mpi_errno =
                 MPIC_Recv(tmp_recvbuf, count, datatype, step1_recvfrom[i], MPIR_ALLREDUCE_TAG, comm,
                           MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             /* Do reduction of reduced data */
             mpi_errno = MPIR_Reduce_local(tmp_recvbuf, recvbuf, count, datatype, op);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 
@@ -163,8 +163,8 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                 mpi_errno =
                     MPIC_Isend((char *) recvbuf + send_offset, send_cnt,
                                datatype, dst, MPIR_ALLREDUCE_TAG, comm, &recv_reqs[num_rreq++],
-                               errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                               coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                 rank_for_offset = MPII_Recexchalgo_reverse_digits_step2(rank, nranks, k);
                 MPII_Recexchalgo_get_count_and_offset(rank_for_offset, j, k, nranks,
@@ -177,14 +177,14 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                 mpi_errno =
                     MPIC_Irecv((char *) tmp_recvbuf + recv_offset, recv_cnt, datatype,
                                dst, MPIR_ALLREDUCE_TAG, comm, &recv_reqs[num_rreq++]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                 mpi_errno = MPIC_Waitall(num_rreq, recv_reqs, MPI_STATUSES_IGNORE);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 mpi_errno =
                     MPIR_Reduce_local((char *) tmp_recvbuf + recv_offset,
                                       (char *) recvbuf + recv_offset, recv_cnt, datatype, op);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
 
@@ -210,7 +210,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                         recv_count += cnts[offset + x];
                     mpi_errno = MPIC_Irecv(((char *) recvbuf + recv_offset), recv_count, datatype,
                                            nbr, MPIR_ALLREDUCE_TAG, comm, &recv_reqs[num_rreq++]);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
                 recv_phase--;
             }
@@ -226,12 +226,12 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                     send_count += cnts[offset + x];
                 mpi_errno = MPIC_Isend(((char *) recvbuf + send_offset), send_count, datatype,
                                        nbr, MPIR_ALLREDUCE_TAG, comm, &send_reqs[num_sreq++],
-                                       errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                       coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
             /* wait on prev recvs */
             mpi_errno = MPIC_Waitall((k - 1), recv_reqs, MPI_STATUSES_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             phase--;
             if (single_phase_recv == false) {
@@ -249,18 +249,18 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                             send_count += cnts[offset + x];
                         mpi_errno =
                             MPIC_Isend(((char *) recvbuf + send_offset), send_count, datatype, nbr,
-                                       MPIR_ALLREDUCE_TAG, comm, &send_reqs[num_sreq++], errflag);
-                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                       MPIR_ALLREDUCE_TAG, comm, &send_reqs[num_sreq++], coll_attr);
+                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     }
                     /* wait on prev recvs */
                     mpi_errno = MPIC_Waitall((k - 1), recv_reqs + (k - 1), MPI_STATUSES_IGNORE);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                     phase--;
                 }
             }
             mpi_errno = MPIC_Waitall(num_sreq, send_reqs, MPI_STATUSES_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 
@@ -269,18 +269,18 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
     if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
         mpi_errno = MPIC_Recv(recvbuf, count, datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm,
                               MPI_STATUS_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         if (step1_nrecvs > 0) {
             for (i = 0; i < step1_nrecvs; i++) {
                 mpi_errno =
                     MPIC_Isend(recvbuf, count, datatype, step1_recvfrom[i], MPIR_ALLREDUCE_TAG,
-                               comm, &send_reqs[i], errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                               comm, &send_reqs[i], coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
 
             mpi_errno = MPIC_Waitall(i, send_reqs, MPI_STATUSES_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
@@ -112,7 +112,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
             mpi_errno =
                 MPIC_Recv(tmp_recvbuf, count, datatype, step1_recvfrom[i], MPIR_ALLREDUCE_TAG, comm,
-                          MPI_STATUS_IGNORE);
+                          coll_attr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             /* Do reduction of reduced data */
             mpi_errno = MPIR_Reduce_local(tmp_recvbuf, recvbuf, count, datatype, op);
@@ -176,7 +176,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                     recv_cnt += cnts[offset + x];
                 mpi_errno =
                     MPIC_Irecv((char *) tmp_recvbuf + recv_offset, recv_cnt, datatype,
-                               dst, MPIR_ALLREDUCE_TAG, comm, &recv_reqs[num_rreq++]);
+                               dst, MPIR_ALLREDUCE_TAG, comm, coll_attr, &recv_reqs[num_rreq++]);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                 mpi_errno = MPIC_Waitall(num_rreq, recv_reqs, MPI_STATUSES_IGNORE);
@@ -209,7 +209,8 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
                     for (x = 0; x < current_cnt; x++)
                         recv_count += cnts[offset + x];
                     mpi_errno = MPIC_Irecv(((char *) recvbuf + recv_offset), recv_count, datatype,
-                                           nbr, MPIR_ALLREDUCE_TAG, comm, &recv_reqs[num_rreq++]);
+                                           nbr, MPIR_ALLREDUCE_TAG, comm,
+                                           coll_attr, &recv_reqs[num_rreq++]);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
                 recv_phase--;
@@ -268,7 +269,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
      * send the data to non-partcipating rans */
     if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
         mpi_errno = MPIC_Recv(recvbuf, count, datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm,
-                              MPI_STATUS_IGNORE);
+                              coll_attr, MPI_STATUS_IGNORE);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         if (step1_nrecvs > 0) {

--- a/src/mpi/coll/allreduce/allreduce_intra_recexch.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recexch.c
@@ -161,7 +161,8 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
             for (i = 0; i < step1_nrecvs; i++) {        /* participating rank gets data from non-partcipating ranks */
                 mpi_errno = MPIC_Irecv(nbr_buffer[i], count,
                                        datatype, step1_recvfrom[i],
-                                       MPIR_ALLREDUCE_TAG, comm, &recv_reqs[recv_nreq++]);
+                                       MPIR_ALLREDUCE_TAG, comm,
+                                       coll_attr, &recv_reqs[recv_nreq++]);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
             mpi_errno = MPIC_Waitall(recv_nreq, recv_reqs, MPI_STATUSES_IGNORE);
@@ -187,7 +188,7 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
                 nbr = step2_nbrs[phase + j][i];
                 mpi_errno =
                     MPIC_Irecv(nbr_buffer[buf++], count, datatype, nbr, MPIR_ALLREDUCE_TAG,
-                               comm, &recv_reqs[recv_nreq++]);
+                               comm, coll_attr, &recv_reqs[recv_nreq++]);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
@@ -252,7 +253,7 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
      * send the data to non-partcipating rans */
     if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
         mpi_errno = MPIC_Recv(recvbuf, count, datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm,
-                              MPI_STATUS_IGNORE);
+                              coll_attr, MPI_STATUS_IGNORE);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {

--- a/src/mpi/coll/allreduce/allreduce_intra_recexch.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recexch.c
@@ -18,7 +18,7 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
                                  MPI_Aint count,
                                  MPI_Datatype datatype,
                                  MPI_Op op, MPIR_Comm * comm, int k, int single_phase_recv,
-                                 MPIR_Errflag_t errflag)
+                                 int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
     int is_commutative, rank, nranks, nbr, myidx;
@@ -154,23 +154,23 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
     if (!in_step2) {    /* even */
         /* non-participating rank sends the data to a participating rank */
         mpi_errno = MPIC_Send(recvbuf, count,
-                              datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                              datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {    /* odd */
         if (step1_nrecvs) {
             for (i = 0; i < step1_nrecvs; i++) {        /* participating rank gets data from non-partcipating ranks */
                 mpi_errno = MPIC_Irecv(nbr_buffer[i], count,
                                        datatype, step1_recvfrom[i],
                                        MPIR_ALLREDUCE_TAG, comm, &recv_reqs[recv_nreq++]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
             mpi_errno = MPIC_Waitall(recv_nreq, recv_reqs, MPI_STATUSES_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* Do reduction of reduced data */
             for (i = 0; i < step1_nrecvs && count > 0; i++) {   /* participating rank gets data from non-partcipating ranks */
                 mpi_errno = MPIR_Reduce_local(nbr_buffer[i], recvbuf, count, datatype, op);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
     }
@@ -188,7 +188,7 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
                 mpi_errno =
                     MPIC_Irecv(nbr_buffer[buf++], count, datatype, nbr, MPIR_ALLREDUCE_TAG,
                                comm, &recv_reqs[recv_nreq++]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
 
@@ -197,17 +197,17 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
         for (i = 0; i < k - 1; i++) {
             nbr = step2_nbrs[phase][i];
             mpi_errno = MPIC_Isend(recvbuf, count, datatype, nbr, MPIR_ALLREDUCE_TAG, comm,
-                                   &send_reqs[send_nreq++], errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                   &send_reqs[send_nreq++], coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             if (rank > nbr) {
             }
         }
 
         mpi_errno = MPIC_Waitall(send_nreq, send_reqs, MPI_STATUSES_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         mpi_errno = MPIC_Waitall((k - 1), recv_reqs, MPI_STATUSES_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         if (is_commutative && !is_float) {
             myidx = k - 1;
@@ -215,7 +215,7 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
             myidx = find_myidx(step2_nbrs[phase], k, rank);
         }
         mpi_errno = do_reduce(nbr_buffer, recvbuf, k, myidx, count, datatype, op);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         if (single_phase_recv == false) {       /* post sends and do reduction for the 2nd phase */
             phase++;
@@ -227,15 +227,15 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
 
                     mpi_errno =
                         MPIC_Isend(recvbuf, count, datatype, nbr, MPIR_ALLREDUCE_TAG, comm,
-                                   &send_reqs[send_nreq++], errflag);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                   &send_reqs[send_nreq++], coll_attr);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
 
                 mpi_errno = MPIC_Waitall(send_nreq, send_reqs, MPI_STATUSES_IGNORE);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                 mpi_errno = MPIC_Waitall((k - 1), recv_reqs + (k - 1), MPI_STATUSES_IGNORE);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                 if (is_commutative && !is_float) {
                     myidx = k - 1;
@@ -243,7 +243,7 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
                     myidx = find_myidx(step2_nbrs[phase], k, rank);
                 }
                 mpi_errno = do_reduce(nbr_buffer + k - 1, recvbuf, k, myidx, count, datatype, op);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
     }
@@ -253,17 +253,17 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
     if (step1_sendto != -1) {   /* I am a Step 2 non-participating rank */
         mpi_errno = MPIC_Recv(recvbuf, count, datatype, step1_sendto, MPIR_ALLREDUCE_TAG, comm,
                               MPI_STATUS_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {
             mpi_errno =
                 MPIC_Isend(recvbuf, count, datatype, step1_recvfrom[i], MPIR_ALLREDUCE_TAG,
-                           comm, &send_reqs[i], errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                           comm, &send_reqs[i], coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         mpi_errno = MPIC_Waitall(i, send_reqs, MPI_STATUSES_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     if (in_step2 && (k > MAX_RADIX || count * extent > 8192)) {

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
@@ -32,7 +32,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
     MPI_Aint true_extent, true_lb, extent;
     void *tmp_buf;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
     is_commutative = MPIR_Op_is_commutative(op);
 

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
@@ -22,7 +22,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
                                             void *recvbuf,
                                             MPI_Aint count,
                                             MPI_Datatype datatype,
-                                            MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                            MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     MPIR_CHKLMEM_DECL(1);
     int comm_size, rank;
@@ -66,8 +66,8 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIC_Send(recvbuf, count,
-                                  datatype, rank + 1, MPIR_ALLREDUCE_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  datatype, rank + 1, MPIR_ALLREDUCE_TAG, comm_ptr, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not participate in recursive
@@ -77,7 +77,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
             mpi_errno = MPIC_Recv(tmp_buf, count,
                                   datatype, rank - 1,
                                   MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
@@ -112,8 +112,8 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
             mpi_errno = MPIC_Sendrecv(recvbuf, count, datatype,
                                       dst, MPIR_ALLREDUCE_TAG, tmp_buf,
                                       count, datatype, dst,
-                                      MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* tmp_buf contains data received in this step.
              * recvbuf contains data accumulated so far */
@@ -140,12 +140,12 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
     if (rank < 2 * rem) {
         if (rank % 2)   /* odd */
             mpi_errno = MPIC_Send(recvbuf, count,
-                                  datatype, rank - 1, MPIR_ALLREDUCE_TAG, comm_ptr, errflag);
+                                  datatype, rank - 1, MPIR_ALLREDUCE_TAG, comm_ptr, coll_attr);
         else    /* even */
             mpi_errno = MPIC_Recv(recvbuf, count,
                                   datatype, rank + 1,
                                   MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
@@ -76,7 +76,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
         } else {        /* odd */
             mpi_errno = MPIC_Recv(tmp_buf, count,
                                   datatype, rank - 1,
-                                  MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                  MPIR_ALLREDUCE_TAG, comm_ptr, coll_attr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* do the reduction on received data. since the
@@ -144,7 +144,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
         else    /* even */
             mpi_errno = MPIC_Recv(recvbuf, count,
                                   datatype, rank + 1,
-                                  MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                  MPIR_ALLREDUCE_TAG, comm_ptr, coll_attr, MPI_STATUS_IGNORE);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
   fn_exit:

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
@@ -70,7 +70,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
-             * process does not pariticipate in recursive
+             * process does not participate in recursive
              * doubling */
             newrank = -1;
         } else {        /* odd */

--- a/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
@@ -90,7 +90,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
-             * process does not pariticipate in recursive
+             * process does not participate in recursive
              * doubling */
             newrank = -1;
         } else {        /* odd */

--- a/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
@@ -42,8 +42,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
                                                   void *recvbuf,
                                                   MPI_Aint count,
                                                   MPI_Datatype datatype,
-                                                  MPI_Op op,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                  MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     MPIR_CHKLMEM_DECL(3);
     int comm_size, rank;
@@ -86,8 +85,8 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIC_Send(recvbuf, count,
-                                  datatype, rank + 1, MPIR_ALLREDUCE_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  datatype, rank + 1, MPIR_ALLREDUCE_TAG, comm_ptr, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not participate in recursive
@@ -97,7 +96,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
             mpi_errno = MPIC_Recv(tmp_buf, count,
                                   datatype, rank - 1,
                                   MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
@@ -176,8 +175,8 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
                                       (char *) tmp_buf +
                                       disps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
-                                      MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* tmp_buf contains data received in this step.
              * recvbuf contains data accumulated so far */
@@ -235,8 +234,8 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
                                       (char *) recvbuf +
                                       disps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
-                                      MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             if (newrank > newdst)
                 send_idx = recv_idx;
@@ -250,12 +249,12 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
     if (rank < 2 * rem) {
         if (rank % 2)   /* odd */
             mpi_errno = MPIC_Send(recvbuf, count,
-                                  datatype, rank - 1, MPIR_ALLREDUCE_TAG, comm_ptr, errflag);
+                                  datatype, rank - 1, MPIR_ALLREDUCE_TAG, comm_ptr, coll_attr);
         else    /* even */
             mpi_errno = MPIC_Recv(recvbuf, count,
                                   datatype, rank + 1,
                                   MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
@@ -95,7 +95,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
         } else {        /* odd */
             mpi_errno = MPIC_Recv(tmp_buf, count,
                                   datatype, rank - 1,
-                                  MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                  MPIR_ALLREDUCE_TAG, comm_ptr, coll_attr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* do the reduction on received data. since the
@@ -253,7 +253,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
         else    /* even */
             mpi_errno = MPIC_Recv(recvbuf, count,
                                   datatype, rank + 1,
-                                  MPIR_ALLREDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                  MPIR_ALLREDUCE_TAG, comm_ptr, coll_attr, MPI_STATUS_IGNORE);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
   fn_exit:

--- a/src/mpi/coll/allreduce/allreduce_intra_ring.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_ring.c
@@ -77,7 +77,8 @@ int MPIR_Allreduce_intra_ring(const void *sendbuf, void *recvbuf, MPI_Aint count
         mpi_errno = MPIR_Sched_next_tag(comm, &tag);
         MPIR_ERR_CHECK(mpi_errno);
 
-        mpi_errno = MPIC_Irecv(tmpbuf, cnts[recv_rank], datatype, src, tag, comm, &reqs[0]);
+        mpi_errno = MPIC_Irecv(tmpbuf, cnts[recv_rank], datatype, src, tag, comm,
+                               coll_attr, &reqs[0]);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         mpi_errno = MPIC_Isend((char *) recvbuf + displs[send_rank] * extent, cnts[send_rank],

--- a/src/mpi/coll/allreduce/allreduce_intra_smp.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_smp.c
@@ -6,8 +6,7 @@
 #include "mpiimpl.h"
 
 int MPIR_Allreduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
-                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                             MPIR_Errflag_t errflag)
+                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -23,12 +22,13 @@ int MPIR_Allreduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
              * allreduce is in recvbuf. Pass that as the sendbuf to reduce. */
 
             mpi_errno =
-                MPIR_Reduce(recvbuf, NULL, count, datatype, op, 0, comm_ptr->node_comm, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_Reduce(recvbuf, NULL, count, datatype, op, 0, comm_ptr->node_comm, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         } else {
             mpi_errno =
-                MPIR_Reduce(sendbuf, recvbuf, count, datatype, op, 0, comm_ptr->node_comm, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_Reduce(sendbuf, recvbuf, count, datatype, op, 0, comm_ptr->node_comm,
+                            coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     } else {
         /* only one process on the node. copy sendbuf to recvbuf */
@@ -42,14 +42,14 @@ int MPIR_Allreduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
     if (comm_ptr->node_roots_comm != NULL) {
         mpi_errno =
             MPIR_Allreduce(MPI_IN_PLACE, recvbuf, count, datatype, op, comm_ptr->node_roots_comm,
-                           errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                           coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* now broadcast the result among local processes */
     if (comm_ptr->node_comm != NULL) {
-        mpi_errno = MPIR_Bcast(recvbuf, count, datatype, 0, comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        mpi_errno = MPIR_Bcast(recvbuf, count, datatype, 0, comm_ptr->node_comm, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
     goto fn_exit;
 

--- a/src/mpi/coll/allreduce/allreduce_intra_tree.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_tree.c
@@ -150,7 +150,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
 
             mpi_errno =
                 MPIC_Recv(recv_address, msgsize, datatype, child, MPIR_ALLREDUCE_TAG, comm_ptr,
-                          MPI_STATUS_IGNORE);
+                          coll_attr, MPI_STATUS_IGNORE);
             /* for communication errors, just record the error but continue */
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
@@ -179,7 +179,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
         if (my_tree.parent != -1) {
             mpi_errno = MPIC_Recv(reduce_address, msgsize,
                                   datatype, my_tree.parent, MPIR_ALLREDUCE_TAG, comm_ptr,
-                                  MPI_STATUS_IGNORE);
+                                  coll_attr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
         if (num_children) {

--- a/src/mpi/coll/allreduce/allreduce_intra_tree.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_tree.c
@@ -16,7 +16,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
                               MPI_Datatype datatype,
                               MPI_Op op, MPIR_Comm * comm_ptr,
                               int tree_type, int k, int chunk_size,
-                              int buffer_per_child, MPIR_Errflag_t errflag)
+                              int buffer_per_child, int coll_attr)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
@@ -152,7 +152,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
                 MPIC_Recv(recv_address, msgsize, datatype, child, MPIR_ALLREDUCE_TAG, comm_ptr,
                           MPI_STATUS_IGNORE);
             /* for communication errors, just record the error but continue */
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             if (is_commutative) {
                 mpi_errno = MPIR_Reduce_local(recv_address, reduce_address, msgsize, datatype, op);
@@ -172,15 +172,15 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
         if (rank != root) {     /* send data to the parent */
             mpi_errno =
                 MPIC_Isend(reduce_address, msgsize, datatype, my_tree.parent, MPIR_ALLREDUCE_TAG,
-                           comm_ptr, &reqs[num_reqs++], errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                           comm_ptr, &reqs[num_reqs++], coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         if (my_tree.parent != -1) {
             mpi_errno = MPIC_Recv(reduce_address, msgsize,
                                   datatype, my_tree.parent, MPIR_ALLREDUCE_TAG, comm_ptr,
                                   MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
         if (num_children) {
             for (i = 0; i < num_children; i++) {
@@ -189,8 +189,8 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
                 MPIR_Assert(child != 0);
                 mpi_errno = MPIC_Isend(reduce_address, msgsize,
                                        datatype, child,
-                                       MPIR_ALLREDUCE_TAG, comm_ptr, &reqs[num_reqs++], errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                       MPIR_ALLREDUCE_TAG, comm_ptr, &reqs[num_reqs++], coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
 
@@ -199,7 +199,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
 
     if (num_reqs > 0) {
         mpi_errno = MPIC_Waitall(num_reqs, reqs, MPI_STATUSES_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     if (!is_tree_leaf) {

--- a/src/mpi/coll/allreduce_group/allreduce_group.c
+++ b/src/mpi/coll/allreduce_group/allreduce_group.c
@@ -72,7 +72,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
-             * process does not pariticipate in recursive
+             * process does not participate in recursive
              * doubling */
             newrank = -1;
         } else {        /* odd */

--- a/src/mpi/coll/allreduce_group/allreduce_group.c
+++ b/src/mpi/coll/allreduce_group/allreduce_group.c
@@ -77,7 +77,9 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
             newrank = -1;
         } else {        /* odd */
             to_comm_rank(csrc, group_rank - 1);
-            mpi_errno = MPIC_Recv(tmp_buf, count, datatype, csrc, tag, comm_ptr, MPI_STATUS_IGNORE);
+            mpi_errno =
+                MPIC_Recv(tmp_buf, count, datatype, csrc, tag, comm_ptr, coll_attr,
+                          MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* do the reduction on received data. since the
@@ -278,7 +280,9 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
             mpi_errno = MPIC_Send(recvbuf, count, datatype, cdst, tag, comm_ptr, coll_attr);
         } else {        /* even */
             to_comm_rank(csrc, group_rank + 1);
-            mpi_errno = MPIC_Recv(recvbuf, count, datatype, csrc, tag, comm_ptr, MPI_STATUS_IGNORE);
+            mpi_errno =
+                MPIC_Recv(recvbuf, count, datatype, csrc, tag, comm_ptr, coll_attr,
+                          MPI_STATUS_IGNORE);
         }
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }

--- a/src/mpi/coll/allreduce_group/allreduce_group.h
+++ b/src/mpi/coll/allreduce_group/allreduce_group.h
@@ -10,9 +10,9 @@
 
 int MPII_Allreduce_group(void *sendbuf, void *recvbuf, MPI_Aint count,
                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                         MPIR_Group * group_ptr, int tag, MPIR_Errflag_t errflag);
+                         MPIR_Group * group_ptr, int tag, int coll_attr);
 int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                               MPIR_Group * group_ptr, int tag, MPIR_Errflag_t errflag);
+                               MPIR_Group * group_ptr, int tag, int coll_attr);
 
 #endif /* ALLREDUCE_GROUP_H_INCLUDED */

--- a/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
+++ b/src/mpi/coll/alltoall/alltoall_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Alltoall_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                             MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                             MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/alltoall/alltoall_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoall/alltoall_inter_pairwise_exchange.c
@@ -19,7 +19,7 @@
 int MPIR_Alltoall_inter_pairwise_exchange(const void *sendbuf, MPI_Aint sendcount,
                                           MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                           MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                          MPIR_Errflag_t errflag)
+                                          int coll_attr)
 {
     int local_size, remote_size, max_size, i;
     MPI_Aint sendtype_extent, recvtype_extent;
@@ -58,8 +58,8 @@ int MPIR_Alltoall_inter_pairwise_exchange(const void *sendbuf, MPI_Aint sendcoun
         mpi_errno = MPIC_Sendrecv(sendaddr, sendcount, sendtype, dst,
                                   MPIR_ALLTOALL_TAG, recvaddr,
                                   recvcount, recvtype, src,
-                                  MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  MPIR_ALLTOALL_TAG, comm_ptr, &status, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     return mpi_errno_ret;

--- a/src/mpi/coll/alltoall/alltoall_intra_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_brucks.c
@@ -23,7 +23,7 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
                                MPI_Datatype sendtype,
                                void *recvbuf,
                                MPI_Aint recvcount,
-                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                               MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, i, pof2;
     MPI_Aint sendtype_extent, recvtype_extent;
@@ -107,8 +107,8 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
 
         mpi_errno = MPIC_Sendrecv(tmp_buf, newtype_sz, MPI_BYTE, dst,
                                   MPIR_ALLTOALL_TAG, recvbuf, 1, newtype,
-                                  src, MPIR_ALLTOALL_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  src, MPIR_ALLTOALL_TAG, comm_ptr, MPI_STATUS_IGNORE, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         MPIR_Type_free_impl(&newtype);
 

--- a/src/mpi/coll/alltoall/alltoall_intra_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_brucks.c
@@ -52,7 +52,7 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
     pack_size = recvcount * comm_size * recvtype_sz;
     MPIR_CHKLMEM_MALLOC(tmp_buf, void *, pack_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
 
-    /* Do Phase 1 of the algorithim. Shift the data blocks on process i
+    /* Do Phase 1 of the algorithm. Shift the data blocks on process i
      * upwards by a distance of i blocks. Store the result in recvbuf. */
     mpi_errno = MPIR_Localcopy((char *) sendbuf +
                                rank * sendcount * sendtype_extent,

--- a/src/mpi/coll/alltoall/alltoall_intra_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_brucks.c
@@ -37,7 +37,7 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
     void *tmp_buf;
     MPIR_CHKLMEM_DECL(6);
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     MPIR_Assert(sendbuf != MPI_IN_PLACE);

--- a/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
@@ -108,8 +108,7 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
                                  MPI_Datatype sendtype,
                                  void *recvbuf,
                                  MPI_Aint recvcnt,
-                                 MPI_Datatype recvtype, MPIR_Comm * comm, int k,
-                                 MPIR_Errflag_t errflag)
+                                 MPI_Datatype recvtype, MPIR_Comm * comm, int k, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -253,18 +252,18 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
             mpi_errno =
                 MPIC_Irecv(tmp_rbuf[j - 1], packsize, MPI_BYTE, src, MPIR_ALLTOALL_TAG, comm,
                            &reqs[num_reqs++]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             mpi_errno =
                 MPIC_Isend(tmp_sbuf[j - 1], packsize, MPI_BYTE, dst, MPIR_ALLTOALL_TAG, comm,
-                           &reqs[num_reqs++], errflag);
+                           &reqs[num_reqs++], coll_attr);
             if (mpi_errno) {
                 MPIR_ERR_POP(mpi_errno);
             }
         }
 
         MPIC_Waitall(num_reqs, reqs, MPI_STATUSES_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         for (j = 1; j < k; j++) {
             if (delta * j >= size)      /* if the first location exceeds comm size, nothing is to be sent */

--- a/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
@@ -251,7 +251,7 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
 
             mpi_errno =
                 MPIC_Irecv(tmp_rbuf[j - 1], packsize, MPI_BYTE, src, MPIR_ALLTOALL_TAG, comm,
-                           &reqs[num_reqs++]);
+                           coll_attr, &reqs[num_reqs++]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             mpi_errno =

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
@@ -27,8 +27,7 @@ int MPIR_Alltoall_intra_pairwise(const void *sendbuf,
                                  MPI_Datatype sendtype,
                                  void *recvbuf,
                                  MPI_Aint recvcount,
-                                 MPI_Datatype recvtype,
-                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                 MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, i;
     MPI_Aint sendtype_extent, recvtype_extent;
@@ -76,8 +75,8 @@ int MPIR_Alltoall_intra_pairwise(const void *sendbuf,
                                   ((char *) recvbuf +
                                    src * recvcount * recvtype_extent),
                                   recvcount, recvtype, src,
-                                  MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  MPIR_ALLTOALL_TAG, comm_ptr, &status, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
@@ -25,7 +25,7 @@ int MPIR_Alltoall_intra_pairwise_sendrecv_replace(const void *sendbuf,
                                                   void *recvbuf,
                                                   MPI_Aint recvcount,
                                                   MPI_Datatype recvtype,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                  MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, i, j;
     MPI_Aint recvtype_extent;
@@ -56,15 +56,15 @@ int MPIR_Alltoall_intra_pairwise_sendrecv_replace(const void *sendbuf,
                 mpi_errno =
                     MPIC_Sendrecv_replace(((char *) recvbuf + j * recvcount * recvtype_extent),
                                           recvcount, recvtype, j, MPIR_ALLTOALL_TAG, j,
-                                          MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                          MPIR_ALLTOALL_TAG, comm_ptr, &status, coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             } else if (rank == j) {
                 /* same as above with i/j args reversed */
                 mpi_errno =
                     MPIC_Sendrecv_replace(((char *) recvbuf + i * recvcount * recvtype_extent),
                                           recvcount, recvtype, i, MPIR_ALLTOALL_TAG, i,
-                                          MPIR_ALLTOALL_TAG, comm_ptr, &status, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                          MPIR_ALLTOALL_TAG, comm_ptr, &status, coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/alltoall/alltoall_intra_scattered.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_scattered.c
@@ -32,8 +32,7 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
                                   MPI_Datatype sendtype,
                                   void *recvbuf,
                                   MPI_Aint recvcount,
-                                  MPI_Datatype recvtype,
-                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                  MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, i;
     MPI_Aint sendtype_extent, recvtype_extent;
@@ -74,7 +73,7 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
                                    dst * recvcount * recvtype_extent,
                                    recvcount, recvtype, dst,
                                    MPIR_ALLTOALL_TAG, comm_ptr, &reqarray[i]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         for (i = 0; i < ss; i++) {
@@ -82,13 +81,13 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
             mpi_errno = MPIC_Isend((char *) sendbuf +
                                    dst * sendcount * sendtype_extent,
                                    sendcount, sendtype, dst,
-                                   MPIR_ALLTOALL_TAG, comm_ptr, &reqarray[i + ss], errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                   MPIR_ALLTOALL_TAG, comm_ptr, &reqarray[i + ss], coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         /* ... then wait for them to finish: */
         mpi_errno = MPIC_Waitall(2 * ss, reqarray, starray);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/alltoall/alltoall_intra_scattered.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_scattered.c
@@ -72,7 +72,7 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
             mpi_errno = MPIC_Irecv((char *) recvbuf +
                                    dst * recvcount * recvtype_extent,
                                    recvcount, recvtype, dst,
-                                   MPIR_ALLTOALL_TAG, comm_ptr, &reqarray[i]);
+                                   MPIR_ALLTOALL_TAG, comm_ptr, coll_attr, &reqarray[i]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 

--- a/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
+++ b/src/mpi/coll/alltoallv/alltoallv_allcomm_nb.c
@@ -8,7 +8,7 @@
 int MPIR_Alltoallv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
                               const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
                               const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
-                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                              MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/alltoallv/alltoallv_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoallv/alltoallv_inter_pairwise_exchange.c
@@ -23,7 +23,7 @@ int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint *
                                            const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                            void *recvbuf, const MPI_Aint * recvcounts,
                                            const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                           MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                           MPIR_Comm * comm_ptr, int coll_attr)
 {
     int local_size, remote_size, max_size, i;
     MPI_Aint send_extent, recv_extent;
@@ -66,8 +66,8 @@ int MPIR_Alltoallv_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint *
 
         mpi_errno = MPIC_Sendrecv(sendaddr, sendcount, sendtype, dst,
                                   MPIR_ALLTOALLV_TAG, recvaddr, recvcount,
-                                  recvtype, src, MPIR_ALLTOALLV_TAG, comm_ptr, &status, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  recvtype, src, MPIR_ALLTOALLV_TAG, comm_ptr, &status, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     return mpi_errno_ret;

--- a/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
@@ -22,7 +22,7 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                    const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                                    void *recvbuf, const MPI_Aint * recvcounts,
                                                    const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, i, j;
     MPI_Aint recv_extent;
@@ -59,8 +59,8 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                   recvcounts[j], recvtype,
                                                   j, MPIR_ALLTOALLV_TAG,
                                                   j, MPIR_ALLTOALLV_TAG,
-                                                  comm_ptr, &status, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                                  comm_ptr, &status, coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             } else if (rank == j) {
                 /* same as above with i/j args reversed */
@@ -68,8 +68,8 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                   recvcounts[i], recvtype,
                                                   i, MPIR_ALLTOALLV_TAG,
                                                   i, MPIR_ALLTOALLV_TAG,
-                                                  comm_ptr, &status, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                                  comm_ptr, &status, coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
@@ -24,8 +24,7 @@
 int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcounts,
                                    const MPI_Aint * sdispls, MPI_Datatype sendtype, void *recvbuf,
                                    const MPI_Aint * recvcounts, const MPI_Aint * rdispls,
-                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                   MPIR_Errflag_t errflag)
+                                   MPI_Datatype recvtype, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, i;
     MPI_Aint send_extent, recv_extent;
@@ -73,7 +72,7 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
                     mpi_errno = MPIC_Irecv((char *) recvbuf + rdispls[dst] * recv_extent,
                                            recvcounts[dst], recvtype, dst,
                                            MPIR_ALLTOALLV_TAG, comm_ptr, &reqarray[req_cnt]);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     req_cnt++;
                 }
             }
@@ -88,22 +87,22 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
                     mpi_errno = MPIC_Isend((char *) sendbuf + sdispls[dst] * send_extent,
                                            sendcounts[dst], sendtype, dst,
                                            MPIR_ALLTOALLV_TAG, comm_ptr,
-                                           &reqarray[req_cnt], errflag);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                           &reqarray[req_cnt], coll_attr);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     req_cnt++;
                 }
             }
         }
 
         mpi_errno = MPIC_Waitall(req_cnt, reqarray, starray);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         /* --BEGIN ERROR HANDLING-- */
         if (mpi_errno == MPI_ERR_IN_STATUS) {
             for (i = 0; i < req_cnt; i++) {
                 if (starray[i].MPI_ERROR != MPI_SUCCESS) {
                     mpi_errno = starray[i].MPI_ERROR;
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
             }
         }

--- a/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
@@ -71,7 +71,8 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
                 if (type_size) {
                     mpi_errno = MPIC_Irecv((char *) recvbuf + rdispls[dst] * recv_extent,
                                            recvcounts[dst], recvtype, dst,
-                                           MPIR_ALLTOALLV_TAG, comm_ptr, &reqarray[req_cnt]);
+                                           MPIR_ALLTOALLV_TAG, comm_ptr,
+                                           coll_attr, &reqarray[req_cnt]);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     req_cnt++;
                 }

--- a/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
@@ -37,7 +37,7 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
 
     MPIR_CHKLMEM_DECL(2);
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
     /* Get extent of recv type, but send type is only valid if (sendbuf!=MPI_IN_PLACE) */
     MPIR_Datatype_get_extent_macro(recvtype, recv_extent);

--- a/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
+++ b/src/mpi/coll/alltoallw/alltoallw_allcomm_nb.c
@@ -8,8 +8,7 @@
 int MPIR_Alltoallw_allcomm_nb(const void *sendbuf, const MPI_Aint sendcounts[],
                               const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                               void *recvbuf, const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
-                              const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                              MPIR_Errflag_t errflag)
+                              const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/alltoallw/alltoallw_inter_pairwise_exchange.c
+++ b/src/mpi/coll/alltoallw/alltoallw_inter_pairwise_exchange.c
@@ -23,7 +23,7 @@ int MPIR_Alltoallw_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint s
                                            const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                            void *recvbuf, const MPI_Aint recvcounts[],
                                            const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                           MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                           MPIR_Comm * comm_ptr, int coll_attr)
 {
     int local_size, remote_size, max_size, i;
     int mpi_errno = MPI_SUCCESS;
@@ -67,8 +67,8 @@ int MPIR_Alltoallw_inter_pairwise_exchange(const void *sendbuf, const MPI_Aint s
         mpi_errno = MPIC_Sendrecv(sendaddr, sendcount, sendtype,
                                   dst, MPIR_ALLTOALLW_TAG, recvaddr,
                                   recvcount, recvtype, src,
-                                  MPIR_ALLTOALLW_TAG, comm_ptr, &status, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  MPIR_ALLTOALLW_TAG, comm_ptr, &status, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
     return mpi_errno_ret;
 }

--- a/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
@@ -23,7 +23,7 @@ int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                    const MPI_Aint recvcounts[],
                                                    const MPI_Aint rdispls[],
                                                    const MPI_Datatype recvtypes[],
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, i, j;
     int mpi_errno = MPI_SUCCESS;
@@ -56,16 +56,16 @@ int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                   recvcounts[j], recvtypes[j],
                                                   j, MPIR_ALLTOALLW_TAG,
                                                   j, MPIR_ALLTOALLW_TAG,
-                                                  comm_ptr, &status, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                                  comm_ptr, &status, coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             } else if (rank == j) {
                 /* same as above with i/j args reversed */
                 mpi_errno = MPIC_Sendrecv_replace(((char *) recvbuf + rdispls[i]),
                                                   recvcounts[i], recvtypes[i],
                                                   i, MPIR_ALLTOALLW_TAG,
                                                   i, MPIR_ALLTOALLW_TAG,
-                                                  comm_ptr, &status, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                                  comm_ptr, &status, coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
@@ -23,7 +23,7 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
                                    const MPI_Aint sdispls[], const MPI_Datatype sendtypes[],
                                    void *recvbuf, const MPI_Aint recvcounts[],
                                    const MPI_Aint rdispls[], const MPI_Datatype recvtypes[],
-                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                   MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, i;
     int mpi_errno = MPI_SUCCESS;
@@ -86,7 +86,7 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
                     mpi_errno = MPIC_Isend((char *) sendbuf + sdispls[dst],
                                            sendcounts[dst], sendtypes[dst], dst,
                                            MPIR_ALLTOALLW_TAG, comm_ptr,
-                                           &reqarray[outstanding_requests], errflag);
+                                           &reqarray[outstanding_requests], coll_attr);
                     MPIR_ERR_CHECK(mpi_errno);
 
                     outstanding_requests++;
@@ -95,14 +95,14 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
         }
 
         mpi_errno = MPIC_Waitall(outstanding_requests, reqarray, starray);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         /* --BEGIN ERROR HANDLING-- */
         if (mpi_errno == MPI_ERR_IN_STATUS) {
             for (i = 0; i < outstanding_requests; i++) {
                 if (starray[i].MPI_ERROR != MPI_SUCCESS) {
                     mpi_errno = starray[i].MPI_ERROR;
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
             }
         }

--- a/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
@@ -36,7 +36,7 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
     MPI_Aint type_size;
     MPIR_CHKLMEM_DECL(2);
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     /* When MPI_IN_PLACE, we use pair-wise sendrecv_replace in order to conserve memory usage,

--- a/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
@@ -70,7 +70,7 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
                     mpi_errno = MPIC_Irecv((char *) recvbuf + rdispls[dst],
                                            recvcounts[dst], recvtypes[dst], dst,
                                            MPIR_ALLTOALLW_TAG, comm_ptr,
-                                           &reqarray[outstanding_requests]);
+                                           coll_attr, &reqarray[outstanding_requests]);
                     MPIR_ERR_CHECK(mpi_errno);
 
                     outstanding_requests++;

--- a/src/mpi/coll/barrier/barrier_allcomm_nb.c
+++ b/src/mpi/coll/barrier/barrier_allcomm_nb.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Barrier_allcomm_nb(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+int MPIR_Barrier_allcomm_nb(MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/barrier/barrier_inter_bcast.c
+++ b/src/mpi/coll/barrier/barrier_inter_bcast.c
@@ -17,7 +17,7 @@
  * group.
  */
 
-int MPIR_Barrier_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+int MPIR_Barrier_inter_bcast(MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, mpi_errno = MPI_SUCCESS, root;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -35,29 +35,29 @@ int MPIR_Barrier_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
     newcomm_ptr = comm_ptr->local_comm;
 
     /* do a barrier on the local intracommunicator */
-    mpi_errno = MPIR_Barrier(newcomm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    mpi_errno = MPIR_Barrier(newcomm_ptr, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     if (comm_ptr->is_low_group) {
         /* bcast to right */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
-        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         /* receive bcast from right */
         root = 0;
-        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         /* receive bcast from left */
         root = 0;
-        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         /* bcast to left */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
-        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
   fn_exit:
     return mpi_errno_ret;

--- a/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
+++ b/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
@@ -96,7 +96,7 @@ int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, int coll_attr)
             /* recv from (k-1) nbrs */
             mpi_errno =
                 MPIC_Irecv(NULL, 0, MPI_BYTE, from, MPIR_BARRIER_TAG, comm,
-                           &recv_reqs[(j - 1) + ((k - 1) * (i & 1))]);
+                           coll_attr, &recv_reqs[(j - 1) + ((k - 1) * (i & 1))]);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             /* wait on recvs from prev phase */
             if (i > 0 && j == 1) {

--- a/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
+++ b/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
@@ -16,7 +16,7 @@
  * process i sends to process (i + 2^k) % p and receives from process
  * (i - 2^k + p) % p.
  */
-int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, int coll_attr)
 {
     int size, rank, src, dst, mask, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -29,8 +29,8 @@ int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t errfla
         src = (rank - mask + size) % size;
         mpi_errno = MPIC_Sendrecv(NULL, 0, MPI_BYTE, dst,
                                   MPIR_BARRIER_TAG, NULL, 0, MPI_BYTE,
-                                  src, MPIR_BARRIER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  src, MPIR_BARRIER_TAG, comm_ptr, MPI_STATUS_IGNORE, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         mask <<= 1;
     }
 
@@ -40,7 +40,7 @@ int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t errfla
 /* Algorithm: high radix dissemination
  * Similar to dissemination algorithm, but generalized with high radix k
  */
-int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t errflag)
+int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
     int i, j, nranks, rank;
@@ -60,7 +60,7 @@ int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t e
         k = nranks;
 
     if (k == 2) {
-        return MPIR_Barrier_intra_dissemination(comm, errflag);
+        return MPIR_Barrier_intra_dissemination(comm, coll_attr);
     }
 
     /* If k value is greater than the maximum radix defined by MAX_RADIX macro,
@@ -97,27 +97,27 @@ int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t e
             mpi_errno =
                 MPIC_Irecv(NULL, 0, MPI_BYTE, from, MPIR_BARRIER_TAG, comm,
                            &recv_reqs[(j - 1) + ((k - 1) * (i & 1))]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             /* wait on recvs from prev phase */
             if (i > 0 && j == 1) {
                 mpi_errno =
                     MPIC_Waitall(k - 1, &recv_reqs[((k - 1) * ((i - 1) & 1))], MPI_STATUSES_IGNORE);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
 
             mpi_errno =
                 MPIC_Isend(NULL, 0, MPI_BYTE, to, MPIR_BARRIER_TAG, comm, &send_reqs[j - 1],
-                           errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                           coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
         mpi_errno = MPIC_Waitall(k - 1, send_reqs, MPI_STATUSES_IGNORE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         shift *= k;
     }
 
     mpi_errno =
         MPIC_Waitall(k - 1, recv_reqs + ((k - 1) * ((nphases - 1) & 1)), MPI_STATUSES_IGNORE);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
   fn_exit:
     if (k > MAX_RADIX) {

--- a/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
+++ b/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
@@ -21,7 +21,7 @@ int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, int coll_attr)
     int size, rank, src, dst, mask, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, size);
 
     mask = 0x1;
     while (mask < size) {

--- a/src/mpi/coll/barrier/barrier_intra_recexch.c
+++ b/src/mpi/coll/barrier/barrier_intra_recexch.c
@@ -8,14 +8,13 @@
 
 /* Algorithm: call Allreduce's recursive exchange algorithm
  */
-int MPIR_Barrier_intra_recexch(MPIR_Comm * comm, int k, int single_phase_recv,
-                               MPIR_Errflag_t errflag)
+int MPIR_Barrier_intra_recexch(MPIR_Comm * comm, int k, int single_phase_recv, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Allreduce_intra_recexch(MPI_IN_PLACE, NULL, 0,
                                              MPI_BYTE, MPI_SUM, comm,
-                                             k, single_phase_recv, errflag);
+                                             k, single_phase_recv, coll_attr);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpi/coll/barrier/barrier_intra_smp.c
+++ b/src/mpi/coll/barrier/barrier_intra_smp.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -14,14 +14,14 @@ int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 
     /* do the intranode barrier on all nodes */
     if (comm_ptr->node_comm != NULL) {
-        mpi_errno = MPIR_Barrier(comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        mpi_errno = MPIR_Barrier(comm_ptr->node_comm, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* do the barrier across roots of all nodes */
     if (comm_ptr->node_roots_comm != NULL) {
-        mpi_errno = MPIR_Barrier(comm_ptr->node_roots_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        mpi_errno = MPIR_Barrier(comm_ptr->node_roots_comm, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* release the local processes on each node with a 1-byte
@@ -29,8 +29,8 @@ int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
      * anything) */
     if (comm_ptr->node_comm != NULL) {
         int i = 0;
-        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, 0, comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, 0, comm_ptr->node_comm, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     return mpi_errno_ret;

--- a/src/mpi/coll/bcast/Makefile.mk
+++ b/src/mpi/coll/bcast/Makefile.mk
@@ -14,6 +14,7 @@ mpi_core_sources +=											\
     src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c	\
     src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c		\
     src/mpi/coll/bcast/bcast_intra_smp.c						\
+    src/mpi/coll/bcast/bcast_intra_smp_new.c \
     src/mpi/coll/bcast/bcast_intra_tree.c				\
     src/mpi/coll/bcast/bcast_intra_pipelined_tree.c			\
     src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c

--- a/src/mpi/coll/bcast/bcast.h
+++ b/src/mpi/coll/bcast/bcast.h
@@ -10,6 +10,6 @@
 
 int MPII_Scatter_for_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
                            int root, MPIR_Comm * comm_ptr, MPI_Aint nbytes, void *tmp_buf,
-                           int is_contig, MPIR_Errflag_t errflag);
+                           int is_contig, int coll_attr);
 
 #endif /* BCAST_H_INCLUDED */

--- a/src/mpi/coll/bcast/bcast_allcomm_nb.c
+++ b/src/mpi/coll/bcast/bcast_allcomm_nb.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 
 int MPIR_Bcast_allcomm_nb(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                          MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                          MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
+++ b/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
@@ -37,7 +37,8 @@ int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer,
         rank = comm_ptr->rank;
 
         if (rank == 0) {
-            mpi_errno = MPIC_Recv(buffer, count, datatype, root, MPIR_BCAST_TAG, comm_ptr, &status);
+            mpi_errno = MPIC_Recv(buffer, count, datatype, root, MPIR_BCAST_TAG, comm_ptr,
+                                  coll_attr, &status);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 

--- a/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
+++ b/src/mpi/coll/bcast/bcast_inter_remote_send_local_bcast.c
@@ -14,7 +14,7 @@
 int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer,
                                              MPI_Aint count,
                                              MPI_Datatype datatype,
-                                             int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                             int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, mpi_errno;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -29,8 +29,8 @@ int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer,
         mpi_errno = MPI_SUCCESS;
     } else if (root == MPI_ROOT) {
         /* root sends to rank 0 on remote group and returns */
-        mpi_errno = MPIC_Send(buffer, count, datatype, 0, MPIR_BCAST_TAG, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        mpi_errno = MPIC_Send(buffer, count, datatype, 0, MPIR_BCAST_TAG, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         /* remote group. rank 0 on remote group receives from root */
 
@@ -38,21 +38,21 @@ int MPIR_Bcast_inter_remote_send_local_bcast(void *buffer,
 
         if (rank == 0) {
             mpi_errno = MPIC_Recv(buffer, count, datatype, root, MPIR_BCAST_TAG, comm_ptr, &status);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         /* Get the local intracommunicator */
         if (!comm_ptr->local_comm) {
             mpi_errno = MPII_Setup_intercomm_localcomm(comm_ptr);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         newcomm_ptr = comm_ptr->local_comm;
 
         /* now do the usual broadcast on this intracommunicator
          * with rank 0 as root. */
-        mpi_errno = MPIR_Bcast_allcomm_auto(buffer, count, datatype, 0, newcomm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        mpi_errno = MPIR_Bcast_allcomm_auto(buffer, count, datatype, 0, newcomm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     MPIR_FUNC_EXIT;

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -91,10 +91,10 @@ int MPIR_Bcast_intra_binomial(void *buffer,
                 src += comm_size;
             if (!is_contig)
                 mpi_errno = MPIC_Recv(tmp_buf, nbytes, MPI_BYTE, src,
-                                      MPIR_BCAST_TAG, comm_ptr, status_p);
+                                      MPIR_BCAST_TAG, comm_ptr, coll_attr, status_p);
             else
                 mpi_errno = MPIC_Recv(buffer, count, datatype, src,
-                                      MPIR_BCAST_TAG, comm_ptr, status_p);
+                                      MPIR_BCAST_TAG, comm_ptr, coll_attr, status_p);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 #ifdef HAVE_ERROR_CHECKING
             /* check that we received as much as we expected */

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -12,8 +12,7 @@
  */
 int MPIR_Bcast_intra_binomial(void *buffer,
                               MPI_Aint count,
-                              MPI_Datatype datatype,
-                              int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                              MPI_Datatype datatype, int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, comm_size, src, dst;
     int relative_rank, mask;
@@ -96,11 +95,11 @@ int MPIR_Bcast_intra_binomial(void *buffer,
             else
                 mpi_errno = MPIC_Recv(buffer, count, datatype, src,
                                       MPIR_BCAST_TAG, comm_ptr, status_p);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 #ifdef HAVE_ERROR_CHECKING
             /* check that we received as much as we expected */
             MPIR_Get_count_impl(status_p, MPI_BYTE, &recvd_size);
-            MPIR_ERR_COLL_CHECK_SIZE(recvd_size, nbytes, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECK_SIZE(recvd_size, nbytes, coll_attr, mpi_errno_ret);
 #endif
             break;
         }
@@ -126,11 +125,11 @@ int MPIR_Bcast_intra_binomial(void *buffer,
                 dst -= comm_size;
             if (!is_contig)
                 mpi_errno = MPIC_Send(tmp_buf, nbytes, MPI_BYTE, dst,
-                                      MPIR_BCAST_TAG, comm_ptr, errflag);
+                                      MPIR_BCAST_TAG, comm_ptr, coll_attr);
             else
                 mpi_errno = MPIC_Send(buffer, count, datatype, dst,
-                                      MPIR_BCAST_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      MPIR_BCAST_TAG, comm_ptr, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
         mask >>= 1;
     }

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -32,7 +32,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
     void *tmp_buf = NULL;
     MPIR_CHKLMEM_DECL(1);
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
     if (HANDLE_IS_BUILTIN(datatype))
         is_contig = 1;

--- a/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
@@ -119,7 +119,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                 if (src != -1) {        /* post receive from parent */
                     mpi_errno =
                         MPIC_Irecv((char *) sendbuf + offset, msgsize, MPI_BYTE,
-                                   src, MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++]);
+                                   src, MPIR_BCAST_TAG, comm_ptr, coll_attr, &reqs[num_req++]);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
                 offset += msgsize;
@@ -132,7 +132,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                 if (src != -1) {
                     mpi_errno =
                         MPIC_Irecv((char *) sendbuf + offset, msgsize, MPI_BYTE,
-                                   src, MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++]);
+                                   src, MPIR_BCAST_TAG, comm_ptr, coll_attr, &reqs[num_req++]);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
                 offset += msgsize;
@@ -165,7 +165,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
             if (src != -1) {
                 mpi_errno =
                     MPIC_Recv((char *) sendbuf + offset, msgsize, MPI_BYTE,
-                              src, MPIR_BCAST_TAG, comm_ptr, &status);
+                              src, MPIR_BCAST_TAG, comm_ptr, coll_attr, &status);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
                 MPIR_ERR_COLL_CHECK_SIZE(recvd_size, msgsize, coll_attr, mpi_errno_ret);

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -199,7 +199,8 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                      * relative_rank, dst); */
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset),
                                           nbytes - offset < 0 ? 0 : nbytes - offset,
-                                          MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, &status);
+                                          MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr,
+                                          coll_attr, &status);
                     /* nprocs_completed is also equal to the no. of processes
                      * whose data we don't have */
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -29,8 +29,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                                                           MPI_Aint count,
                                                           MPI_Datatype datatype,
                                                           int root,
-                                                          MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t errflag)
+                                                          MPIR_Comm * comm_ptr, int coll_attr)
 {
     MPI_Status status;
     int rank, comm_size, dst;
@@ -80,8 +79,8 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
     scatter_size = (nbytes + comm_size - 1) / comm_size;        /* ceiling division */
 
     mpi_errno = MPII_Scatter_for_bcast(buffer, count, datatype, root, comm_ptr,
-                                       nbytes, tmp_buf, is_contig, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                       nbytes, tmp_buf, is_contig, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     /* curr_size is the amount of data that this process now has stored in
      * buffer at byte offset (relative_rank*scatter_size) */
@@ -120,8 +119,8 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                                       curr_size, MPI_BYTE, dst, MPIR_BCAST_TAG,
                                       ((char *) tmp_buf + recv_offset),
                                       (nbytes - recv_offset < 0 ? 0 : nbytes - recv_offset),
-                                      MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, &status, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, &status, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             if (mpi_errno) {
                 recv_size = 0;
             } else
@@ -185,11 +184,11 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                      * fflush(stdout); */
                     mpi_errno = MPIC_Send(((char *) tmp_buf + offset),
                                           recv_size, MPI_BYTE, dst,
-                                          MPIR_BCAST_TAG, comm_ptr, errflag);
+                                          MPIR_BCAST_TAG, comm_ptr, coll_attr);
                     /* recv_size was set in the previous
                      * receive. that's the amount of data to be
                      * sent now. */
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
                 /* recv only if this proc. doesn't have data and sender
                  * has data */
@@ -203,7 +202,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                                           MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, &status);
                     /* nprocs_completed is also equal to the no. of processes
                      * whose data we don't have */
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     if (mpi_errno) {
                         recv_size = 0;
                     } else
@@ -224,7 +223,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
 
 #ifdef HAVE_ERROR_CHECKING
     /* check that we received as much as we expected */
-    MPIR_ERR_COLL_CHECK_SIZE(curr_size, nbytes, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECK_SIZE(curr_size, nbytes, coll_attr, mpi_errno_ret);
 #endif
 
     if (!is_contig) {

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -90,7 +90,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
     if (curr_size < 0)
         curr_size = 0;
 
-    /* medium size allgather and pof2 comm_size. use recurive doubling. */
+    /* medium size allgather and pof2 comm_size. use recursive doubling. */
 
     mask = 0x1;
     i = 0;

--- a/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
@@ -24,7 +24,7 @@
 int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
                                             MPI_Aint count,
                                             MPI_Datatype datatype,
-                                            int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                            int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, comm_size;
     int mpi_errno = MPI_SUCCESS;
@@ -71,8 +71,8 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
     scatter_size = (nbytes + comm_size - 1) / comm_size;        /* ceiling division */
 
     mpi_errno = MPII_Scatter_for_bcast(buffer, count, datatype, root, comm_ptr,
-                                       nbytes, tmp_buf, is_contig, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                       nbytes, tmp_buf, is_contig, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     /* long-message allgather or medium-size but non-power-of-two. use ring algorithm. */
 
@@ -104,8 +104,8 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
         mpi_errno = MPIC_Sendrecv((char *) tmp_buf + right_disp, right_count,
                                   MPI_BYTE, right, MPIR_BCAST_TAG,
                                   (char *) tmp_buf + left_disp, left_count,
-                                  MPI_BYTE, left, MPIR_BCAST_TAG, comm_ptr, &status, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  MPI_BYTE, left, MPIR_BCAST_TAG, comm_ptr, &status, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
         curr_size += recvd_size;
         j = jnext;
@@ -114,7 +114,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
 
 #ifdef HAVE_ERROR_CHECKING
     /* check that we received as much as we expected */
-    MPIR_ERR_COLL_CHECK_SIZE(curr_size, nbytes, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECK_SIZE(curr_size, nbytes, coll_attr, mpi_errno_ret);
 #endif
 
     if (!is_contig) {

--- a/src/mpi/coll/bcast/bcast_intra_smp.c
+++ b/src/mpi/coll/bcast/bcast_intra_smp.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 
 /* FIXME This function uses some heuristsics based off of some testing on a
- * cluster at Argonne.  We need a better system for detrmining and controlling
+ * cluster at Argonne.  We need a better system for determining and controlling
  * the cutoff points for these algorithms.  If I've done this right, you should
  * be able to make changes along these lines almost exclusively in this function
  * and some new functions. [goodell@ 2008/01/07] */

--- a/src/mpi/coll/bcast/bcast_intra_smp.c
+++ b/src/mpi/coll/bcast/bcast_intra_smp.c
@@ -46,7 +46,7 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
             } else if (0 == comm_ptr->node_comm->rank) {
                 mpi_errno =
                     MPIC_Recv(buffer, count, datatype, MPIR_Get_intranode_rank(comm_ptr, root),
-                              MPIR_BCAST_TAG, comm_ptr->node_comm, status_p);
+                              MPIR_BCAST_TAG, comm_ptr->node_comm, coll_attr, status_p);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 #ifdef HAVE_ERROR_CHECKING
                 /* check that we received as much as we expected */

--- a/src/mpi/coll/bcast/bcast_intra_smp_new.c
+++ b/src/mpi/coll/bcast/bcast_intra_smp_new.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+
+/* The sticky point in the old smp bcast is when root is not a local root, resulting
+ * an extra send/recv. With the new MPIR_Subgroup, we don't have to, in principle.
+ */
+int MPIR_Bcast_intra_smp_new(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
+                             MPIR_Comm * comm_ptr, int coll_attr)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int mpi_errno_ret = MPI_SUCCESS;
+    MPI_Aint type_size, nbytes = 0;
+    MPI_Status *status_p;
+#ifdef HAVE_ERROR_CHECKING
+    MPI_Status status;
+    status_p = &status;
+    MPI_Aint recvd_size;
+#else
+    status_p = MPI_STATUS_IGNORE;
+#endif
+
+    MPIR_Assert(comm_ptr->hierarchy_kind == MPIR_COMM_HIERARCHY_KIND__PARENT);
+    MPIR_Assert(MPIR_COLL_ATTR_GET_SUBGROUP(coll_attr) == 0);
+
+    int node_group = -1, node_cross_group = -1;
+    for (int i = 0; i < comm_ptr->num_subgroups; i++) {
+        if (comm_ptr->subgroups[i].kind == MPIR_SUBGROUP_NODE) {
+            node_group = i;
+        }
+        if (comm_ptr->subgroups[i].kind == MPIR_SUBGROUP_NODE_CROSS) {
+            node_cross_group = i;
+        }
+    }
+    MPIR_Assert(node_group > 0 && node_cross_group > 0);
+
+#define NODEGROUP(field) comm_ptr->subgroups[node_group].field
+    int local_rank, local_size;
+    local_rank = NODEGROUP(rank);
+    local_size = NODEGROUP(size);
+
+    int local_root_rank = MPIR_Get_intranode_rank(comm_ptr, root);
+    int inter_root_rank = MPIR_Get_internode_rank(comm_ptr, root);
+    int node_attr = coll_attr | MPIR_COLL_ATTR_SUBGROUP(node_group);
+    int node_cross_attr = coll_attr | MPIR_COLL_ATTR_SUBGROUP(node_cross_group);
+
+    MPIR_Datatype_get_size_macro(datatype, type_size);
+
+    nbytes = type_size * count;
+    if (nbytes == 0)
+        goto fn_exit;   /* nothing to do */
+
+    if ((nbytes < MPIR_CVAR_BCAST_SHORT_MSG_SIZE) || (local_size < MPIR_CVAR_BCAST_MIN_PROCS)) {
+        /* send to intranode-rank 0 on the root's node */
+        if (local_size > 1 && local_root_rank > 0) {
+            if (root == comm_ptr->rank) {
+                int node_root = NODEGROUP(proc_table)[0];
+                mpi_errno = MPIC_Send(buffer, count, datatype, node_root, MPIR_BCAST_TAG, comm_ptr,
+                                      coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
+            } else if (local_rank == 0) {
+                mpi_errno = MPIC_Recv(buffer, count, datatype, root, MPIR_BCAST_TAG, comm_ptr,
+                                      coll_attr, status_p);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
+#ifdef HAVE_ERROR_CHECKING
+                /* check that we received as much as we expected */
+                MPIR_Get_count_impl(status_p, MPI_BYTE, &recvd_size);
+                MPIR_ERR_COLL_CHECK_SIZE(recvd_size, nbytes, coll_attr, mpi_errno_ret);
+#endif
+            }
+
+        }
+
+        /* perform the internode broadcast */
+        if (local_rank == 0) {
+            mpi_errno = MPIR_Bcast_intra_binomial(buffer, count, datatype, inter_root_rank,
+                                                  comm_ptr, node_cross_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
+        }
+
+        /* perform the intranode broadcast */
+        if (local_size > 1) {
+            mpi_errno = MPIR_Bcast_intra_binomial(buffer, count, datatype, 0, comm_ptr, node_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
+        }
+    } else {    /* (nbytes > MPIR_CVAR_BCAST_SHORT_MSG_SIZE) && (comm_ptr->size >= MPIR_CVAR_BCAST_MIN_PROCS) */
+
+        /* supposedly...
+         * smp+doubling good for pof2
+         * reg+ring better for non-pof2 */
+        if (nbytes < MPIR_CVAR_BCAST_LONG_MSG_SIZE && MPL_is_pof2(local_size)) {
+            /* medium-sized msg and pof2 np */
+
+            /* perform the intranode broadcast on the root's node */
+            if (local_size > 1 && local_root_rank > 0) {        /* is not the node root (0) and is on our node (!-1) */
+                /* FIXME binomial may not be the best algorithm for on-node
+                 * bcast.  We need a more comprehensive system for selecting the
+                 * right algorithms here. */
+                mpi_errno = MPIR_Bcast_intra_binomial(buffer, count, datatype, local_root_rank,
+                                                      comm_ptr, node_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
+            }
+
+            /* perform the internode broadcast */
+            if (local_rank == 0) {
+                mpi_errno = MPIR_Bcast_intra_binomial(buffer, count, datatype, inter_root_rank,
+                                                      comm_ptr, node_cross_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
+            }
+
+            /* perform the intranode broadcast on all except for the root's node */
+            if (local_size > 1 && local_root_rank <= 0) {       /* 0 if root was local root too, -1 if different node than root */
+                /* FIXME binomial may not be the best algorithm for on-node
+                 * bcast.  We need a more comprehensive system for selecting the
+                 * right algorithms here. */
+                mpi_errno = MPIR_Bcast_intra_binomial(buffer, count, datatype, 0,
+                                                      comm_ptr, node_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
+            }
+        } else {        /* large msg or non-pof2 */
+
+            /* FIXME It would be good to have an SMP-aware version of this
+             * algorithm that (at least approximately) minimized internode
+             * communication. */
+            mpi_errno = MPIR_Bcast_intra_binomial(buffer, count, datatype, root,
+                                                  comm_ptr, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
+        }
+    }
+
+  fn_exit:
+    return mpi_errno_ret;
+}

--- a/src/mpi/coll/bcast/bcast_intra_smp_new.c
+++ b/src/mpi/coll/bcast/bcast_intra_smp_new.c
@@ -5,6 +5,35 @@
 
 #include "mpiimpl.h"
 
+/* TODO: move this to commutil.c */
+static void MPIR_Comm_construct_internode_roots_group(MPIR_Comm * comm, int root,
+                                                      int *group_p, int *root_rank_p)
+{
+    int inter_size = comm->num_external;
+    int inter_rank = comm->internode_table[comm->rank];
+
+    MPIR_COMM_NEW_SUBGROUP(comm, MPIR_SUBGROUP_TEMP, inter_size, inter_rank);
+    int inter_group = MPIR_COMM_LAST_SUBGROUP(comm);
+
+    int *proc_table = MPL_malloc(inter_size * sizeof(int), MPL_MEM_OTHER);
+    for (int i = 0; i < inter_size; i++) {
+        proc_table[i] = -1;
+    }
+    for (int i = 0; i < comm->remote_size; i++) {
+        int r = comm->internode_table[i];
+        if (proc_table[r] == -1) {
+            proc_table[r] = i;
+        }
+    }
+    int inter_root_rank = comm->internode_table[root];
+    proc_table[inter_root_rank] = root;
+
+    comm->subgroups[inter_group].proc_table = proc_table;
+
+    *group_p = inter_group;
+    *root_rank_p = inter_root_rank;
+}
+
 /* The sticky point in the old smp bcast is when root is not a local root, resulting
  * an extra send/recv. With the new MPIR_Subgroup, we don't have to, in principle.
  */
@@ -14,28 +43,19 @@ int MPIR_Bcast_intra_smp_new(void *buffer, MPI_Aint count, MPI_Datatype datatype
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
     MPI_Aint type_size, nbytes = 0;
-    MPI_Status *status_p;
-#ifdef HAVE_ERROR_CHECKING
-    MPI_Status status;
-    status_p = &status;
-    MPI_Aint recvd_size;
-#else
-    status_p = MPI_STATUS_IGNORE;
-#endif
+    int node_group = -1, inter_group = -1;
 
-    MPIR_Assert(comm_ptr->hierarchy_kind == MPIR_COMM_HIERARCHY_KIND__PARENT);
+    MPIR_Assert(comm_ptr->hierarchy_kind == MPIR_COMM_HIERARCHY_KIND__PARENT ||
+                comm_ptr->hierarchy_kind == MPIR_COMM_HIERARCHY_KIND__FLAT);
     MPIR_Assert(MPIR_COLL_ATTR_GET_SUBGROUP(coll_attr) == 0);
 
-    int node_group = -1, node_cross_group = -1;
     for (int i = 0; i < comm_ptr->num_subgroups; i++) {
         if (comm_ptr->subgroups[i].kind == MPIR_SUBGROUP_NODE) {
             node_group = i;
-        }
-        if (comm_ptr->subgroups[i].kind == MPIR_SUBGROUP_NODE_CROSS) {
-            node_cross_group = i;
+            break;
         }
     }
-    MPIR_Assert(node_group > 0 && node_cross_group > 0);
+    MPIR_Assert(node_group > 0);
 
 #define NODEGROUP(field) comm_ptr->subgroups[node_group].field
     int local_rank, local_size;
@@ -43,9 +63,22 @@ int MPIR_Bcast_intra_smp_new(void *buffer, MPI_Aint count, MPI_Datatype datatype
     local_size = NODEGROUP(size);
 
     int local_root_rank = MPIR_Get_intranode_rank(comm_ptr, root);
-    int inter_root_rank = MPIR_Get_internode_rank(comm_ptr, root);
+
+    int local_root = 0;
+    if (local_root_rank > 0) {
+        local_root = local_root_rank;
+    }
+
+    /* Construct an internode group */
+    int inter_root_rank = -1;
+#define INTERGROUP(field) comm_ptr->subgroups[inter_group].field
+    if (local_rank == local_root) {
+        MPIR_Comm_construct_internode_roots_group(comm_ptr, root, &inter_group, &inter_root_rank);
+        MPIR_Assert(inter_group > 0);
+    }
+
     int node_attr = coll_attr | MPIR_COLL_ATTR_SUBGROUP(node_group);
-    int node_cross_attr = coll_attr | MPIR_COLL_ATTR_SUBGROUP(node_cross_group);
+    int inter_attr = coll_attr | MPIR_COLL_ATTR_SUBGROUP(inter_group);
 
     MPIR_Datatype_get_size_macro(datatype, type_size);
 
@@ -53,84 +86,31 @@ int MPIR_Bcast_intra_smp_new(void *buffer, MPI_Aint count, MPI_Datatype datatype
     if (nbytes == 0)
         goto fn_exit;   /* nothing to do */
 
-    if ((nbytes < MPIR_CVAR_BCAST_SHORT_MSG_SIZE) || (local_size < MPIR_CVAR_BCAST_MIN_PROCS)) {
-        /* send to intranode-rank 0 on the root's node */
-        if (local_size > 1 && local_root_rank > 0) {
-            if (root == comm_ptr->rank) {
-                int node_root = NODEGROUP(proc_table)[0];
-                mpi_errno = MPIC_Send(buffer, count, datatype, node_root, MPIR_BCAST_TAG, comm_ptr,
-                                      coll_attr);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
-            } else if (local_rank == 0) {
-                mpi_errno = MPIC_Recv(buffer, count, datatype, root, MPIR_BCAST_TAG, comm_ptr,
-                                      coll_attr, status_p);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
-#ifdef HAVE_ERROR_CHECKING
-                /* check that we received as much as we expected */
-                MPIR_Get_count_impl(status_p, MPI_BYTE, &recvd_size);
-                MPIR_ERR_COLL_CHECK_SIZE(recvd_size, nbytes, coll_attr, mpi_errno_ret);
-#endif
-            }
-
-        }
-
+    if ((nbytes < MPIR_CVAR_BCAST_SHORT_MSG_SIZE) || (local_size < MPIR_CVAR_BCAST_MIN_PROCS) ||
+        (nbytes < MPIR_CVAR_BCAST_LONG_MSG_SIZE && MPL_is_pof2(local_size))) {
         /* perform the internode broadcast */
-        if (local_rank == 0) {
+        if (local_rank == local_root) {
             mpi_errno = MPIR_Bcast_intra_binomial(buffer, count, datatype, inter_root_rank,
-                                                  comm_ptr, node_cross_attr);
+                                                  comm_ptr, inter_attr);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         /* perform the intranode broadcast */
         if (local_size > 1) {
-            mpi_errno = MPIR_Bcast_intra_binomial(buffer, count, datatype, 0, comm_ptr, node_attr);
+            mpi_errno = MPIR_Bcast_intra_binomial(buffer, count, datatype, local_root,
+                                                  comm_ptr, node_attr);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
-    } else {    /* (nbytes > MPIR_CVAR_BCAST_SHORT_MSG_SIZE) && (comm_ptr->size >= MPIR_CVAR_BCAST_MIN_PROCS) */
-
-        /* supposedly...
-         * smp+doubling good for pof2
-         * reg+ring better for non-pof2 */
-        if (nbytes < MPIR_CVAR_BCAST_LONG_MSG_SIZE && MPL_is_pof2(local_size)) {
-            /* medium-sized msg and pof2 np */
-
-            /* perform the intranode broadcast on the root's node */
-            if (local_size > 1 && local_root_rank > 0) {        /* is not the node root (0) and is on our node (!-1) */
-                /* FIXME binomial may not be the best algorithm for on-node
-                 * bcast.  We need a more comprehensive system for selecting the
-                 * right algorithms here. */
-                mpi_errno = MPIR_Bcast_intra_binomial(buffer, count, datatype, local_root_rank,
-                                                      comm_ptr, node_attr);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
-            }
-
-            /* perform the internode broadcast */
-            if (local_rank == 0) {
-                mpi_errno = MPIR_Bcast_intra_binomial(buffer, count, datatype, inter_root_rank,
-                                                      comm_ptr, node_cross_attr);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
-            }
-
-            /* perform the intranode broadcast on all except for the root's node */
-            if (local_size > 1 && local_root_rank <= 0) {       /* 0 if root was local root too, -1 if different node than root */
-                /* FIXME binomial may not be the best algorithm for on-node
-                 * bcast.  We need a more comprehensive system for selecting the
-                 * right algorithms here. */
-                mpi_errno = MPIR_Bcast_intra_binomial(buffer, count, datatype, 0,
-                                                      comm_ptr, node_attr);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
-            }
-        } else {        /* large msg or non-pof2 */
-
-            /* FIXME It would be good to have an SMP-aware version of this
-             * algorithm that (at least approximately) minimized internode
-             * communication. */
-            mpi_errno = MPIR_Bcast_intra_binomial(buffer, count, datatype, root,
-                                                  comm_ptr, coll_attr);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
-        }
+    } else {
+        /* large msg or non-pof2 */
+        /* FIXME: better algorithm selection */
+        mpi_errno = MPIR_Bcast_intra_binomial(buffer, count, datatype, root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:
+    if (inter_group > 0) {
+        MPIR_COMM_POP_SUBGROUP(comm_ptr);
+    }
     return mpi_errno_ret;
 }

--- a/src/mpi/coll/bcast/bcast_intra_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_tree.c
@@ -13,7 +13,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
                           MPI_Aint count,
                           MPI_Datatype datatype,
                           int root, MPIR_Comm * comm_ptr, int tree_type,
-                          int branching_factor, int is_nb, MPIR_Errflag_t errflag)
+                          int branching_factor, int is_nb, int coll_attr)
 {
     int rank, comm_size, src, dst, *p, j, k, lrank, is_contig;
     int parent = -1, num_children = 0, num_req = 0, is_root = 0;
@@ -131,10 +131,10 @@ int MPIR_Bcast_intra_tree(void *buffer,
         || (!is_root && tree_type == MPIR_TREE_TYPE_KARY)) {
         src = parent;
         mpi_errno = MPIC_Recv(send_buf, count, dtype, src, MPIR_BCAST_TAG, comm_ptr, &status);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         /* check that we received as much as we expected */
         MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
-        MPIR_ERR_COLL_CHECK_SIZE(recvd_size, nbytes, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECK_SIZE(recvd_size, nbytes, coll_attr, mpi_errno_ret);
     }
     if (tree_type == MPIR_TREE_TYPE_KARY) {
         for (k = 1; k <= branching_factor; k++) {       /* Send to children */
@@ -146,12 +146,12 @@ int MPIR_Bcast_intra_tree(void *buffer,
 
             if (!is_nb) {
                 mpi_errno =
-                    MPIC_Send(send_buf, count, dtype, dst, MPIR_BCAST_TAG, comm_ptr, errflag);
+                    MPIC_Send(send_buf, count, dtype, dst, MPIR_BCAST_TAG, comm_ptr, coll_attr);
             } else {
                 mpi_errno = MPIC_Isend(send_buf, count, dtype, dst,
-                                       MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++], errflag);
+                                       MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++], coll_attr);
             }
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     } else {
         for (j = 0; j < num_children; j++) {
@@ -160,17 +160,17 @@ int MPIR_Bcast_intra_tree(void *buffer,
 
             if (!is_nb) {
                 mpi_errno =
-                    MPIC_Send(send_buf, count, dtype, dst, MPIR_BCAST_TAG, comm_ptr, errflag);
+                    MPIC_Send(send_buf, count, dtype, dst, MPIR_BCAST_TAG, comm_ptr, coll_attr);
             } else {
                 mpi_errno = MPIC_Isend(send_buf, count, dtype, dst,
-                                       MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++], errflag);
+                                       MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++], coll_attr);
             }
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
     if (is_nb) {
         mpi_errno = MPIC_Waitall(num_req, reqs, statuses);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     if (tree_type != MPIR_TREE_TYPE_KARY)

--- a/src/mpi/coll/bcast/bcast_intra_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_tree.c
@@ -130,7 +130,8 @@ int MPIR_Bcast_intra_tree(void *buffer,
     if ((parent != -1 && tree_type != MPIR_TREE_TYPE_KARY)
         || (!is_root && tree_type == MPIR_TREE_TYPE_KARY)) {
         src = parent;
-        mpi_errno = MPIC_Recv(send_buf, count, dtype, src, MPIR_BCAST_TAG, comm_ptr, &status);
+        mpi_errno = MPIC_Recv(send_buf, count, dtype, src, MPIR_BCAST_TAG, comm_ptr,
+                              coll_attr, &status);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         /* check that we received as much as we expected */
         MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);

--- a/src/mpi/coll/bcast/bcast_utils.c
+++ b/src/mpi/coll/bcast/bcast_utils.c
@@ -67,7 +67,8 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
             } else {
                 mpi_errno = MPIC_Recv(((char *) tmp_buf +
                                        relative_rank * scatter_size),
-                                      recv_size, MPI_BYTE, src, MPIR_BCAST_TAG, comm_ptr, &status);
+                                      recv_size, MPI_BYTE, src, MPIR_BCAST_TAG, comm_ptr,
+                                      coll_attr, &status);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 if (mpi_errno) {
                     curr_size = 0;

--- a/src/mpi/coll/bcast/bcast_utils.c
+++ b/src/mpi/coll/bcast/bcast_utils.c
@@ -21,7 +21,7 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
                            MPI_Datatype datatype ATTRIBUTE((unused)),
                            int root,
                            MPIR_Comm * comm_ptr,
-                           MPI_Aint nbytes, void *tmp_buf, int is_contig, MPIR_Errflag_t errflag)
+                           MPI_Aint nbytes, void *tmp_buf, int is_contig, int coll_attr)
 {
     MPI_Status status;
     int rank, comm_size, src, dst;
@@ -68,7 +68,7 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
                 mpi_errno = MPIC_Recv(((char *) tmp_buf +
                                        relative_rank * scatter_size),
                                       recv_size, MPI_BYTE, src, MPIR_BCAST_TAG, comm_ptr, &status);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 if (mpi_errno) {
                     curr_size = 0;
                 } else
@@ -97,8 +97,9 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
                     dst -= comm_size;
                 mpi_errno = MPIC_Send(((char *) tmp_buf +
                                        scatter_size * (relative_rank + mask)),
-                                      send_size, MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      send_size, MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr,
+                                      coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                 curr_size -= send_size;
             }

--- a/src/mpi/coll/coll_algorithms.txt
+++ b/src/mpi/coll/coll_algorithms.txt
@@ -68,6 +68,7 @@ bcast-intra:
     scatter_ring_allgather
     smp
         restrictions: parent-comm
+    smp_new
     tree
         extra_params: tree_type, k, is_non_blocking
         cvar_params: TREE_TYPE, TREE_KVAL, IS_NON_BLOCKING

--- a/src/mpi/coll/cvars.txt
+++ b/src/mpi/coll/cvars.txt
@@ -198,6 +198,7 @@ cvars:
         binomial                                - Force Binomial Tree
         nb                                      - Force nonblocking algorithm
         smp                                     - Force smp algorithm
+        smp_new                                 - Force smp_new algorithm
         scatter_recursive_doubling_allgather    - Force Scatter Recursive-Doubling Allgather
         scatter_ring_allgather                  - Force Scatter Ring
         pipelined_tree                          - Force tree-based pipelined algorithm

--- a/src/mpi/coll/exscan/exscan_allcomm_nb.c
+++ b/src/mpi/coll/exscan/exscan_allcomm_nb.c
@@ -6,8 +6,7 @@
 #include "mpiimpl.h"
 
 int MPIR_Exscan_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
-                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                           MPIR_Errflag_t errflag)
+                           MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
@@ -48,7 +48,7 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
                                          void *recvbuf,
                                          MPI_Aint count,
                                          MPI_Datatype datatype,
-                                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                         MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     MPI_Status status;
     int rank, comm_size;
@@ -93,8 +93,8 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
             mpi_errno = MPIC_Sendrecv(partial_scan, count, datatype,
                                       dst, MPIR_EXSCAN_TAG, tmp_buf,
                                       count, datatype, dst,
-                                      MPIR_EXSCAN_TAG, comm_ptr, &status, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      MPIR_EXSCAN_TAG, comm_ptr, &status, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             if (rank > dst) {
                 mpi_errno = MPIR_Reduce_local(tmp_buf, partial_scan, count, datatype, op);

--- a/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
@@ -59,7 +59,7 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
     void *partial_scan, *tmp_buf;
     MPIR_CHKLMEM_DECL(2);
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
     is_commutative = MPIR_Op_is_commutative(op);
 

--- a/src/mpi/coll/gather/gather_allcomm_nb.c
+++ b/src/mpi/coll/gather/gather_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Gather_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                            void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                           MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                           MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/gather/gather_inter_linear.c
+++ b/src/mpi/coll/gather/gather_inter_linear.c
@@ -15,7 +15,7 @@
 
 int MPIR_Gather_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                              void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                             MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                             MPIR_Comm * comm_ptr, int coll_attr)
 {
     int remote_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -37,12 +37,12 @@ int MPIR_Gather_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Dataty
             mpi_errno =
                 MPIC_Recv(((char *) recvbuf + recvcount * i * extent), recvcount, recvtype, i,
                           MPIR_GATHER_TAG, comm_ptr, &status);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     } else {
         mpi_errno =
-            MPIC_Send(sendbuf, sendcount, sendtype, root, MPIR_GATHER_TAG, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIC_Send(sendbuf, sendcount, sendtype, root, MPIR_GATHER_TAG, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     return mpi_errno_ret;

--- a/src/mpi/coll/gather/gather_inter_linear.c
+++ b/src/mpi/coll/gather/gather_inter_linear.c
@@ -36,7 +36,7 @@ int MPIR_Gather_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Dataty
         for (i = 0; i < remote_size; i++) {
             mpi_errno =
                 MPIC_Recv(((char *) recvbuf + recvcount * i * extent), recvcount, recvtype, i,
-                          MPIR_GATHER_TAG, comm_ptr, &status);
+                          MPIR_GATHER_TAG, comm_ptr, coll_attr, &status);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     } else {

--- a/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
+++ b/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
@@ -36,7 +36,7 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sen
         /* root receives data from rank 0 on remote group */
         mpi_errno =
             MPIC_Recv(recvbuf, recvcount * remote_size, recvtype, 0, MPIR_GATHER_TAG, comm_ptr,
-                      &status);
+                      coll_attr, &status);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         /* remote group. Rank 0 allocates temporary buffer, does

--- a/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
+++ b/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
@@ -16,7 +16,7 @@
 int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sendcount,
                                                MPI_Datatype sendtype, void *recvbuf,
                                                MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                               MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, local_size, remote_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -37,7 +37,7 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sen
         mpi_errno =
             MPIC_Recv(recvbuf, recvcount * remote_size, recvtype, 0, MPIR_GATHER_TAG, comm_ptr,
                       &status);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         /* remote group. Rank 0 allocates temporary buffer, does
          * local intracommunicator gather, and then sends the data
@@ -68,13 +68,13 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sen
         /* now do the a local gather on this intracommunicator */
         mpi_errno = MPIR_Gather(sendbuf, sendcount, sendtype,
                                 tmp_buf, sendcount * sendtype_sz, MPI_BYTE, 0, newcomm_ptr,
-                                errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         if (rank == 0) {
             mpi_errno = MPIC_Send(tmp_buf, sendcount * local_size * sendtype_sz, MPI_BYTE,
-                                  root, MPIR_GATHER_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  root, MPIR_GATHER_TAG, comm_ptr, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -58,7 +58,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
     MPIR_CHKLMEM_DECL(1);
 
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
     /* Use binomial tree algorithm. */
 

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -39,7 +39,7 @@ cvars:
  */
 int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                               MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
@@ -139,13 +139,13 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                                                   mask) % comm_size) * (MPI_Aint) recvcount *
                                                 extent)), (MPI_Aint) recvblks * recvcount,
                                               recvtype, src, MPIR_GATHER_TAG, comm_ptr, &status);
-                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
                         /* small transfer size case. cast ok */
                         MPIR_Assert(recvblks * nbytes == (int) (recvblks * nbytes));
                         mpi_errno = MPIC_Recv(tmp_buf, (int) (recvblks * nbytes),
                                               MPI_BYTE, src, MPIR_GATHER_TAG, comm_ptr, &status);
-                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                         copy_offset = rank + mask;
                         copy_blks = recvblks;
                     } else {
@@ -165,7 +165,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
 
                         mpi_errno = MPIC_Recv(recvbuf, 1, tmp_type, src,
                                               MPIR_GATHER_TAG, comm_ptr, &status);
-                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                         MPIR_Type_free_impl(&tmp_type);
                     }
@@ -186,7 +186,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset),
                                           recvblks * nbytes, MPI_BYTE, src,
                                           MPIR_GATHER_TAG, comm_ptr, &status);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     curr_cnt += (recvblks * nbytes);
                 }
             }
@@ -197,12 +197,12 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
             if (!tmp_buf_size) {
                 /* leaf nodes send directly from sendbuf */
                 mpi_errno = MPIC_Send(sendbuf, sendcount, sendtype, dst,
-                                      MPIR_GATHER_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      MPIR_GATHER_TAG, comm_ptr, coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
                 mpi_errno = MPIC_Send(tmp_buf, curr_cnt, MPI_BYTE, dst,
-                                      MPIR_GATHER_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      MPIR_GATHER_TAG, comm_ptr, coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             } else {
                 MPI_Aint blocks[2];
                 MPI_Aint struct_displs[2];
@@ -226,8 +226,8 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                 MPIR_ERR_CHECK(mpi_errno);
 
                 mpi_errno = MPIC_Send(MPI_BOTTOM, 1, tmp_type, dst,
-                                      MPIR_GATHER_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      MPIR_GATHER_TAG, comm_ptr, coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 MPIR_Type_free_impl(&tmp_type);
                 if (types[1] != MPI_BYTE)
                     MPIR_Type_free_impl(&types[1]);

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -138,13 +138,15 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                                                (((rank +
                                                   mask) % comm_size) * (MPI_Aint) recvcount *
                                                 extent)), (MPI_Aint) recvblks * recvcount,
-                                              recvtype, src, MPIR_GATHER_TAG, comm_ptr, &status);
+                                              recvtype, src, MPIR_GATHER_TAG, comm_ptr,
+                                              coll_attr, &status);
                         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
                         /* small transfer size case. cast ok */
                         MPIR_Assert(recvblks * nbytes == (int) (recvblks * nbytes));
                         mpi_errno = MPIC_Recv(tmp_buf, (int) (recvblks * nbytes),
-                                              MPI_BYTE, src, MPIR_GATHER_TAG, comm_ptr, &status);
+                                              MPI_BYTE, src, MPIR_GATHER_TAG, comm_ptr,
+                                              coll_attr, &status);
                         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                         copy_offset = rank + mask;
                         copy_blks = recvblks;
@@ -164,7 +166,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                         MPIR_ERR_CHECK(mpi_errno);
 
                         mpi_errno = MPIC_Recv(recvbuf, 1, tmp_type, src,
-                                              MPIR_GATHER_TAG, comm_ptr, &status);
+                                              MPIR_GATHER_TAG, comm_ptr, coll_attr, &status);
                         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                         MPIR_Type_free_impl(&tmp_type);
@@ -185,7 +187,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                         offset = (mask - 1) * nbytes;
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset),
                                           recvblks * nbytes, MPI_BYTE, src,
-                                          MPIR_GATHER_TAG, comm_ptr, &status);
+                                          MPIR_GATHER_TAG, comm_ptr, coll_attr, &status);
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     curr_cnt += (recvblks * nbytes);
                 }

--- a/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
@@ -42,7 +42,7 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
                                 const MPI_Aint * recvcounts,
                                 const MPI_Aint * displs,
                                 MPI_Datatype recvtype,
-                                int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
@@ -89,7 +89,7 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
         }
         /* ... then wait for *all* of them to finish: */
         mpi_errno = MPIC_Waitall(reqs, reqarray, starray);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     else if (root != MPI_PROC_NULL) {   /* non-root nodes, and in the intercomm. case, non-root nodes on remote side */
@@ -108,12 +108,12 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
 
             if (comm_size >= min_procs) {
                 mpi_errno = MPIC_Ssend(sendbuf, sendcount, sendtype, root,
-                                       MPIR_GATHERV_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                       MPIR_GATHERV_TAG, comm_ptr, coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             } else {
                 mpi_errno = MPIC_Send(sendbuf, sendcount, sendtype, root,
-                                      MPIR_GATHERV_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      MPIR_GATHERV_TAG, comm_ptr, coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
@@ -82,7 +82,8 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
                 } else {
                     mpi_errno = MPIC_Irecv(((char *) recvbuf + displs[i] * extent),
                                            recvcounts[i], recvtype, i,
-                                           MPIR_GATHERV_TAG, comm_ptr, &reqarray[reqs++]);
+                                           MPIR_GATHERV_TAG, comm_ptr,
+                                           coll_attr, &reqarray[reqs++]);
                     MPIR_ERR_CHECK(mpi_errno);
                 }
             }

--- a/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
@@ -54,7 +54,7 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
     MPI_Status *starray;
     MPIR_CHKLMEM_DECL(2);
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
     /* If rank == root, then I recv lots, otherwise I send */
     if (((comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) && (root == rank)) ||

--- a/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_nb.c
@@ -7,8 +7,7 @@
 
 int MPIR_Gatherv_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                             void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
-                            MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr,
-                            MPIR_Errflag_t errflag)
+                            MPI_Datatype recvtype, int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -168,7 +168,7 @@ int MPIC_Send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, 
 }
 
 int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int tag,
-              MPIR_Comm * comm_ptr, MPI_Status * status)
+              MPIR_Comm * comm_ptr, int coll_attr, MPI_Status * status)
 {
     int mpi_errno = MPI_SUCCESS;
     int attr = 0;
@@ -511,7 +511,7 @@ int MPIC_Issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest
 }
 
 int MPIC_Irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source,
-               int tag, MPIR_Comm * comm_ptr, MPIR_Request ** request_ptr)
+               int tag, MPIR_Comm * comm_ptr, int coll_attr, MPIR_Request ** request_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     int attr = 0;

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -127,7 +127,7 @@ int MPIC_Wait(MPIR_Request * request_ptr)
    this is OK since there is no data that can be received corrupted. */
 
 int MPIC_Send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-              MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+              MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     int attr = 0;
@@ -144,7 +144,7 @@ int MPIC_Send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, 
                          "**countneg", "**countneg %d", count);
 
     MPIR_PT2PT_ATTR_SET_CONTEXT_OFFSET(attr, MPIR_CONTEXT_COLL_OFFSET);
-    MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
+    MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, coll_attr);
 
     DO_MPID_ISEND(buf, count, datatype, dest, tag, comm_ptr, attr, &request_ptr);
     MPIR_ERR_CHECK(mpi_errno);
@@ -216,7 +216,7 @@ int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int 
 }
 
 int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+               MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     int attr = 0;
@@ -233,7 +233,7 @@ int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
                          "**countneg", "**countneg %d", count);
 
     MPIR_PT2PT_ATTR_SET_CONTEXT_OFFSET(attr, MPIR_CONTEXT_COLL_OFFSET);
-    MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
+    MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, coll_attr);
     MPIR_PT2PT_ATTR_SET_SYNCFLAG(attr);
 
     DO_MPID_ISEND(buf, count, datatype, dest, tag, comm_ptr, attr, &request_ptr);
@@ -260,7 +260,7 @@ int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
 int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                   int dest, int sendtag, void *recvbuf, MPI_Aint recvcount,
                   MPI_Datatype recvtype, int source, int recvtag,
-                  MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t errflag)
+                  MPIR_Comm * comm_ptr, MPI_Status * status, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     int attr = 0;
@@ -296,7 +296,7 @@ int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype
         MPIR_ERR_CHKANDSTMT(send_req_ptr == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
                             "**nomemreq");
     } else {
-        MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
+        MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, coll_attr);
         DO_MPID_ISEND(sendbuf, sendcount, sendtype, dest, sendtag, comm_ptr, attr, &send_req_ptr);
         MPIR_ERR_CHECK(mpi_errno);
     }
@@ -339,7 +339,7 @@ int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype
 int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
                           int dest, int sendtag,
                           int source, int recvtag,
-                          MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t errflag)
+                          MPIR_Comm * comm_ptr, MPI_Status * status, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPI_Status mystatus;
@@ -358,7 +358,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
 
     if (status == MPI_STATUS_IGNORE)
         status = &mystatus;
-    switch (errflag) {
+    switch (coll_attr) {
         case MPIR_ERR_NONE:
             break;
         case MPIR_ERR_PROC_FAILED:
@@ -396,7 +396,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
         sreq = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
         MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     } else {
-        MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
+        MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, coll_attr);
         DO_MPID_ISEND(tmpbuf, actual_pack_bytes, MPI_PACKED, dest, sendtag, comm_ptr, attr, &sreq);
         MPIR_ERR_CHECK(mpi_errno);
         if (mpi_errno != MPI_SUCCESS) {
@@ -442,7 +442,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
 }
 
 int MPIC_Isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-               MPIR_Comm * comm_ptr, MPIR_Request ** request_ptr, MPIR_Errflag_t errflag)
+               MPIR_Comm * comm_ptr, MPIR_Request ** request_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     int attr = 0;
@@ -461,7 +461,7 @@ int MPIC_Isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
                          "**countneg", "**countneg %d", count);
 
     MPIR_PT2PT_ATTR_SET_CONTEXT_OFFSET(attr, MPIR_CONTEXT_COLL_OFFSET);
-    MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
+    MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, coll_attr);
 
     DO_MPID_ISEND(buf, count, datatype, dest, tag, comm_ptr, attr, request_ptr);
     MPIR_ERR_CHECK(mpi_errno);
@@ -476,7 +476,7 @@ int MPIC_Isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
 }
 
 int MPIC_Issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-                MPIR_Comm * comm_ptr, MPIR_Request ** request_ptr, MPIR_Errflag_t errflag)
+                MPIR_Comm * comm_ptr, MPIR_Request ** request_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     int attr = 0;
@@ -495,7 +495,7 @@ int MPIC_Issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest
                          "**countneg", "**countneg %d", count);
 
     MPIR_PT2PT_ATTR_SET_CONTEXT_OFFSET(attr, MPIR_CONTEXT_COLL_OFFSET);
-    MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
+    MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, coll_attr);
     MPIR_PT2PT_ATTR_SET_SYNCFLAG(attr);
 
     DO_MPID_ISEND(buf, count, datatype, dest, tag, comm_ptr, attr, request_ptr);
@@ -569,7 +569,7 @@ int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status * statuses)
     mpi_errno = MPIR_Waitall(numreq, requests, status_array);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* The errflag value here is for all requests, not just a single one.  If
+    /* The coll_attr value here is for all requests, not just a single one.  If
      * in the future, this function is used for multiple collectives at a
      * single time, we may have to change that. */
     for (i = 0; i < numreq; ++i) {

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks.c
@@ -19,7 +19,7 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
     int n_invtcs;
     int tag;
     int src, dst, p_of_k = 0;   /* Largest power of k that is (strictly) smaller than 'size' */
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     int rank = MPIR_Comm_rank(comm);
     int size = MPIR_Comm_size(comm);
@@ -85,10 +85,10 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                              recvcount, recvtype, sched, 0, NULL, &vtx_id);
     }
 
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     /* All following sends/recvs and copies depend on this dtcopy */
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     n_invtcs = 0;
     for (i = 0; i < nphases; i++) {
@@ -119,7 +119,7 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                 MPIR_TSP_sched_irecv((char *) tmp_recvbuf + j * recvcount * delta * recvtype_extent,
                                      count, recvtype, src, tag, comm, sched, 0, NULL, &vtx_id);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             recv_id[i_recv++] = vtx_id;
             /* Send from the start of recv till `count` amount of data. */
             if (i == 0)
@@ -129,13 +129,13 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
             else
                 mpi_errno = MPIR_TSP_sched_isend(tmp_recvbuf, count, recvtype, dst, tag,
                                                  comm, sched, n_invtcs, recv_id, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
         n_invtcs += (k - 1);
         delta *= k;
     }
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     if (rank != 0) {    /* No shift required for rank 0 */
         mpi_errno =
@@ -143,12 +143,12 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                      (size - rank) * recvcount * recvtype_extent, rank * recvcount,
                                      recvtype, (char *) recvbuf, rank * recvcount, recvtype, sched,
                                      0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         mpi_errno =
             MPIR_TSP_sched_localcopy((char *) tmp_recvbuf, (size - rank) * recvcount, recvtype,
                                      (char *) recvbuf + rank * recvcount * recvtype_extent,
                                      (size - rank) * recvcount, recvtype, sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch.c
@@ -74,7 +74,7 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step1(int step1_sendto, int *
 
     MPIR_FUNC_ENTER;
 
-    if (step1_sendto != -1) {   /* non-participating rank sends the data to a partcipating rank */
+    if (step1_sendto != -1) {   /* non-participating rank sends the data to a participating rank */
         void *buf_to_send;
         MPI_Aint send_offset = rank * recv_extent * recvcount;
         if (is_inplace)

--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch.c
@@ -18,7 +18,7 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_data_exchange(int rank, int n
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int partner, offset, count, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -36,7 +36,7 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_data_exchange(int rank, int n
             MPIR_TSP_sched_isend(((char *) recvbuf + send_offset), count * recvcount, recvtype,
                                  partner, tag, comm, sched, 0, NULL, &vtx_id);
 
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         /* calculate offset and count of the data to be received from the partner */
         MPII_Recexchalgo_get_count_and_offset(partner, 0, k, nranks, &count, &offset);
@@ -48,7 +48,7 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_data_exchange(int rank, int n
         mpi_errno =
             MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), count * recvcount, recvtype,
                                  partner, tag, comm, sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     MPIR_FUNC_EXIT;
@@ -69,7 +69,7 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step1(int step1_sendto, int *
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i;
     int vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
 
     MPIR_FUNC_ENTER;
@@ -84,14 +84,14 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step1(int step1_sendto, int *
         mpi_errno =
             MPIR_TSP_sched_isend(buf_to_send, recvcount, recvtype, step1_sendto, tag, comm, sched,
                                  0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets the data from non-participating rank */
             MPI_Aint recv_offset = step1_recvfrom[i] * recv_extent * recvcount;
             mpi_errno = MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), recvcount, recvtype,
                                              step1_recvfrom[i], tag, comm, sched, n_invtcs, invtx,
                                              &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 
@@ -114,7 +114,7 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step2(int step1_sendto, int s
     int phase, i, j, count, nbr, offset, rank_for_offset;
     int *recv_id = *recv_id_;
     int nrecvs = 0, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
 
     MPIR_FUNC_ENTER;
@@ -138,7 +138,7 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step2(int step1_sendto, int s
             mpi_errno =
                 MPIR_TSP_sched_isend(((char *) recvbuf + send_offset), count * recvcount, recvtype,
                                      nbr, tag, comm, sched, nrecvs, recv_id, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST,
                              "phase %d nbr is %d send offset %d count %d depend on %d", phase,
@@ -157,7 +157,7 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step2(int step1_sendto, int s
                 MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), count * recvcount, recvtype,
                                      nbr, tag, comm, sched, 0, NULL, &vtx_id);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             recv_id[j * (k - 1) + i] = vtx_id;
             nrecvs++;
@@ -192,7 +192,7 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step3(int step1_sendto, int *
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -200,13 +200,13 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step3(int step1_sendto, int *
         mpi_errno =
             MPIR_TSP_sched_irecv(recvbuf, recvcount * nranks, recvtype, step1_sendto, tag, comm,
                                  sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     for (i = 0; i < step1_nrecvs; i++) {
         mpi_errno = MPIR_TSP_sched_isend(recvbuf, recvcount * nranks, recvtype, step1_recvfrom[i],
                                          tag, comm, sched, nrecvs, recv_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     MPIR_FUNC_EXIT;
@@ -243,7 +243,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, MPI_Aint sendco
     int nrecvs;
     int *recv_id;
     int tag;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(1);
 
     MPIR_FUNC_ENTER;
@@ -276,7 +276,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, MPI_Aint sendco
             MPIR_TSP_sched_localcopy(sendbuf, recvcount, recvtype,
                                      (char *) recvbuf + rank * recv_extent * recvcount, recvcount,
                                      recvtype, sched, 0, NULL, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         n_invtcs = 1;
         invtx = dtcopy_id;
     } else {
@@ -289,7 +289,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, MPI_Aint sendco
                                                   recv_extent, recvcount, recvtype, n_invtcs,
                                                   &invtx, comm, sched);
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     /* For distance halving algorithm, exchange the data with digit reversed partner
      * so that finally the data is in the correct order. */
@@ -299,7 +299,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, MPI_Aint sendco
                                                                   T, recvbuf, recvtype, recv_extent,
                                                                   recvcount, tag, comm, sched);
             mpi_errno = MPIR_TSP_sched_fence(sched);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring.c
@@ -22,7 +22,7 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
     int is_inplace = (sendbuf == MPI_IN_PLACE);
     int tag;
     int vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPI_Aint recvtype_lb, recvtype_extent;
     MPI_Aint sendtype_lb, sendtype_extent;
@@ -69,7 +69,7 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
                                              (char *) buf1, recvcount, recvtype, sched, 0, NULL,
                                              &dtcopy_id[0]);
     }
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     /* In ring algorithm src and dst are fixed */
     src = (size + rank - 1) % size;
@@ -110,12 +110,12 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
                 vtcs[2] = recv_id[(i - 1) % 3];
             }
         }
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         mpi_errno = MPIR_TSP_sched_irecv((char *) rbuf, recvcount, recvtype,
                                          src, tag, comm, sched, nvtcs, vtcs, &recv_id[i % 3]);
 
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         copy_dst = (size + rank - i - 1) % size;        /* Destination offset of the copy */
         mpi_errno = MPIR_TSP_sched_localcopy((char *) rbuf, recvcount, recvtype,
@@ -124,7 +124,7 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
                                              recvcount, recvtype, sched, 1, &recv_id[i % 3],
                                              &dtcopy_id[i % 3]);
 
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         data_buf = sbuf;
         sbuf = rbuf;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks.c
@@ -56,7 +56,7 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
     int idx = 0, vtx_id;
     int prev_delta = 0;
     int count_length, top_count, bottom_count, left_count;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -201,10 +201,10 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
         mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, sendcount, sendtype, tmp_recvbuf,
                                              recvcounts[rank], recvtype, sched, 0, NULL, &vtx_id);
 
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     idx = 0;
     delta = 1;
@@ -221,7 +221,7 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                 MPIR_TSP_sched_irecv((char *) tmp_recvbuf + recv_index[idx] * recvtype_extent,
                                      r_counts[i][j - 1], recvtype, src, tag, comm, sched, 0, NULL,
                                      &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             recv_id[idx] = vtx_id;
             idx++;
@@ -230,13 +230,13 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
             mpi_errno =
                 MPIR_TSP_sched_isend(tmp_recvbuf, s_counts[i][j - 1], recvtype, dst, tag, comm,
                                      sched, n_invtcs, recv_id, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
         n_invtcs += (k - 1);
         delta *= k;
     }
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     /* No shift required for rank 0 */
     if (rank != 0) {
@@ -252,12 +252,12 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                 MPIR_TSP_sched_localcopy((char *) tmp_recvbuf + bottom_count * recvtype_extent,
                                          top_count, recvtype, recvbuf, top_count, recvtype, sched,
                                          0, NULL, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             mpi_errno = MPIR_TSP_sched_localcopy(tmp_recvbuf, bottom_count, recvtype,
                                                  (char *) recvbuf + top_count * recvtype_extent,
                                                  bottom_count, recvtype, sched, 0, NULL, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         } else {
             for (i = 0; i < size; i++) {
                 src = (rank + i) % size;        /* Rank whose data it is copying */
@@ -267,7 +267,7 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                                      (char *) recvbuf +
                                                      displs[src] * recvtype_extent, recvcounts[src],
                                                      recvtype, sched, 0, NULL, &vtx_id);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
@@ -83,7 +83,7 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_step1(int step1_sendto, int 
 
     MPIR_FUNC_ENTER;
 
-    if (step1_sendto != -1) {   /* non-participating rank sends the data to a partcipating rank */
+    if (step1_sendto != -1) {   /* non-participating rank sends the data to a participating rank */
         void *buf_to_send;
         MPI_Aint send_offset = displs[rank] * recv_extent;
         if (is_inplace)

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
@@ -20,7 +20,7 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int 
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int partner, offset, count;
     int i, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -42,7 +42,7 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int 
         mpi_errno =
             MPIR_TSP_sched_isend(((char *) recvbuf + send_offset), send_count, recvtype, partner,
                                  tag, comm, sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         /* calculate offset and count of the data to be received from the partner */
         MPII_Recexchalgo_get_count_and_offset(partner, 0, k, nranks, &count, &offset);
@@ -56,7 +56,7 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int 
         /* recv data from my partner */
         mpi_errno = MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), recv_count, recvtype,
                                          partner, tag, comm, sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     MPIR_FUNC_EXIT;
@@ -78,7 +78,7 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_step1(int step1_sendto, int 
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
 
     MPIR_FUNC_ENTER;
@@ -93,7 +93,7 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_step1(int step1_sendto, int 
         mpi_errno =
             MPIR_TSP_sched_isend(buf_to_send, recvcounts[rank], recvtype, step1_sendto, tag, comm,
                                  sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets the data from non-participating rank */
             MPI_Aint recv_offset = displs[step1_recvfrom[i]] * recv_extent;
@@ -101,7 +101,7 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_step1(int step1_sendto, int 
                 MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset),
                                      recvcounts[step1_recvfrom[i]], recvtype, step1_recvfrom[i],
                                      tag, comm, sched, n_invtcs, invtx, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 
@@ -127,7 +127,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
     int vtx_id;
     int *recv_id = *recv_id_;
     int nrecvs = 0;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -152,7 +152,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
                 send_count += recvcounts[offset + x];
             mpi_errno = MPIR_TSP_sched_isend(((char *) recvbuf + send_offset), send_count, recvtype,
                                              nbr, tag, comm, sched, nrecvs, recv_id, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST,
                              "phase %d nbr is %d send offset %d count %d depend on %d \n", phase,
@@ -173,7 +173,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
             mpi_errno =
                 MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), recv_count, recvtype,
                                      nbr, tag, comm, sched, 0, NULL, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             recv_id[j * (k - 1) + i] = vtx_id;
             nrecvs++;
@@ -209,7 +209,7 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_step3(int step1_sendto, int 
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     MPI_Aint total_count = 0;
     int i, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -221,13 +221,13 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_step3(int step1_sendto, int 
         mpi_errno =
             MPIR_TSP_sched_irecv(recvbuf, total_count, recvtype, step1_sendto, tag, comm, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     for (i = 0; i < step1_nrecvs; i++) {
         mpi_errno = MPIR_TSP_sched_isend(recvbuf, total_count, recvtype, step1_recvfrom[i],
                                          tag, comm, sched, nrecvs, recv_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     MPIR_FUNC_EXIT;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring.c
@@ -22,7 +22,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
     int send_rank, recv_rank;
     void *data_buf, *buf1, *buf2, *sbuf, *rbuf;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -97,7 +97,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
             mpi_errno =
                 MPIR_TSP_sched_isend(sbuf, recvcounts[send_rank], recvtype, dst, tag, comm, sched,
                                      nvtcs, vtcs, &send_id[i % 3]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             nvtcs = 0;
         } else {
             nvtcs = 2;
@@ -107,7 +107,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
             mpi_errno =
                 MPIR_TSP_sched_isend(sbuf, recvcounts[send_rank], recvtype, dst, tag, comm, sched,
                                      nvtcs, vtcs, &send_id[i % 3]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             if (i == 1) {
                 nvtcs = 2;
@@ -124,14 +124,14 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
         mpi_errno =
             MPIR_TSP_sched_irecv(rbuf, recvcounts[recv_rank], recvtype, src, tag, comm, sched,
                                  nvtcs, vtcs, &recv_id[i % 3]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         /* Copy to correct position in recvbuf */
         mpi_errno =
             MPIR_TSP_sched_localcopy(rbuf, recvcounts[recv_rank], recvtype,
                                      (char *) recvbuf + displs[recv_rank] * extent,
                                      recvcounts[recv_rank], recvtype, sched, 1, &recv_id[i % 3],
                                      &dtcopy_id[i % 3]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         data_buf = sbuf;
         sbuf = rbuf;
@@ -140,7 +140,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
     }
 
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
   fn_exit:
     MPIR_FUNC_EXIT;

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
@@ -35,7 +35,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
     void **step1_recvbuf = NULL;
     void **nbr_buffer;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -68,7 +68,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
     if (in_step2 && !is_inplace && count > 0) { /* copy the data to recvbuf but only if you are a rank participating in Step 2 */
         mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
                                              recvbuf, count, datatype, sched, 0, NULL, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* Step 1 */
@@ -127,7 +127,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
             mpi_errno =
                 MPIR_TSP_sched_localcopy(recvbuf, count, datatype, tmp_buf, count, datatype, sched,
                                          nvtcs, vtcs, &dtcopy_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         }
         /* myidx is the index in the neighbors list such that
@@ -155,7 +155,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
             mpi_errno =
                 MPIR_TSP_sched_isend(tmp_buf, count, datatype, nbr, tag, comm, sched, nvtcs, vtcs,
                                      &send_id[i]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             if (rank > nbr) {
                 myidx = i + 1;
             }
@@ -171,7 +171,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
             mpi_errno =
                 MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, sched, nvtcs,
                                      vtcs, &recv_id[buf]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             if (count != 0) {
                 nvtcs = 1;
@@ -184,7 +184,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                 mpi_errno =
                     MPIR_TSP_sched_reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op,
                                                 sched, nvtcs, vtcs, &reduce_id[counter]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
 
         }
@@ -200,7 +200,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                 MPIR_TSP_sched_irecv(nbr_buffer[buf], count, datatype, nbr, tag, comm, sched, nvtcs,
                                      vtcs, &recv_id[buf]);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             if (count != 0) {
                 nvtcs = 1;
@@ -214,16 +214,16 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
                     mpi_errno =
                         MPIR_TSP_sched_reduce_local(nbr_buffer[buf], recvbuf, count, datatype, op,
                                                     sched, nvtcs, vtcs, &reduce_id[counter]);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 } else {
                     mpi_errno =
                         MPIR_TSP_sched_reduce_local(recvbuf, nbr_buffer[buf], count, datatype, op,
                                                     sched, nvtcs, vtcs, &reduce_id[counter]);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     mpi_errno =
                         MPIR_TSP_sched_localcopy(nbr_buffer[buf], count, datatype, recvbuf, count,
                                                  datatype, sched, 1, &reduce_id[counter], &vtx_id);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                     reduce_id[counter] = vtx_id;
                 }
             }
@@ -236,7 +236,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
         mpi_errno =
             MPIR_TSP_sched_irecv(recvbuf, count, datatype, step1_sendto, tag, comm, sched, 0, NULL,
                                  &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {
             if (count == 0) {
@@ -256,7 +256,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
             mpi_errno =
                 MPIR_TSP_sched_isend(recvbuf, count, datatype, step1_recvfrom[i], tag, comm, sched,
                                      nvtcs, vtcs, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv.c
@@ -38,7 +38,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
     void *tmp_recvbuf;
     void **step1_recvbuf = NULL;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     int allgather_algo_type = MPIR_IALLGATHER_RECEXCH_TYPE_DISTANCE_HALVING;
     int redscat_algo_type = IREDUCE_SCATTER_RECEXCH_TYPE_DISTANCE_HALVING;
     MPIR_CHKLMEM_DECL(2);
@@ -76,7 +76,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
     if (in_step2 && !is_inplace && count > 0) { /* copy the data to tmp_recvbuf but only if you are a rank participating in Step 2 */
         mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
                                              recvbuf, count, datatype, sched, 0, NULL, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After initial dt copy\n"));
 
@@ -141,13 +141,13 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
         mpi_errno =
             MPIR_TSP_sched_irecv(recvbuf, count, datatype, step1_sendto, tag, comm, sched, 1,
                                  &sink_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         for (i = 0; i < step1_nrecvs; i++) {
             mpi_errno =
                 MPIR_TSP_sched_isend(recvbuf, count, datatype, step1_recvfrom[i], tag, comm, sched,
                                      nvtcs, recv_id, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recursive_exchange_common.c
@@ -52,7 +52,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
     int i, nvtcs, vtx_id;
     int mpi_errno_ret = MPI_SUCCESS;
     void **step1_recvbuf;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    int coll_attr = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
     /* Step 1 */
@@ -68,8 +68,8 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
                                  NULL, &vtx_id);
         if (mpi_errno) {
             /* for communication errors, just record the error but continue */
-            errflag = MPIR_ERR_OTHER;
-            MPIR_ERR_SET(mpi_errno, errflag, "**fail");
+            coll_attr = MPIR_ERR_OTHER;
+            MPIR_ERR_SET(mpi_errno, coll_attr, "**fail");
             MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
         }
     } else {    /* Step 2 participating rank */
@@ -98,7 +98,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
             mpi_errno = MPIR_TSP_sched_irecv(step1_recvbuf[i], count, datatype,
                                              step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
                                              &recv_id[i]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             if (count != 0) {   /* Reduce only if data is present */
                 /* setup reduce dependencies */
                 nvtcs = 1;
@@ -117,7 +117,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_step1(const void *sendbuf,
                 mpi_errno = MPIR_TSP_sched_reduce_local(step1_recvbuf[i], recvbuf, count,
                                                         datatype, op, sched, nvtcs, vtcs,
                                                         &reduce_id[i]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_ring.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_ring.c
@@ -25,7 +25,7 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
     int send_rank, recv_rank, total_count;
     void *tmpbuf;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
     MPIR_CHKLMEM_DECL(4);
@@ -67,7 +67,7 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
                                      NULL, &vtx_id);
         MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_TSP_sched_fence(sched);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* Phase 2: Ring based send recv reduce scatter */
@@ -91,7 +91,7 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
         mpi_errno =
             MPIR_TSP_sched_irecv(tmpbuf, cnts[recv_rank], datatype, src, tag, comm, sched, nvtcs,
                                  &vtcs, &recv_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         mpi_errno =
             MPIR_TSP_sched_reduce_local(tmpbuf, (char *) recvbuf + displs[recv_rank] * extent,
@@ -103,12 +103,12 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
         mpi_errno =
             MPIR_TSP_sched_isend((char *) recvbuf + displs[send_rank] * extent, cnts[send_rank],
                                  datatype, dst, tag, comm, sched, nvtcs, &vtcs, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
     MPIR_CHKLMEM_MALLOC(reduce_id, int *, 2 * sizeof(int), mpi_errno, "reduce_id", MPL_MEM_COLL);
 
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     /* Phase 3: Allgatherv ring, so everyone has the reduced data */
     MPIR_TSP_Iallgatherv_sched_intra_ring(MPI_IN_PLACE, -1, MPI_DATATYPE_NULL, recvbuf, cnts,

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree.c
@@ -33,7 +33,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
     int nvtcs;
     int tag, vtx_id;
     int root = 0;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
     MPIR_FUNC_ENTER;
@@ -95,7 +95,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_TSP_sched_localcopy(sendbuf, count, datatype,
                                              recvbuf, count, datatype, sched, 0, NULL, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* initialize arrays to store graph vertex indices */
@@ -142,7 +142,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
             mpi_errno = MPIR_TSP_sched_irecv(recv_address, msgsize, datatype, child, tag, comm,
                                              sched, nvtcs, vtcs, &recv_id[i]);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             /* Setup dependencies for reduction. Reduction depends on the corresponding recv to complete */
             vtcs[0] = recv_id[i];
             nvtcs = 1;
@@ -151,7 +151,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
                 mpi_errno = MPIR_TSP_sched_reduce_local(recv_address, reduce_address, msgsize,
                                                         datatype, op, sched, nvtcs, vtcs,
                                                         &reduce_id[i]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             } else {    /* wait for the previous allreduce to complete */
 
                 /* NOTE: Make sure that knomial tree is being constructed differently for allreduce for optimal performance.
@@ -164,11 +164,11 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
                 mpi_errno =
                     MPIR_TSP_sched_reduce_local(reduce_address, recv_address, msgsize, datatype, op,
                                                 sched, nvtcs, vtcs, &reduce_id[i]);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 mpi_errno =
                     MPIR_TSP_sched_localcopy(recv_address, msgsize, datatype, reduce_address,
                                              msgsize, datatype, sched, 1, &reduce_id[i], &vtx_id);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 reduce_id[i] = vtx_id;
             }
         }
@@ -188,7 +188,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
             mpi_errno =
                 MPIR_TSP_sched_isend(reduce_address, msgsize, datatype, my_tree.parent, tag, comm,
                                      sched, nvtcs, vtcs, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         /* Broadcast start here */
@@ -202,7 +202,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
             mpi_errno =
                 MPIR_TSP_sched_irecv(reduce_address, msgsize, datatype,
                                      my_tree.parent, tag, comm, sched, 1, &sink_id, &bcast_recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         if (num_children) {
@@ -212,7 +212,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
             mpi_errno = MPIR_TSP_sched_imcast(reduce_address, msgsize, datatype,
                                               ut_int_array(my_tree.children), num_children, tag,
                                               comm, sched, nvtcs, vtcs, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         offset += msgsize;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks.c
@@ -53,7 +53,7 @@ brucks_sched_pup(int pack, void *rbuf, void *pupbuf, MPI_Datatype rtype, MPI_Ain
     int sink_id, vtx_id;
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -79,14 +79,14 @@ brucks_sched_pup(int pack, void *rbuf, void *pupbuf, MPI_Datatype rtype, MPI_Ain
                 MPIR_TSP_sched_localcopy((char *) rbuf + offset * count * type_extent, count, rtype,
                                          (char *) pupbuf + *pupsize, count, rtype, sched, ninvtcs,
                                          invtcs, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             dtcopy_id[counter++] = vtx_id;
         } else {
             mpi_errno =
                 MPIR_TSP_sched_localcopy((char *) pupbuf + *pupsize, count, rtype,
                                          (char *) rbuf + offset * count * type_extent, count, rtype,
                                          sched, ninvtcs, invtcs, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             dtcopy_id[counter++] = vtx_id;
         }
 
@@ -102,7 +102,7 @@ brucks_sched_pup(int pack, void *rbuf, void *pupbuf, MPI_Datatype rtype, MPI_Ain
     }
 
     mpi_errno = MPIR_TSP_sched_selective_sink(sched, counter, dtcopy_id, &sink_id);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     MPL_free(dtcopy_id);
 
@@ -136,7 +136,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
     void *tmp_buf = NULL;
     const void *senddata;
     int tag;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_CHKLMEM_DECL(6);
 
@@ -197,7 +197,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
         mpi_errno = MPIR_TSP_sched_localcopy(recvbuf, size * recvcount, recvtype,
                                              tmp_buf, size * recvcount, recvtype, sched, 0, NULL,
                                              &invtcs[0]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         n_invtcs = 1;
         senddata = tmp_buf;
     } else {
@@ -210,15 +210,15 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                          (size - rank) * sendcount, sendtype,
                                          recvbuf, (size - rank) * recvcount, recvtype, sched,
                                          n_invtcs, invtcs, &vtx_id);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     mpi_errno = MPIR_TSP_sched_localcopy(senddata, rank * sendcount, sendtype,
                                          (void *) ((char *) recvbuf +
                                                    (size - rank) * recvcount * r_extent),
                                          rank * recvcount, recvtype, sched, n_invtcs, invtcs,
                                          &vtx_id);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     mpi_errno = MPIR_TSP_sched_fence(sched);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     /* Step 2: Allocate buffer space for packing/receiving data for every phase */
     delta = 1;
@@ -285,7 +285,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
             mpi_errno =
                 MPIR_TSP_sched_isend(tmp_sbuf[i][j - 1], packsize, MPI_BYTE, dst, tag,
                                      comm, sched, 1, &packids[j - 1], &sendids[j - 1]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             if (i != 0 && buffer_per_phase == 0) {      /* this dependency holds only when we don't have dedicated recv buffer per phase */
                 *recv_invtcs = unpackids[j - 1];
@@ -295,7 +295,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                 MPIR_TSP_sched_irecv(tmp_rbuf[i][j - 1], packsize, MPI_BYTE,
                                      src, tag, comm, sched, recv_ninvtcs, recv_invtcs,
                                      &recvids[j - 1]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             *(unpack_invtcs + 1) = recvids[j - 1];
             unpack_ninvtcs = 2;
@@ -322,7 +322,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                  (size - rank - 1) * recvcount, recvtype, tmp_buf,
                                  (size - rank - 1) * recvcount, recvtype, sched,
                                  num_unpacks_in_last_phase, unpackids, &invtcs[0]);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     mpi_errno =
         MPIR_TSP_sched_localcopy(recvbuf, (rank + 1) * recvcount, recvtype,
@@ -330,7 +330,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                            (size - rank - 1) * recvcount * r_extent),
                                  (rank + 1) * recvcount, recvtype, sched, num_unpacks_in_last_phase,
                                  unpackids, &invtcs[1]);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     /* invert the buffer now to get the result in desired order */
     for (i = 0; i < size; i++) {
@@ -340,7 +340,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                                      (void *) ((char *) recvbuf +
                                                (size - i - 1) * recvcount * r_extent), recvcount,
                                      recvtype, sched, 2, invtcs, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring.c
@@ -41,7 +41,7 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
     int i, src, dst, copy_dst;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     /* Temporary buffers to execute the ring algorithm */
     void *buf1, *buf2, *data_buf, *sbuf, *rbuf;
@@ -85,7 +85,7 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
     mpi_errno = MPIR_TSP_sched_localcopy((char *) data_buf, size * recvcount, recvtype,
                                          (char *) buf1, size * recvcount, recvtype, sched, 0,
                                          NULL, &dtcopy_id[0]);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                     (MPL_DBG_FDEST,
@@ -103,7 +103,7 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                                              sendcount, sendtype,
                                              (char *) recvbuf + rank * recvcount * recvtype_extent,
                                              recvcount, recvtype, sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* in ring algorithm, source and destination of messages are fixed */
@@ -134,7 +134,7 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
         mpi_errno =
             MPIR_TSP_sched_isend((char *) sbuf, size * recvcount, recvtype, dst, tag, comm, sched,
                                  nvtcs, vtcs, &send_id[i % 3]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         /* schedule recv */
         if (i == 0)
             nvtcs = 0;
@@ -152,7 +152,7 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
         mpi_errno =
             MPIR_TSP_sched_irecv((char *) rbuf, size * recvcount, recvtype, src, tag, comm, sched,
                                  nvtcs, vtcs, &recv_id[i % 3]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         /* destination offset of the copy */
         copy_dst = (size + rank - i - 1) % size;
@@ -168,7 +168,7 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
                                      recvcount, recvtype, sched, 1, &recv_id[i % 3],
                                      &dtcopy_id[i % 3]);
 
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         /* swap sbuf and rbuf - using data_buf as intermediate buffer */
         data_buf = sbuf;
         sbuf = rbuf;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_scattered.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_scattered.c
@@ -53,7 +53,7 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
     int size, rank, vtx_id;
     int is_inplace;
     int tag = 0;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -99,9 +99,9 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
             MPIR_TSP_sched_localcopy((char *) recvbuf, size * recvcount, recvtype,
                                      (char *) data_buf, size * recvcount, recvtype, sched, 0, NULL,
                                      &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         mpi_errno = MPIR_TSP_sched_fence(sched);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         data_buf = (void *) sendbuf;
     }
@@ -112,13 +112,13 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
         mpi_errno =
             MPIR_TSP_sched_irecv((char *) recvbuf + src * recvcount * recvtype_extent,
                                  recvcount, recvtype, src, tag, comm, sched, 0, NULL, &recv_id[i]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         dst = (rank - i + size) % size;
         mpi_errno =
             MPIR_TSP_sched_isend((char *) data_buf + dst * sendcount * sendtype_extent,
                                  sendcount, sendtype, dst, tag, comm, sched, 0, NULL, &send_id[i]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* Post more send/recv pairs as the previous ones finish */
@@ -133,21 +133,21 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
             vtcs[idx++] = send_id[(i + j) % bblock];
         }
         mpi_errno = MPIR_TSP_sched_selective_sink(sched, 2 * ww, vtcs, &invtcs);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         for (j = 0; j < ww; j++) {
             src = (rank + i + j) % size;
             mpi_errno =
                 MPIR_TSP_sched_irecv((char *) recvbuf + src * recvcount * recvtype_extent,
                                      recvcount, recvtype, src, tag, comm, sched, 1, &invtcs,
                                      &recv_id[(i + j) % bblock]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             dst = (rank - i - j + size) % size;
             mpi_errno =
                 MPIR_TSP_sched_isend((char *) data_buf + dst * sendcount * sendtype_extent,
                                      sendcount, sendtype, dst, tag, comm, sched, 1, &invtcs,
                                      &send_id[(i + j) % bblock]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked.c
@@ -20,7 +20,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
     int nranks, rank;
     int i, j, comm_block, dst;
     int tag = 0, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -58,7 +58,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                 mpi_errno = MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[dst] * recv_extent,
                                                  recvcounts[dst], recvtype, dst, tag, comm, sched,
                                                  0, NULL, &vtx_id);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
 
@@ -68,13 +68,13 @@ int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                 mpi_errno = MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst] * send_extent,
                                                  sendcounts[dst], sendtype, dst, tag, comm, sched,
                                                  0, NULL, &vtx_id);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
 
         /* force our block of sends/recvs to complete before starting the next block */
         mpi_errno = MPIR_TSP_sched_fence(sched);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace.c
@@ -21,7 +21,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
     int i, dst, send_id, recv_id, dtcopy_id = -1, vtcs[2];
     void *tmp_buf = NULL;
     int tag = 0;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -54,12 +54,12 @@ int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
             mpi_errno = MPIR_TSP_sched_isend((char *) recvbuf + rdispls[dst] * recv_extent,
                                              recvcounts[dst], recvtype, dst, tag, comm,
                                              sched, nvtcs, vtcs, &send_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             mpi_errno =
                 MPIR_TSP_sched_irecv(tmp_buf, recvcounts[dst], recvtype, dst, tag, comm,
                                      sched, nvtcs, vtcs, &recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             nvtcs = 2;
             vtcs[0] = send_id;
@@ -68,7 +68,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
                                                  ((char *) recvbuf +
                                                   rdispls[dst] * recv_extent), recvcounts[dst],
                                                  recvtype, sched, nvtcs, vtcs, &dtcopy_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered.c
@@ -21,7 +21,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Ain
     int invtcs;
     int tag;
     int *vtcs, *recv_id, *send_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
     MPIR_Assert(!(sendbuf == MPI_IN_PLACE));
@@ -66,14 +66,14 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Ain
             MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[src] * recvtype_extent,
                                  recvcounts[src], recvtype, src, tag, comm, sched, 0, NULL,
                                  &recv_id[i]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         dst = (rank - i + size) % size;
         mpi_errno =
             MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst] * sendtype_extent,
                                  sendcounts[dst], sendtype, dst, tag, comm, sched, 0, NULL,
                                  &send_id[i]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* Post more send/recv pairs as the previous ones finish */
@@ -88,7 +88,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Ain
             vtcs[i_vtcs++] = send_id[(i + j) % bblock];
         }
         mpi_errno = MPIR_TSP_sched_selective_sink(sched, 2 * ww, vtcs, &invtcs);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         for (j = 0; j < ww; j++) {
             src = (rank + i + j) % size;
@@ -96,14 +96,14 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Ain
                 MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[src] * recvtype_extent,
                                      recvcounts[src], recvtype, src, tag, comm, sched, 1, &invtcs,
                                      &recv_id[(i + j) % bblock]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             dst = (rank - i - j + size) % size;
             mpi_errno =
                 MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst] * sendtype_extent,
                                      sendcounts[dst], sendtype, dst, tag, comm, sched, 1, &invtcs,
                                      &send_id[(i + j) % bblock]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked.c
@@ -20,7 +20,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
     size_t sendtype_size, recvtype_size;
     int nranks, rank;
     int i, j, comm_block, dst;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -50,7 +50,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                     mpi_errno = MPIR_TSP_sched_irecv((char *) recvbuf + rdispls[dst],
                                                      recvcounts[dst], recvtypes[dst], dst, tag,
                                                      comm, sched, 0, NULL, &vtx_id);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
             }
         }
@@ -63,14 +63,14 @@ int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
                     mpi_errno = MPIR_TSP_sched_isend((char *) sendbuf + sdispls[dst],
                                                      sendcounts[dst], sendtypes[dst], dst, tag,
                                                      comm, sched, 0, NULL, &vtx_id);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
             }
         }
 
         /* force our block of sends/recvs to complete before starting the next block */
         mpi_errno = MPIR_TSP_sched_fence(sched);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace.c
@@ -22,7 +22,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
     int nranks, rank, nvtcs;
     int i, dst, send_id, recv_id, dtcopy_id = -1, vtcs[2];
     void *tmp_buf = NULL, *adj_tmp_buf = NULL;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -65,11 +65,11 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
             mpi_errno = MPIR_TSP_sched_isend((char *) recvbuf + rdispls[dst],
                                              recvcounts[dst], recvtypes[dst], dst, tag, comm, sched,
                                              nvtcs, vtcs, &send_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             mpi_errno =
                 MPIR_TSP_sched_irecv(adj_tmp_buf, recvcounts[dst], recvtypes[dst], dst, tag, comm,
                                      sched, nvtcs, vtcs, &recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             nvtcs = 2;
             vtcs[0] = send_id;
@@ -77,7 +77,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
             mpi_errno = MPIR_TSP_sched_localcopy(adj_tmp_buf, recvcounts[dst], recvtypes[dst],
                                                  ((char *) recvbuf + rdispls[dst]), recvcounts[dst],
                                                  recvtypes[dst], sched, nvtcs, vtcs, &dtcopy_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/ibarrier/ibarrier_intra_tsp_dissem.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_tsp_dissem.c
@@ -10,7 +10,7 @@ int MPIR_TSP_Ibarrier_sched_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret ATTRIBUTE((unused)) = MPI_SUCCESS;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     int i, j, nranks, rank;
     int p_of_k, shift, to, from;        /* minimum power of k that is greater than or equal to number of ranks */
     int nphases = 0;
@@ -53,14 +53,14 @@ int MPIR_TSP_Ibarrier_sched_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_
             mpi_errno =
                 MPIR_TSP_sched_irecv(NULL, 0, MPI_BYTE, from, tag, comm, sched, 0, NULL,
                                      &recv_ids[i * (k - 1) + j - 1]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST, "dissem barrier - scheduling send to %d\n", to));
             mpi_errno =
                 MPIR_TSP_sched_isend(NULL, 0, MPI_BYTE, to, tag, comm, sched, i * (k - 1), recv_ids,
                                      &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST, "dissem barrier - scheduled phase %d\n", i));

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
@@ -28,7 +28,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
     int current_child, next_child, lrank, total_count, sink_id;
     int num_children, *child_subtree_size = NULL;
     int num_send_dependencies;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
     /* For correctness, transport based collectives need to get the
@@ -86,7 +86,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
                                          0, NULL, &vtx_id);
             MPIR_ERR_CHECK(mpi_errno);
             mpi_errno = MPIR_TSP_sched_fence(sched);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 
@@ -160,7 +160,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
             MPIR_TSP_sched_irecv((char *) tmp_buf + displs[rank], recv_size, MPI_BYTE,
                                  my_tree.parent, tag, comm, sched, 0, NULL, &recv_id);
 #endif
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "rank:%d posts recv", rank));
 
     }
@@ -177,13 +177,13 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
                                          child_subtree_size[i], MPI_BYTE,
                                          child, tag, comm, sched, num_send_dependencies, &recv_id,
                                          &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
 
     MPIR_Treealgo_tree_free(&my_tree);
     mpi_errno = MPIR_TSP_sched_fence(sched);    /* wait for scatter to complete */
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     if (allgatherv_algo == MPIR_CVAR_IALLGATHERV_INTRA_ALGORITHM_tsp_ring)
         /* Schedule Allgatherv ring */

--- a/src/mpi/coll/ibcast/ibcast_tsp_tree.c
+++ b/src/mpi/coll/ibcast/ibcast_tsp_tree.c
@@ -26,7 +26,7 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype 
     int num_children;
     MPIR_Treealgo_tree_t my_tree;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -73,14 +73,14 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype 
                 MPIR_TSP_sched_irecv_status((char *) buffer + offset * extent, msgsize,
                                             datatype, my_tree.parent, tag, comm,
                                             &ibcast_state->status, sched, 0, NULL, &recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             MPIR_TSP_sched_cb(&MPII_Ibcast_sched_test_length, ibcast_state, sched, 1, &recv_id,
                               &vtx_id);
 #else
             mpi_errno =
                 MPIR_TSP_sched_irecv((char *) buffer + offset * extent, msgsize, datatype,
                                      my_tree.parent, tag, comm, sched, 0, NULL, &recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 #endif
         }
 
@@ -90,7 +90,7 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype 
                                               ut_int_array(my_tree.children), num_children, tag,
                                               comm, sched, (my_tree.parent != -1) ? 1 : 0, &recv_id,
                                               &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
         offset += msgsize;
     }

--- a/src/mpi/coll/igather/igather_tsp_tree.c
+++ b/src/mpi/coll/igather/igather_tsp_tree.c
@@ -26,7 +26,7 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     MPIR_Treealgo_tree_t my_tree, parents_tree;
     int next_child, num_children, *child_subtree_size = NULL;
     int num_dependencies;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPI_Aint *child_data_offset;
     MPIR_CHKLMEM_DECL(3);
 
@@ -138,7 +138,7 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
         mpi_errno =
             MPIR_TSP_sched_isend(tmp_buf, sendcount, sendtype, my_tree.parent, tag, comm, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "rank:%d posts recv\n", rank));
     } else {
         num_dependencies = 0;
@@ -152,7 +152,7 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
             mpi_errno =
                 MPIR_TSP_sched_localcopy(data_buf, sendcount, sendtype,
                                          tmp_buf, recvcount, recvtype, sched, 0, NULL, &dtcopy_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             num_dependencies++;
         }
 
@@ -162,13 +162,13 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
                 MPIR_TSP_sched_irecv((char *) tmp_buf + child_data_offset[i] * recvtype_extent,
                                      child_subtree_size[i] * recvcount, recvtype, child, tag, comm,
                                      sched, num_dependencies, &dtcopy_id, &recv_id[i]);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         if (my_tree.parent != -1) {
             mpi_errno = MPIR_TSP_sched_isend(tmp_buf, recv_size, recvtype, my_tree.parent,
                                              tag, comm, sched, num_children, recv_id, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
     }
@@ -178,12 +178,12 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
                                              (char *) recvbuf + root * recvcount * recvtype_extent,
                                              (size - root) * recvcount, recvtype, sched,
                                              num_children, recv_id, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         mpi_errno =
             MPIR_TSP_sched_localcopy((char *) tmp_buf + (size - root) * recvcount * recvtype_extent,
                                      root * recvcount, recvtype, recvbuf, root * recvcount,
                                      recvtype, sched, 1, &dtcopy_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     MPIR_Treealgo_tree_free(&my_tree);

--- a/src/mpi/coll/igatherv/igatherv_tsp_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_tsp_linear.c
@@ -30,7 +30,7 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcou
     MPI_Aint extent;
     int min_procs;
     int tag;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     rank = comm_ptr->rank;
 
@@ -62,7 +62,7 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcou
                                                      recvcounts[i], recvtype, i, tag, comm_ptr,
                                                      sched, 0, NULL, &vtx_id);
                 }
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
     } else if (root != MPI_PROC_NULL) {
@@ -87,7 +87,7 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcou
                 mpi_errno =
                     MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, root, tag, comm_ptr, sched,
                                          0, NULL, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/include/csel_container.h
+++ b/src/mpi/coll/include/csel_container.h
@@ -57,6 +57,7 @@ typedef enum {
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Bcast_intra_scatter_recursive_doubling_allgather,
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Bcast_intra_scatter_ring_allgather,
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Bcast_intra_smp,
+    MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Bcast_intra_smp_new,
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Bcast_intra_tree,
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Bcast_intra_pipelined_tree,
     MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Bcast_inter_remote_send_local_bcast,

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear.c
@@ -20,7 +20,7 @@ int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, MPI_A
     int *srcs, *dsts;
     int tag, vtx_id;
     MPI_Aint recvtype_extent;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -46,7 +46,7 @@ int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, MPI_A
         mpi_errno =
             MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, dsts[k], tag, comm_ptr, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     for (l = 0; l < indegree; ++l) {
@@ -54,7 +54,7 @@ int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, MPI_A
         mpi_errno =
             MPIR_TSP_sched_irecv(rb, recvcount, recvtype, srcs[l], tag, comm_ptr, sched, 0, NULL,
                                  &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear.c
@@ -22,7 +22,7 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_
     int *srcs, *dsts;
     int tag, vtx_id;
     MPI_Aint recvtype_extent;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(2);
 
     MPIR_FUNC_ENTER;
@@ -47,7 +47,7 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_
         mpi_errno =
             MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, dsts[k], tag, comm_ptr, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     for (l = 0; l < indegree; ++l) {
@@ -55,7 +55,7 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_
         mpi_errno =
             MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtype, srcs[l], tag, comm_ptr, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear.c
@@ -20,7 +20,7 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, MPI_Ai
     int *srcs, *dsts;
     MPI_Aint sendtype_extent, recvtype_extent;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -49,7 +49,7 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, MPI_Ai
         mpi_errno =
             MPIR_TSP_sched_isend(sb, sendcount, sendtype, dsts[k], tag, comm_ptr, sched, 0, NULL,
                                  &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* need reverse the order to ensure matching when the graph is from MPI_Cart_create and
@@ -60,7 +60,7 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, MPI_Ai
         mpi_errno =
             MPIR_TSP_sched_irecv(rb, recvcount, recvtype, srcs[l], tag, comm_ptr, sched, 0, NULL,
                                  &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear.c
@@ -23,7 +23,7 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf,
     int k, l;
     int *srcs, *dsts;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPI_Aint sendtype_extent, recvtype_extent;
 
     MPIR_FUNC_ENTER;
@@ -52,7 +52,7 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf,
         mpi_errno =
             MPIR_TSP_sched_isend(sb, sendcounts[k], sendtype, dsts[k], tag, comm_ptr, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* need reverse the order to ensure matching when the graph is from MPI_Cart_create and
@@ -63,7 +63,7 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf,
         mpi_errno =
             MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtype, srcs[l], tag, comm_ptr, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear.c
@@ -23,7 +23,7 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf,
     int k, l;
     int *srcs, *dsts;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -50,7 +50,7 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf,
         mpi_errno =
             MPIR_TSP_sched_isend(sb, sendcounts[k], sendtypes[k], dsts[k], tag, comm_ptr, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* need reverse the order to ensure matching when the graph is from MPI_Cart_create and
@@ -63,7 +63,7 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf,
         mpi_errno =
             MPIR_TSP_sched_irecv(rb, recvcounts[l], recvtypes[l], srcs[l], tag, comm_ptr, sched, 0,
                                  NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree.c
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree.c
@@ -38,7 +38,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
     int dtcopy_id = -1;
     int nvtcs;
     int tag;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(3);
 
     MPIR_FUNC_ENTER;
@@ -172,7 +172,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
         reduce_buffer = (void *) sendbuf;
     }
 
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     /* initialize arrays to store graph vertex indices */
     MPIR_CHKLMEM_MALLOC(vtcs, int *, sizeof(int) * (num_children + 1),
@@ -217,7 +217,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
             mpi_errno = MPIR_TSP_sched_irecv(recv_address, msgsize, datatype, child, tag, comm,
                                              sched, nvtcs, vtcs, &recv_id[i]);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             /* Setup dependencies for reduction. Reduction depends on the corresponding recv to complete */
             vtcs[0] = recv_id[i];
             nvtcs = 1;
@@ -244,7 +244,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
                 reduce_id[i] = vtx_id;
 
             }
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         if (is_commutative && buffer_per_child) {       /* wait for all the reductions */
@@ -262,7 +262,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
             mpi_errno =
                 MPIR_TSP_sched_isend(reduce_address, msgsize, datatype, my_tree.parent, tag, comm,
                                      sched, nvtcs, vtcs, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         /* send data to the root of the collective operation */
@@ -276,7 +276,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
                     MPIR_TSP_sched_irecv((char *) recvbuf + offset * extent, msgsize, datatype,
                                          tree_root, tag, comm, sched, 0, NULL, &vtx_id);
             }
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         offset += msgsize;

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
@@ -54,7 +54,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
     MPI_Aint send_cnt, recv_cnt, send_offset, recv_offset;
     int nvtcs, vtcs[2];
     int send_id, recv_id, reduce_id = -1;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -88,7 +88,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
             mpi_errno =
                 MPIR_TSP_sched_isend((char *) tmp_results + send_offset, send_cnt,
                                      datatype, dst, tag, comm, sched, nvtcs, vtcs, &send_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             rank_for_offset =
                 (is_dist_halving) ? MPII_Recexchalgo_reverse_digits_step2(rank, nranks, k) : rank;
@@ -106,7 +106,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
                 MPIR_TSP_sched_irecv((char *) tmp_recvbuf + recv_offset, recv_cnt,
                                      datatype, dst, tag, comm, sched, nvtcs, vtcs, &recv_id);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             nvtcs = 2;
             vtcs[0] = send_id;
@@ -115,7 +115,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
                 MPIR_TSP_sched_reduce_local((char *) tmp_recvbuf + recv_offset,
                                             (char *) tmp_results + recv_offset,
                                             recv_cnt, datatype, op, sched, nvtcs, vtcs, &reduce_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 
@@ -150,7 +150,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
     void *tmp_recvbuf = NULL, *tmp_results = NULL;
     MPI_Aint *displs;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(1);
 
     MPIR_FUNC_ENTER;
@@ -203,7 +203,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
             mpi_errno = MPIR_TSP_sched_localcopy(recvbuf, total_count, datatype,
                                                  tmp_results, total_count, datatype, sched, 0,
                                                  NULL, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After initial dt copy"));
 
@@ -218,7 +218,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
         mpi_errno =
             MPIR_TSP_sched_isend(buf_to_send, total_count, datatype, step1_sendto, tag, comm, sched,
                                  0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     } else {    /* Step 2 participating rank */
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
@@ -228,12 +228,12 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
             mpi_errno = MPIR_TSP_sched_irecv(tmp_recvbuf, total_count, datatype,
                                              step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
                                              &recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             nvtcs++;
             vtcs[1] = recv_id;
             mpi_errno = MPIR_TSP_sched_reduce_local(tmp_recvbuf, tmp_results, total_count,
                                                     datatype, op, sched, nvtcs, vtcs, &reduce_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 
@@ -255,7 +255,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
         mpi_errno = MPIR_TSP_sched_localcopy((char *) tmp_results + displs[rank] * extent,
                                              recvcounts[rank], datatype, recvbuf, recvcounts[rank],
                                              datatype, sched, nvtcs, vtcs, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "After Step 2"));
@@ -266,7 +266,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
         mpi_errno =
             MPIR_TSP_sched_irecv(recvbuf, recvcounts[rank], datatype, step1_sendto, tag, comm,
                                  sched, 1, &sink_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
     for (i = 0; i < step1_nrecvs; i++) {
         nvtcs = 1;
@@ -274,7 +274,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
         mpi_errno = MPIR_TSP_sched_isend((char *) tmp_results + displs[step1_recvfrom[i]] * extent,
                                          recvcounts[step1_recvfrom[i]], datatype, step1_recvfrom[i],
                                          tag, comm, sched, nvtcs, vtcs, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Done Step 3"));

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch.c
@@ -27,7 +27,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
     int nvtcs, vtcs[2];
     void *tmp_recvbuf = NULL, *tmp_results = NULL;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -64,7 +64,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
             mpi_errno = MPIR_TSP_sched_localcopy(recvbuf, total_count, datatype,
                                                  tmp_results, total_count, datatype, sched, 0,
                                                  NULL, &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* Step 1 */
@@ -78,7 +78,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
         mpi_errno =
             MPIR_TSP_sched_isend(buf_to_send, total_count, datatype, step1_sendto, tag, comm, sched,
                                  0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {    /* Step 2 participating rank */
         for (i = 0; i < step1_nrecvs; i++) {    /* participating rank gets data from non-partcipating ranks */
             /* recv dependencies */
@@ -87,12 +87,12 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
             mpi_errno = MPIR_TSP_sched_irecv(tmp_recvbuf, total_count, datatype,
                                              step1_recvfrom[i], tag, comm, sched, nvtcs, vtcs,
                                              &recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             nvtcs++;
             vtcs[1] = recv_id;
             mpi_errno = MPIR_TSP_sched_reduce_local(tmp_recvbuf, tmp_results, total_count,
                                                     datatype, op, sched, nvtcs, vtcs, &reduce_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 
@@ -120,7 +120,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
             mpi_errno =
                 MPIR_TSP_sched_isend((char *) tmp_results + send_offset, send_cnt * recvcount,
                                      datatype, dst, tag, comm, sched, nvtcs, vtcs, &send_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             MPII_Recexchalgo_get_count_and_offset(rank, phase, k, nranks, &recv_cnt, &offset);
             MPI_Aint recv_offset = offset * extent * recvcount;
@@ -128,7 +128,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
             mpi_errno =
                 MPIR_TSP_sched_irecv(tmp_recvbuf, recv_cnt * recvcount,
                                      datatype, dst, tag, comm, sched, nvtcs, vtcs, &recv_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             nvtcs = 2;
             vtcs[0] = send_id;
@@ -138,7 +138,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
                                             (char *) tmp_results + recv_offset,
                                             recv_cnt * recvcount, datatype, op, sched, nvtcs, vtcs,
                                             &reduce_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
     if (in_step2) {
@@ -149,7 +149,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
             MPIR_TSP_sched_localcopy((char *) tmp_results + rank * recvcount * extent, recvcount,
                                      datatype, recvbuf, recvcount, datatype, sched, nvtcs, vtcs,
                                      &dtcopy_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* Step 3: This is reverse of Step 1. Ranks that participated in Step 2
@@ -158,7 +158,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
         mpi_errno =
             MPIR_TSP_sched_irecv(recvbuf, recvcount, datatype, step1_sendto, tag, comm, sched, 1,
                                  &step1_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
     for (i = 0; i < step1_nrecvs; i++) {
         nvtcs = 1;
@@ -167,7 +167,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
             MPIR_TSP_sched_isend((char *) tmp_results + recvcount * step1_recvfrom[i] * extent,
                                  recvcount, datatype, step1_recvfrom[i], tag, comm, sched, nvtcs,
                                  vtcs, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling.c
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling.c
@@ -22,7 +22,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
     void *partial_scan = NULL;
     void *tmp_buf = NULL;
     int tag = 0, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -49,7 +49,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
         mpi_errno =
             MPIR_TSP_sched_localcopy(sendbuf, count, datatype, recvbuf, count, datatype, sched, 0,
                                      NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         mpi_errno =
             MPIR_TSP_sched_localcopy(sendbuf, count, datatype, partial_scan, count, datatype, sched,
                                      0, NULL, &dtcopy_id);
@@ -58,7 +58,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
             MPIR_TSP_sched_localcopy(recvbuf, count, datatype, partial_scan, count, datatype, sched,
                                      0, NULL, &dtcopy_id);
 
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     tmp_buf = MPIR_TSP_sched_malloc(count * extent, sched);
     mask = 0x1;
@@ -78,7 +78,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
                 MPIR_TSP_sched_isend(partial_scan, count, datatype, dst, tag, comm, sched, nvtcs,
                                      vtcs, &send_id);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             if (recv_reduce != -1) {
                 nvtcs++;
@@ -88,7 +88,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
                 MPIR_TSP_sched_irecv(tmp_buf, count, datatype, dst, tag, comm, sched, nvtcs, vtcs,
                                      &recv_id);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             nvtcs = 2;
             vtcs[0] = send_id;
@@ -97,30 +97,30 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
                 mpi_errno = MPIR_TSP_sched_reduce_local(tmp_buf, partial_scan, count,
                                                         datatype, op, sched, nvtcs, vtcs,
                                                         &reduce_id);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                 mpi_errno = MPIR_TSP_sched_reduce_local(tmp_buf, recvbuf, count,
                                                         datatype, op, sched, nvtcs, vtcs,
                                                         &recv_reduce);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             } else {
                 if (is_commutative) {
                     mpi_errno = MPIR_TSP_sched_reduce_local(tmp_buf, partial_scan, count,
                                                             datatype, op, sched, nvtcs, vtcs,
                                                             &reduce_id);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 } else {
                     mpi_errno = MPIR_TSP_sched_reduce_local(partial_scan, tmp_buf, count,
                                                             datatype, op, sched, nvtcs, vtcs,
                                                             &reduce_id);
 
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                     mpi_errno = MPIR_TSP_sched_localcopy(tmp_buf, count, datatype,
                                                          partial_scan, count, datatype, sched, 1,
                                                          &reduce_id, &vtx_id);
                     reduce_id = vtx_id;
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                 }
                 recv_reduce = -1;

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree.c
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree.c
@@ -32,7 +32,7 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     MPI_Aint offset, recv_size;
     int tag;
     int num_send_dependencies;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL(2);
 
     size = MPIR_Comm_size(comm);
@@ -127,12 +127,12 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
                                      (size - root) * sendcount, sendtype, tmp_buf,
                                      (size - root) * sendcount, sendtype, sched, 0, NULL,
                                      &dtcopy_id[0]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         mpi_errno =
             MPIR_TSP_sched_localcopy(sendbuf, root * sendcount, sendtype,
                                      (char *) tmp_buf + (size - root) * sendcount * sendtype_extent,
                                      root * sendcount, sendtype, sched, 0, NULL, &dtcopy_id[1]);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         num_send_dependencies = 2;
     } else if (root == 0 && lrank == 0) {
@@ -150,7 +150,7 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     if (my_tree.parent != -1) {
         mpi_errno = MPIR_TSP_sched_irecv(tmp_buf, recv_size, recvtype, my_tree.parent,
                                          tag, comm, sched, 0, NULL, &recv_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "rank:%d posts recv", rank));
     }
 
@@ -161,19 +161,19 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
                                          child_subtree_size[i] * sendcount, sendtype,
                                          child, tag, comm, sched, num_send_dependencies,
                                          (lrank == 0) ? dtcopy_id : &recv_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     if (num_children > 0 && lrank != 0) {       /* copy data from tmp_buf to recvbuf */
         mpi_errno = MPIR_TSP_sched_localcopy(tmp_buf, recvcount, recvtype, recvbuf,
                                              recvcount, recvtype, sched, 1, &recv_id, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     if (lrank == 0 && !is_inplace) {    /* root puts data in recvbuf */
         mpi_errno = MPIR_TSP_sched_localcopy(tmp_buf, sendcount, sendtype, recvbuf,
                                              recvcount, recvtype, sched, 0, NULL, &vtx_id);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     MPIR_Treealgo_tree_free(&my_tree);

--- a/src/mpi/coll/iscatterv/iscatterv_tsp_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_tsp_linear.c
@@ -19,7 +19,7 @@ int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const MPI_Aint 
     MPI_Aint extent;
     int i;
     int tag, vtx_id;
-    MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
+    int coll_attr ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
 
@@ -61,7 +61,7 @@ int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const MPI_Aint 
                                                      sched, 0, NULL, &vtx_id);
                 }
             }
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 
@@ -71,7 +71,7 @@ int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const MPI_Aint 
             mpi_errno =
                 MPIR_TSP_sched_irecv(recvbuf, recvcount, recvtype, root, tag, comm_ptr, sched, 0,
                                      NULL, &vtx_id);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/reduce/reduce_allcomm_nb.c
+++ b/src/mpi/coll/reduce/reduce_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Reduce_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count,
                            MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                           MPIR_Errflag_t errflag)
+                           int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
+++ b/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
@@ -18,8 +18,7 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
                                                MPI_Aint count,
                                                MPI_Datatype datatype,
                                                MPI_Op op,
-                                               int root,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                               int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, mpi_errno;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -37,7 +36,7 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
     if (root == MPI_ROOT) {
         /* root receives data from rank 0 on remote group */
         mpi_errno = MPIC_Recv(recvbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm_ptr, &status);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         /* remote group. Rank 0 allocates temporary buffer, does
          * local intracommunicator reduce, and then sends the data
@@ -64,13 +63,13 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
         newcomm_ptr = comm_ptr->local_comm;
 
         /* now do a local reduce on this intracommunicator */
-        mpi_errno = MPIR_Reduce(sendbuf, tmp_buf, count, datatype, op, 0, newcomm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        mpi_errno = MPIR_Reduce(sendbuf, tmp_buf, count, datatype, op, 0, newcomm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         if (rank == 0) {
             mpi_errno = MPIC_Send(tmp_buf, count, datatype, root,
-                                  MPIR_REDUCE_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  MPIR_REDUCE_TAG, comm_ptr, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
+++ b/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
@@ -35,7 +35,8 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
 
     if (root == MPI_ROOT) {
         /* root receives data from rank 0 on remote group */
-        mpi_errno = MPIC_Recv(recvbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm_ptr, &status);
+        mpi_errno = MPIC_Recv(recvbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm_ptr,
+                              coll_attr, &status);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         /* remote group. Rank 0 allocates temporary buffer, does

--- a/src/mpi/coll/reduce/reduce_intra_binomial.c
+++ b/src/mpi/coll/reduce/reduce_intra_binomial.c
@@ -24,7 +24,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
     void *tmp_buf;
     MPIR_CHKLMEM_DECL(2);
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
     /* Create a temporary buffer */
 

--- a/src/mpi/coll/reduce/reduce_intra_binomial.c
+++ b/src/mpi/coll/reduce/reduce_intra_binomial.c
@@ -97,7 +97,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
             if (source < comm_size) {
                 source = (source + lroot) % comm_size;
                 mpi_errno = MPIC_Recv(tmp_buf, count, datatype, source,
-                                      MPIR_REDUCE_TAG, comm_ptr, &status);
+                                      MPIR_REDUCE_TAG, comm_ptr, coll_attr, &status);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                 /* The sender is above us, so the received buffer must be
@@ -130,7 +130,8 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
             mpi_errno = MPIC_Send(recvbuf, count, datatype, root,
                                   MPIR_REDUCE_TAG, comm_ptr, coll_attr);
         } else if (rank == root) {
-            mpi_errno = MPIC_Recv(recvbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm_ptr, &status);
+            mpi_errno = MPIC_Recv(recvbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm_ptr,
+                                  coll_attr, &status);
         }
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }

--- a/src/mpi/coll/reduce/reduce_intra_binomial.c
+++ b/src/mpi/coll/reduce/reduce_intra_binomial.c
@@ -80,7 +80,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
      * and send/operate on that.
      *
      * In general, we can't use MPI_PACK, because the alignment of that
-     * is rather vague, and the data may not be re-usable.  What we actually
+     * is rather vague, and the data may not be reusable.  What we actually
      * need is a "squeeze" operation that removes the skips.
      */
     mask = 0x1;

--- a/src/mpi/coll/reduce/reduce_intra_binomial.c
+++ b/src/mpi/coll/reduce/reduce_intra_binomial.c
@@ -13,7 +13,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
                                void *recvbuf,
                                MPI_Aint count,
                                MPI_Datatype datatype,
-                               MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                               MPI_Op op, int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -98,7 +98,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
                 source = (source + lroot) % comm_size;
                 mpi_errno = MPIC_Recv(tmp_buf, count, datatype, source,
                                       MPIR_REDUCE_TAG, comm_ptr, &status);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                 /* The sender is above us, so the received buffer must be
                  * the second argument (in the noncommutative case). */
@@ -118,8 +118,8 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
              * my parent */
             source = ((relrank & (~mask)) + lroot) % comm_size;
             mpi_errno = MPIC_Send(recvbuf, count, datatype,
-                                  source, MPIR_REDUCE_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  source, MPIR_REDUCE_TAG, comm_ptr, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             break;
         }
         mask <<= 1;
@@ -128,11 +128,11 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
     if (!is_commutative && (root != 0)) {
         if (rank == 0) {
             mpi_errno = MPIC_Send(recvbuf, count, datatype, root,
-                                  MPIR_REDUCE_TAG, comm_ptr, errflag);
+                                  MPIR_REDUCE_TAG, comm_ptr, coll_attr);
         } else if (rank == root) {
             mpi_errno = MPIC_Recv(recvbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm_ptr, &status);
         }
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -110,7 +110,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
-             * process does not pariticipate in recursive
+             * process does not participate in recursive
              * doubling */
             newrank = -1;
         } else {        /* even */

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -115,7 +115,8 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
             newrank = -1;
         } else {        /* even */
             mpi_errno = MPIC_Recv(tmp_buf, count,
-                                  datatype, rank + 1, MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                  datatype, rank + 1, MPIR_REDUCE_TAG, comm_ptr,
+                                  coll_attr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* do the reduction on received data. */
@@ -237,7 +238,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
                     disps[i] = disps[i - 1] + cnts[i - 1];
 
                 mpi_errno = MPIC_Recv(recvbuf, cnts[0], datatype,
-                                      0, MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                      0, MPIR_REDUCE_TAG, comm_ptr, coll_attr, MPI_STATUS_IGNORE);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 newrank = 0;
                 send_idx = 0;
@@ -321,7 +322,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
                 mpi_errno = MPIC_Recv((char *) recvbuf +
                                       disps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
-                                      MPIR_REDUCE_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                      MPIR_REDUCE_TAG, comm_ptr, coll_attr, MPI_STATUS_IGNORE);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
 

--- a/src/mpi/coll/reduce/reduce_intra_smp.c
+++ b/src/mpi/coll/reduce/reduce_intra_smp.c
@@ -7,7 +7,7 @@
 
 int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                           MPI_Datatype datatype, MPI_Op op, int root, MPIR_Comm * comm_ptr,
-                          MPIR_Errflag_t errflag)
+                          int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -38,8 +38,8 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
     /* do the intranode reduce on all nodes other than the root's node */
     if (comm_ptr->node_comm != NULL && MPIR_Get_intranode_rank(comm_ptr, root) == -1) {
         mpi_errno = MPIR_Reduce(sendbuf, tmp_buf, count, datatype,
-                                op, 0, comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                op, 0, comm_ptr->node_comm, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* do the internode reduce to the root's node */
@@ -50,8 +50,8 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
             const void *buf = (comm_ptr->node_comm == NULL ? sendbuf : tmp_buf);
             mpi_errno = MPIR_Reduce(buf, NULL, count, datatype,
                                     op, MPIR_Get_internode_rank(comm_ptr, root),
-                                    comm_ptr->node_roots_comm, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                    comm_ptr->node_roots_comm, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         } else {        /* I am on root's node. I have not participated in the earlier reduce. */
             if (comm_ptr->rank != root) {
                 /* I am not the root though. I don't have a valid recvbuf.
@@ -59,8 +59,8 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
 
                 mpi_errno = MPIR_Reduce(sendbuf, tmp_buf, count, datatype,
                                         op, MPIR_Get_internode_rank(comm_ptr, root),
-                                        comm_ptr->node_roots_comm, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                        comm_ptr->node_roots_comm, coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                 /* point sendbuf at tmp_buf to make final intranode reduce easy */
                 sendbuf = tmp_buf;
@@ -69,8 +69,8 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
 
                 mpi_errno = MPIR_Reduce(sendbuf, recvbuf, count, datatype,
                                         op, MPIR_Get_internode_rank(comm_ptr, root),
-                                        comm_ptr->node_roots_comm, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                        comm_ptr->node_roots_comm, coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
                 /* set sendbuf to MPI_IN_PLACE to make final intranode reduce easy. */
                 sendbuf = MPI_IN_PLACE;
@@ -83,8 +83,8 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
     if (comm_ptr->node_comm != NULL && MPIR_Get_intranode_rank(comm_ptr, root) != -1) {
         mpi_errno = MPIR_Reduce(sendbuf, recvbuf, count, datatype,
                                 op, MPIR_Get_intranode_rank(comm_ptr, root),
-                                comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                comm_ptr->node_comm, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Reduce_scatter_allcomm_nb(const void *sendbuf, void *recvbuf, const MPI_Aint recvcounts[],
                                    MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                   MPIR_Errflag_t errflag)
+                                   int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
@@ -15,8 +15,7 @@
 int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, void *recvbuf,
                                                           const MPI_Aint recvcounts[],
                                                           MPI_Datatype datatype, MPI_Op op,
-                                                          MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t errflag)
+                                                          MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, mpi_errno, root, local_size, total_count, i;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -62,26 +61,26 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                             root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                             root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         /* reduce to rank 0 of left group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                             root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                             root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* Get the local intracommunicator */
@@ -93,8 +92,8 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
     newcomm_ptr = comm_ptr->local_comm;
 
     mpi_errno = MPIR_Scatterv(tmp_buf, recvcounts, disps, datatype, recvbuf,
-                              recvcounts[rank], datatype, 0, newcomm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                              recvcounts[rank], datatype, 0, newcomm_ptr, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
@@ -22,8 +22,7 @@
  */
 int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
                                              const MPI_Aint recvcounts[], MPI_Datatype datatype,
-                                             MPI_Op op, MPIR_Comm * comm_ptr,
-                                             MPIR_Errflag_t errflag)
+                                             MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -102,8 +101,8 @@ int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
                                   size, datatype, peer, MPIR_REDUCE_SCATTER_TAG,
                                   incoming_data + recv_offset * true_extent,
                                   size, datatype, peer, MPIR_REDUCE_SCATTER_TAG,
-                                  comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  comm_ptr, MPI_STATUS_IGNORE, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         /* always perform the reduction at recv_offset, the data at send_offset
          * is now our peer's responsibility */
         if (rank > peer) {

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
@@ -15,7 +15,7 @@
  */
 int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
                                        const MPI_Aint recvcounts[], MPI_Datatype datatype,
-                                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                       MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;
@@ -83,16 +83,16 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
                                       MPIR_REDUCE_SCATTER_TAG, tmp_recvbuf,
                                       recvcounts[rank], datatype, src,
                                       MPIR_REDUCE_SCATTER_TAG, comm_ptr,
-                                      MPI_STATUS_IGNORE, errflag);
+                                      MPI_STATUS_IGNORE, coll_attr);
         else
             mpi_errno = MPIC_Sendrecv(((char *) recvbuf + disps[dst] * extent),
                                       recvcounts[dst], datatype, dst,
                                       MPIR_REDUCE_SCATTER_TAG, tmp_recvbuf,
                                       recvcounts[rank], datatype, src,
                                       MPIR_REDUCE_SCATTER_TAG, comm_ptr,
-                                      MPI_STATUS_IGNORE, errflag);
+                                      MPI_STATUS_IGNORE, coll_attr);
 
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         if (sendbuf != MPI_IN_PLACE) {
             mpi_errno = MPIR_Reduce_local(tmp_recvbuf, recvbuf, recvcounts[rank], datatype, op);

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
@@ -19,8 +19,7 @@
  */
 int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recvbuf,
                                                  const MPI_Aint recvcounts[], MPI_Datatype datatype,
-                                                 MPI_Op op, MPIR_Comm * comm_ptr,
-                                                 MPIR_Errflag_t errflag)
+                                                 MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;
@@ -150,9 +149,9 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
                                       MPIR_REDUCE_SCATTER_TAG,
                                       tmp_recvbuf, 1, recvtype, dst,
                                       MPIR_REDUCE_SCATTER_TAG, comm_ptr,
-                                      MPI_STATUS_IGNORE, errflag);
+                                      MPI_STATUS_IGNORE, coll_attr);
             received = 1;
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         /* if some processes in this process's subtree in this step
@@ -191,8 +190,8 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
                     && (dst >= tree_root + nprocs_completed)) {
                     /* send the current result */
                     mpi_errno = MPIC_Send(tmp_recvbuf, 1, recvtype,
-                                          dst, MPIR_REDUCE_SCATTER_TAG, comm_ptr, errflag);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                          dst, MPIR_REDUCE_SCATTER_TAG, comm_ptr, coll_attr);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
                 /* recv only if this proc. doesn't have data and sender
                  * has data */
@@ -202,7 +201,7 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
                     mpi_errno = MPIC_Recv(tmp_recvbuf, 1, recvtype, dst,
                                           MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
                     received = 1;
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
                 tmp_mask >>= 1;
                 k--;

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
@@ -199,7 +199,8 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
                          (dst < tree_root + nprocs_completed) &&
                          (rank >= tree_root + nprocs_completed)) {
                     mpi_errno = MPIC_Recv(tmp_recvbuf, 1, recvtype, dst,
-                                          MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                          MPIR_REDUCE_SCATTER_TAG, comm_ptr,
+                                          coll_attr, MPI_STATUS_IGNORE);
                     received = 1;
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -118,7 +118,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
-             * process does not pariticipate in recursive
+             * process does not participate in recursive
              * doubling */
             newrank = -1;
         } else {        /* odd */

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -50,7 +50,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
     int pof2, old_i, newrank;
     MPIR_CHKLMEM_DECL(5);
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     {

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -36,8 +36,7 @@
  */
 int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvbuf,
                                                 const MPI_Aint recvcounts[], MPI_Datatype datatype,
-                                                MPI_Op op, MPIR_Comm * comm_ptr,
-                                                MPIR_Errflag_t errflag)
+                                                MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;
@@ -114,8 +113,8 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
     if (rank < 2 * rem) {
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIC_Send(tmp_results, total_count,
-                                  datatype, rank + 1, MPIR_REDUCE_SCATTER_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  datatype, rank + 1, MPIR_REDUCE_SCATTER_TAG, comm_ptr, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not participate in recursive
@@ -125,7 +124,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
             mpi_errno = MPIC_Recv(tmp_recvbuf, total_count,
                                   datatype, rank - 1,
                                   MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
@@ -201,7 +200,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
                                           newdisps[recv_idx] * extent,
                                           recv_cnt, datatype, dst,
                                           MPIR_REDUCE_SCATTER_TAG, comm_ptr,
-                                          MPI_STATUS_IGNORE, errflag);
+                                          MPI_STATUS_IGNORE, coll_attr);
             else if ((send_cnt == 0) && (recv_cnt != 0))
                 mpi_errno = MPIC_Recv((char *) tmp_recvbuf +
                                       newdisps[recv_idx] * extent,
@@ -211,9 +210,9 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
                 mpi_errno = MPIC_Send((char *) tmp_results +
                                       newdisps[send_idx] * extent,
                                       send_cnt, datatype,
-                                      dst, MPIR_REDUCE_SCATTER_TAG, comm_ptr, errflag);
+                                      dst, MPIR_REDUCE_SCATTER_TAG, comm_ptr, coll_attr);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* tmp_recvbuf contains data received in this step.
              * tmp_results contains data accumulated so far */
@@ -251,15 +250,15 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
                 mpi_errno = MPIC_Send((char *) tmp_results +
                                       disps[rank - 1] * extent, recvcounts[rank - 1],
                                       datatype, rank - 1,
-                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr, errflag);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr, coll_attr);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         } else {        /* even */
             if (recvcounts[rank]) {
                 mpi_errno = MPIC_Recv(recvbuf, recvcounts[rank],
                                       datatype, rank + 1,
                                       MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
     }

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -123,7 +123,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
         } else {        /* odd */
             mpi_errno = MPIC_Recv(tmp_recvbuf, total_count,
                                   datatype, rank - 1,
-                                  MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                  MPIR_REDUCE_SCATTER_TAG, comm_ptr, coll_attr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* do the reduction on received data. since the
@@ -205,7 +205,8 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
                 mpi_errno = MPIC_Recv((char *) tmp_recvbuf +
                                       newdisps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
-                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr,
+                                      coll_attr, MPI_STATUS_IGNORE);
             else if ((recv_cnt == 0) && (send_cnt != 0))
                 mpi_errno = MPIC_Send((char *) tmp_results +
                                       newdisps[send_idx] * extent,
@@ -257,7 +258,8 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
             if (recvcounts[rank]) {
                 mpi_errno = MPIC_Recv(recvbuf, recvcounts[rank],
                                       datatype, rank + 1,
-                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                      MPIR_REDUCE_SCATTER_TAG, comm_ptr,
+                                      coll_attr, MPI_STATUS_IGNORE);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Reduce_scatter_block_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint recvcount,
                                          MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                         MPIR_Errflag_t errflag)
+                                         int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_inter_remote_reduce_local_scatter.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_inter_remote_reduce_local_scatter.c
@@ -17,8 +17,7 @@ int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *send
                                                                 MPI_Aint recvcount,
                                                                 MPI_Datatype datatype,
                                                                 MPI_Op op,
-                                                                MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t errflag)
+                                                                MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, mpi_errno, root, local_size;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -52,26 +51,26 @@ int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *send
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                             root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         /* reduce to rank 0 of right group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                             root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else {
         /* reduce to rank 0 of left group */
         root = 0;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                             root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         /* reduce from right group to rank 0 */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
         mpi_errno = MPIR_Reduce_allcomm_auto(sendbuf, tmp_buf, total_count, datatype, op,
-                                             root, comm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                             root, comm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     /* Get the local intracommunicator */
@@ -81,8 +80,8 @@ int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *send
     newcomm_ptr = comm_ptr->local_comm;
 
     mpi_errno = MPIR_Scatter(tmp_buf, recvcount, datatype, recvbuf,
-                             recvcount, datatype, 0, newcomm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                             recvcount, datatype, 0, newcomm_ptr, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
@@ -24,8 +24,7 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
                                                    void *recvbuf,
                                                    MPI_Aint recvcount,
                                                    MPI_Datatype datatype,
-                                                   MPI_Op op,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -100,8 +99,8 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
                                   size, datatype, peer, MPIR_REDUCE_SCATTER_BLOCK_TAG,
                                   incoming_data + recv_offset * true_extent,
                                   size, datatype, peer, MPIR_REDUCE_SCATTER_BLOCK_TAG,
-                                  comm_ptr, MPI_STATUS_IGNORE, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  comm_ptr, MPI_STATUS_IGNORE, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         /* always perform the reduction at recv_offset, the data at send_offset
          * is now our peer's responsibility */
         if (rank > peer) {

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
@@ -24,8 +24,7 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
                                              void *recvbuf,
                                              MPI_Aint recvcount,
                                              MPI_Datatype datatype,
-                                             MPI_Op op,
-                                             MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                             MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;
@@ -85,16 +84,16 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
                                       MPIR_REDUCE_SCATTER_BLOCK_TAG, tmp_recvbuf,
                                       recvcount, datatype, src,
                                       MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
-                                      MPI_STATUS_IGNORE, errflag);
+                                      MPI_STATUS_IGNORE, coll_attr);
         else
             mpi_errno = MPIC_Sendrecv(((char *) recvbuf + disps[dst] * extent),
                                       recvcount, datatype, dst,
                                       MPIR_REDUCE_SCATTER_BLOCK_TAG, tmp_recvbuf,
                                       recvcount, datatype, src,
                                       MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
-                                      MPI_STATUS_IGNORE, errflag);
+                                      MPI_STATUS_IGNORE, coll_attr);
 
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         if (sendbuf != MPI_IN_PLACE) {
             mpi_errno = MPIR_Reduce_local(tmp_recvbuf, recvbuf, recvcount, datatype, op);

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
@@ -25,7 +25,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
                                                        MPI_Aint recvcount,
                                                        MPI_Datatype datatype,
                                                        MPI_Op op,
-                                                       MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                       MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;
@@ -147,9 +147,9 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
                                       MPIR_REDUCE_SCATTER_BLOCK_TAG,
                                       tmp_recvbuf, 1, recvtype, dst,
                                       MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
-                                      MPI_STATUS_IGNORE, errflag);
+                                      MPI_STATUS_IGNORE, coll_attr);
             received = 1;
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         /* if some processes in this process's subtree in this step
@@ -188,8 +188,8 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
                     && (dst >= tree_root + nprocs_completed)) {
                     /* send the current result */
                     mpi_errno = MPIC_Send(tmp_recvbuf, 1, recvtype,
-                                          dst, MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, errflag);
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                          dst, MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, coll_attr);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
                 /* recv only if this proc. doesn't have data and sender
                  * has data */
@@ -200,7 +200,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
                                           MPIR_REDUCE_SCATTER_BLOCK_TAG,
                                           comm_ptr, MPI_STATUS_IGNORE);
                     received = 1;
-                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }
                 tmp_mask >>= 1;
                 k--;

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
@@ -198,7 +198,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
                          (rank >= tree_root + nprocs_completed)) {
                     mpi_errno = MPIC_Recv(tmp_recvbuf, 1, recvtype, dst,
                                           MPIR_REDUCE_SCATTER_BLOCK_TAG,
-                                          comm_ptr, MPI_STATUS_IGNORE);
+                                          comm_ptr, coll_attr, MPI_STATUS_IGNORE);
                     received = 1;
                     MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 }

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -40,7 +40,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
                                                       MPI_Aint recvcount,
                                                       MPI_Datatype datatype,
                                                       MPI_Op op,
-                                                      MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                      MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, comm_size, i;
     MPI_Aint extent, true_extent, true_lb;
@@ -115,8 +115,8 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
         if (rank % 2 == 0) {    /* even */
             mpi_errno = MPIC_Send(tmp_results, total_count,
                                   datatype, rank + 1,
-                                  MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
              * process does not participate in recursive
@@ -126,7 +126,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
             mpi_errno = MPIC_Recv(tmp_recvbuf, total_count,
                                   datatype, rank - 1,
                                   MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* do the reduction on received data. since the
              * ordering is right, it doesn't matter whether
@@ -204,7 +204,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
                                           newdisps[recv_idx] * extent,
                                           recv_cnt, datatype, dst,
                                           MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
-                                          MPI_STATUS_IGNORE, errflag);
+                                          MPI_STATUS_IGNORE, coll_attr);
             else if ((send_cnt == 0) && (recv_cnt != 0))
                 mpi_errno = MPIC_Recv((char *) tmp_recvbuf +
                                       newdisps[recv_idx] * extent,
@@ -214,9 +214,9 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
                 mpi_errno = MPIC_Send((char *) tmp_results +
                                       newdisps[send_idx] * extent,
                                       send_cnt, datatype,
-                                      dst, MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, errflag);
+                                      dst, MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, coll_attr);
 
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* tmp_recvbuf contains data received in this step.
              * tmp_results contains data accumulated so far */
@@ -249,13 +249,13 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
             mpi_errno = MPIC_Send((char *) tmp_results +
                                   disps[rank - 1] * extent, recvcount,
                                   datatype, rank - 1,
-                                  MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, errflag);
+                                  MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, coll_attr);
         } else {        /* even */
             mpi_errno = MPIC_Recv(recvbuf, recvcount,
                                   datatype, rank + 1,
                                   MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, MPI_STATUS_IGNORE);
         }
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -53,7 +53,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
     int pof2, old_i, newrank;
     MPIR_CHKLMEM_DECL(5);
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     {

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -125,7 +125,8 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
         } else {        /* odd */
             mpi_errno = MPIC_Recv(tmp_recvbuf, total_count,
                                   datatype, rank - 1,
-                                  MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                  MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
+                                  coll_attr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             /* do the reduction on received data. since the
@@ -209,7 +210,8 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
                 mpi_errno = MPIC_Recv((char *) tmp_recvbuf +
                                       newdisps[recv_idx] * extent,
                                       recv_cnt, datatype, dst,
-                                      MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                      MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
+                                      coll_attr, MPI_STATUS_IGNORE);
             else if ((recv_cnt == 0) && (send_cnt != 0))
                 mpi_errno = MPIC_Send((char *) tmp_results +
                                       newdisps[send_idx] * extent,
@@ -253,7 +255,8 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
         } else {        /* even */
             mpi_errno = MPIC_Recv(recvbuf, recvcount,
                                   datatype, rank + 1,
-                                  MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                  MPIR_REDUCE_SCATTER_BLOCK_TAG, comm_ptr,
+                                  coll_attr, MPI_STATUS_IGNORE);
         }
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -119,7 +119,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 
             /* temporarily set the rank to -1 so that this
-             * process does not pariticipate in recursive
+             * process does not participate in recursive
              * doubling */
             newrank = -1;
         } else {        /* odd */

--- a/src/mpi/coll/scan/scan_allcomm_nb.c
+++ b/src/mpi/coll/scan/scan_allcomm_nb.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 
 int MPIR_Scan_allcomm_nb(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
-                         MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                         MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/scan/scan_intra_recursive_doubling.c
+++ b/src/mpi/coll/scan/scan_intra_recursive_doubling.c
@@ -55,7 +55,7 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
     void *partial_scan, *tmp_buf;
     MPIR_CHKLMEM_DECL(2);
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
     is_commutative = MPIR_Op_is_commutative(op);
 

--- a/src/mpi/coll/scan/scan_intra_recursive_doubling.c
+++ b/src/mpi/coll/scan/scan_intra_recursive_doubling.c
@@ -44,7 +44,7 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
                                        void *recvbuf,
                                        MPI_Aint count,
                                        MPI_Datatype datatype,
-                                       MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                       MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     MPI_Status status;
     int rank, comm_size;
@@ -97,8 +97,8 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
             mpi_errno = MPIC_Sendrecv(partial_scan, count, datatype,
                                       dst, MPIR_SCAN_TAG, tmp_buf,
                                       count, datatype, dst,
-                                      MPIR_SCAN_TAG, comm_ptr, &status, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                      MPIR_SCAN_TAG, comm_ptr, &status, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
             if (rank > dst) {
                 mpi_errno = MPIR_Reduce_local(tmp_buf, partial_scan, count, datatype, op);

--- a/src/mpi/coll/scan/scan_intra_smp.c
+++ b/src/mpi/coll/scan/scan_intra_smp.c
@@ -58,7 +58,7 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
     if (comm_ptr->node_roots_comm != NULL && comm_ptr->node_comm != NULL) {
         mpi_errno = MPIC_Recv(localfulldata, count, datatype,
                               comm_ptr->node_comm->local_size - 1, MPIR_SCAN_TAG,
-                              comm_ptr->node_comm, &status);
+                              comm_ptr->node_comm, coll_attr, &status);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else if (comm_ptr->node_roots_comm == NULL &&
                comm_ptr->node_comm != NULL &&
@@ -88,7 +88,7 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
         if (MPIR_Get_internode_rank(comm_ptr, rank) != 0) {
             mpi_errno = MPIC_Recv(tempbuf, count, datatype,
                                   MPIR_Get_internode_rank(comm_ptr, rank) - 1,
-                                  MPIR_SCAN_TAG, comm_ptr->node_roots_comm, &status);
+                                  MPIR_SCAN_TAG, comm_ptr->node_roots_comm, coll_attr, &status);
             noneed = 0;
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }

--- a/src/mpi/coll/scan/scan_intra_smp.c
+++ b/src/mpi/coll/scan/scan_intra_smp.c
@@ -7,8 +7,7 @@
 
 
 int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
-                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                        MPIR_Errflag_t errflag)
+                        MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -44,8 +43,9 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
     /* perform intranode scan to get temporary result in recvbuf. if there is only
      * one process, just copy the raw data. */
     if (comm_ptr->node_comm != NULL) {
-        mpi_errno = MPIR_Scan(sendbuf, recvbuf, count, datatype, op, comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        mpi_errno =
+            MPIR_Scan(sendbuf, recvbuf, count, datatype, op, comm_ptr->node_comm, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
         MPIR_ERR_CHECK(mpi_errno);
@@ -59,13 +59,13 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
         mpi_errno = MPIC_Recv(localfulldata, count, datatype,
                               comm_ptr->node_comm->local_size - 1, MPIR_SCAN_TAG,
                               comm_ptr->node_comm, &status);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else if (comm_ptr->node_roots_comm == NULL &&
                comm_ptr->node_comm != NULL &&
                MPIR_Get_intranode_rank(comm_ptr, rank) == comm_ptr->node_comm->local_size - 1) {
         mpi_errno = MPIC_Send(recvbuf, count, datatype,
-                              0, MPIR_SCAN_TAG, comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                              0, MPIR_SCAN_TAG, comm_ptr->node_comm, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     } else if (comm_ptr->node_roots_comm != NULL) {
         localfulldata = recvbuf;
     }
@@ -76,21 +76,21 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
      * main process of node 3. */
     if (comm_ptr->node_roots_comm != NULL) {
         mpi_errno = MPIR_Scan(localfulldata, prefulldata, count, datatype,
-                              op, comm_ptr->node_roots_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                              op, comm_ptr->node_roots_comm, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         if (MPIR_Get_internode_rank(comm_ptr, rank) != comm_ptr->node_roots_comm->local_size - 1) {
             mpi_errno = MPIC_Send(prefulldata, count, datatype,
                                   MPIR_Get_internode_rank(comm_ptr, rank) + 1,
-                                  MPIR_SCAN_TAG, comm_ptr->node_roots_comm, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                  MPIR_SCAN_TAG, comm_ptr->node_roots_comm, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
         if (MPIR_Get_internode_rank(comm_ptr, rank) != 0) {
             mpi_errno = MPIC_Recv(tempbuf, count, datatype,
                                   MPIR_Get_internode_rank(comm_ptr, rank) - 1,
                                   MPIR_SCAN_TAG, comm_ptr->node_roots_comm, &status);
             noneed = 0;
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 
@@ -101,14 +101,14 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
      * reduce it with recvbuf to get final result if necessary. */
 
     if (comm_ptr->node_comm != NULL) {
-        mpi_errno = MPIR_Bcast(&noneed, 1, MPI_INT, 0, comm_ptr->node_comm, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        mpi_errno = MPIR_Bcast(&noneed, 1, MPI_INT, 0, comm_ptr->node_comm, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     if (noneed == 0) {
         if (comm_ptr->node_comm != NULL) {
-            mpi_errno = MPIR_Bcast(tempbuf, count, datatype, 0, comm_ptr->node_comm, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            mpi_errno = MPIR_Bcast(tempbuf, count, datatype, 0, comm_ptr->node_comm, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
 
         mpi_errno = MPIR_Reduce_local(tempbuf, recvbuf, count, datatype, op);

--- a/src/mpi/coll/scatter/scatter_allcomm_nb.c
+++ b/src/mpi/coll/scatter/scatter_allcomm_nb.c
@@ -7,7 +7,7 @@
 
 int MPIR_Scatter_allcomm_nb(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                             void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                            MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                            MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/scatter/scatter_inter_linear.c
+++ b/src/mpi/coll/scatter/scatter_inter_linear.c
@@ -38,8 +38,8 @@ int MPIR_Scatter_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     } else {
-        mpi_errno =
-            MPIC_Recv(recvbuf, recvcount, recvtype, root, MPIR_SCATTER_TAG, comm_ptr, &status);
+        mpi_errno = MPIC_Recv(recvbuf, recvcount, recvtype, root, MPIR_SCATTER_TAG, comm_ptr,
+                              coll_attr, &status);
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 

--- a/src/mpi/coll/scatter/scatter_inter_linear.c
+++ b/src/mpi/coll/scatter/scatter_inter_linear.c
@@ -14,7 +14,7 @@
 
 int MPIR_Scatter_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                              MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                              MPIR_Comm * comm_ptr, int coll_attr)
 {
     int remote_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -34,13 +34,13 @@ int MPIR_Scatter_inter_linear(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
         for (i = 0; i < remote_size; i++) {
             mpi_errno =
                 MPIC_Send(((char *) sendbuf + sendcount * i * extent), sendcount, sendtype, i,
-                          MPIR_SCATTER_TAG, comm_ptr, errflag);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                          MPIR_SCATTER_TAG, comm_ptr, coll_attr);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     } else {
         mpi_errno =
             MPIC_Recv(recvbuf, recvcount, recvtype, root, MPIR_SCATTER_TAG, comm_ptr, &status);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     return mpi_errno_ret;

--- a/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
@@ -54,7 +54,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
                                 "tmp_buf", MPL_MEM_BUFFER);
 
             mpi_errno = MPIC_Recv(tmp_buf, recvcount * local_size * recvtype_sz, MPI_BYTE,
-                                  root, MPIR_SCATTER_TAG, comm_ptr, &status);
+                                  root, MPIR_SCATTER_TAG, comm_ptr, coll_attr, &status);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         } else {
             /* silence -Wmaybe-uninitialized due to MPIR_Scatter by non-zero ranks */

--- a/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
@@ -58,7 +58,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
                                   root, MPIR_SCATTER_TAG, comm_ptr, &status);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
         } else {
-            /* silience -Wmaybe-uninitialized due to MPIR_Scatter by non-zero ranks */
+            /* silence -Wmaybe-uninitialized due to MPIR_Scatter by non-zero ranks */
             recvtype_sz = 0;
         }
 

--- a/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
@@ -16,8 +16,7 @@
 int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                 int root, MPIR_Comm * comm_ptr,
-                                                 MPIR_Errflag_t errflag)
+                                                 int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, local_size, remote_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -37,8 +36,8 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
         /* root sends all data to rank 0 on remote group and returns */
         mpi_errno =
             MPIC_Send(sendbuf, sendcount * remote_size, sendtype, 0, MPIR_SCATTER_TAG, comm_ptr,
-                      errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                      coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         goto fn_exit;
     } else {
         /* remote group. rank 0 receives data from root. need to
@@ -56,7 +55,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
 
             mpi_errno = MPIC_Recv(tmp_buf, recvcount * local_size * recvtype_sz, MPI_BYTE,
                                   root, MPIR_SCATTER_TAG, comm_ptr, &status);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         } else {
             /* silence -Wmaybe-uninitialized due to MPIR_Scatter by non-zero ranks */
             recvtype_sz = 0;
@@ -70,8 +69,8 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
 
         /* now do the usual scatter on this intracommunicator */
         mpi_errno = MPIR_Scatter(tmp_buf, recvcount * recvtype_sz, MPI_BYTE,
-                                 recvbuf, recvcount, recvtype, 0, newcomm_ptr, errflag);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                 recvbuf, recvcount, recvtype, 0, newcomm_ptr, coll_attr);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
   fn_exit:

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -28,7 +28,7 @@
 /* not declared static because a machine-specific function may call this one in some cases */
 int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                                MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                MPIR_Comm * comm_ptr, int coll_attr)
 {
     MPI_Status status;
     MPI_Aint extent = 0;
@@ -118,11 +118,11 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
             if (relative_rank % 2) {
                 mpi_errno = MPIC_Recv(recvbuf, recvcount, recvtype,
                                       src, MPIR_SCATTER_TAG, comm_ptr, &status);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             } else {
                 mpi_errno = MPIC_Recv(tmp_buf, tmp_buf_size, MPI_BYTE, src,
                                       MPIR_SCATTER_TAG, comm_ptr, &status);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 if (mpi_errno) {
                     curr_cnt = 0;
                 } else
@@ -153,16 +153,16 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
                 mpi_errno = MPIC_Send(((char *) sendbuf +
                                        extent * sendcount * mask),
                                       send_subtree_cnt,
-                                      sendtype, dst, MPIR_SCATTER_TAG, comm_ptr, errflag);
+                                      sendtype, dst, MPIR_SCATTER_TAG, comm_ptr, coll_attr);
             } else {
                 /* non-zero root and others */
                 send_subtree_cnt = curr_cnt - nbytes * mask;
                 /* mask is also the size of this process's subtree */
                 mpi_errno = MPIC_Send(((char *) tmp_buf + nbytes * mask),
                                       send_subtree_cnt,
-                                      MPI_BYTE, dst, MPIR_SCATTER_TAG, comm_ptr, errflag);
+                                      MPI_BYTE, dst, MPIR_SCATTER_TAG, comm_ptr, coll_attr);
             }
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             curr_cnt -= send_subtree_cnt;
         }
         mask >>= 1;

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -117,11 +117,11 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
              * receive data into a temporary buffer. */
             if (relative_rank % 2) {
                 mpi_errno = MPIC_Recv(recvbuf, recvcount, recvtype,
-                                      src, MPIR_SCATTER_TAG, comm_ptr, &status);
+                                      src, MPIR_SCATTER_TAG, comm_ptr, coll_attr, &status);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             } else {
                 mpi_errno = MPIC_Recv(tmp_buf, tmp_buf_size, MPI_BYTE, src,
-                                      MPIR_SCATTER_TAG, comm_ptr, &status);
+                                      MPIR_SCATTER_TAG, comm_ptr, coll_attr, &status);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
                 if (mpi_errno) {
                     curr_cnt = 0;

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -42,7 +42,7 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
     int mpi_errno_ret = MPI_SUCCESS;
     MPIR_CHKLMEM_DECL(4);
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
     if (rank == root)
         MPIR_Datatype_get_extent_macro(sendtype, extent);

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -20,7 +20,7 @@
 int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcounts,
                                  const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
                                  MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                 MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rank, comm_size, mpi_errno = MPI_SUCCESS;
     int mpi_errno_ret = MPI_SUCCESS;
@@ -58,21 +58,22 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcount
                 } else {
                     mpi_errno = MPIC_Isend(((char *) sendbuf + displs[i] * extent),
                                            sendcounts[i], sendtype, i,
-                                           MPIR_SCATTERV_TAG, comm_ptr, &reqarray[reqs++], errflag);
+                                           MPIR_SCATTERV_TAG, comm_ptr, &reqarray[reqs++],
+                                           coll_attr);
                     MPIR_ERR_CHECK(mpi_errno);
                 }
             }
         }
         /* ... then wait for *all* of them to finish: */
         mpi_errno = MPIC_Waitall(reqs, reqarray, starray);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     }
 
     else if (root != MPI_PROC_NULL) {   /* non-root nodes, and in the intercomm. case, non-root nodes on remote side */
         if (recvcount) {
             mpi_errno = MPIC_Recv(recvbuf, recvcount, recvtype, root,
                                   MPIR_SCATTERV_TAG, comm_ptr, MPI_STATUS_IGNORE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }
 

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -30,7 +30,7 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcount
     MPI_Status *starray;
     MPIR_CHKLMEM_DECL(2);
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, coll_attr, rank, comm_size);
 
     /* If I'm the root, then scatter */
     if (((comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) && (root == rank)) ||

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -72,7 +72,7 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcount
     else if (root != MPI_PROC_NULL) {   /* non-root nodes, and in the intercomm. case, non-root nodes on remote side */
         if (recvcount) {
             mpi_errno = MPIC_Recv(recvbuf, recvcount, recvtype, root,
-                                  MPIR_SCATTERV_TAG, comm_ptr, MPI_STATUS_IGNORE);
+                                  MPIR_SCATTERV_TAG, comm_ptr, coll_attr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
     }

--- a/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_nb.c
@@ -8,7 +8,7 @@
 int MPIR_Scatterv_allcomm_nb(const void *sendbuf, const MPI_Aint * sendcounts,
                              const MPI_Aint * displs, MPI_Datatype sendtype, void *recvbuf,
                              MPI_Aint recvcount, MPI_Datatype recvtype, int root,
-                             MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                             MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *req_ptr = NULL;

--- a/src/mpi/coll/src/csel.c
+++ b/src/mpi/coll/src/csel.c
@@ -659,14 +659,14 @@ static csel_node_s *prune_tree(csel_node_s * root, MPIR_Comm * comm_ptr)
                 break;
 
             case CSEL_NODE_TYPE__OPERATOR__COMM_AVG_PPN_LE:
-                if (comm_ptr->local_size <= node->u.comm_avg_ppn_le.val * comm_ptr->node_count)
+                if (comm_ptr->local_size <= node->u.comm_avg_ppn_le.val * comm_ptr->num_external)
                     node = node->success;
                 else
                     node = node->failure;
                 break;
 
             case CSEL_NODE_TYPE__OPERATOR__COMM_AVG_PPN_LT:
-                if (comm_ptr->local_size < node->u.comm_avg_ppn_le.val * comm_ptr->node_count)
+                if (comm_ptr->local_size < node->u.comm_avg_ppn_le.val * comm_ptr->num_external)
                     node = node->success;
                 else
                     node = node->failure;
@@ -1329,14 +1329,14 @@ void *MPIR_Csel_search(void *csel_, MPIR_Csel_coll_sig_s coll_info)
                 break;
 
             case CSEL_NODE_TYPE__OPERATOR__COMM_AVG_PPN_LE:
-                if (comm_ptr->local_size <= node->u.comm_avg_ppn_le.val * comm_ptr->node_count)
+                if (comm_ptr->local_size <= node->u.comm_avg_ppn_le.val * comm_ptr->num_external)
                     node = node->success;
                 else
                     node = node->failure;
                 break;
 
             case CSEL_NODE_TYPE__OPERATOR__COMM_AVG_PPN_LT:
-                if (comm_ptr->local_size < node->u.comm_avg_ppn_le.val * comm_ptr->node_count)
+                if (comm_ptr->local_size < node->u.comm_avg_ppn_le.val * comm_ptr->num_external)
                     node = node->success;
                 else
                     node = node->failure;

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -75,7 +75,7 @@ static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t 
                                vtxp->u.irecv.count,
                                vtxp->u.irecv.dt,
                                vtxp->u.irecv.src, vtxp->u.irecv.tag, vtxp->u.irecv.comm,
-                               &vtxp->u.irecv.req);
+                               r->u.nbc.coll_attr, &vtxp->u.irecv.req);
 
                     if (MPIR_Request_is_complete(vtxp->u.irecv.req)) {
                         MPIR_Request_free(vtxp->u.irecv.req);
@@ -104,7 +104,8 @@ static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t 
                                vtxp->u.irecv_status.count,
                                vtxp->u.irecv_status.dt,
                                vtxp->u.irecv_status.src, vtxp->u.irecv_status.tag,
-                               vtxp->u.irecv_status.comm, &vtxp->u.irecv_status.req);
+                               vtxp->u.irecv_status.comm,
+                               r->u.nbc.coll_attr, &vtxp->u.irecv_status.req);
 
                     if (MPIR_Request_is_complete(vtxp->u.irecv_status.req)) {
                         if (vtxp->u.irecv_status.status != MPI_STATUS_IGNORE) {

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -44,7 +44,7 @@ static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t 
                                vtxp->u.isend.dt,
                                vtxp->u.isend.dest,
                                vtxp->u.isend.tag, vtxp->u.isend.comm, &vtxp->u.isend.req,
-                               r->u.nbc.errflag);
+                               r->u.nbc.coll_attr);
 
                     if (MPIR_Request_is_complete(vtxp->u.isend.req)) {
                         MPIR_Request_free(vtxp->u.isend.req);
@@ -144,7 +144,7 @@ static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t 
                                    vtxp->u.imcast.dt,
                                    dests[i],
                                    vtxp->u.imcast.tag, vtxp->u.imcast.comm, &vtxp->u.imcast.req[i],
-                                   r->u.nbc.errflag);
+                                   r->u.nbc.coll_attr);
 
                     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                                     (MPL_DBG_FDEST,
@@ -160,7 +160,7 @@ static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t 
                                 vtxp->u.issend.dt,
                                 vtxp->u.issend.dest,
                                 vtxp->u.issend.tag, vtxp->u.issend.comm, &vtxp->u.issend.req,
-                                r->u.nbc.errflag);
+                                r->u.nbc.coll_attr);
 
                     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                                     (MPL_DBG_FDEST,
@@ -232,11 +232,11 @@ static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t 
                     /* ignore communicator and tag */
                     int ret_errno = vtxp->u.cb.cb_p(NULL, -1, vtxp->u.cb.cb_data);
                     if (unlikely(ret_errno)) {
-                        if (MPIR_ERR_NONE == r->u.nbc.errflag) {
+                        if (MPIR_ERR_NONE == r->u.nbc.coll_attr) {
                             if (MPIX_ERR_PROC_FAILED == MPIR_ERR_GET_CLASS(ret_errno)) {
-                                r->u.nbc.errflag = MPIR_ERR_PROC_FAILED;
+                                r->u.nbc.coll_attr = MPIR_ERR_PROC_FAILED;
                             } else {
-                                r->u.nbc.errflag = MPIR_ERR_OTHER;
+                                r->u.nbc.coll_attr = MPIR_ERR_OTHER;
                             }
                         }
                     }
@@ -683,7 +683,7 @@ int MPII_Genutil_sched_poke(MPII_Genutil_sched_t * sched, int *is_complete, int 
             *made_progress = TRUE;
 
         /* error handling */
-        switch (sched->req->u.nbc.errflag) {
+        switch (sched->req->u.nbc.coll_attr) {
             case MPIR_ERR_PROC_FAILED:
                 MPIR_ERR_SET(sched->req->status.MPI_ERROR, MPIX_ERR_PROC_FAILED, "**comm");
                 break;

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -665,6 +665,9 @@ int MPIR_Comm_create_subcomms(MPIR_Comm * comm)
     MPIR_Assert(num_local > 1 || external_rank >= 0);
     MPIR_Assert(external_rank < 0 || external_procs != NULL);
 
+    comm->num_local = num_local;
+    comm->num_external = num_external;
+
     /* if the node_roots_comm and comm would be the same size, then creating
      * the second communicator is useless and wasteful. */
     if (num_external == comm->remote_size) {

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -523,58 +523,6 @@ int MPIR_Comm_map_free(MPIR_Comm * comm)
     return mpi_errno;
 }
 
-static int get_node_count(MPIR_Comm * comm, int *node_count)
-{
-    int mpi_errno = MPI_SUCCESS;
-    struct uniq_nodes {
-        int id;
-        UT_hash_handle hh;
-    } *node_list = NULL;
-    struct uniq_nodes *s, *tmp;
-
-    if (comm->comm_kind != MPIR_COMM_KIND__INTRACOMM) {
-        *node_count = comm->local_size;
-        goto fn_exit;
-    } else if (comm->hierarchy_kind == MPIR_COMM_HIERARCHY_KIND__NODE) {
-        *node_count = 1;
-        goto fn_exit;
-    } else if (comm->hierarchy_kind == MPIR_COMM_HIERARCHY_KIND__NODE_ROOTS) {
-        *node_count = comm->local_size;
-        goto fn_exit;
-    }
-
-    /* go through the list of ranks and add the unique ones to the
-     * node_list array */
-    for (int i = 0; i < comm->local_size; i++) {
-        int node;
-
-        mpi_errno = MPID_Get_node_id(comm, i, &node);
-        MPIR_ERR_CHECK(mpi_errno);
-
-        HASH_FIND_INT(node_list, &node, s);
-        if (s == NULL) {
-            s = (struct uniq_nodes *) MPL_malloc(sizeof(struct uniq_nodes), MPL_MEM_COLL);
-            MPIR_Assert(s);
-            s->id = node;
-            HASH_ADD_INT(node_list, id, s, MPL_MEM_COLL);
-        }
-    }
-
-    /* the final size of our hash table is our node count */
-    *node_count = HASH_COUNT(node_list);
-
-    /* free up everything */
-    HASH_ITER(hh, node_list, s, tmp) {
-        HASH_DEL(node_list, s);
-        MPL_free(s);
-    }
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
 static int MPIR_Comm_commit_internal(MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -582,9 +530,6 @@ static int MPIR_Comm_commit_internal(MPIR_Comm * comm)
 
     /* Notify device of communicator creation */
     mpi_errno = MPID_Comm_commit_pre_hook(comm);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    mpi_errno = get_node_count(comm, &comm->node_count);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Comm_map_free(comm);

--- a/src/mpi/comm/ulfm_impl.c
+++ b/src/mpi/comm/ulfm_impl.c
@@ -194,7 +194,7 @@ int MPIR_Comm_agree_impl(MPIR_Comm * comm_ptr, int *flag)
     int mpi_errno = MPI_SUCCESS, mpi_errno_tmp = MPI_SUCCESS;
     MPIR_Group *comm_grp = NULL, *failed_grp = NULL, *new_group_ptr = NULL, *global_failed = NULL;
     int result, success = 1;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    int errflag = MPIR_ERR_NONE;
     int values[2];
 
     MPIR_FUNC_ENTER;

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -51,7 +51,7 @@ void MPII_init_request(void)
         init_builtin_request(req, MPIR_REQUEST_COMPLETE + i, (MPIR_Request_kind_t) i);
     }
     MPII_REQUEST_CLEAR_DBG(&MPIR_Request_builtin[MPIR_REQUEST_KIND__SEND]);
-    MPIR_Request_builtin[MPIR_REQUEST_KIND__COLL].u.nbc.errflag = MPIR_ERR_NONE;
+    MPIR_Request_builtin[MPIR_REQUEST_KIND__COLL].u.nbc.coll_attr = 0;
     MPIR_Request_builtin[MPIR_REQUEST_KIND__COLL].u.nbc.coll.host_sendbuf = NULL;
     MPIR_Request_builtin[MPIR_REQUEST_KIND__COLL].u.nbc.coll.host_recvbuf = NULL;
     MPIR_Request_builtin[MPIR_REQUEST_KIND__COLL].u.nbc.coll.datatype = MPI_DATATYPE_NULL;

--- a/src/mpi/topo/dist_graph_create.c
+++ b/src/mpi/topo/dist_graph_create.c
@@ -203,7 +203,7 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
         MPIR_ERR_CHKANDJUMP(!buf, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
         mpi_errno = MPIC_Recv(buf, count, MPI_INT, MPI_ANY_SOURCE, MPIR_TOPO_A_TAG,
-                              comm_ptr, MPI_STATUS_IGNORE);
+                              comm_ptr, 0, MPI_STATUS_IGNORE);
         MPIR_ERR_CHECK(mpi_errno);
 
         for (int j = 0; j < count / 2; ++j) {
@@ -236,7 +236,7 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
         MPIR_ERR_CHKANDJUMP(!buf, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
         mpi_errno = MPIC_Recv(buf, count, MPI_INT, MPI_ANY_SOURCE, MPIR_TOPO_B_TAG,
-                              comm_ptr, MPI_STATUS_IGNORE);
+                              comm_ptr, 0, MPI_STATUS_IGNORE);
         MPIR_ERR_CHECK(mpi_errno);
 
         for (int j = 0; j < count / 2; ++j) {

--- a/src/mpid/ch3/include/mpid_coll.h
+++ b/src/mpid/ch3/include/mpid_coll.h
@@ -11,70 +11,70 @@
 #include "../../common/hcoll/hcoll.h"
 #endif
 
-static inline int MPID_Barrier(MPIR_Comm * comm, MPIR_Errflag_t errflag)
+static inline int MPID_Barrier(MPIR_Comm * comm, int coll_attr)
 {
 #ifdef HAVE_HCOLL
-    if (MPI_SUCCESS == hcoll_Barrier(comm, errflag))
+    if (MPI_SUCCESS == hcoll_Barrier(comm, coll_attr))
         return MPI_SUCCESS;
 #endif
-    return MPIR_Barrier_impl(comm, errflag);
+    return MPIR_Barrier_impl(comm, coll_attr);
 }
 
 static inline int MPID_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                             MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                             MPIR_Comm * comm, int coll_attr)
 {
 #ifdef HAVE_HCOLL
-    if (MPI_SUCCESS == hcoll_Bcast(buffer, count, datatype, root, comm, errflag))
+    if (MPI_SUCCESS == hcoll_Bcast(buffer, count, datatype, root, comm, coll_attr))
         return MPI_SUCCESS;
 #endif
-    return MPIR_Bcast_impl(buffer, count, datatype, root, comm, errflag);
+    return MPIR_Bcast_impl(buffer, count, datatype, root, comm, coll_attr);
 }
 
 static inline int MPID_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                 MPIR_Errflag_t errflag)
+                                 int coll_attr)
 {
 #ifdef HAVE_HCOLL
-    if (MPI_SUCCESS == hcoll_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag))
+    if (MPI_SUCCESS == hcoll_Allreduce(sendbuf, recvbuf, count, datatype, op, comm, coll_attr))
         return MPI_SUCCESS;
 #endif
-    return MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    return MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, coll_attr);
 }
 
 static inline int MPID_Allgather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                  void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                 MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                 MPIR_Comm * comm, int coll_attr)
 {
 #ifdef HAVE_HCOLL
     if (MPI_SUCCESS == hcoll_Allgather(sendbuf, sendcount, sendtype, recvbuf,
-                                recvcount, recvtype, comm, errflag))
+                                recvcount, recvtype, comm, coll_attr))
         return MPI_SUCCESS;
 #endif
     return MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                    recvcount, recvtype, comm, errflag);
+                                    recvcount, recvtype, comm, coll_attr);
 }
 
 static inline int MPID_Allgatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                   void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
-                                  MPI_Datatype recvtype, MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                  MPI_Datatype recvtype, MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                                      recvcounts, displs, recvtype, comm,
-                                     errflag);
+                                     coll_attr);
 
     return mpi_errno;
 }
 
 static inline int MPID_Scatter(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                               int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                               int root, MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                  recvcount, recvtype, root, comm, errflag);
+                                  recvcount, recvtype, root, comm, coll_attr);
 
     return mpi_errno;
 }
@@ -82,25 +82,25 @@ static inline int MPID_Scatter(const void *sendbuf, MPI_Aint sendcount, MPI_Data
 static inline int MPID_Scatterv(const void *sendbuf, const MPI_Aint * sendcounts, const MPI_Aint * displs,
                                 MPI_Datatype sendtype, void *recvbuf, MPI_Aint recvcount,
                                 MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                                MPIR_Errflag_t errflag)
+                                int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Scatterv_impl(sendbuf, sendcounts, displs, sendtype,
                                    recvbuf, recvcount, recvtype, root, comm,
-                                   errflag);
+                                   coll_attr);
 
     return mpi_errno;
 }
 
 static inline int MPID_Gather(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                               void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                              int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                              int root, MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                 recvcount, recvtype, root, comm, errflag);
+                                 recvcount, recvtype, root, comm, coll_attr);
 
     return mpi_errno;
 }
@@ -108,25 +108,25 @@ static inline int MPID_Gather(const void *sendbuf, MPI_Aint sendcount, MPI_Datat
 static inline int MPID_Gatherv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                void *recvbuf, const MPI_Aint * recvcounts, const MPI_Aint * displs,
                                MPI_Datatype recvtype, int root, MPIR_Comm * comm,
-                               MPIR_Errflag_t errflag)
+                               int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                                   recvcounts, displs, recvtype, root, comm,
-                                  errflag);
+                                  coll_attr);
 
     return mpi_errno;
 }
 
 static inline int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                                 void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
-                                MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                   recvcount, recvtype, comm, errflag);
+                                   recvcount, recvtype, comm, coll_attr);
 
     return mpi_errno;
 }
@@ -134,13 +134,13 @@ static inline int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
 static inline int MPID_Alltoallv(const void *sendbuf, const MPI_Aint * sendcounts, const MPI_Aint * sdispls,
                                  MPI_Datatype sendtype, void *recvbuf, const MPI_Aint * recvcounts,
                                  const MPI_Aint * rdispls, MPI_Datatype recvtype, MPIR_Comm * comm,
-                                 MPIR_Errflag_t errflag)
+                                 int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
                                     recvbuf, recvcounts, rdispls, recvtype,
-                                    comm, errflag);
+                                    comm, coll_attr);
 
     return mpi_errno;
 }
@@ -149,37 +149,37 @@ static inline int MPID_Alltoallw(const void *sendbuf, const MPI_Aint sendcounts[
                                  const MPI_Datatype sendtypes[], void *recvbuf,
                                  const MPI_Aint recvcounts[], const MPI_Aint rdispls[],
                                  const MPI_Datatype recvtypes[], MPIR_Comm * comm_ptr,
-                                 MPIR_Errflag_t errflag)
+                                 int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Alltoallw_impl(sendbuf, sendcounts, sdispls, sendtypes,
                                     recvbuf, recvcounts, rdispls, recvtypes,
-                                    comm_ptr, errflag);
+                                    comm_ptr, coll_attr);
 
     return mpi_errno;
 }
 
 static inline int MPID_Reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                               MPI_Datatype datatype, MPI_Op op, int root,
-                              MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                              MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root,
-                                 comm, errflag);
+                                 comm, coll_attr);
 
     return mpi_errno;
 }
 
 static inline int MPID_Reduce_scatter(const void *sendbuf, void *recvbuf, const MPI_Aint recvcounts[],
                                       MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm_ptr,
-                                      MPIR_Errflag_t errflag)
+                                      int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts,
-                                         datatype, op, comm_ptr, errflag);
+                                         datatype, op, comm_ptr, coll_attr);
 
     return mpi_errno;
 }
@@ -187,37 +187,37 @@ static inline int MPID_Reduce_scatter(const void *sendbuf, void *recvbuf, const 
 static inline int MPID_Reduce_scatter_block(const void *sendbuf, void *recvbuf,
                                             MPI_Aint recvcount, MPI_Datatype datatype,
                                             MPI_Op op, MPIR_Comm * comm_ptr,
-                                            MPIR_Errflag_t errflag)
+                                            int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount,
                                                datatype, op, comm_ptr,
-                                               errflag);
+                                               coll_attr);
 
     return mpi_errno;
 }
 
 static inline int MPID_Scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                             MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                            MPIR_Errflag_t errflag)
+                            int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm,
-                               errflag);
+                               coll_attr);
 
     return mpi_errno;
 }
 
 static inline int MPID_Exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                               MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                              MPIR_Errflag_t errflag)
+                              int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm,
-                                 errflag);
+                                 coll_attr);
 
     return mpi_errno;
 }

--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -928,7 +928,7 @@ static int ReceivePGAndDistribute( MPIR_Comm *tmp_comm, MPIR_Comm *comm_ptr,
 	if (rank == root) {
 	    /* First, receive the pg description from the partner */
 	    mpi_errno = MPIC_Recv(&j, 1, MPI_INT, 0, recvtag++,
-				  tmp_comm, MPI_STATUS_IGNORE);
+				  tmp_comm, 0, MPI_STATUS_IGNORE);
 	    *recvtag_p = recvtag;
 	    MPIR_ERR_CHECK(mpi_errno);
 	    pg_str = (char*)MPL_malloc(j, MPL_MEM_DYNAMIC);
@@ -936,7 +936,7 @@ static int ReceivePGAndDistribute( MPIR_Comm *tmp_comm, MPIR_Comm *comm_ptr,
 		MPIR_ERR_POP(mpi_errno);
 	    }
 	    mpi_errno = MPIC_Recv(pg_str, j, MPI_CHAR, 0, recvtag++,
-				  tmp_comm, MPI_STATUS_IGNORE);
+				  tmp_comm, 0, MPI_STATUS_IGNORE);
 	    *recvtag_p = recvtag;
 	    MPIR_ERR_CHECK(mpi_errno);
 	}

--- a/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
+++ b/src/mpid/ch3/src/mpid_comm_get_all_failed_procs.c
@@ -107,7 +107,7 @@ int MPID_Comm_get_all_failed_procs(MPIR_Comm *comm_ptr, MPIR_Group **failed_grou
         for (i = 1; i < comm_ptr->local_size; i++) {
             /* Get everyone's list of failed processes to aggregate */
             ret_errno = MPIC_Recv(remote_bitarray, bitarray_size, MPI_INT,
-                i, tag, comm_ptr, MPI_STATUS_IGNORE);
+                i, tag, comm_ptr, 0, MPI_STATUS_IGNORE);
             if (ret_errno) continue;
 
             /* Combine the received bitarray with my own */
@@ -134,7 +134,7 @@ int MPID_Comm_get_all_failed_procs(MPIR_Comm *comm_ptr, MPIR_Group **failed_grou
 
         /* Get the resulting bitarray back from rank 0 */
         mpi_errno = MPIC_Recv(remote_bitarray, bitarray_size, MPI_INT, 0,
-            tag, comm_ptr, MPI_STATUS_IGNORE);
+            tag, comm_ptr, 0, MPI_STATUS_IGNORE);
 
         /* Convert the bitarray into a group */
         *failed_group = bitarray_to_group(comm_ptr, remote_bitarray);

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -10,7 +10,7 @@
 #   - src/mpid/ch4/shm/src/shm_noinline.h
 #   - src/mpid/ch4/shm/posix/posix_noinline.h
 #   - src/mpid/ch4/shm/stubshm/shm_noinline.h
-# It also gnerates the stub codes in 
+# It also generates the stub codes in 
 #   - src/mpid/ch4/netmod/stubnm
 #   - src/mpid/ch4/shm/stubshm
 #

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -275,56 +275,56 @@ Native API:
   rank_is_local : int
       NM*: target, comm
   mpi_barrier : int
-      NM*: comm, errflag
-     SHM*: comm, errflag
+      NM*: comm, coll_attr
+     SHM*: comm, coll_attr
   mpi_bcast : int
-      NM*: buffer, count, datatype, root, comm, errflag
-     SHM*: buffer, count, datatype, root, comm, errflag
+      NM*: buffer, count, datatype, root, comm, coll_attr
+     SHM*: buffer, count, datatype, root, comm, coll_attr
   mpi_allreduce : int
-      NM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
-     SHM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
+      NM*: sendbuf, recvbuf, count, datatype, op, comm, coll_attr
+     SHM*: sendbuf, recvbuf, count, datatype, op, comm, coll_attr
   mpi_allgather : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, errflag
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, errflag
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, coll_attr
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, coll_attr
   mpi_allgatherv : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, errflag
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, errflag
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, coll_attr
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, coll_attr
   mpi_scatter : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, errflag
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, errflag
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, coll_attr
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, coll_attr
   mpi_scatterv : int
-      NM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr, errflag
-     SHM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr, errflag
+      NM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr, coll_attr
+     SHM*: sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm_ptr, coll_attr
   mpi_gather : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, errflag
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, errflag
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, coll_attr
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, coll_attr
   mpi_gatherv : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, errflag
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, errflag
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, coll_attr
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, coll_attr
   mpi_alltoall : int
-      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, errflag
-     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, errflag
+      NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, coll_attr
+     SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, coll_attr
   mpi_alltoallv : int
-      NM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, errflag
-     SHM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, errflag
+      NM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, coll_attr
+     SHM*: sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, coll_attr
   mpi_alltoallw : int
-      NM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, errflag
-     SHM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, errflag
+      NM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, coll_attr
+     SHM*: sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, coll_attr
   mpi_reduce : int
-      NM*: sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag
-     SHM*: sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag
+      NM*: sendbuf, recvbuf, count, datatype, op, root, comm_ptr, coll_attr
+     SHM*: sendbuf, recvbuf, count, datatype, op, root, comm_ptr, coll_attr
   mpi_reduce_scatter : int
-      NM*: sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, errflag
-     SHM*: sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, errflag
+      NM*: sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, coll_attr
+     SHM*: sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, coll_attr
   mpi_reduce_scatter_block : int
-      NM*: sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, errflag
-     SHM*: sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, errflag
+      NM*: sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, coll_attr
+     SHM*: sendbuf, recvbuf, recvcount, datatype, op, comm_ptr, coll_attr
   mpi_scan : int
-      NM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
-     SHM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
+      NM*: sendbuf, recvbuf, count, datatype, op, comm, coll_attr
+     SHM*: sendbuf, recvbuf, count, datatype, op, comm, coll_attr
   mpi_exscan : int
-      NM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
-     SHM*: sendbuf, recvbuf, count, datatype, op, comm, errflag
+      NM*: sendbuf, recvbuf, count, datatype, op, comm, coll_attr
+     SHM*: sendbuf, recvbuf, count, datatype, op, comm, coll_attr
   mpi_neighbor_allgather : int
       NM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm
      SHM*: sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm
@@ -453,7 +453,7 @@ PARAM:
     disp_unit_p: int *
     displs: const MPI_Aint *
     dst_vci: int
-    errflag: MPIR_Errflag_t
+    coll_attr: int
     flag: int *
     group: MPIR_Group *
     handler_id: int

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -175,52 +175,52 @@ int MPID_Comm_set_hints(MPIR_Comm *, MPIR_Info *);
 int MPID_Comm_commit_post_hook(MPIR_Comm *);
 int MPID_Stream_create_hook(MPIR_Stream * stream);
 int MPID_Stream_free_hook(MPIR_Stream * stream);
-MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Barrier(MPIR_Comm *, int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Bcast(void *, MPI_Aint, MPI_Datatype, int, MPIR_Comm *,
-                                        MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                        int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Allreduce(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
-                                            MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                            MPIR_Comm *, int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                             MPI_Datatype, MPIR_Comm *,
-                                            MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                            int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Allgatherv(const void *, MPI_Aint, MPI_Datatype, void *,
                                              const MPI_Aint *, const MPI_Aint *, MPI_Datatype,
-                                             MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                             MPIR_Comm *, int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Scatter(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                           MPI_Datatype, int, MPIR_Comm *,
-                                          MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                          int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Scatterv(const void *, const MPI_Aint *, const MPI_Aint *,
                                            MPI_Datatype, void *, MPI_Aint, MPI_Datatype, int,
-                                           MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                           MPIR_Comm *, int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Gather(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                          MPI_Datatype, int, MPIR_Comm *,
-                                         MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                         int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Gatherv(const void *, MPI_Aint, MPI_Datatype, void *,
                                           const MPI_Aint *, const MPI_Aint *, MPI_Datatype, int,
-                                          MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                          MPIR_Comm *, int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *, MPI_Aint, MPI_Datatype, void *, MPI_Aint,
                                            MPI_Datatype, MPIR_Comm *,
-                                           MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                           int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Alltoallv(const void *, const MPI_Aint *, const MPI_Aint *,
                                             MPI_Datatype, void *, const MPI_Aint *,
                                             const MPI_Aint *, MPI_Datatype, MPIR_Comm *,
-                                            MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                            int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Alltoallw(const void *, const MPI_Aint[], const MPI_Aint[],
                                             const MPI_Datatype[], void *, const MPI_Aint[],
                                             const MPI_Aint[], const MPI_Datatype[], MPIR_Comm *,
-                                            MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                            int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op, int,
-                                         MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                         MPIR_Comm *, int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter(const void *, void *, const MPI_Aint[],
                                                  MPI_Datatype, MPI_Op, MPIR_Comm *,
-                                                 MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                                 int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Reduce_scatter_block(const void *, void *, MPI_Aint, MPI_Datatype,
                                                        MPI_Op, MPIR_Comm *,
-                                                       MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                                       int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Scan(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
-                                       MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                       MPIR_Comm *, int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Exscan(const void *, void *, MPI_Aint, MPI_Datatype, MPI_Op,
-                                         MPIR_Comm *, MPIR_Errflag_t) MPL_STATIC_INLINE_SUFFIX;
+                                         MPIR_Comm *, int coll_attr) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Neighbor_allgather(const void *, MPI_Aint, MPI_Datatype, void *,
                                                      MPI_Aint, MPI_Datatype,
                                                      MPIR_Comm *) MPL_STATIC_INLINE_SUFFIX;

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_coll.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_coll.h
@@ -6,22 +6,20 @@
 #ifndef NETMOD_AM_FALLBACK_COLL_H_INCLUDED
 #define NETMOD_AM_FALLBACK_COLL_H_INCLUDED
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Barrier_impl(comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
-                                                int root, MPIR_Comm * comm_ptr,
-                                                MPIR_Errflag_t errflag)
+                                                int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                     MPI_Aint count, MPI_Datatype datatype,
-                                                    MPI_Op op, MPIR_Comm * comm_ptr,
-                                                    MPIR_Errflag_t errflag)
+                                                    MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
@@ -29,7 +27,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf,
                                recvcount, recvtype, comm_ptr, errflag);
@@ -39,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                     MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcounts, displs, recvtype, comm_ptr, errflag);
@@ -48,8 +46,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                 int root, MPIR_Comm * comm_ptr,
-                                                 MPIR_Errflag_t errflag)
+                                                 int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf,
                             recvcount, recvtype, root, comm_ptr, errflag);
@@ -59,8 +56,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   const MPI_Aint * recvcounts,
                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcounts, displs, recvtype, root, comm_ptr, errflag);
@@ -69,8 +65,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcount, recvtype, root, comm_ptr, errflag);
@@ -80,7 +75,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
                                                    const MPI_Aint * displs, MPI_Datatype sendtype,
                                                    void *recvbuf, MPI_Aint recvcount,
                                                    MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Scatterv_impl(sendbuf, sendcounts, displs, sendtype,
                               recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
@@ -89,7 +84,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
                               recvcount, recvtype, comm_ptr, errflag);
@@ -100,7 +95,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
                                                     const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                                     void *recvbuf, const MPI_Aint * recvcounts,
                                                     const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
                                recvbuf, recvcounts, rdispls, recvtype, comm_ptr, errflag);
@@ -113,7 +108,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
                                                     const MPI_Aint recvcounts[],
                                                     const MPI_Aint rdispls[],
                                                     const MPI_Datatype recvtypes[],
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Alltoallw_impl(sendbuf, sendcounts, sdispls, sendtypes,
                                recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, errflag);
@@ -121,7 +116,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                 MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
 }
@@ -129,8 +124,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
                                                          const MPI_Aint recvcounts[],
                                                          MPI_Datatype datatype, MPI_Op op,
-                                                         MPIR_Comm * comm_ptr,
-                                                         MPIR_Errflag_t errflag)
+                                                         MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, errflag);
 }
@@ -138,8 +132,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, vo
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                                MPI_Aint recvcount,
                                                                MPI_Datatype datatype, MPI_Op op,
-                                                               MPIR_Comm * comm_ptr,
-                                                               MPIR_Errflag_t errflag)
+                                                               MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount,
                                           datatype, op, comm_ptr, errflag);
@@ -147,14 +140,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                               MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                 MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
@@ -17,7 +17,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
     int mpi_errno = MPI_SUCCESS;
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-    MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
+    int coll_attr = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
     bool syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr);
 
     int vci_src, vci_dst;

--- a/src/mpid/ch4/netmod/ofi/ofi_coll.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_coll.h
@@ -30,13 +30,13 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Barrier_impl(comm, errflag);
+    mpi_errno = MPIR_Barrier_impl(comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -49,11 +49,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag
 }
 
 static inline int MPIDI_OFI_bcast_json(void *buffer, MPI_Aint count, MPI_Datatype datatype,
-                                       int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                       int root, MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm, errflag);
+    mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm, coll_attr);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -63,7 +63,7 @@ static inline int MPIDI_OFI_bcast_json(void *buffer, MPI_Aint count, MPI_Datatyp
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
-                                                int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                int root, MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
     enum fi_datatype fi_dt;
@@ -97,7 +97,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MP
             goto fallback;
             break;
         case MPIR_CVAR_BCAST_OFI_INTRA_ALGORITHM_auto:
-            mpi_errno = MPIDI_OFI_bcast_json(buffer, count, datatype, root, comm, errflag);
+            mpi_errno = MPIDI_OFI_bcast_json(buffer, count, datatype, root, comm, coll_attr);
             break;
         default:
             MPIR_Assert(0);
@@ -106,7 +106,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MP
     goto fn_exit;
 
   fallback:
-    mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm, errflag);
+    mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm, coll_attr);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_FUNC_EXIT;
@@ -119,14 +119,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MP
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                     MPI_Aint count, MPI_Datatype datatype,
-                                                    MPI_Op op, MPIR_Comm * comm,
-                                                    MPIR_Errflag_t errflag)
+                                                    MPI_Op op, MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -141,14 +140,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Allgather_impl(sendbuf, sendcount, sendtype,
-                                    recvbuf, recvcount, recvtype, comm, errflag);
+                                    recvbuf, recvcount, recvtype, comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -164,14 +163,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                     MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype,
-                                     recvbuf, recvcounts, displs, recvtype, comm, errflag);
+                                     recvbuf, recvcounts, displs, recvtype, comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -186,14 +185,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                 int root, MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                 int root, MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                 recvcount, recvtype, root, comm, errflag);
+                                 recvcount, recvtype, root, comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -209,15 +208,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   const MPI_Aint * recvcounts,
                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                  recvcounts, displs, recvtype, root, comm, errflag);
+                                  recvcounts, displs, recvtype, root, comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -233,15 +231,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                  recvcount, recvtype, root, comm, errflag);
+                                  recvcount, recvtype, root, comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -257,14 +254,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
                                                    const MPI_Aint * displs, MPI_Datatype sendtype,
                                                    void *recvbuf, MPI_Aint recvcount,
                                                    MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Scatterv_impl(sendbuf, sendcounts, displs, sendtype, recvbuf,
-                                   recvcount, recvtype, root, comm, errflag);
+                                   recvcount, recvtype, root, comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -279,14 +276,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Alltoall_impl(sendbuf, sendcount, sendtype,
-                                   recvbuf, recvcount, recvtype, comm, errflag);
+                                   recvbuf, recvcount, recvtype, comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -303,7 +300,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
                                                     const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                                     void *recvbuf, const MPI_Aint * recvcounts,
                                                     const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -311,7 +308,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
 
     mpi_errno = MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls,
                                     sendtype, recvbuf, recvcounts,
-                                    rdispls, recvtype, comm, errflag);
+                                    rdispls, recvtype, comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -330,7 +327,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
                                                     const MPI_Aint recvcounts[],
                                                     const MPI_Aint rdispls[],
                                                     const MPI_Datatype recvtypes[],
-                                                    MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -338,7 +335,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
 
     mpi_errno = MPIR_Alltoallw_impl(sendbuf, sendcounts, sdispls,
                                     sendtypes, recvbuf, recvcounts,
-                                    rdispls, recvtypes, comm, errflag);
+                                    rdispls, recvtypes, comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -352,13 +349,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                 MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                 MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm, errflag);
+    mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -373,13 +370,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
                                                          const MPI_Aint recvcounts[],
                                                          MPI_Datatype datatype, MPI_Op op,
-                                                         MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                         MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm, errflag);
+    mpi_errno =
+        MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -394,14 +392,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, vo
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                                MPI_Aint recvcount,
                                                                MPI_Datatype datatype, MPI_Op op,
-                                                               MPIR_Comm * comm,
-                                                               MPIR_Errflag_t errflag)
+                                                               MPIR_Comm * comm, int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount, datatype, op, comm, errflag);
+    MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount, datatype, op, comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -415,13 +412,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                               MPIR_Errflag_t errflag)
+                                               int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    mpi_errno = MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -435,13 +432,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbu
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, MPIR_Comm * comm,
-                                                 MPIR_Errflag_t errflag)
+                                                 int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    mpi_errno = MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm, coll_attr);
 
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -508,7 +508,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_fallback(const void *buf, MPI_Aint c
                                                      MPIR_Comm * comm, int context_offset,
                                                      MPIDI_av_entry_t * addr, int vci_src,
                                                      int vci_dst, MPIR_Request ** request,
-                                                     MPIR_Errflag_t err_flag)
+                                                     int err_flag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -580,7 +580,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
                                             int context_offset, MPIDI_av_entry_t * addr,
                                             int vci_src, int vci_dst,
                                             MPIR_Request ** request, int noreq,
-                                            uint64_t syncflag, MPIR_Errflag_t err_flag)
+                                            uint64_t syncflag, int err_flag)
 {
     int dt_contig, mpi_errno;
     size_t data_sz;
@@ -689,7 +689,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
     MPIR_FUNC_ENTER;
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-    MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
+    int errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
 
     int vci_src, vci_dst;
     MPIDI_OFI_SEND_VNIS(vci_src, vci_dst);      /* defined just above */

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -47,8 +47,7 @@
 #define MPIDI_OFI_ERR_PROC_FAILED (0x2ULL)
 
 /* Set the error bits */
-MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_idata_set_error_bits(uint64_t * data_field,
-                                                             MPIR_Errflag_t errflag)
+MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_idata_set_error_bits(uint64_t * data_field, int errflag)
 {
     switch (errflag) {
         case MPIR_ERR_OTHER:

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -63,13 +63,13 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_idata_set_error_bits(uint64_t * data_fie
     }
 }
 
-/* Get the error flag from the OFI data field. */
+/* Get the mpi error code from the OFI data field. */
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_idata_get_error_bits(uint64_t idata)
 {
     if ((idata >> MPIDI_OFI_IDATA_SRC_BITS) & MPIDI_OFI_ERR_OTHER) {
-        return MPIR_ERR_OTHER;
+        return MPI_ERR_OTHER;
     } else if ((idata >> MPIDI_OFI_IDATA_SRC_BITS) & MPIDI_OFI_ERR_PROC_FAILED) {
-        return MPIR_ERR_PROC_FAILED;
+        return MPIX_ERR_PROC_FAILED;
     } else {
         return MPI_SUCCESS;
     }

--- a/src/mpid/ch4/netmod/ucx/ucx_coll.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_coll.h
@@ -11,17 +11,17 @@
 #include "../../../common/hcoll/hcoll.h"
 #endif
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
 #ifdef HAVE_HCOLL
-    mpi_errno = hcoll_Barrier(comm_ptr, errflag);
+    mpi_errno = hcoll_Barrier(comm_ptr, coll_attr);
     if (mpi_errno != MPI_SUCCESS)
 #endif
     {
-        mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
+        mpi_errno = MPIR_Barrier_impl(comm_ptr, coll_attr);
     }
 
     MPIR_FUNC_EXIT;
@@ -29,18 +29,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Err
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
-                                                int root, MPIR_Comm * comm_ptr,
-                                                MPIR_Errflag_t errflag)
+                                                int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
 #ifdef HAVE_HCOLL
-    mpi_errno = hcoll_Bcast(buffer, count, datatype, root, comm_ptr, errflag);
+    mpi_errno = hcoll_Bcast(buffer, count, datatype, root, comm_ptr, coll_attr);
     if (mpi_errno != MPI_SUCCESS)
 #endif
     {
-        mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
+        mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, coll_attr);
     }
 
     MPIR_FUNC_EXIT;
@@ -49,18 +48,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MP
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                     MPI_Aint count, MPI_Datatype datatype,
-                                                    MPI_Op op, MPIR_Comm * comm_ptr,
-                                                    MPIR_Errflag_t errflag)
+                                                    MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
 #ifdef HAVE_HCOLL
-    mpi_errno = hcoll_Allreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
+    mpi_errno = hcoll_Allreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, coll_attr);
     if (mpi_errno != MPI_SUCCESS)
 #endif
     {
-        mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
+        mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, coll_attr);
     }
 
     MPIR_FUNC_EXIT;
@@ -70,19 +68,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
 #ifdef HAVE_HCOLL
     mpi_errno = hcoll_Allgather(sendbuf, sendcount, sendtype, recvbuf,
-                                recvcount, recvtype, comm_ptr, errflag);
+                                recvcount, recvtype, comm_ptr, coll_attr);
     if (mpi_errno != MPI_SUCCESS)
 #endif
     {
         mpi_errno = MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                        recvcount, recvtype, comm_ptr, errflag);
+                                        recvcount, recvtype, comm_ptr, coll_attr);
     }
 
     MPIR_FUNC_EXIT;
@@ -93,13 +91,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                     MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                     recvcounts, displs, recvtype, comm_ptr, errflag);
+                                     recvcounts, displs, recvtype, comm_ptr, coll_attr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -108,14 +106,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                  MPI_Datatype sendtype, void *recvbuf,
                                                  MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                 int root, MPIR_Comm * comm_ptr,
-                                                 MPIR_Errflag_t errflag)
+                                                 int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                 recvcount, recvtype, root, comm_ptr, errflag);
+                                 recvcount, recvtype, root, comm_ptr, coll_attr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -125,14 +122,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   const MPI_Aint * recvcounts,
                                                   const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                  recvcounts, displs, recvtype, root, comm_ptr, errflag);
+                                  recvcounts, displs, recvtype, root, comm_ptr, coll_attr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -141,14 +137,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                  recvcount, recvtype, root, comm_ptr, errflag);
+                                  recvcount, recvtype, root, comm_ptr, coll_attr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -158,13 +153,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
                                                    const MPI_Aint * displs, MPI_Datatype sendtype,
                                                    void *recvbuf, MPI_Aint recvcount,
                                                    MPI_Datatype recvtype, int root,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Scatterv_impl(sendbuf, sendcounts, displs, sendtype,
-                                   recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
+                                   recvbuf, recvcount, recvtype, root, comm_ptr, coll_attr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -173,19 +168,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                   MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
 #ifdef HAVE_HCOLL
     mpi_errno = hcoll_Alltoall(sendbuf, sendcount, sendtype, recvbuf,
-                               recvcount, recvtype, comm_ptr, errflag);
+                               recvcount, recvtype, comm_ptr, coll_attr);
     if (mpi_errno != MPI_SUCCESS)
 #endif
     {
         mpi_errno = MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
-                                       recvcount, recvtype, comm_ptr, errflag);
+                                       recvcount, recvtype, comm_ptr, coll_attr);
     }
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -196,19 +191,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
                                                     const MPI_Aint * sdispls, MPI_Datatype sendtype,
                                                     void *recvbuf, const MPI_Aint * recvcounts,
                                                     const MPI_Aint * rdispls, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
 #ifdef HAVE_HCOLL
     mpi_errno = hcoll_Alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
-                                recvcounts, rdispls, recvtype, comm_ptr, errflag);
+                                recvcounts, rdispls, recvtype, comm_ptr, coll_attr);
     if (mpi_errno != MPI_SUCCESS)
 #endif
     {
         mpi_errno = MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
-                                        recvbuf, recvcounts, rdispls, recvtype, comm_ptr, errflag);
+                                        recvbuf, recvcounts, rdispls, recvtype, comm_ptr,
+                                        coll_attr);
     }
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -221,13 +217,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
                                                     const MPI_Aint recvcounts[],
                                                     const MPI_Aint rdispls[],
                                                     const MPI_Datatype recvtypes[],
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Alltoallw_impl(sendbuf, sendcounts, sdispls, sendtypes,
-                                    recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, errflag);
+                                    recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, coll_attr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -235,18 +231,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                 MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
 #ifdef HAVE_HCOLL
-    mpi_errno = hcoll_Reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
+    mpi_errno = hcoll_Reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, coll_attr);
     if (mpi_errno != MPI_SUCCESS)
 #endif
     {
         mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr,
-                                     errflag);
+                                     coll_attr);
     }
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -255,14 +251,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
                                                          const MPI_Aint recvcounts[],
                                                          MPI_Datatype datatype, MPI_Op op,
-                                                         MPIR_Comm * comm_ptr,
-                                                         MPIR_Errflag_t errflag)
+                                                         MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts,
-                                         datatype, op, comm_ptr, errflag);
+                                         datatype, op, comm_ptr, coll_attr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -271,14 +266,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, vo
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                                MPI_Aint recvcount,
                                                                MPI_Datatype datatype, MPI_Op op,
-                                                               MPIR_Comm * comm_ptr,
-                                                               MPIR_Errflag_t errflag)
+                                                               MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
     mpi_errno = MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount,
-                                               datatype, op, comm_ptr, errflag);
+                                               datatype, op, comm_ptr, coll_attr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -286,12 +280,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                MPI_Datatype datatype, MPI_Op op,
-                                               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                               MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
+    mpi_errno = MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, coll_attr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -299,12 +293,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbu
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_exscan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                  MPI_Datatype datatype, MPI_Op op,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                 MPIR_Comm * comm_ptr, int coll_attr)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
+    mpi_errno = MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, coll_attr);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ucx/ucx_send.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_send.h
@@ -133,7 +133,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
     int vci_src, vci_dst;
     MPIDI_UCX_SEND_VNIS(vci_src, vci_dst);
 
-    MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
+    int errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
     switch (errflag) {
         case MPIR_ERR_NONE:
             break;

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -37,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_lmt(const void *buf, MPI_Aint count
                                                  int context_offset, MPIDI_av_entry_t * addr,
                                                  MPIDI_IPCI_ipc_attr_t ipc_attr,
                                                  int vci_src, int vci_dst, MPIR_Request ** request,
-                                                 bool syncflag, MPIR_Errflag_t errflag)
+                                                 bool syncflag, int errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -59,7 +59,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
     MPIR_FUNC_ENTER;
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-    MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
+    int errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
     bool syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr);
     int vci_src, vci_dst;
     /* note: MPIDI_POSIX_SEND_VSIS defined in posix_send.h */

--- a/src/mpid/ch4/shm/posix/posix_coll_gpu_ipc.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_gpu_ipc.h
@@ -131,7 +131,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_gpu_ipc_read(void *buffer,
                                                                 MPI_Aint count,
                                                                 MPI_Datatype datatype,
                                                                 int root, MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t errflag)
+                                                                int coll_attr)
 {
     MPIR_FUNC_ENTER;
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
@@ -186,8 +186,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_gpu_ipc_read(void *buffer,
     goto fn_exit;
   fallback:
     /* Fall back to other algorithms as gpu ipc bcast cannot be used */
-    mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     goto fn_exit;
 }
 
@@ -198,7 +198,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoall_gpu_ipc_read(const void *s
                                                                    MPI_Aint recvcount,
                                                                    MPI_Datatype recvtype,
                                                                    MPIR_Comm * comm_ptr,
-                                                                   MPIR_Errflag_t errflag)
+                                                                   int coll_attr)
 {
     MPIR_FUNC_ENTER;
     MPIR_CHKLMEM_DECL(3);
@@ -280,8 +280,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoall_gpu_ipc_read(const void *s
   fallback:
     /* Fall back to other algorithms as gpu ipc alltoall cannot be used */
     mpi_errno = MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
-                                   comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                   comm_ptr, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     goto fn_exit;
 }
 
@@ -292,7 +292,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgather_gpu_ipc_read(const void *
                                                                     MPI_Aint recvcount,
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm_ptr,
-                                                                    MPIR_Errflag_t errflag)
+                                                                    int coll_attr)
 {
     MPIR_FUNC_ENTER;
     MPIR_CHKLMEM_DECL(3);
@@ -374,8 +374,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgather_gpu_ipc_read(const void *
   fallback:
     /* Fall back to other algorithms as gpu ipc allgather cannot be used */
     mpi_errno = MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
-                                    comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                    comm_ptr, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     goto fn_exit;
 }
 
@@ -387,7 +387,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgatherv_gpu_ipc_read(const void 
                                                                      const MPI_Aint * displs,
                                                                      MPI_Datatype recvtype,
                                                                      MPIR_Comm * comm_ptr,
-                                                                     MPIR_Errflag_t errflag)
+                                                                     int coll_attr)
 {
     MPIR_FUNC_ENTER;
     MPIR_CHKLMEM_DECL(3);
@@ -473,8 +473,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgatherv_gpu_ipc_read(const void 
   fallback:
     /* Fall back to other algorithms as gpu ipc allgatherv cannot be used */
     mpi_errno = MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
-                                     recvtype, comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                                     recvtype, comm_ptr, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     goto fn_exit;
 }
 
@@ -483,9 +483,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_gpu_ipc_read(void *buffer,
                                                                 MPI_Aint count,
                                                                 MPI_Datatype datatype,
                                                                 int root, MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t errflag)
+                                                                int coll_attr)
 {
-    return MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
+    return MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, coll_attr);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoall_gpu_ipc_read(const void *sendbuf,
@@ -495,10 +495,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoall_gpu_ipc_read(const void *s
                                                                    MPI_Aint recvcount,
                                                                    MPI_Datatype recvtype,
                                                                    MPIR_Comm * comm_ptr,
-                                                                   MPIR_Errflag_t errflag)
+                                                                   int coll_attr)
 {
     return MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
-                              comm_ptr, errflag);
+                              comm_ptr, coll_attr);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgather_gpu_ipc_read(const void *sendbuf,
@@ -508,10 +508,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgather_gpu_ipc_read(const void *
                                                                     MPI_Aint recvcount,
                                                                     MPI_Datatype recvtype,
                                                                     MPIR_Comm * comm_ptr,
-                                                                    MPIR_Errflag_t errflag)
+                                                                    int coll_attr)
 {
     return MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
-                               comm_ptr, errflag);
+                               comm_ptr, coll_attr);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgatherv_gpu_ipc_read(const void *sendbuf,
@@ -522,10 +522,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgatherv_gpu_ipc_read(const void 
                                                                      const MPI_Aint * displs,
                                                                      MPI_Datatype recvtype,
                                                                      MPIR_Comm * comm_ptr,
-                                                                     MPIR_Errflag_t errflag)
+                                                                     int coll_attr)
 {
     return MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype,
-                                comm_ptr, errflag);
+                                comm_ptr, coll_attr);
 }
 #endif /* !MPIDI_CH4_SHM_ENABLE_GPU */
 

--- a/src/mpid/ch4/shm/posix/posix_coll_release_gather.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_release_gather.h
@@ -39,7 +39,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
                                                                   MPI_Aint count,
                                                                   MPI_Datatype datatype,
                                                                   int root, MPIR_Comm * comm_ptr,
-                                                                  MPIR_Errflag_t errflag)
+                                                                  int coll_attr)
 {
     MPIR_FUNC_ENTER;
 
@@ -95,7 +95,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
                 mpi_errno =
                     MPIR_Typerep_pack(ori_buffer, ori_count, ori_datatype, 0, buffer, count,
                                       &actual_packed_unpacked_bytes, MPIR_TYPEREP_FLAG_NONE);
-                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+                MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
             }
         }
     }
@@ -122,15 +122,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
         mpi_errno =
             MPIDI_POSIX_mpi_release_gather_release(MPIR_get_contig_ptr(buffer, offset + true_lb),
                                                    chunk_count, MPI_BYTE, root, comm_ptr,
-                                                   errflag,
+                                                   coll_attr,
                                                    MPIDI_POSIX_RELEASE_GATHER_OPCODE_BCAST);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         mpi_errno =
             MPIDI_POSIX_mpi_release_gather_gather(NULL, NULL, 0, MPI_DATATYPE_NULL,
-                                                  MPI_OP_NULL, root, comm_ptr, errflag,
+                                                  MPI_OP_NULL, root, comm_ptr, coll_attr,
                                                   MPIDI_POSIX_RELEASE_GATHER_OPCODE_BCAST);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         offset += chunk_count;
     }
 
@@ -140,7 +140,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
             mpi_errno =
                 MPIR_Typerep_unpack(buffer, count, ori_buffer, ori_count, ori_datatype, 0,
                                     &actual_packed_unpacked_bytes, MPIR_TYPEREP_FLAG_NONE);
-            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+            MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         }
         MPL_free(buffer);
     }
@@ -152,8 +152,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
     goto fn_exit;
   fallback:
     /* Fall back to other algo as release_gather based bcast cannot be used */
-    mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     goto fn_exit;
 }
 
@@ -168,7 +168,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
                                                                    MPI_Datatype datatype,
                                                                    MPI_Op op, int root,
                                                                    MPIR_Comm * comm_ptr,
-                                                                   MPIR_Errflag_t errflag)
+                                                                   int coll_attr)
 {
     int i;
     MPI_Aint num_chunks, chunk_size_floor, chunk_size_ceil;
@@ -187,7 +187,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
         /* Simply copy the data from sendbuf to recvbuf if there is only 1 rank and MPI_IN_PLACE
          * is not used */
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         goto fn_exit;
     }
 
@@ -230,17 +230,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
 
         mpi_errno =
             MPIDI_POSIX_mpi_release_gather_release(NULL, chunk_count, datatype, root,
-                                                   comm_ptr, errflag,
+                                                   comm_ptr, coll_attr,
                                                    MPIDI_POSIX_RELEASE_GATHER_OPCODE_REDUCE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         mpi_errno =
             MPIDI_POSIX_mpi_release_gather_gather((char *) sendbuf + offset * extent,
                                                   (char *) recvbuf + offset * extent,
                                                   chunk_count, datatype, op, root, comm_ptr,
-                                                  errflag,
+                                                  coll_attr,
                                                   MPIDI_POSIX_RELEASE_GATHER_OPCODE_REDUCE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         offset += chunk_count;
     }
 
@@ -251,8 +251,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_reduce_release_gather(const void *s
     goto fn_exit;
   fallback:
     /* Fall back to other algo as release_gather algo cannot be used */
-    mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     goto fn_exit;
 }
 
@@ -266,7 +266,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
                                                                       MPI_Datatype datatype,
                                                                       MPI_Op op,
                                                                       MPIR_Comm * comm_ptr,
-                                                                      MPIR_Errflag_t errflag)
+                                                                      int coll_attr)
 {
     int i;
     MPI_Aint num_chunks, chunk_size_floor, chunk_size_ceil;
@@ -280,7 +280,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
         /* Simply copy the data from sendbuf to recvbuf if there is only 1 rank and MPI_IN_PLACE
          * is not used */
         mpi_errno = MPIR_Localcopy(sendbuf, count, datatype, recvbuf, count, datatype);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         goto fn_exit;
     }
 
@@ -325,16 +325,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
             MPIDI_POSIX_mpi_release_gather_gather((char *) sendbuf + offset * extent,
                                                   (char *) recvbuf + offset * extent,
                                                   chunk_count, datatype, op, 0, comm_ptr,
-                                                  errflag,
+                                                  coll_attr,
                                                   MPIDI_POSIX_RELEASE_GATHER_OPCODE_ALLREDUCE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
         mpi_errno =
             MPIDI_POSIX_mpi_release_gather_release((char *) recvbuf + offset * extent, chunk_count,
                                                    datatype, 0,
-                                                   comm_ptr, errflag,
+                                                   comm_ptr, coll_attr,
                                                    MPIDI_POSIX_RELEASE_GATHER_OPCODE_ALLREDUCE);
-        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+        MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
         offset += chunk_count;
     }
 
@@ -346,8 +346,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
     goto fn_exit;
 
   fallback:
-    mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     goto fn_exit;
 }
 
@@ -355,7 +355,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allreduce_release_gather(const void
  * framework.
  */
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier_release_gather(MPIR_Comm * comm_ptr,
-                                                                    MPIR_Errflag_t errflag)
+                                                                    int coll_attr)
 {
     int mpi_errno = MPI_SUCCESS, mpi_errno_ret = MPI_SUCCESS;
 
@@ -378,14 +378,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier_release_gather(MPIR_Comm * 
 
     mpi_errno =
         MPIDI_POSIX_mpi_release_gather_gather(NULL, NULL, 0, MPI_DATATYPE_NULL, MPI_OP_NULL, 0,
-                                              comm_ptr, errflag,
+                                              comm_ptr, coll_attr,
                                               MPIDI_POSIX_RELEASE_GATHER_OPCODE_BARRIER);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
     mpi_errno =
-        MPIDI_POSIX_mpi_release_gather_release(NULL, 0, MPI_DATATYPE_NULL, 0, comm_ptr, errflag,
+        MPIDI_POSIX_mpi_release_gather_release(NULL, 0, MPI_DATATYPE_NULL, 0, comm_ptr, coll_attr,
                                                MPIDI_POSIX_RELEASE_GATHER_OPCODE_BARRIER);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -395,8 +395,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_barrier_release_gather(MPIR_Comm * 
     goto fn_exit;
 
   fallback:
-    mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
-    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
+    mpi_errno = MPIR_Barrier_impl(comm_ptr, coll_attr);
+    MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, coll_attr, mpi_errno_ret);
     goto fn_exit;
 }
 

--- a/src/mpid/ch4/shm/posix/posix_send.h
+++ b/src/mpid/ch4/shm/posix/posix_send.h
@@ -33,7 +33,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_isend(const void *buf, MPI_Aint cou
     int mpi_errno = MPI_SUCCESS;
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-    MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
+    int errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
     bool syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr);
 
     int vci_src, vci_dst;

--- a/src/mpid/ch4/shm/posix/release_gather/nb_bcast_release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_bcast_release_gather.h
@@ -99,7 +99,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_root_datacopy_completion(void *v,
             } else if (rank == 0) {
                 MPIC_Irecv(MPIDI_POSIX_RELEASE_GATHER_NB_IBCAST_DATA_ADDR(segment),
                            per_call_data->count, per_call_data->datatype, per_call_data->root,
-                           per_call_data->tag, comm_ptr, &(per_call_data->rreq));
+                           per_call_data->tag, comm_ptr, 0, &(per_call_data->rreq));
                 *done = 1;
             }
         } else {

--- a/src/mpid/ch4/shm/posix/release_gather/nb_reduce_release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_reduce_release_gather.h
@@ -248,7 +248,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_reduce_start_sendrecv_completion(
     if (root != 0) {
         if (rank == root) {
             MPIC_Irecv(per_call_data->recv_buf, per_call_data->count, per_call_data->datatype,
-                       0, per_call_data->tag, comm_ptr, &(per_call_data->rreq));
+                       0, per_call_data->tag, comm_ptr, 0, &(per_call_data->rreq));
         } else if (rank == 0) {
             MPIC_Isend(MPIDI_POSIX_RELEASE_GATHER_NB_REDUCE_DATA_ADDR(rank, segment),
                        per_call_data->count, per_call_data->datatype, per_call_data->root,

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.c
@@ -410,7 +410,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
                             (void **) &(release_gather_info_ptr->flags_addr));
         if (mpi_errno) {
             /* for communication errors, just record the error but continue */
-            MPIR_ERR_ADD(mpi_errno_ret, MPIR_ERR_OTHER);
+            MPIR_ERR_ADD(mpi_errno_ret, MPI_ERR_OTHER);
         }
 
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno_ret, errflag, mpi_errno_ret);
@@ -441,7 +441,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
             MPIDU_shm_alloc(comm_ptr, RELEASE_GATHER_FIELD(comm_ptr, bcast_shm_size),
                             (void **) &(RELEASE_GATHER_FIELD(comm_ptr, bcast_buf_addr)));
         if (mpi_errno) {
-            MPIR_ERR_ADD(mpi_errno_ret, MPIR_ERR_OTHER);
+            MPIR_ERR_ADD(mpi_errno_ret, MPI_ERR_OTHER);
         }
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
     }
@@ -463,7 +463,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
                             (void **) &(RELEASE_GATHER_FIELD(comm_ptr, reduce_buf_addr)));
         if (mpi_errno) {
             /* for communication errors, just record the error but continue */
-            MPIR_ERR_ADD(mpi_errno_ret, MPIR_ERR_OTHER);
+            MPIR_ERR_ADD(mpi_errno_ret, MPI_ERR_OTHER);
         }
         MPIR_ERR_COLL_CHECKANDCONT(mpi_errno_ret, errflag, mpi_errno_ret);
         MPIR_ERR_CHECK(mpi_errno_ret);

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.h
@@ -119,7 +119,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
                 MPI_Aint recv_bytes;
                 mpi_errno =
                     MPIC_Recv((char *) bcast_data_addr + 2 * MPIDU_SHM_CACHE_LINE_LEN, count,
-                              datatype, root, MPIR_BCAST_TAG, comm_ptr, &status);
+                              datatype, root, MPIR_BCAST_TAG, comm_ptr, coll_attr, &status);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
                 MPIR_Get_count_impl(&status, MPI_BYTE, &recv_bytes);
                 MPIR_Typerep_copy(bcast_data_addr, &recv_bytes, sizeof(int),
@@ -140,7 +140,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
                 /* When error checking is disabled, MPI_STATUS_IGNORE is used */
                 mpi_errno =
                     MPIC_Recv(bcast_data_addr, count, datatype, root, MPIR_BCAST_TAG, comm_ptr,
-                              MPI_STATUS_IGNORE);
+                              coll_attr, MPI_STATUS_IGNORE);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
 #endif
             }
@@ -381,7 +381,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_gather(const void *i
             if (rank == root) {
                 mpi_errno =
                     MPIC_Recv(outbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm_ptr,
-                              MPI_STATUS_IGNORE);
+                              coll_attr, MPI_STATUS_IGNORE);
                 MPIR_ERR_COLL_CHECKANDCONT(mpi_errno, errflag, mpi_errno_ret);
             } else if (rank == 0) {
                 MPIR_ERR_CHKANDJUMP(!reduce_data_addr, mpi_errno, MPI_ERR_OTHER, "**nomem");

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.h
@@ -131,7 +131,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
                 if ((int) recv_bytes != count) {
                     /* It is OK to compare with count because datatype is always MPI_BYTE for Bcast */
                     errflag = MPIR_ERR_OTHER;
-                    MPIR_ERR_SET(mpi_errno, errflag, "**fail");
+                    MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**fail");
                     MPIR_ERR_ADD(mpi_errno_ret, mpi_errno);
                 }
 #else

--- a/src/mpid/ch4/shm/src/shm_am_fallback_coll.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_coll.h
@@ -6,22 +6,21 @@
 #ifndef SHM_AM_FALLBACK_COLL_H_INCLUDED
 #define SHM_AM_FALLBACK_COLL_H_INCLUDED
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Barrier_impl(comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, MPI_Aint count,
                                                  MPI_Datatype datatype, int root,
-                                                 MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                 MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                      MPI_Aint count, MPI_Datatype datatype,
-                                                     MPI_Op op, MPIR_Comm * comm_ptr,
-                                                     MPIR_Errflag_t errflag)
+                                                     MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
@@ -29,7 +28,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                     MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf,
                                recvcount, recvtype, comm_ptr, errflag);
@@ -40,7 +39,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, MPI_A
                                                       const MPI_Aint * recvcounts,
                                                       const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                      MPIR_Errflag_t errflag)
+                                                      int coll_attr)
 {
     return MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcounts, displs, recvtype, comm_ptr, errflag);
@@ -49,8 +48,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, MPI_A
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf,
                             recvcount, recvtype, root, comm_ptr, errflag);
@@ -60,8 +58,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, MPI_Aint
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const MPI_Aint * recvcounts,
                                                    const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                   int root, MPIR_Comm * comm_ptr,
-                                                   MPIR_Errflag_t errflag)
+                                                   int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcounts, displs, recvtype, root, comm_ptr, errflag);
@@ -70,8 +67,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, MPI_Aint
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   int root, MPIR_Comm * comm_ptr,
-                                                   MPIR_Errflag_t errflag)
+                                                   int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf,
                              recvcount, recvtype, root, comm_ptr, errflag);
@@ -82,7 +78,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf,
                                                     const MPI_Aint * displs, MPI_Datatype sendtype,
                                                     void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Scatterv_impl(sendbuf, sendcounts, displs, sendtype,
                               recvbuf, recvcount, recvtype, root, comm_ptr, errflag);
@@ -91,7 +87,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
                               recvcount, recvtype, comm_ptr, errflag);
@@ -104,7 +100,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * rdispls,
                                                      MPI_Datatype recvtype, MPIR_Comm * comm_ptr,
-                                                     MPIR_Errflag_t errflag)
+                                                     int coll_attr)
 {
     return MPIR_Alltoallv_impl(sendbuf, sendcounts, sdispls, sendtype,
                                recvbuf, recvcounts, rdispls, recvtype, comm_ptr, errflag);
@@ -117,7 +113,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf,
                                                      const MPI_Aint recvcounts[],
                                                      const MPI_Aint rdispls[],
                                                      const MPI_Datatype recvtypes[],
-                                                     MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                     MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Alltoallw_impl(sendbuf, sendcounts, sdispls, sendtypes,
                                recvbuf, recvcounts, rdispls, recvtypes, comm_ptr, errflag);
@@ -125,8 +121,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
 }
@@ -134,8 +129,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *rec
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
                                                           const MPI_Aint recvcounts[],
                                                           MPI_Datatype datatype, MPI_Op op,
-                                                          MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t errflag)
+                                                          MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr, errflag);
 }
@@ -143,8 +137,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, v
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
                                                                 MPI_Aint recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t errflag)
+                                                                MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount,
                                           datatype, op, comm_ptr, errflag);
@@ -152,14 +145,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *send
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,
                                                 MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Scan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                  MPIR_Comm * comm_ptr, int coll_attr)
 {
     return MPIR_Exscan_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, errflag);
 }

--- a/src/mpid/ch4/shm/src/shm_am_fallback_send.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_send.h
@@ -17,7 +17,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf,
     int mpi_errno = MPI_SUCCESS;
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-    MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
+    int coll_attr = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
     bool syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr);
 
     int vci_src, vci_dst;

--- a/src/mpid/ch4/shm/src/shm_coll.h
+++ b/src/mpid/ch4/shm/src/shm_coll.h
@@ -9,13 +9,13 @@
 #include <shm.h>
 #include "../posix/shm_inline.h"
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm, MPIR_Errflag_t errflag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm, int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_barrier(comm, errflag);
+    ret = MPIDI_POSIX_mpi_barrier(comm, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -23,13 +23,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_barrier(MPIR_Comm * comm, MPIR_Errfla
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, MPI_Aint count,
                                                  MPI_Datatype datatype, int root, MPIR_Comm * comm,
-                                                 MPIR_Errflag_t errflag)
+                                                 int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_bcast(buffer, count, datatype, root, comm, errflag);
+    ret = MPIDI_POSIX_mpi_bcast(buffer, count, datatype, root, comm, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -37,14 +37,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_bcast(void *buffer, MPI_Aint count,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *recvbuf,
                                                      MPI_Aint count, MPI_Datatype datatype,
-                                                     MPI_Op op, MPIR_Comm * comm,
-                                                     MPIR_Errflag_t errflag)
+                                                     MPI_Op op, MPIR_Comm * comm, int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_allreduce(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    ret = MPIDI_POSIX_mpi_allreduce(sendbuf, recvbuf, count, datatype, op, comm, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -53,14 +52,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allreduce(const void *sendbuf, void *
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
                                                      MPI_Datatype sendtype, void *recvbuf,
                                                      MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                     MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                     MPIR_Comm * comm, int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_allgather(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                    recvtype, comm, errflag);
+                                    recvtype, comm, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -71,14 +70,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, MPI_A
                                                       const MPI_Aint * recvcounts,
                                                       const MPI_Aint * displs,
                                                       MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                      MPIR_Errflag_t errflag)
+                                                      int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_allgatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
-                                     displs, recvtype, comm, errflag);
+                                     displs, recvtype, comm, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -87,15 +86,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_allgatherv(const void *sendbuf, MPI_A
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                   int root, MPIR_Comm * comm,
-                                                   MPIR_Errflag_t errflag)
+                                                   int root, MPIR_Comm * comm, int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_scatter(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                  recvtype, root, comm, errflag);
+                                  recvtype, root, comm, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -106,14 +104,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf,
                                                     const MPI_Aint * displs, MPI_Datatype sendtype,
                                                     void *recvbuf, MPI_Aint recvcount,
                                                     MPI_Datatype recvtype, int root,
-                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm_ptr, int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_scatterv(sendbuf, sendcounts, displs, sendtype, recvbuf,
-                                   recvcount, recvtype, root, comm_ptr, errflag);
+                                   recvcount, recvtype, root, comm_ptr, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -122,15 +120,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scatterv(const void *sendbuf,
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
                                                   MPI_Datatype sendtype, void *recvbuf,
                                                   MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                  int root, MPIR_Comm * comm,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm, int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_gather(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                 recvtype, root, comm, errflag);
+                                 recvtype, root, comm, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -140,15 +137,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, MPI_Aint
                                                    MPI_Datatype sendtype, void *recvbuf,
                                                    const MPI_Aint * recvcounts,
                                                    const MPI_Aint * displs, MPI_Datatype recvtype,
-                                                   int root, MPIR_Comm * comm,
-                                                   MPIR_Errflag_t errflag)
+                                                   int root, MPIR_Comm * comm, int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_gatherv(sendbuf, sendcount, sendtype, recvbuf, recvcounts,
-                                  displs, recvtype, root, comm, errflag);
+                                  displs, recvtype, root, comm, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -157,14 +153,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_gatherv(const void *sendbuf, MPI_Aint
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
                                                     MPI_Datatype sendtype, void *recvbuf,
                                                     MPI_Aint recvcount, MPI_Datatype recvtype,
-                                                    MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                    MPIR_Comm * comm, int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_alltoall(sendbuf, sendcount, sendtype, recvbuf, recvcount,
-                                   recvtype, comm, errflag);
+                                   recvtype, comm, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -177,14 +173,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallv(const void *sendbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * rdispls,
                                                      MPI_Datatype recvtype, MPIR_Comm * comm,
-                                                     MPIR_Errflag_t errflag)
+                                                     int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
-                                    recvcounts, rdispls, recvtype, comm, errflag);
+                                    recvcounts, rdispls, recvtype, comm, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -197,14 +193,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf,
                                                      const MPI_Aint * recvcounts,
                                                      const MPI_Aint * rdispls,
                                                      const MPI_Datatype recvtypes[],
-                                                     MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                     MPIR_Comm * comm, int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
-                                    recvcounts, rdispls, recvtypes, comm, errflag);
+                                    recvcounts, rdispls, recvtypes, comm, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -212,14 +208,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_alltoallw(const void *sendbuf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  int root, MPIR_Comm * comm_ptr,
-                                                  MPIR_Errflag_t errflag)
+                                                  int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, errflag);
+    ret = MPIDI_POSIX_mpi_reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -228,15 +223,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce(const void *sendbuf, void *rec
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
                                                           const MPI_Aint * recvcounts,
                                                           MPI_Datatype datatype, MPI_Op op,
-                                                          MPIR_Comm * comm_ptr,
-                                                          MPIR_Errflag_t errflag)
+                                                          MPIR_Comm * comm_ptr, int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_reduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op,
-                                         comm_ptr, errflag);
+                                         comm_ptr, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -245,15 +239,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter(const void *sendbuf, v
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *sendbuf,
                                                                 void *recvbuf, MPI_Aint recvcount,
                                                                 MPI_Datatype datatype, MPI_Op op,
-                                                                MPIR_Comm * comm_ptr,
-                                                                MPIR_Errflag_t errflag)
+                                                                MPIR_Comm * comm_ptr, int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
     ret = MPIDI_POSIX_mpi_reduce_scatter_block(sendbuf, recvbuf, recvcount, datatype,
-                                               op, comm_ptr, errflag);
+                                               op, comm_ptr, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -261,13 +254,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_reduce_scatter_block(const void *send
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvbuf,
                                                 MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                MPIR_Comm * comm, int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_scan(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    ret = MPIDI_POSIX_mpi_scan(sendbuf, recvbuf, count, datatype, op, comm, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;
@@ -275,13 +268,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_scan(const void *sendbuf, void *recvb
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_exscan(const void *sendbuf, void *recvbuf,
                                                   MPI_Aint count, MPI_Datatype datatype, MPI_Op op,
-                                                  MPIR_Comm * comm, MPIR_Errflag_t errflag)
+                                                  MPIR_Comm * comm, int coll_attr)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_exscan(sendbuf, recvbuf, count, datatype, op, comm, errflag);
+    ret = MPIDI_POSIX_mpi_exscan(sendbuf, recvbuf, count, datatype, op, comm, coll_attr);
 
     MPIR_FUNC_EXIT;
     return ret;

--- a/src/mpid/ch4/shm/src/topotree.c
+++ b/src/mpid/ch4/shm/src/topotree.c
@@ -476,7 +476,7 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, in
     int *package_ctr = NULL;
     int topo_depth = 0;
     int package_level = 0, i, max_ranks_per_package = 0;
-    MPIR_Errflag_t errflag = MPIR_ERR_NONE;
+    int coll_attr = MPIR_ERR_NONE;
     int (*shared_region_ptr)[topo_depth];
 
     MPIR_FUNC_ENTER;
@@ -500,7 +500,7 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, in
         shared_region_ptr[rank][depth++] = MPIR_hwtopo_get_lid(gid);
         gid = MPIR_hwtopo_get_ancestor(gid, topo_depth - depth - 1);
     }
-    mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
+    mpi_errno = MPIR_Barrier_impl(comm_ptr, coll_attr);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* STEP 3. Root has all the bind_map information, now build tree */
@@ -558,7 +558,7 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, in
                                        0 /*left_skewed */ , bcast_tree_type);
         MPIR_ERR_CHECK(mpi_errno);
     }
-    mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
+    mpi_errno = MPIR_Barrier_impl(comm_ptr, coll_attr);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Every rank copies their tree out from shared memory */
@@ -567,7 +567,7 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, in
         MPIDI_SHM_print_topotree_file("BCAST", comm_ptr->context_id, rank, bcast_tree);
 
     /* Wait until shared memory is available */
-    mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
+    mpi_errno = MPIR_Barrier_impl(comm_ptr, coll_attr);
     MPIR_ERR_CHECK(mpi_errno);
     /* Generate the reduce tree */
     /* For Reduce, package leaders are added after the package local ranks, and the per_package
@@ -581,7 +581,7 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, in
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
+    mpi_errno = MPIR_Barrier_impl(comm_ptr, coll_attr);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* each rank copy the reduce tree out */
@@ -590,7 +590,7 @@ int MPIDI_SHM_topology_tree_init(MPIR_Comm * comm_ptr, int root, int bcast_k, in
     if (MPIDI_SHM_TOPOTREE_DEBUG)
         MPIDI_SHM_print_topotree_file("REDUCE", comm_ptr->context_id, rank, reduce_tree);
     /* Wait for all ranks to copy out the tree */
-    mpi_errno = MPIR_Barrier_impl(comm_ptr, errflag);
+    mpi_errno = MPIR_Barrier_impl(comm_ptr, coll_attr);
     MPIR_ERR_CHECK(mpi_errno);
     /* Cleanup */
     if (rank == root) {

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -245,12 +245,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, M
 #ifndef HAVE_ERROR_CHECKING
             coll_ret =
                 MPIC_Recv(buffer, count, datatype, intra_root, MPIR_BCAST_TAG, comm->node_comm,
-                          MPI_STATUS_IGNORE);
+                          coll_attr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(coll_ret, coll_attr, mpi_errno);
 #else
             coll_ret =
                 MPIC_Recv(buffer, count, datatype, intra_root, MPIR_BCAST_TAG, comm->node_comm,
-                          &status);
+                          coll_attr, &status);
             MPIR_ERR_COLL_CHECKANDCONT(coll_ret, coll_attr, mpi_errno);
 
             MPIR_Datatype_get_size_macro(datatype, type_size);
@@ -458,12 +458,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_delta(void *buffer, M
 #ifndef HAVE_ERROR_CHECKING
             coll_ret =
                 MPIC_Recv(buffer, count, datatype, intra_root, MPIR_BCAST_TAG, comm->node_comm,
-                          MPI_STATUS_IGNORE);
+                          coll_attr, MPI_STATUS_IGNORE);
             MPIR_ERR_COLL_CHECKANDCONT(coll_ret, coll_attr, mpi_errno);
 #else
             coll_ret =
                 MPIC_Recv(buffer, count, datatype, intra_root, MPIR_BCAST_TAG, comm->node_comm,
-                          &status);
+                          coll_attr, &status);
             MPIR_ERR_COLL_CHECKANDCONT(coll_ret, coll_attr, mpi_errno);
 
             MPIR_Datatype_get_size_macro(datatype, type_size);
@@ -1004,7 +1004,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_alpha(const void *se
         if (comm->rank == 0) {
             MPIC_Send(recvbuf, count, datatype, root, MPIR_REDUCE_TAG, comm, coll_attr);
         } else if (comm->rank == root) {
-            MPIC_Recv(ori_recvbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm, MPI_STATUS_IGNORE);
+            MPIC_Recv(ori_recvbuf, count, datatype, 0, MPIR_REDUCE_TAG, comm,
+                      coll_attr, MPI_STATUS_IGNORE);
         }
     }
 
@@ -1719,7 +1720,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
     if (comm_ptr->node_roots_comm != NULL && comm_ptr->node_comm != NULL) {
         coll_ret = MPIC_Recv(localfulldata, count, datatype,
                              comm_ptr->node_comm->local_size - 1, MPIR_SCAN_TAG,
-                             comm_ptr->node_comm, &status);
+                             comm_ptr->node_comm, coll_attr, &status);
         MPIR_ERR_COLL_CHECKANDCONT(coll_ret, coll_attr, mpi_errno);
     } else if (comm_ptr->node_roots_comm == NULL &&
                comm_ptr->node_comm != NULL &&
@@ -1749,7 +1750,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
         if (MPIR_Get_internode_rank(comm_ptr, rank) != 0) {
             coll_ret = MPIC_Recv(tempbuf, count, datatype,
                                  MPIR_Get_internode_rank(comm_ptr, rank) - 1,
-                                 MPIR_SCAN_TAG, comm_ptr->node_roots_comm, &status);
+                                 MPIR_SCAN_TAG, comm_ptr->node_roots_comm, coll_attr, &status);
             noneed = 0;
             MPIR_ERR_COLL_CHECKANDCONT(coll_ret, coll_attr, mpi_errno);
         }

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -755,6 +755,10 @@ int MPIDI_Comm_create_multi_leaders(MPIR_Comm * comm)
     rank = MPIR_Comm_rank(comm);
 
     external_rank = comm->internode_table[rank];
+    /* FIXME: this is very restrictive. Do we have sufficient check?
+     *        Not only it asserts the same number of ranks per node,
+     *        the ranks have to be ordered exactly round-robin.
+     */
     for (i = 0; i < num_external; ++i) {
         external_procs[i] = i * num_local + local_rank;
     }

--- a/src/mpid/ch4/src/mpidig_send.h
+++ b/src/mpid/ch4/src/mpidig_send.h
@@ -46,7 +46,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
                                                MPIR_Comm * comm, int context_offset,
                                                MPIDI_av_entry_t * addr, uint8_t flags,
                                                int src_vci, int dst_vci,
-                                               MPIR_Request ** request, MPIR_Errflag_t errflag)
+                                               MPIR_Request ** request, int errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq;
@@ -122,8 +122,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_isend(const void *buf,
                                               int rank,
                                               int tag, MPIR_Comm * comm, int context_offset,
                                               MPIDI_av_entry_t * addr, int src_vci, int dst_vci,
-                                              MPIR_Request ** request,
-                                              bool syncflag, MPIR_Errflag_t errflag)
+                                              MPIR_Request ** request, bool syncflag, int errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;

--- a/src/mpid/common/hcoll/hcoll.h
+++ b/src/mpid/common/hcoll/hcoll.h
@@ -23,21 +23,21 @@ int hcoll_initialize(void);
 int hcoll_comm_create(MPIR_Comm * comm, void *param);
 int hcoll_comm_destroy(MPIR_Comm * comm, void *param);
 
-int hcoll_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t err);
+int hcoll_Barrier(MPIR_Comm * comm_ptr, int coll_attr);
 int hcoll_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                MPIR_Comm * comm_ptr, MPIR_Errflag_t err);
+                MPIR_Comm * comm_ptr, int coll_attr);
 int hcoll_Reduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
-                 MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t err);
+                 MPI_Op op, int root, MPIR_Comm * comm_ptr, int coll_attr);
 int hcoll_Allgather(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf, int rcount,
-                    MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t err);
+                    MPI_Datatype rdtype, MPIR_Comm * comm_ptr, int coll_attr);
 int hcoll_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
-                    MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t err);
+                    MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr);
 int hcoll_Alltoall(const void *sbuf, int scount, MPI_Datatype sdtype, void *rbuf, int rcount,
-                   MPI_Datatype rdtype, MPIR_Comm * comm_ptr, MPIR_Errflag_t err);
+                   MPI_Datatype rdtype, MPIR_Comm * comm_ptr, int coll_attr);
 int hcoll_Alltoallv(const void *sbuf, const MPI_Aint * scounts, const MPI_Aint * sdispls,
                     MPI_Datatype sdtype, void *rbuf, const MPI_Aint * rcounts,
                     const MPI_Aint * rdispls, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                    MPIR_Errflag_t err);
+                    int coll_attr);
 
 int hcoll_do_progress(int vci, int *made_progress);
 

--- a/src/mpid/common/hcoll/hcoll_ops.c
+++ b/src/mpid/common/hcoll/hcoll_ops.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 #include "hcoll.h"
 
-int hcoll_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t err)
+int hcoll_Barrier(MPIR_Comm * comm_ptr, int coll_attr)
 {
     int rc = -1;
     MPI_Comm comm = comm_ptr->handle;
@@ -22,7 +22,7 @@ int hcoll_Barrier(MPIR_Comm * comm_ptr, MPIR_Errflag_t err)
 }
 
 int hcoll_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
-                MPIR_Comm * comm_ptr, MPIR_Errflag_t err)
+                MPIR_Comm * comm_ptr, int coll_attr)
 {
     dte_data_representation_t dtype;
     int rc = -1;
@@ -49,7 +49,7 @@ int hcoll_Bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype, int root,
 }
 
 int hcoll_Reduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
-                 MPI_Op op, int root, MPIR_Comm * comm_ptr, MPIR_Errflag_t err)
+                 MPI_Op op, int root, MPIR_Comm * comm_ptr, int coll_attr)
 {
     dte_data_representation_t dtype;
     hcoll_dte_op_t *Op;
@@ -80,7 +80,7 @@ int hcoll_Reduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatyp
 }
 
 int hcoll_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Datatype datatype,
-                    MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t err)
+                    MPI_Op op, MPIR_Comm * comm_ptr, int coll_attr)
 {
     dte_data_representation_t Dtype;
     hcoll_dte_op_t *Op;
@@ -111,7 +111,7 @@ int hcoll_Allreduce(const void *sendbuf, void *recvbuf, MPI_Aint count, MPI_Data
 
 int hcoll_Allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
                     void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                    MPIR_Errflag_t err)
+                    int coll_attr)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -144,8 +144,7 @@ int hcoll_Allgather(const void *sbuf, int scount, MPI_Datatype sdtype,
 }
 
 int hcoll_Alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
-                   void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                   MPIR_Errflag_t err)
+                   void *rbuf, int rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr, int coll_attr)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;
@@ -180,7 +179,7 @@ int hcoll_Alltoall(const void *sbuf, int scount, MPI_Datatype sdtype,
 int hcoll_Alltoallv(const void *sbuf, const MPI_Aint * scounts, const MPI_Aint * sdispls,
                     MPI_Datatype sdtype, void *rbuf, const MPI_Aint * rcounts,
                     const MPI_Aint * rdispls, MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
-                    MPIR_Errflag_t err)
+                    int coll_attr)
 {
     MPI_Comm comm = comm_ptr->handle;
     dte_data_representation_t stype;

--- a/src/mpid/common/hcoll/hcoll_rte.c
+++ b/src/mpid/common/hcoll/hcoll_rte.c
@@ -134,7 +134,7 @@ static int recv_nb(struct dte_data_representation_t data,
     size = (size_t) data.rep.in_line_rep.data_handle.in_line.packed_size * count / 8;
     dtype = MPI_CHAR;
     request = NULL;
-    mpi_errno = MPIC_Irecv(buffer, size, dtype, ec_h.rank, tag, comm, &request);
+    mpi_errno = MPIC_Irecv(buffer, size, dtype, ec_h.rank, tag, comm, 0, &request);
     MPIR_Assert(request);
     req->data = (void *) request;
     req->status = HCOLRTE_REQUEST_ACTIVE;

--- a/src/mpid/common/hcoll/hcoll_rte.c
+++ b/src/mpid/common/hcoll/hcoll_rte.c
@@ -169,8 +169,7 @@ static int send_nb(dte_data_representation_t data,
     size = (size_t) data.rep.in_line_rep.data_handle.in_line.packed_size * count / 8;
     dtype = MPI_CHAR;
     request = NULL;
-    MPIR_Errflag_t err = MPIR_ERR_NONE;
-    mpi_errno = MPIC_Isend(buffer, size, dtype, ec_h.rank, tag, comm, &request, err);
+    mpi_errno = MPIC_Isend(buffer, size, dtype, ec_h.rank, tag, comm, &request, MPIR_ERR_NONE);
     MPIR_Assert(request);
     req->data = (void *) request;
     req->status = HCOLRTE_REQUEST_ACTIVE;

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -262,7 +262,8 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
             MPL_DBG_MSG_D(MPIR_DBG_COMM, VERBOSE, "starting RECV entry %d\n", (int) idx);
             comm = e->u.recv.comm;
             ret_errno = MPIC_Irecv(e->u.recv.buf, e->u.recv.count, e->u.recv.datatype,
-                                   e->u.recv.src, s->tag, comm, &e->u.recv.rreq);
+                                   e->u.recv.src, s->tag, comm, r->u.nbc.coll_attr,
+                                   &e->u.recv.rreq);
             /* Check if the error is actually fatal to the NBC or we can continue. */
             if (unlikely(ret_errno)) {
                 if (!MPIR_COLL_ATTR_GET_ERRFLAG(r->u.nbc.coll_attr)) {

--- a/src/util/mpir_nodemap.c
+++ b/src/util/mpir_nodemap.c
@@ -451,16 +451,16 @@ int MPIR_nodeid_init(void)
                              MPIR_Strerror(errno, strerrbuf, MPIR_STRERROR_BUF_SIZE), errno);
         my_hostname[MAX_HOSTNAME_LEN - 1] = '\0';
 
-        mpi_errno = MPIR_Allgather_impl(MPI_IN_PLACE, MAX_HOSTNAME_LEN, MPI_CHAR,
-                                        allhostnames, MAX_HOSTNAME_LEN, MPI_CHAR,
-                                        node_roots_comm, MPIR_ERR_NONE);
+        mpi_errno = MPIR_Allgather_fallback(MPI_IN_PLACE, MAX_HOSTNAME_LEN, MPI_CHAR,
+                                            allhostnames, MAX_HOSTNAME_LEN, MPI_CHAR,
+                                            node_roots_comm, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_Comm *node_comm = MPIR_Process.comm_world->node_comm;
     if (node_comm) {
-        mpi_errno = MPIR_Bcast_impl(allhostnames, MAX_HOSTNAME_LEN * MPIR_Process.num_nodes,
-                                    MPI_CHAR, 0, node_comm, MPIR_ERR_NONE);
+        mpi_errno = MPIR_Bcast_fallback(allhostnames, MAX_HOSTNAME_LEN * MPIR_Process.num_nodes,
+                                        MPI_CHAR, 0, node_comm, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/test/mpi/maint/coll_cvars.txt
+++ b/test/mpi/maint/coll_cvars.txt
@@ -351,6 +351,7 @@ algorithms:
             composition:3
             binomial
             smp
+            smp_new
             scatter_recursive_doubling_allgather
             scatter_ring_allgather
 	    tree


### PR DESCRIPTION
## Pull Request Description
Add a `coll_attr` parameter to replace the `errflag` parameter in internal collective interfaces. Make the lower 8-bit of `coll_attr` compatible to the lower 8-bit of pt2pt `attr`, which will avoid extra code to translate bits such as `errflags` when passing from collective to point-to-point. The next 8-bit is used for subgroup indexes, enabling group collectives without extra subcomms (which are expensive to maintain). We may extend in future `coll_attr` for passing hints such as memory alloc kinds and algorithm choices.

Add a bcast `smp_new` algorithm that are similar to bcast `smp` but uses comm subgroups instead. Because we can construct lightweight custom subgroup, we can avoid the extra local send/recv or bcast step when `root` is not one of the "node roots". Instead of the `node_roots_comm`, we can construct a `inter_group` made of the actual local roots.

NOTE: the bcast `smp_new` is covered in the collective cvar tests.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
