### PR TITLE
Update generic.json to Modify the bcast algorithm selection

### DIFF
--- a/maint/tuning/coll/mpir/generic.json
+++ b/maint/tuning/coll/mpir/generic.json
@@ -36,13 +36,9 @@
                     {
                         "algorithm=MPIR_Bcast_intra_binomial":{}
                     },
-                    "avg_msg_size<=524288":
-                    {
-                        "algorithm=MPIR_Bcast_intra_scatter_recursive_doubling_allgather":{}
-                    },
                     "avg_msg_size=any":
                     {
-                        "algorithm=MPIR_Bcast_intra_scatter_ring_allgather":{}
+                        "algorithm=MPIR_Bcast_intra_scatter_recursive_doubling_allgather":{}
                     }
                 },
                 "comm_hierarchy=any":
@@ -51,13 +47,9 @@
                     {
                         "algorithm=MPIR_Bcast_intra_binomial":{}
                     },
-                    "avg_msg_size<=524288":
-                    {
-                        "algorithm=MPIR_Bcast_intra_scatter_recursive_doubling_allgather":{}
-                    },
                     "avg_msg_size=any":
                     {
-                        "algorithm=MPIR_Bcast_intra_scatter_ring_allgather":{}
+                        "algorithm=MPIR_Bcast_intra_scatter_recursive_doubling_allgather":{}
                     }
                 }
             },


### PR DESCRIPTION
## Pull Request Description
I am a fan of mpich research, and while testing mpich performance on a cluster, I found that the mpir layer algorithm has some room for optimization in selecting branches. I analyzed the default algorithm selection rules of MPI_Bcast in mpich, mainly focusing on the algorithm selection of medium and long messages.
**1、Default algorithm selection analysis：**
The allgather implemented by the ring algorithm, messages are passed between adjacent processes, the size of the data received each time is (total data/number of processes), in the process of storing and forwarding messages, the buffers used are close, that is, stored and sent in linear order. Since the same amount of data is received and sent each time, and every process in the communication domain is fully utilized, the communication is in a balanced state. Imagine if a long message uses a recursive doubling algorithm, as the communication distance increases by the power of 2, the amount of data carried by each process also increases by the power of 2. If the number of processes is equal to a quadratic power, each process has a peer process to exchange data communication, and only need to exchange data with the peer process; If the number of processes is not equal to the quadratic power, the process whose process number is outside the power of 2 has no communication with the peer process. In this case, at each step of the recursive doubling, the process in the range needs to send data to the process outside the range, resulting in a doubling of the traffic in the communication domain. Due to the large message length, the message transmission time is also greatly increased, and the time that other processes wait for the two communicating processes to complete the communication is greatly increased, resulting in an unbalanced state of communication. Therefore, the scatter_ring_allgather is better suited when Bcast passes long messages.
    The allgather implementation of recursive doubling, where messages are communicated in pairs, reduces the number of communications compared to the ring algorithm, from (p-1) to lgp. If the message length is moderate, regardless of whether the number of processes is a quadratic power, it will not cause the problem that the second half of the communication takes a long time per communication because the message length is too long, and it will not cause the communication to fall into an unbalanced state. Therefore, the scatter_recursive_doubling_allgather is more suitable for Bcast to pass medium messages. When the number of processes is greater than 8 and to a power of two, scatter_recursive_doubling_allgather for medium messages and scatter_ring_allgather for long messages; When the number of processes is greater than 8 and non-quadratic, scatter_ring_allgather is selected for both medium and large messages.
**2、Insufficient analysis and  conclusion:**
However, the above default algorithm selection has some shortcomings, it does not make a special choice for the number of processes in the communication domain. From the above analysis, we can see that the ring algorithm is used to achieve allgather for long messages. If the number of processes is a non-quadratic power, the recursive doubling algorithm is used. Due to the long message length, the processes in the quadratic power range will generate extra overhead to synchronize the data carried by themselves to processes outside the range. Although the (p-1) step required by the ring algorithm is reduced to the lgp step, with the increase of communication distance, the amount of data carried by the process increases, and the time spent on each step in the second half of communication is also longer, resulting in the total time of using recursive doubling is greater than that of the ring algorithm. We naturally consider the case where the number of processes is a quadratic power, and with recursive doubling there is no additional synchronization, so for long messages, does the ring algorithm have an advantage over the recursive doubling algorithm?
    When we analyze the time complexity, the Allgather for a recursive doubling is about lgp·α + n·((p-1)/p)·β, and the Allgather for a ring algorithm is (p-1)·α + n·((p-1)/p)·β. The approximate value here is because the additional time cost cannot be quantified if the number of processes is a non-quadratic power, so the time is the time taken if the number of processes is a quadratic power. Where α is the delay (or startup time) of each message, and its value is independent of the message size; If p>8, lgp is obviously less than (p-1), so lgp·α is less than (p-1)·α, and it is obvious that recursive doubling is better than the loop algorithm in the case of quadratic powers.
The scatter_recursive_doubling_allgather algorithm is superior to the scatter_ring_allgather algorithm if the number of processes in the communication domain is a power of two, for both medium and long messages. In the case of non-quadratic powers, the opposite is [true.]
**3、Modification steps:**
Modify the algorithm selection rules, that is, the selection branch in the tuning json file, to use the scatter_recursive_doubling_allgather algorithm for long messages if the number of processes is 8 or greater and the number of processes involved in the communication is a power of 2.
**4、Experimental result**
I tested it using benchmark5.9,See the attachment for details.
  |   | before | after
np | ppn | Avg Latency(us) |   | Avg Latency(us) |  
16 | 2 | 383.23 | scatter_ring_allgather | 244.87 | scatter_recursive_doubling_allgather
32 | 4 | 602.09 | scatter_ring_allgather | 342.85 | scatter_recursive_doubling_allgather
48 | 6 | 837.67 | scatter_ring_allgather | 838.74 | scatter_ring_allgather
64 | 8 | 1063.77 | scatter_ring_allgather | 526.16 | scatter_recursive_doubling_allgather
80 | 10 | 1017.38 | scatter_ring_allgather | 1014.32 | scatter_ring_allgather
96 | 12 | 1035.03 | scatter_ring_allgather | 1033.27 | scatter_ring_allgather
112 | 14 | 1135.69 | scatter_ring_allgather | 1131.73 | scatter_ring_allgather
128 | 16 | 1496.47 | scatter_ring_allgather | 853.39 | scatter_recursive_doubling_allgather
144 | 18 | 1639.34 | scatter_ring_allgather | 1647.73 | scatter_ring_allgather
160 | 20 | 1486.51 | scatter_ring_allgather | 1422.20 | scatter_ring_allgather
176 | 22 | 1477.88 | scatter_ring_allgather | 1428.47 | scatter_ring_allgather
192 | 24 | 1589.40 | scatter_ring_allgather | 1632.54 | scatter_ring_allgather
208 | 26 | 1787.09 | scatter_ring_allgather | 1755.54 | scatter_ring_allgather
224 | 28 | 1889.16 | scatter_ring_allgather | 1879.12 | scatter_ring_allgather


[bcast test.xlsx](https://github.com/pmodels/mpich/files/12182484/bcast.test.xlsx)


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
[bcast test.xlsx](https://github.com/pmodels/mpich/files/12189333/bcast.test.xlsx)
