### PR TITLE
ch4/rma/gpu: bypass yaksa when copying contiguous GPU buffers

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -363,6 +363,7 @@ typedef struct MPIDIG_win_shared_info {
     MPIDI_GPU_ipc_handle_t ipc_handle;
 #endif
     int mapped_type;            /* 0: gpu ipc mapped 1: gpu host mmapped 2: xpmem */
+    int global_dev_id;          /* device ID if mapped_type is 0 */
 } MPIDIG_win_shared_info_t;
 
 #define MPIDIG_ACCU_ORDER_RAR (1)

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -85,6 +85,21 @@ cvars:
         read - use read protocol
         write - use write protocol if remote device is visible
 
+    - name        : MPIR_CVAR_CH4_IPC_GPU_RMA_ENGINE_TYPE
+      category    : CH4
+      type        : enum
+      default     : auto
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : |-
+        By default, select engine type automatically
+        yaksa - don't select, use yaksa
+        auto - select automatically
+        compute - use compute engine
+        copy_high_bandwidth - use high-bandwidth copy engine
+        copy_low_latency - use low-latency copy engine
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_win.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_win.c
@@ -152,6 +152,7 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
         shared_table[i].shm_base_addr = NULL;
         shared_table[i].ipc_mapped_device = -1;
         shared_table[i].ipc_type = ipc_shared_table[i].ipc_type;
+        shared_table[i].global_dev_id = -1;
 
         if (i == shm_comm_ptr->rank) {
             shared_table[i].shm_base_addr = win->base;
@@ -192,6 +193,7 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
                                                                  false);
                             MPIR_ERR_CHECK(mpi_errno);
                             shared_table[i].mapped_type = 0;
+                            shared_table[i].global_dev_id = handle.global_dev_id;
                         }
                         shared_table[i].ipc_mapped_device = map_dev_id;
                     }

--- a/src/mpid/ch4/shm/posix/posix_pre.h
+++ b/src/mpid/ch4/shm/posix/posix_pre.h
@@ -129,7 +129,7 @@ do { \
 } while (0)
 
 typedef struct MPIDI_POSIX_rma_req {
-    MPIR_Typerep_req typerep_req;
+    MPIR_gpu_req yreq;
     struct MPIDI_POSIX_rma_req *next;
 } MPIDI_POSIX_rma_req_t;
 

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -169,14 +169,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
             mpi_errno =
                 MPIR_Ilocalcopy_gpu(origin_addr, origin_count, origin_datatype, 0, &origin_attr,
                                     target_addr, target_count, target_datatype, 0, &target_attr,
-                                    MPL_GPU_COPY_D2D_OUTGOING, engine_type, 1, &yreq);
+                                    MPL_GPU_COPY_DIRECTION_NONE, engine_type, 1, &yreq);
             if (yreq.type != MPIR_NULL_REQUEST)
                 MPIDI_POSIX_rma_outstanding_req_enqueu(yreq, &win->dev.shm.posix);
         } else {
             mpi_errno =
                 MPIR_Localcopy_gpu(origin_addr, origin_count, origin_datatype, 0, &origin_attr,
                                    target_addr, target_count, target_datatype, 0, &target_attr,
-                                   MPL_GPU_COPY_D2D_OUTGOING, engine_type, 1);
+                                   MPL_GPU_COPY_DIRECTION_NONE, engine_type, 1);
         }
         goto fn_exit;
     }
@@ -261,14 +261,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
             mpi_errno = MPIR_Ilocalcopy_gpu(target_addr, target_count,
                                             target_datatype, 0, NULL, origin_addr,
                                             origin_count, origin_datatype, 0, NULL,
-                                            MPL_GPU_COPY_D2D_INCOMING, engine_type, 1, &yreq);
+                                            MPL_GPU_COPY_DIRECTION_NONE, engine_type, 1, &yreq);
             if (yreq.type != MPIR_NULL_REQUEST)
                 MPIDI_POSIX_rma_outstanding_req_enqueu(yreq, &win->dev.shm.posix);
         } else {
             mpi_errno = MPIR_Localcopy_gpu(target_addr, target_count,
                                            target_datatype, 0, NULL, origin_addr,
                                            origin_count, origin_datatype, 0, NULL,
-                                           MPL_GPU_COPY_D2D_INCOMING, engine_type, 1);
+                                           MPL_GPU_COPY_DIRECTION_NONE, engine_type, 1);
         }
         goto fn_exit;
     }

--- a/src/mpid/ch4/shm/posix/posix_types.h
+++ b/src/mpid/ch4/shm/posix/posix_types.h
@@ -46,14 +46,14 @@ typedef struct {
 
 extern MPIDI_POSIX_global_t MPIDI_POSIX_global;
 
-MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_rma_outstanding_req_enqueu(MPIR_Typerep_req typerep_req,
+MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_rma_outstanding_req_enqueu(MPIR_gpu_req yreq,
                                                                      MPIDI_POSIX_win_t * posix_win)
 {
     MPIDI_POSIX_rma_req_t *req;
     req = MPL_malloc(sizeof(MPIDI_POSIX_rma_req_t), MPL_MEM_RMA);
     MPIR_Assert(req);
 
-    req->typerep_req = typerep_req;
+    req->yreq = yreq;
     req->next = NULL;
     LL_APPEND(posix_win->outstanding_reqs_head, posix_win->outstanding_reqs_tail, req);
 }
@@ -66,9 +66,20 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_rma_outstanding_req_flushall(MPIDI_POS
     MPIDI_POSIX_rma_req_t *req, *req_tmp;
     /* No dependency between requests, thus can safely wait one by one. */
     LL_FOREACH_SAFE(posix_win->outstanding_reqs_head, req, req_tmp) {
-        int mpi_errno ATTRIBUTE((unused));
-        mpi_errno = MPIR_Typerep_wait(req->typerep_req);
-        MPIR_Assert(mpi_errno == MPI_SUCCESS);
+        int mpi_errno ATTRIBUTE((unused)) = MPI_SUCCESS;
+
+        if (req->yreq.type == MPIR_TYPEREP_REQUEST) {
+            mpi_errno = MPIR_Typerep_wait(req->yreq.u.y_req);
+            MPIR_Assert(mpi_errno == MPI_SUCCESS);
+        } else if (req->yreq.type == MPIR_GPU_REQUEST) {
+            int completed = 0;
+            while (!completed) {
+                mpi_errno = MPL_gpu_test(&req->yreq.u.gpu_req, &completed);
+                MPIR_Assert(mpi_errno == MPI_SUCCESS);
+            }
+        } else {
+            MPIR_Assert(req->yreq.type == MPIR_NULL_REQUEST);
+        }
 
         LL_DELETE(posix_win->outstanding_reqs_head, posix_win->outstanding_reqs_tail, req);
         MPL_free(req);

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -59,9 +59,9 @@ typedef enum {
 typedef enum {
     MPL_GPU_COPY_D2H = 0,
     MPL_GPU_COPY_H2D,
-    MPL_GPU_COPY_D2D_INCOMING,
-    MPL_GPU_COPY_D2D_OUTGOING,
-    MPL_GPU_COPY_DIRECTION_NONE,
+    MPL_GPU_COPY_D2D_INCOMING,  /* copy from remote to local */
+    MPL_GPU_COPY_D2D_OUTGOING,  /* copy from local to remote */
+    MPL_GPU_COPY_DIRECTION_NONE,  /* copy in any direction and to/from any buffer type */
 } MPL_gpu_copy_direction_t;
 
 #define MPL_GPU_COPY_DIRECTION_TYPES 4


### PR DESCRIPTION
## Pull Request Description

This PR adds support to bypass Yaksa in RMA paths for contiguous buffers. It also fixes a performance bug in the case when communicating between two node-local devices, where the other device is not visible to the process due to setting `ZE_AFFINITY_MASK`.

~Last 3 commits only~
~Depends on #6608 (for `MPIR_Ilocalcopy` and all related non-blocking copy support)~

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
