### PR TITLE
hydra: fix duplicate keys in debug mode

### DIFF
--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -538,7 +538,6 @@ for option in $enable_g ; do
         yes|all)
 		PAC_APPEND_FLAG(-g, CFLAGS)
 		AC_DEFINE(USE_MEMORY_TRACING,1,[Define if memory tracing is enabled])
-		AC_DEFINE(PMI_KEY_CHECK,1,[Define if we should check for PMI key collisions])
 		;;
         *)
 		;;

--- a/src/pm/hydra/lib/pmiserv_common.c
+++ b/src/pm/hydra/lib/pmiserv_common.c
@@ -140,7 +140,7 @@ HYD_status HYD_kvs_find(struct HYD_kvs *kvs_list, const char *key, const char **
     return HYD_SUCCESS;
 }
 
-HYD_status HYD_pmcd_pmi_add_kvs(const char *key, const char *val, struct HYD_kvs * kvs, int *ret)
+HYD_status HYD_pmcd_pmi_add_kvs(const char *key, const char *val, struct HYD_kvs * kvs, int debug)
 {
     struct HYD_kvs_pair *key_pair;
     HYD_status status = HYD_SUCCESS;
@@ -152,19 +152,18 @@ HYD_status HYD_pmcd_pmi_add_kvs(const char *key, const char *val, struct HYD_kvs
     snprintf(key_pair->val, PMI_MAXVALLEN, "%s", val);
     key_pair->next = NULL;
 
-    *ret = 0;
-
     if (kvs->key_pair == NULL) {
         kvs->key_pair = key_pair;
     } else {
-#ifdef PMI_KEY_CHECK
-        const char *dummy_val;
-        int found;
-        HYD_kvs_find(kvs, key, &dummy_val, &found);
-        if (found) {
-            *ret = -1;
+        if (debug) {
+            const char *orig_val;
+            int found;
+            HYD_kvs_find(kvs, key, &orig_val, &found);
+            if (found) {
+                HYDU_dump(stdout, "add to kvs: duplicate key %s - replacing value %s with %s.\n",
+                          key, orig_val, val);
+            }
         }
-#endif
         key_pair->next = kvs->key_pair;
         kvs->key_pair = key_pair;
     }

--- a/src/pm/hydra/lib/pmiserv_common.c
+++ b/src/pm/hydra/lib/pmiserv_common.c
@@ -160,10 +160,9 @@ HYD_status HYD_pmcd_pmi_add_kvs(const char *key, const char *val, struct HYD_kvs
 #ifdef PMI_KEY_CHECK
         const char *dummy_val;
         int found;
-        HYD_kvs_find(kvs, key, &val, &found);
+        HYD_kvs_find(kvs, key, &dummy_val, &found);
         if (found) {
             *ret = -1;
-            goto fn_fail;
         }
 #endif
         key_pair->next = kvs->key_pair;

--- a/src/pm/hydra/lib/pmiserv_common.h
+++ b/src/pm/hydra/lib/pmiserv_common.h
@@ -41,7 +41,7 @@ struct HYD_pmcd_init_hdr {
 HYD_status HYD_pmcd_pmi_allocate_kvs(struct HYD_kvs **kvs);
 void HYD_pmcd_free_pmi_kvs_list(struct HYD_kvs *kvs_list);
 HYD_status HYD_kvs_find(struct HYD_kvs *kvs_list, const char *key, const char **val, int *found);
-HYD_status HYD_pmcd_pmi_add_kvs(const char *key, const char *val, struct HYD_kvs *kvs, int *ret);
+HYD_status HYD_pmcd_pmi_add_kvs(const char *key, const char *val, struct HYD_kvs *kvs, int debug);
 void HYD_kvs_iter_begin(struct HYD_kvs *kvs_list, bool new_only);
 void HYD_kvs_iter_end(struct HYD_kvs *kvs_list);
 bool HYD_kvs_iter_next(struct HYD_kvs *kvs_list, const char **key, const char **val);

--- a/src/pm/hydra/mpiexec/pmiserv_kvs.c
+++ b/src/pm/hydra/mpiexec/pmiserv_kvs.c
@@ -109,8 +109,7 @@ HYD_status HYD_pmiserv_kvs_put(struct HYD_proxy *proxy, int process_fd, int pgid
     pg = PMISERV_pg_by_id(proxy->pgid);
     pg_scratch = (struct HYD_pmcd_pmi_pg_scratch *) pg->pg_scratch;
 
-    int ret;
-    status = HYD_pmcd_pmi_add_kvs(key, val, pg_scratch->kvs, &ret);
+    status = HYD_pmcd_pmi_add_kvs(key, val, pg_scratch->kvs, HYD_server_info.user_global.debug);
     HYDU_ERR_POP(status, "unable to put data into kvs\n");
 
     struct PMIU_cmd pmi_response;
@@ -144,9 +143,8 @@ HYD_status HYD_pmiserv_kvs_mput(struct HYD_proxy *proxy, int process_fd, int pgi
 
     /* FIXME: leak of pmi's abstraction */
     for (int i = 0; i < pmi->num_tokens; i++) {
-        int ret;
         status = HYD_pmcd_pmi_add_kvs(pmi->tokens[i].key, pmi->tokens[i].val,
-                                      pg_scratch->kvs, &ret);
+                                      pg_scratch->kvs, HYD_server_info.user_global.debug);
         HYDU_ERR_POP(status, "unable to add key pair to kvs\n");
     }
 

--- a/src/pm/hydra/mpiexec/pmiserv_spawn.c
+++ b/src/pm/hydra/mpiexec/pmiserv_spawn.c
@@ -209,8 +209,8 @@ static HYD_status fill_preput_kvs(struct HYD_kvs *kvs, int preput_num, struct PM
     HYD_status status = HYD_SUCCESS;
 
     for (int i = 0; i < preput_num; i++) {
-        int ret;
-        status = HYD_pmcd_pmi_add_kvs(infos[i].key, infos[i].val, kvs, &ret);
+        status = HYD_pmcd_pmi_add_kvs(infos[i].key, infos[i].val, kvs,
+                                      HYD_server_info.user_global.debug);
         HYDU_ERR_POP(status, "unable to add key pair to kvs\n");
     }
 

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -621,7 +621,7 @@ HYD_status fn_finalize(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 HYD_status fn_info_putnodeattr(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
-    int ret, pmi_errno;
+    int pmi_errno;
     struct PMIU_cmd pmi_response;
     HYDU_FUNC_ENTER();
 
@@ -640,7 +640,8 @@ HYD_status fn_info_putnodeattr(struct pmip_downstream *p, struct PMIU_cmd *pmi)
         goto fn_exit;
     }
 
-    status = HYD_pmcd_pmi_add_kvs(key, val, PMIP_pg_from_downstream(p)->kvs, &ret);
+    status = HYD_pmcd_pmi_add_kvs(key, val, PMIP_pg_from_downstream(p)->kvs,
+                                  HYD_pmcd_pmip.user_global.debug);
     HYDU_ERR_POP(status, "unable to put data into kvs\n");
 
     pmi_errno = PMIU_msg_set_response(pmi, &pmi_response, is_static);


### PR DESCRIPTION
## Pull Request Description

Follow-up of https://github.com/pmodels/mpich/pull/6564, in particular comment https://github.com/pmodels/mpich/pull/6564#discussion_r1268210661

This PR enables duplicate keys also in debug mode of hydra (see `PMI_KEY_CHECK`).

In contrast to my comment in 6564, I think we should not print a debug message for duplicate keys in debug mode because that will lead to failing session re-init tests.

## Author Checklist
* [X] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [X] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [X] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
