### PR TITLE
ch4/isend-irecv: add parent reques completion in isend/irecv

### DIFF
--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -136,14 +136,14 @@ Non Native API:
 
 Native API:
   mpi_isend : int
-      NM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p
-     SHM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p
+      NM*: buf, count, datatype, rank, tag, comm, attr-2, addr, parent_cc_ptr, req_p
+     SHM*: buf, count, datatype, rank, tag, comm, attr-2, addr, parent_cc_ptr, req_p
   mpi_cancel_send : int
       NM*: sreq
      SHM*: sreq
   mpi_irecv : int
-      NM*: buf-2, count, datatype, rank, tag, comm, attr-2, addr, req_p, partner
-     SHM*: buf-2, count, datatype, rank, tag, comm, attr-2, req_p
+      NM*: buf-2, count, datatype, rank, tag, comm, attr-2, addr, parent_cc_ptr, req_p, partner
+     SHM*: buf-2, count, datatype, rank, tag, comm, attr-2, parent_cc_ptr, req_p
   mpi_imrecv : int
       NM*: buf-2, count, datatype, message
      SHM*: buf-2, count, datatype, message
@@ -477,6 +477,7 @@ PARAM:
     origin_addr-2: void *
     origin_count: MPI_Aint
     origin_datatype: MPI_Datatype
+    parent_cc_ptr: MPIR_cc_t*
     partner: MPIR_Request *
     port_name: const char *
     port_name-2: char *

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
@@ -6,13 +6,15 @@
 #ifndef NETMOD_AM_FALLBACK_SEND_H_INCLUDED
 #define NETMOD_AM_FALLBACK_SEND_H_INCLUDED
 
+/* parent_cc_ptr: allows the created request to decrement the counter of a parent request when completed. use NULL to not use this mechanism */
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
                                                 MPI_Aint count,
                                                 MPI_Datatype datatype,
                                                 int rank,
                                                 int tag,
                                                 MPIR_Comm * comm, int attr,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request)
+                                                MPIDI_av_entry_t * addr,
+                                                MPIR_cc_t * parent_cc_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -27,6 +29,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci_src).lock);
     mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                  vci_src, vci_dst, request, syncflag, errflag);
+    /* if the parent_cc_ptr exists */
+    if (parent_cc_ptr) {
+        if (MPIR_Request_is_complete(*request)) {
+            /* if the request is already completed, decrement the parent counter */
+            MPIR_cc_dec(parent_cc_ptr);
+        } else {
+            /* if the request is not done yet, assign the completion pointer to the parent one and it will be decremented later */
+            (*request)->dev.completion_notification = parent_cc_ptr;
+        }
+    }
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci_src).lock);
 
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -319,8 +319,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
                                                 int rank,
                                                 int tag,
                                                 MPIR_Comm * comm, int attr,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                MPIR_Request * partner)
+                                                MPIDI_av_entry_t * addr,
+                                                MPIR_cc_t * parent_cc_ptr,
+                                                MPIR_Request ** request, MPIR_Request * partner)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
@@ -353,6 +354,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
                                        context_offset, addr, vci_src, vci_dst, request,
                                        MPIDI_OFI_ON_HEAP, 0ULL);
         MPIDI_REQUEST_SET_LOCAL(*request, 0, partner);
+    }
+
+    /* if the parent_cc_ptr exists */
+    if (parent_cc_ptr) {
+        if (MPIR_Request_is_complete(*request)) {
+            /* if the request is already completed, decrement the parent counter */
+            MPIR_cc_dec(parent_cc_ptr);
+        } else {
+            /* if the request is not done yet, assign the completion pointer to the parent one and it will be decremented later */
+            (*request)->dev.completion_notification = parent_cc_ptr;
+        }
     }
     if (need_cs) {
         MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vci_dst);

--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -213,8 +213,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
                                                 int rank,
                                                 int tag,
                                                 MPIR_Comm * comm, int attr,
-                                                MPIDI_av_entry_t * addr, MPIR_Request ** request,
-                                                MPIR_Request * partner)
+                                                MPIDI_av_entry_t * addr,
+                                                MPIR_cc_t * parent_cc_ptr,
+                                                MPIR_Request ** request, MPIR_Request * partner)
 {
     int mpi_errno;
     MPIR_FUNC_ENTER;
@@ -238,6 +239,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
         MPIDI_UCX_recv(buf, count, datatype, rank, tag, comm, context_offset, addr, vci_dst,
                        request);
     MPIDI_REQUEST_SET_LOCAL(*request, 0, partner);
+
+    /* if the parent_cc_ptr exists */
+    if (parent_cc_ptr) {
+        if (MPIR_Request_is_complete(*request)) {
+            /* if the request is already completed, decrement the parent counter */
+            MPIR_cc_dec(parent_cc_ptr);
+        } else {
+            /* if the request is not done yet, assign the completion pointer to the parent one and it will be decremented later */
+            (*request)->dev.completion_notification = parent_cc_ptr;
+        }
+    }
     if (need_cs) {
         MPIDI_UCX_THREAD_CS_EXIT_VCI(vci_dst);
     }

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -53,6 +53,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
                                                       MPI_Datatype datatype, int rank, int tag,
                                                       MPIR_Comm * comm, int attr,
                                                       MPIDI_av_entry_t * addr,
+                                                      MPIR_cc_t * parent_cc_ptr,
                                                       MPIR_Request ** request, bool * done)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -150,6 +151,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
         /* TODO: add flattening datatype protocol for noncontig send. Different
          * threshold may be required to tradeoff the flattening overhead.*/
     }
+
+    /* if the parent_cc_ptr exists */
+    if (parent_cc_ptr) {
+        if (MPIR_Request_is_complete(*request)) {
+            /* if the request is already completed, decrement the parent counter */
+            MPIR_cc_dec(parent_cc_ptr);
+        } else {
+            /* if the request is not done yet, assign the completion pointer to the parent one and it will be decremented later */
+            (*request)->dev.completion_notification = parent_cc_ptr;
+        }
+    }
   fn_exit:
     MPIDI_POSIX_THREAD_CS_EXIT_VCI(vci_src);
     MPIR_FUNC_EXIT;
@@ -161,19 +173,20 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
 MPL_STATIC_INLINE_PREFIX int MPIDI_IPC_mpi_isend(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
                                                  MPIR_Comm * comm, int attr,
-                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
+                                                 MPIDI_av_entry_t * addr,
+                                                 MPIR_cc_t * parent_cc_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
     bool done = false;
     mpi_errno = MPIDI_IPCI_try_lmt_isend(buf, count, datatype, rank, tag, comm,
-                                         attr, addr, request, &done);
+                                         attr, addr, parent_cc_ptr, request, &done);
     MPIR_ERR_CHECK(mpi_errno);
 
     if (!done) {
         mpi_errno = MPIDI_POSIX_mpi_isend(buf, count, datatype, rank, tag, comm,
-                                          attr, addr, request);
+                                          attr, addr, parent_cc_ptr, request);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpid/ch4/shm/posix/posix_send.h
+++ b/src/mpid/ch4/shm/posix/posix_send.h
@@ -28,7 +28,9 @@
 MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_isend(const void *buf, MPI_Aint count,
                                                    MPI_Datatype datatype, int rank, int tag,
                                                    MPIR_Comm * comm, int attr,
-                                                   MPIDI_av_entry_t * addr, MPIR_Request ** request)
+                                                   MPIDI_av_entry_t * addr,
+                                                   MPIR_cc_t * parent_cc_ptr,
+                                                   MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -78,6 +80,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_isend(const void *buf, MPI_Aint cou
         mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                      vci_src, vci_dst, request, syncflag, errflag);
     }
+    /* if the parent_cc_ptr exists */
+    if (parent_cc_ptr) {
+        if (MPIR_Request_is_complete(*request)) {
+            /* if the request is already completed, decrement the parent counter */
+            MPIR_cc_dec(parent_cc_ptr);
+        } else {
+            /* if the request is not done yet, assign the completion pointer to the parent one and
+             * it will be decremented later */
+            (*request)->dev.completion_notification = parent_cc_ptr;
+        }
+    }
+
     MPIDI_POSIX_THREAD_CS_EXIT_VCI(vci_src);
 
     return mpi_errno;

--- a/src/mpid/ch4/shm/src/shm_am_fallback_send.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_send.h
@@ -12,7 +12,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf,
                                                  int rank,
                                                  int tag,
                                                  MPIR_Comm * comm, int attr,
-                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
+                                                 MPIDI_av_entry_t * addr,
+                                                 MPIR_cc_t * parent_cc_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -27,6 +28,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf,
     MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci_src).lock);
     mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                  vci_src, vci_dst, request, syncflag, errflag);
+
+    /* if the parent_cc_ptr exists */
+    if (parent_cc_ptr) {
+        if (MPIR_Request_is_complete(*request)) {
+            /* if the request is already completed, decrement the parent counter */
+            MPIR_cc_dec(parent_cc_ptr);
+        } else {
+            /* if the request is not done yet, assign the completion pointer to the parent one and it will be decremented later */
+            (*request)->dev.completion_notification = parent_cc_ptr;
+        }
+    }
+
     MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci_src).lock);
 
     return mpi_errno;

--- a/src/mpid/ch4/shm/src/shm_p2p.h
+++ b/src/mpid/ch4/shm/src/shm_p2p.h
@@ -13,7 +13,8 @@
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count,
                                                  MPI_Datatype datatype, int rank, int tag,
                                                  MPIR_Comm * comm, int attr,
-                                                 MPIDI_av_entry_t * addr, MPIR_Request ** request)
+                                                 MPIDI_av_entry_t * addr,
+                                                 MPIR_cc_t * parent_cc_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -24,10 +25,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf, MPI_Aint count
      *   always use MPIR_Localcopy to move the data and support GPU buffers efficiently
      *   with yaksa */
     if (rank == comm->rank || count == 0) {
-        mpi_errno =
-            MPIDI_POSIX_mpi_isend(buf, count, datatype, rank, tag, comm, attr, addr, request);
+        mpi_errno = MPIDI_POSIX_mpi_isend(buf, count, datatype, rank, tag, comm, attr, addr,
+                                          parent_cc_ptr, request);
     } else {
-        mpi_errno = MPIDI_IPC_mpi_isend(buf, count, datatype, rank, tag, comm, attr, addr, request);
+        mpi_errno = MPIDI_IPC_mpi_isend(buf, count, datatype, rank, tag, comm, attr, addr,
+                                        parent_cc_ptr request);
     }
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -52,13 +54,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_send(MPIR_Request * sreq)
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                                                  int rank, int tag, MPIR_Comm * comm,
-                                                 int context_offset, MPIR_Request ** request)
+                                                 int context_offset,
+                                                 MPIR_cc_t * parent_cc_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
     mpi_errno =
-        MPIDI_POSIX_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, request);
+        MPIDI_POSIX_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, parent_cc_ptr,
+                              request);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_request.h
+++ b/src/mpid/ch4/src/ch4_request.h
@@ -108,6 +108,9 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_Request_complete_fast(MPIR_Request * req)
     int incomplete;
     MPIR_cc_decr(req->cc_ptr, &incomplete);
     if (!incomplete) {
+        if (req->dev.completion_notification) {
+            MPIR_cc_dec(req->dev.completion_notification);
+        }
         MPIDI_CH4_REQUEST_FREE(req);
     }
 }

--- a/src/mpid/ch4/src/ch4_self.h
+++ b/src/mpid/ch4/src/ch4_self.h
@@ -9,15 +9,17 @@
 int MPIDI_Self_init(void);
 int MPIDI_Self_finalize(void);
 int MPIDI_Self_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
-                     MPIR_Comm * comm, int attr, MPIR_Request ** request);
+                     MPIR_Comm * comm, int attr, MPIR_cc_t * parent_cc_ptr,
+                     MPIR_Request ** request);
 int MPIDI_Self_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
-                     MPIR_Comm * comm, int attr, MPIR_Request ** request);
-int MPIDI_Self_iprobe(int rank, int tag, MPIR_Comm * comm, int attr,
-                      int *flag, MPI_Status * status);
-int MPIDI_Self_improbe(int rank, int tag, MPIR_Comm * comm, int attr,
-                       int *flag, MPIR_Request ** message, MPI_Status * status);
-int MPIDI_Self_imrecv(char *buf, MPI_Aint count, MPI_Datatype datatype,
-                      MPIR_Request * message, MPIR_Request ** request);
+                     MPIR_Comm * comm, int attr, MPIR_cc_t * parent_cc_ptr,
+                     MPIR_Request ** request);
+int MPIDI_Self_iprobe(int rank, int tag, MPIR_Comm * comm, int attr, int *flag,
+                      MPI_Status * status);
+int MPIDI_Self_improbe(int rank, int tag, MPIR_Comm * comm, int attr, int *flag,
+                       MPIR_Request ** message, MPI_Status * status);
+int MPIDI_Self_imrecv(char *buf, MPI_Aint count, MPI_Datatype datatype, MPIR_Request * message,
+                      MPIR_Request ** request);
 int MPIDI_Self_cancel(MPIR_Request * request);
 
 #endif /* MPIDI_SELF_H_INCLUDED */

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -15,20 +15,25 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_isend(const void *buf,
                                          int rank,
                                          int tag,
                                          MPIR_Comm * comm, int attr,
-                                         MPIDI_av_entry_t * av, MPIR_Request ** req)
+                                         MPIDI_av_entry_t * av,
+                                         MPIR_cc_t * parent_cc_ptr, MPIR_Request ** req)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
     *(req) = NULL;
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    mpi_errno = MPIDI_NM_mpi_isend(buf, count, datatype, rank, tag, comm, attr, av, req);
+    mpi_errno =
+        MPIDI_NM_mpi_isend(buf, count, datatype, rank, tag, comm, attr, av, parent_cc_ptr, req);
 #else
     int r;
     if ((r = MPIDI_av_is_local(av)))
-        mpi_errno = MPIDI_SHM_mpi_isend(buf, count, datatype, rank, tag, comm, attr, av, req);
+        mpi_errno =
+            MPIDI_SHM_mpi_isend(buf, count, datatype, rank, tag, comm, attr, av, parent_cc_ptr,
+                                req);
     else
-        mpi_errno = MPIDI_NM_mpi_isend(buf, count, datatype, rank, tag, comm, attr, av, req);
+        mpi_errno =
+            MPIDI_NM_mpi_isend(buf, count, datatype, rank, tag, comm, attr, av, parent_cc_ptr, req);
     if (mpi_errno == MPI_SUCCESS)
         MPIDI_REQUEST(*req, is_local) = r;
 #endif
@@ -54,10 +59,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend(const void *buf,
     MPIR_FUNC_ENTER;
 
     if (MPIR_is_self_comm(comm)) {
-        mpi_errno = MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, attr, request);
+        mpi_errno = MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, attr, NULL, request);
     } else {
         av = MPIDIU_comm_rank_to_av(comm, rank);
-        mpi_errno = MPIDI_isend(buf, count, datatype, rank, tag, comm, attr, av, request);
+        mpi_errno = MPIDI_isend(buf, count, datatype, rank, tag, comm, attr, av, NULL, request);
     }
 
     MPIR_ERR_CHECK(mpi_errno);
@@ -110,10 +115,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irsend(const void *buf,
     MPIR_FUNC_ENTER;
 
     if (MPIR_is_self_comm(comm)) {
-        mpi_errno = MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, attr, request);
+        mpi_errno = MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, attr, NULL, request);
     } else {
         av = MPIDIU_comm_rank_to_av(comm, rank);
-        mpi_errno = MPIDI_isend(buf, count, datatype, rank, tag, comm, attr, av, request);
+        mpi_errno = MPIDI_isend(buf, count, datatype, rank, tag, comm, attr, av, NULL, request);
     }
 
     MPIR_ERR_CHECK(mpi_errno);


### PR DESCRIPTION
## Pull Request Description
**[Partitioned communication]** Add support for meta request completion as part of the isend/irecv path.

Meta requests are common in partitioned communication and continuation API.
This PR allows a request to complete an isend/irecv call and notify a parent's completion counter when doing so.

This is needed for tracking down the completion of partitioned communication requests at low cost

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
