### PR TITLE
ch4: fix MPIDIG_mpi_irecv in error case

### DIFF
--- a/src/mpid/ch4/src/mpidig_recv.h
+++ b/src/mpid/ch4/src/mpidig_recv.h
@@ -340,8 +340,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_irecv(void *buf,
     mpi_errno = MPIDIG_do_irecv(buf, count, datatype, rank, tag, comm, context_offset, vci,
                                 request, 0ULL);
     MPIR_ERR_CHECK(mpi_errno);
-  fn_exit:
+
     MPIDI_REQUEST_SET_LOCAL(*request, is_local, partner);
+
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:


### PR DESCRIPTION

## Pull Request Description

When MPIDIG_do_irecv returns an error, the request is set to NULL. Blindly calling MPIDI_REQUEST_SET_LOCAL raises segfaults.

This is triggered by test errors/pt2pt/truncmsg2 due to its datatype mismatch error. It only triggers when we hit am-only unexpected matching case.

Fixes #6641 

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
