### PR TITLE
hydra: proxy use localhost for PMI_PORT

### DIFF
--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -777,7 +777,8 @@ static HYD_status launch_procs(struct pmip_pg *pg)
          */
         int listen_fd;
         status = HYDU_sock_create_and_listen_portstr(HYD_pmcd_pmip.user_global.iface,
-                                                     NULL, NULL, &pmi_port, &listen_fd,
+                                                     (char *) "localhost", NULL,
+                                                     &pmi_port, &listen_fd,
                                                      pmi_listen_cb, (void *) (intptr_t) pg->idx);
         HYDU_ERR_POP(status, "unable to create PMI port\n");
 


### PR DESCRIPTION
## Pull Request Description
When hydra is invoked with `--pmi-port` option, it sets PMI_PORT using hostname from gethostname function. However, gethostname do not always return a hostname that is usable for connecting to localhost, for example, on osx. Directly use "localhost" instead.

Fixes #6621 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
