### PR TITLE
ch4/gpu: Add CVAR for choosing GPU IPC protocol

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -1271,6 +1271,9 @@ int MPL_gpu_finalize(void)
 
     MPL_event_pool_destroy();
 
+    MPL_free(mask_contents.dev_id);
+    MPL_free(mask_contents.subdev_id);
+
     return MPL_SUCCESS;
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -2653,13 +2653,16 @@ int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, in
 
     mem_id = ptr_attr->prop.id;
 
+    nfds = 0;   /* must initialized to 0 */
     if (zexMemGetIpcHandles) {
-        nfds = 0;       /* must initialized to 0 */
         ret = zexMemGetIpcHandles(ze_context, ptr, &nfds, NULL);
         ZE_ERR_CHECK(ret);
-        assert(nfds <= 2);
-        ret = zexMemGetIpcHandles(ze_context, ptr, &nfds, ze_ipc_handle);
-    } else {
+        if (nfds) {
+            assert(nfds <= 2);
+            ret = zexMemGetIpcHandles(ze_context, ptr, &nfds, ze_ipc_handle);
+        }
+    }
+    if (!nfds) {
         ret = zeMemGetIpcHandle(ze_context, ptr, &ze_ipc_handle[0]);
         nfds = 1;
     }
@@ -2938,13 +2941,16 @@ int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,
     if (cache_entry && cache_entry->mapped_ptr) {
         base = cache_entry->mapped_ptr;
     } else {
+        nfds = 0;       /* must be initialized to 0 */
         if (zexMemGetIpcHandles) {
-            nfds = 0;   /* must be initialized to 0 */
             ret = zexMemGetIpcHandles(ze_context, pbase, &nfds, NULL);
             ZE_ERR_CHECK(ret);
-            assert(nfds <= 2);
-            ret = zexMemGetIpcHandles(ze_context, pbase, &nfds, ze_ipc_handle);
-        } else {
+            if (nfds) {
+                assert(nfds <= 2);
+                ret = zexMemGetIpcHandles(ze_context, pbase, &nfds, ze_ipc_handle);
+            }
+        }
+        if (!nfds) {
             ret = zeMemGetIpcHandle(ze_context, pbase, &ze_ipc_handle[0]);
             nfds = 1;
         }


### PR DESCRIPTION
## Pull Request Description

This PR adds support for selecting the IPC protocol (i.e. read vs. write) and the GPU engine type for IPC paths with an option for auto-selection based on the environment and scenario.

Additionally this PR adds a fix to cleanup `mask_contents` in the ZE MPL backend

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
