### PR TITLE
ch4/ucx: remove MPIR_pmi_barrier in finalize

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -363,9 +363,6 @@ int MPIDI_UCX_mpi_finalize_hook(void)
         ucp_request_release(pending[i]);
     }
 
-    mpi_errno = MPIR_pmi_barrier();
-    MPIR_ERR_CHECK(mpi_errno);
-
     for (int i = 0; i < MPIDI_UCX_global.num_vcis; i++) {
         if (MPIDI_UCX_global.ctx[i].worker != NULL) {
             ucp_worker_release_address(MPIDI_UCX_global.ctx[i].worker,


### PR DESCRIPTION
## Pull Request Description
The PMI barrier seems unnecessary. Having the process stuck in PMI_barrier may prevent other processes to complete the previous ucp_disconnect_nb.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
