### PR TITLE
pmi: refactor libpmiutil.la

### DIFF
--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -144,14 +144,14 @@ m4_define([pmi_embedded_dir],[modules/pmi])
 #       we need the "pmi/src" path for accessing internal headers such as pmi_wire.h
 if test "$FROM_MPICH" = "yes"; then
     pmi_includedir="-I$main_top_srcdir/src/pmi/src"
-    pmi_lib="$main_top_builddir/src/pmi/libpmi.la"
+    pmi_lib="$main_top_builddir/src/pmi/libpmiutil.la"
 else
     # TODO: option for --with-pmilib=xxx
     pmi_srcdir=pmi_embedded_dir
     pmi_includedir='-I$(top_srcdir)/pmi_embedded_dir/src'
     pmi_subdir_args="--enable-embedded"
     PAC_CONFIG_SUBDIR_ARGS(pmi_embedded_dir, [$pmi_subdir_args])
-    pmi_lib='$(top_builddir)/pmi_embedded_dir/libpmi.la'
+    pmi_lib='$(top_builddir)/pmi_embedded_dir/libpmiutil.la'
 fi
 
 # Documentation

--- a/src/pmi/Makefile.am
+++ b/src/pmi/Makefile.am
@@ -6,8 +6,16 @@
 ACLOCAL_AMFLAGS = -I confdb
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
+noinst_LTLIBRARIES = libpmiutil.la
+
+libpmiutil_la_SOURCES = \
+    src/pmi_wire.c \
+    src/pmi_msg.c \
+    src/pmi_common.c \
+    src/pmi_util.c
+
 if EMBEDDED_MODE
-noinst_LTLIBRARIES = libpmi.la
+noinst_LTLIBRARIES += libpmi.la
 
 else
 include_HEADERS = \
@@ -20,12 +28,8 @@ endif
 SUBDIRS = @mpl_srcdir@
 AM_CPPFLAGS += @mpl_includedir@
 
-libpmi_la_LIBADD = @mpl_lib@
+libpmi_la_LIBADD = @mpl_lib@ libpmiutil.la
 
 libpmi_la_SOURCES = \
     src/pmi_v1.c \
-    src/pmi_v2.c \
-    src/pmi_wire.c \
-    src/pmi_msg.c \
-    src/pmi_common.c \
-    src/pmi_util.c
+    src/pmi_v2.c


### PR DESCRIPTION
## Pull Request Description

Rafactor the common pmi utility code into libtool convenience library. The utitlity routines are not exposed if we configure `--with-pmilib=install`, thus hydra won't build. Making the utility code into convenience library let hydra directly access the routines.

Fixes https://github.com/pmodels/mpich/pull/6602#issuecomment-1664151198

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
