### PR TITLE
ch4/ofi: remove MPIDI_OFI_MAX_VNIS

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -23,9 +23,6 @@
      : __FILE__                                 \
 )
 
-/* TODO: This should come from provider capability */
-#define MPIDI_OFI_MAX_VNIS                  16
-
 #define MPIDI_OFI_MAP_NOT_FOUND            ((void*)(-1UL))
 #define MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE  (16 * 1024)
 #define MPIDI_OFI_MAX_NUM_AM_BUFFERS       (8)
@@ -368,8 +365,8 @@ typedef struct {
 
     /* Mutexes and endpoints */
     MPIDI_OFI_cacheline_mutex_t mutexes[MAX_OFI_MUTEXES];
-    MPIDI_OFI_context_t ctx[MPIDI_OFI_MAX_VNIS * MPIDI_OFI_MAX_NICS];
-    MPIDI_OFI_per_vci_t per_vci[MPIDI_OFI_MAX_VNIS];
+    MPIDI_OFI_context_t ctx[MPIDI_CH4_MAX_VCIS * MPIDI_OFI_MAX_NICS];
+    MPIDI_OFI_per_vci_t per_vci[MPIDI_CH4_MAX_VCIS];
     int num_vcis;
     int num_nics;
     int num_close_nics;


### PR DESCRIPTION
## Pull Request Description
MPIDI_OFI_MAX_VNIS is no longer in use. It is replaced by MPIDI_CH4_MAX_VCIS. This is necessary to have consistent vci between the ch4/shm/netmod layer.

For some reason, `MPIDI_OFI_MAX_VNIS` is set at 16. When we use more than 16 vcis, this results in array overrun. This PR fixes it.

Thanks to @JiakunYan for reporting the issue.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
