### PR TITLE
mpit: skip initcheck for MPI_Pcontrol

### DIFF
--- a/src/binding/c/misc_api.txt
+++ b/src/binding/c/misc_api.txt
@@ -95,7 +95,7 @@ MPI_Get_library_version:
 
 MPI_Pcontrol:
     .desc: Controls profiling
-    .skip: ThreadSafe, validate-PROFILE_LEVEL, validate-VARARGS
+    .skip: initcheck, ThreadSafe, validate-PROFILE_LEVEL, validate-VARARGS
     .impl: direct
 /*
     Notes:


### PR DESCRIPTION
## Pull Request Description
MPI_Pcontrol should be allowed to called before MPI_Init since one of its purpose is to enable/disable profiling.

Fixes #6616 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
