### PR TITLE
mpir_pmi: fix missing return in pmix_optional_bcast_barrier

### DIFF
--- a/maint/code-cleanup.bash
+++ b/maint/code-cleanup.bash
@@ -102,7 +102,7 @@ if [ -z "$1" ]; then
     exit
 fi
 
-filetype_list="\.c$|\.h$|\.c\.in$|\.h\.in$|\.cpp$|\.cpp.in$"
+filetype_list="\.c$|\.h$|\.c\.in$|\.h\.in$|\.cpp$|\.cpp.in$|\.inc$"
 
 ignore_list="doc/"
 ignore_list="$ignore_list|src/mpid/ch3/doc"

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -253,7 +253,7 @@ void MPIR_pmi_abort(int exit_code, const char *error_msg)
 int MPIR_pmi_set_threaded(int is_threaded)
 {
     if (MPIR_CVAR_PMI_VERSION == MPIR_CVAR_PMI_VERSION_2) {
-#if ENABLE_PMI2
+#ifdef ENABLE_PMI2
         PMI2_Set_threaded(is_threaded);
 #endif
     }

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -267,7 +267,7 @@ static int pmix_get_binary(int src, const char *key, char *buf, int *p_size, int
 static int pmix_optional_bcast_barrier(MPIR_PMI_DOMAIN domain)
 {
     if (domain == MPIR_PMI_DOMAIN_LOCAL) {
-        pmix_barrier_local();
+        return pmix_barrier_local();
     } else {
         return pmix_barrier();
     }

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -161,11 +161,10 @@ static int pmix_barrier_local(void)
     int pmi_errno;
 
     int local_size = MPIR_Process.local_size;
-    pmix_proc_t *procs = MPL_malloc(local_size * sizeof(pmix_proc_t), MPL_MEM_OTHER);
+    pmix_proc_t *procs = NULL;
+    PMIX_PROC_CREATE(procs, local_size);
     for (int i = 0; i < local_size; i++) {
-        PMIX_PROC_CONSTRUCT(&procs[i]);
-        strncpy(procs[i].nspace, pmix_proc.nspace, PMIX_MAX_NSLEN);
-        procs[i].rank = MPIR_Process.node_local_map[i];
+        PMIX_LOAD_PROCID(&(procs[i]), pmix_proc.nspace, MPIR_Process.node_local_map[i]);
     }
 
     pmix_info_t *info;
@@ -178,7 +177,7 @@ static int pmix_barrier_local(void)
                          "**pmix_fence %d", pmi_errno);
 
     PMIX_INFO_FREE(info, 1);
-    MPL_free(procs);
+    PMIX_PROC_FREE(procs, local_size);
 
   fn_exit:
     return mpi_errno;

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -53,14 +53,15 @@ static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
     PMIX_VALUE_RELEASE(pvalue);
 
   fn_exit:
+    /* FIXME: support spawn and appnum */
+    *has_parent = 0;
+    *appnum = 0;
     return mpi_errno;
   fn_fail:
     goto fn_exit;
   singleton_out:
     *rank = 0;
     *size = 1;
-    *appnum = 0;
-    *has_parent = 0;
     pmi_kvs_name = MPL_strdup("0");
     goto fn_exit;
 }


### PR DESCRIPTION
## Pull Request Description

Follow up for https://github.com/pmodels/mpich/pull/6580
- Fix a missing return in `pmix_optional_bcast_barrier` (bug that breaks PMIx functionality)
- Mitigate some other compiler warnings

## Author Checklist
* [X] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [X] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [X] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
