### PR TITLE
ch4: fix vci range check in progress

### DIFF
--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -129,7 +129,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_progress_test(MPID_Progress_state * state)
     } else {
         for (int i = 0; i < state->vci_count; i++) {
             int vci = state->vci[i];
-            if (vci >= MPIDI_global.n_vcis) {
+            if (vci >= MPIDI_global.n_total_vcis) {
                 continue;
             }
             MPIDI_PROGRESS(vci);


### PR DESCRIPTION
## Pull Request Description
This fixes a bug introduced in commit "3ac9843d50 - threadcomm: add pt2pt interthread framework". It neglected to consider reserved vci, and thus breaks the gpu stream tests..

Ref: https://github.com/pmodels/mpich/pull/6509/commits/3ac9843d50013cc4f09f10101f9fcc239ad2b1a3?show-viewed-files=true&file-filters%5B%5D=#r1268658158

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
