### PR TITLE
configure: only substitue fortran files if configured

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1040,12 +1040,16 @@ fn_gen_binding_c
 # Create the bindings if necessary 
 if [ $do_f77 = "yes" ] ; then
     fn_f77
+else
+    touch src/binding/fortran/mpif_h/mpif.h.in
 fi
 if [ $do_f90 = "yes" ] ; then
     fn_f90
 fi
 if [ $do_f08 = "yes" ] ; then
     fn_f08
+else
+    touch src/binding/fortran/use_mpi_f08/mpi_f08_compile_constants.f90.in
 fi
 
 if [ $do_cxx = "yes" ] ; then

--- a/configure.ac
+++ b/configure.ac
@@ -4250,11 +4250,6 @@ AC_CONFIG_FILES([Makefile \
 	  mpich-doxygen \
           src/include/mpir_ext.h \
           src/binding/cxx/mpicxx.h \
-	  src/binding/fortran/mpif_h/mpif.h \
-	  src/binding/fortran/mpif_h/setbotf.f \
-	  src/binding/fortran/mpif_h/setbot.c \
-	  src/binding/fortran/use_mpi_f08/mpi_f08_compile_constants.f90 \
-	  src/binding/fortran/use_mpi_f08/mpi_c_interface_types.f90 \
 	  src/packaging/pkgconfig/mpich.pc \
 	  src/packaging/envmods/mpich.module \
           src/env/mpixxx_opts.conf \
@@ -4270,6 +4265,15 @@ AC_CONFIG_FILES([Makefile \
           doc/refman/Makefile \
           doc/userguide/Makefile \
           test/commands/cmdtests])
+if test "$enable_f77" = "yes" ; then
+    AC_CONFIG_FILES([src/binding/fortran/mpif_h/mpif.h \
+                     src/binding/fortran/mpif_h/setbotf.f \
+                     src/binding/fortran/mpif_h/setbot.c])
+fi
+if test "$enable_f08" = "yes" ; then
+    AC_CONFIG_FILES([src/binding/fortran/use_mpi_f08/mpi_f08_compile_constants.f90 \
+                     src/binding/fortran/use_mpi_f08/mpi_c_interface_types.f90])
+fi
 AC_OUTPUT
 
 echo '*****************************************************'


### PR DESCRIPTION
## Pull Request Description
If user add --disable-fortran option, make configure not depend on the fortran files that maybe missing from the autogen.

Fixes #6606 


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
