### PR TITLE
request: avoid poking extra progress

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -8,40 +8,6 @@
 
 #include "mpir_process.h"
 
-/*
-=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
-
-categories :
-    - name : REQUEST
-      description : A category for requests management variables
-
-cvars:
-    - name        : MPIR_CVAR_REQUEST_POLL_FREQ
-      category    : REQUEST
-      type        : int
-      default     : 8
-      class       : none
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_LOCAL
-      description : >-
-        How frequent to poll during completion calls (wait/test) in terms
-        of number of processed requests before polling.
-
-    - name        : MPIR_CVAR_REQUEST_BATCH_SIZE
-      category    : REQUEST
-      type        : int
-      default     : 64
-      class       : none
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_LOCAL
-      description : >-
-        The number of requests to make completion as a batch
-        in MPI_Waitall and MPI_Testall implementation. A large number
-        is likely to cause more cache misses.
-
-=== END_MPI_T_CVAR_INFO_BLOCK ===
-*/
-
 /* NOTE-R1: MPIR_REQUEST_KIND__MPROBE signifies that this is a request created by
  * MPI_Mprobe or MPI_Improbe.  Since we use MPI_Request objects as our
  * MPI_Message objects, we use this separate kind in order to provide stronger

--- a/src/mpi/request/request_impl.c
+++ b/src/mpi/request/request_impl.c
@@ -135,7 +135,6 @@ int MPIR_Request_free_impl(MPIR_Request * request_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPID_Progress_poke();
     switch (request_ptr->kind) {
         case MPIR_REQUEST_KIND__SEND:
         case MPIR_REQUEST_KIND__RECV:

--- a/src/mpi/request/request_impl.c
+++ b/src/mpi/request/request_impl.c
@@ -8,6 +8,10 @@
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===
 
+categories :
+    - name : REQUEST
+      description : A category for requests management variables
+
 cvars:
     - name        : MPIR_CVAR_REQUEST_ERR_FATAL
       category    : REQUEST
@@ -25,6 +29,29 @@ cvars:
         case, which maybe more convenient for debugging. This cvar will also
         make nonblocking shched return error right away as it issues
         operations.
+
+    - name        : MPIR_CVAR_REQUEST_POLL_FREQ
+      category    : REQUEST
+      type        : int
+      default     : 8
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        How frequent to poll during completion calls (wait/test) in terms
+        of number of processed requests before polling.
+
+    - name        : MPIR_CVAR_REQUEST_BATCH_SIZE
+      category    : REQUEST
+      type        : int
+      default     : 64
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        The number of requests to make completion as a batch
+        in MPI_Waitall and MPI_Testall implementation. A large number
+        is likely to cause more cache misses.
 
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */

--- a/src/mpi/request/request_impl.c
+++ b/src/mpi/request/request_impl.c
@@ -38,7 +38,7 @@ cvars:
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_LOCAL
       description : >-
-        How frequent to poll during completion calls (wait/test) in terms
+        How frequent to poll during MPI_{Waitany,Waitsome} in terms
         of number of processed requests before polling.
 
     - name        : MPIR_CVAR_REQUEST_BATCH_SIZE

--- a/src/mpi/request/request_impl.c
+++ b/src/mpi/request/request_impl.c
@@ -277,8 +277,10 @@ int MPIR_Test_state(MPIR_Request * request_ptr, int *flag, MPI_Status * status,
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPID_Progress_test(state);
-    MPIR_ERR_CHECK(mpi_errno);
+    if (!MPIR_Request_is_complete(request_ptr)) {
+        mpi_errno = MPID_Progress_test(state);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
 
   fn_exit:
     return mpi_errno;

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -35,8 +35,7 @@ extern MPL_TLS int global_vci_poll_count;
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_do_global_progress(void)
 {
-    if (MPIDI_global.n_total_vcis == 1 || !MPIDI_global.is_initialized ||
-        !MPIR_CVAR_CH4_GLOBAL_PROGRESS) {
+    if (MPIDI_global.n_vcis == 1 || !MPIDI_global.is_initialized || !MPIR_CVAR_CH4_GLOBAL_PROGRESS) {
         return 0;
     } else {
         global_vci_poll_count++;
@@ -159,10 +158,10 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_progress_state_init(MPID_Progress_state * st
         state->vci_count = 1;
     } else {
         /* global progress by default */
-        for (int i = 0; i < MPIDI_global.n_total_vcis; i++) {
+        for (int i = 0; i < MPIDI_global.n_vcis; i++) {
             state->vci[i] = i;
         }
-        state->vci_count = MPIDI_global.n_total_vcis;
+        state->vci_count = MPIDI_global.n_vcis;
     }
 }
 

--- a/src/mpid/ch4/src/ch4_wait.h
+++ b/src/mpid/ch4/src/ch4_wait.h
@@ -30,6 +30,10 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_set_progress_vci_n(int n, MPIR_Request ** re
             continue;
         }
 
+        if (HANDLE_IS_BUILTIN(reqs[i]->handle) || MPIR_Request_is_complete(reqs[i])) {
+            continue;
+        }
+
         int vci = MPIDI_Request_get_vci(reqs[i]);
         int found = 0;
         for (int j = 0; j < idx; j++) {


### PR DESCRIPTION
## Pull Request Description
Intuitively we may expect a test call such as `MPI_Test{any,some,all}` won't poke progress if there are completed tests for the test calls to return positively. This can be important for applications that use test calls for latency-sensitive usages. However, the previous code always pokes progress in test calls regardless of the requests' completion status. This PR fixes it.

Fixes #6628 
Fixes #6627 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
