### PR TITLE
ch4: Fix persistent MPI_SSEND

### DIFF
--- a/src/mpid/ch4/src/ch4_persist.c
+++ b/src/mpid/ch4/src/ch4_persist.c
@@ -75,8 +75,7 @@ int MPID_Ssend_init(const void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    MPIR_PT2PT_ATTR_SET_SYNCFLAG(attr);
-    mpi_errno = psend_init(MPIDI_PTYPE_SEND, buf, count, datatype, rank, tag, comm, attr, request);
+    mpi_errno = psend_init(MPIDI_PTYPE_SSEND, buf, count, datatype, rank, tag, comm, attr, request);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1302,6 +1302,7 @@
 /pt2pt/probenull
 /pt2pt/probe_unexp
 /pt2pt/pscancel
+/pt2pt/pssend
 /pt2pt/pt2pt_large
 /pt2pt/rcancel
 /pt2pt/recv_any

--- a/test/mpi/pt2pt/Makefile.am
+++ b/test/mpi/pt2pt/Makefile.am
@@ -70,7 +70,8 @@ noinst_PROGRAMS =  \
     pt2pt_large \
     precv_anysrc \
     precv_anysrc_exp \
-    mprobe_self_free
+    mprobe_self_free \
+    pssend
 
 irecv_any_CPPFLAGS = -DTEST_NB $(AM_CPPFLAGS)
 irecv_any_SOURCES  = recv_any.c

--- a/test/mpi/pt2pt/pssend.c
+++ b/test/mpi/pt2pt/pssend.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+/*
+ * This program checks the semantics of persistent synchronous send
+ */
+
+#include "mpitest.h"
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    int size, rank;
+    MPI_Request req;
+    int flag;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    if (size < 2) {
+        fprintf(stderr, "Launch with two processes\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    if (rank == 0) {
+        MPI_Ssend_init(NULL, 0, MPI_DATATYPE_NULL, 1, 0, MPI_COMM_WORLD, &req);
+        MPI_Start(&req);
+
+        /* ssend cannot be complete at this point */
+        MPI_Test(&req, &flag, MPI_STATUS_IGNORE);
+        if (flag != 0) {
+            errs++;
+            fprintf(stderr, "ERROR: synchronous send completed before matching recv was posted\n");
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (rank == 0) {
+        MPI_Wait(&req, MPI_STATUS_IGNORE);
+        MPI_Request_free(&req);
+    } else if (rank == 1) {
+        MPI_Recv(NULL, 0, MPI_DATATYPE_NULL, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+    }
+
+    MTest_Finalize(errs);
+
+    return 0;
+}

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -76,3 +76,4 @@ precv_anysrc 2 timeLimit=60 env=MPIR_CVAR_CH4_OFI_AM_LONG_FORCE_PIPELINE=true
 precv_anysrc_exp 2 timeLimit=60
 pt2pt_large 2
 mprobe_self_free 1
+pssend 2


### PR DESCRIPTION
## Pull Request Description

The persistent path does not make use of the synchronous attribute correctly. Just ignore it and use the previously working persistent request type to indicate a synchronous send.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
