### PR TITLE
coll: add MPIX_EQUAL

### DIFF
--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -272,6 +272,7 @@ typedef int MPI_Op;
 #define MPI_MAXLOC  (MPI_Op)(0x5800000c)
 #define MPI_REPLACE (MPI_Op)(0x5800000d)
 #define MPI_NO_OP   (MPI_Op)(0x5800000e)
+#define MPIX_EQUAL  (MPI_Op)(0x5800000f)
 
 /* MPI errhandler objects */
 typedef int MPI_Errhandler;

--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -238,7 +238,7 @@ const char *MPIR_Handle_get_kind_str(int kind);
 #define MPIR_INFO_PREALLOC 8
 #endif
 
-#define MPIR_OP_N_BUILTIN 15
+#define MPIR_OP_N_BUILTIN 16
 #ifdef MPID_OP_PREALLOC
 #define MPIR_OP_PREALLOC MPID_OP_PREALLOC
 #else

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -36,6 +36,7 @@ typedef enum MPIR_Op_kind {
     MPIR_OP_KIND__MINLOC = 12,
     MPIR_OP_KIND__REPLACE = 13,
     MPIR_OP_KIND__NO_OP = 14,
+    MPIR_OP_KIND__EQUAL = 15,
     MPIR_OP_KIND__USER_NONCOMMUTE = 32,
     MPIR_OP_KIND__USER = 33,
     MPIR_OP_KIND__USER_NONCOMMUTE_LARGE = 34,
@@ -109,6 +110,7 @@ typedef struct MPIR_Op {
      MPID_DEV_OP_DECL
 #endif
 } MPIR_Op;
+
 extern MPIR_Op MPIR_Op_builtin[MPIR_OP_N_BUILTIN];
 extern MPIR_Op MPIR_Op_direct[];
 extern MPIR_Object_alloc_t MPIR_Op_mem;
@@ -169,6 +171,7 @@ void MPIR_MAXLOC(void *, void *, MPI_Aint *, MPI_Datatype *);
 void MPIR_MINLOC(void *, void *, MPI_Aint *, MPI_Datatype *);
 void MPIR_REPLACE(void *, void *, MPI_Aint *, MPI_Datatype *);
 void MPIR_NO_OP(void *, void *, MPI_Aint *, MPI_Datatype *);
+void MPIR_EQUAL(void *, void *, MPI_Aint *, MPI_Datatype *);
 
 int MPIR_MAXF_check_dtype(MPI_Datatype);
 int MPIR_MINF_check_dtype(MPI_Datatype);
@@ -184,6 +187,7 @@ int MPIR_MAXLOC_check_dtype(MPI_Datatype);
 int MPIR_MINLOC_check_dtype(MPI_Datatype);
 int MPIR_REPLACE_check_dtype(MPI_Datatype);
 int MPIR_NO_OP_check_dtype(MPI_Datatype);
+int MPIR_EQUAL_check_dtype(MPI_Datatype);
 
 #define MPIR_Op_add_ref_if_not_builtin(op)               \
     do {                                                 \

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -226,4 +226,9 @@ int MPIR_Op_is_commutative(MPI_Op);
  * use its basic type for operations */
 MPI_Datatype MPIR_Op_get_alt_datatype(MPI_Op op, MPI_Datatype datatype);
 
+int MPIR_Reduce_equal(const void *sendbuf, MPI_Aint count, MPI_Datatype datatype,
+                      int *is_equal, int root, MPIR_Comm * comm_ptr);
+int MPIR_Allreduce_equal(const void *sendbuf, MPI_Aint count, MPI_Datatype datatype,
+                         int *is_equal, MPIR_Comm * comm_ptr);
+
 #endif /* MPIR_OP_H_INCLUDED */

--- a/src/mpi/coll/op/Makefile.mk
+++ b/src/mpi/coll/op/Makefile.mk
@@ -19,4 +19,5 @@ mpi_core_sources += \
     src/mpi/coll/op/opminloc.c       \
     src/mpi/coll/op/opmaxloc.c       \
     src/mpi/coll/op/opno_op.c        \
-    src/mpi/coll/op/opreplace.c
+    src/mpi/coll/op/opreplace.c      \
+    src/mpi/coll/op/opequal.c

--- a/src/mpi/coll/op/opequal.c
+++ b/src/mpi/coll/op/opequal.c
@@ -15,3 +15,20 @@ int MPIR_EQUAL_check_dtype(MPI_Datatype type)
 {
     return MPI_SUCCESS;
 }
+
+int MPIR_Reduce_equal(const void *sendbuf, MPI_Aint count, MPI_Datatype datatype,
+                      int *is_equal, int root, MPIR_Comm * comm_ptr)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Assert(0);
+    return mpi_errno;
+}
+
+
+int MPIR_Allreduce_equal(const void *sendbuf, MPI_Aint count, MPI_Datatype datatype,
+                         int *is_equal, MPIR_Comm * comm_ptr)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Assert(0);
+    return mpi_errno;
+}

--- a/src/mpi/coll/op/opequal.c
+++ b/src/mpi/coll/op/opequal.c
@@ -5,10 +5,33 @@
 
 #include "mpiimpl.h"
 
+/* All internal usage of MPIX_EQUAL should come from MPIR_Reduce_equal and MPIR_Allreduce_equal,
+ * where datatype is MPI_BYTE. Data buffer is a packed buffer where the first 8 bytes holds the
+ * comparison boolean results.
+ */
+
+struct equal_data {
+    uint64_t is_equal;
+    char data[];
+};
+
+#define EQUAL_DATA_OVERHEAD sizeof(struct equal_data)
+
 void MPIR_EQUAL(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
-    /* to be implemented */
-    MPIR_Assert(0);
+    MPIR_Assert(*Len >= EQUAL_DATA_OVERHEAD);
+    MPIR_Assert(*type == MPI_BYTE);
+
+    struct equal_data *in = invec;
+    struct equal_data *inout = inoutvec;
+
+    if (in->is_equal != 1 || inout->is_equal != 1) {
+        inout->is_equal = 0;
+    } else {
+        if (memcmp(in->data, inout->data, (*Len) - EQUAL_DATA_OVERHEAD) != 0) {
+            inout->is_equal = 0;
+        }
+    }
 }
 
 int MPIR_EQUAL_check_dtype(MPI_Datatype type)
@@ -16,12 +39,47 @@ int MPIR_EQUAL_check_dtype(MPI_Datatype type)
     return MPI_SUCCESS;
 }
 
+#define PREPARE_EQUAL_LOCAL_BUF \
+    MPI_Aint type_sz, byte_count; \
+    MPIR_Datatype_get_size_macro(datatype, type_sz); \
+    byte_count = count * type_sz + EQUAL_DATA_OVERHEAD; \
+    \
+    struct equal_data *local_buf; \
+    local_buf = MPL_malloc(byte_count, MPL_MEM_OTHER); \
+    MPIR_Assert(local_buf); \
+    \
+    local_buf->is_equal = 1; \
+    MPI_Aint actual_pack_bytes; \
+    MPIR_Typerep_pack(sendbuf, count, datatype, 0, local_buf->data, count * type_sz, \
+                        &actual_pack_bytes, MPIR_TYPEREP_FLAG_NONE); \
+    MPIR_Assert(actual_pack_bytes == count * type_sz)
+
 int MPIR_Reduce_equal(const void *sendbuf, MPI_Aint count, MPI_Datatype datatype,
                       int *is_equal, int root, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Assert(0);
+
+    PREPARE_EQUAL_LOCAL_BUF;
+
+    /* Not all algorithm will work. In particular, we can't split the message */
+    if (comm_ptr->rank == root) {
+        mpi_errno = MPIR_Reduce_intra_binomial(MPI_IN_PLACE, local_buf, byte_count, MPI_BYTE,
+                                               MPIX_EQUAL, root, comm_ptr, MPIR_ERR_NONE);
+    } else {
+        mpi_errno = MPIR_Reduce_intra_binomial(local_buf, NULL, byte_count, MPI_BYTE,
+                                               MPIX_EQUAL, root, comm_ptr, MPIR_ERR_NONE);
+    }
+    MPIR_ERR_CHECK(mpi_errno);
+
+    if (comm_ptr->rank == root) {
+        *is_equal = local_buf->is_equal;
+    }
+
+  fn_exit:
+    MPL_free(local_buf);
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 
@@ -29,6 +87,20 @@ int MPIR_Allreduce_equal(const void *sendbuf, MPI_Aint count, MPI_Datatype datat
                          int *is_equal, MPIR_Comm * comm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Assert(0);
+
+    PREPARE_EQUAL_LOCAL_BUF;
+
+    /* Not all algorithm will work. In particular, we can't split the message */
+    mpi_errno = MPIR_Allreduce_intra_recursive_doubling(MPI_IN_PLACE, local_buf,
+                                                        byte_count, MPI_BYTE,
+                                                        MPIX_EQUAL, comm_ptr, MPIR_ERR_NONE);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    *is_equal = local_buf->is_equal;
+
+  fn_exit:
+    MPL_free(local_buf);
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }

--- a/src/mpi/coll/op/opequal.c
+++ b/src/mpi/coll/op/opequal.c
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+
+void MPIR_EQUAL(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
+{
+    /* to be implemented */
+    MPIR_Assert(0);
+}
+
+int MPIR_EQUAL_check_dtype(MPI_Datatype type)
+{
+    return MPI_SUCCESS;
+}

--- a/src/mpi/coll/op/oputil.c
+++ b/src/mpi/coll/op/oputil.c
@@ -22,7 +22,8 @@ MPIR_op_function *MPIR_Op_table[] = {
     MPIR_MINLOC,
     MPIR_MAXLOC,
     MPIR_REPLACE,
-    MPIR_NO_OP
+    MPIR_NO_OP,
+    MPIR_EQUAL
 };
 
 MPIR_Op_check_dtype_fn *MPIR_Op_check_dtype_table[] = {
@@ -40,7 +41,8 @@ MPIR_Op_check_dtype_fn *MPIR_Op_check_dtype_table[] = {
     MPIR_MINLOC_check_dtype,
     MPIR_MAXLOC_check_dtype,
     MPIR_REPLACE_check_dtype,
-    MPIR_NO_OP_check_dtype
+    MPIR_NO_OP_check_dtype,
+    MPIR_EQUAL_check_dtype
 };
 
 typedef struct op_name {
@@ -62,7 +64,8 @@ static op_name_t mpi_ops[] = {
     {MPI_MINLOC, "minloc"},
     {MPI_MAXLOC, "maxloc"},
     {MPI_REPLACE, "replace"},
-    {MPI_NO_OP, "no_op"}
+    {MPI_NO_OP, "no_op"},
+    {MPIX_EQUAL, "equal"}
 };
 
 MPI_Datatype MPIR_Op_builtin_search_by_shortname(const char *short_name)

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -1611,6 +1611,8 @@ static const char *GetMPIOpString(MPI_Op o)
             return "MPI_REPLACE";
         case MPI_NO_OP:
             return "MPI_NO_OP";
+        case MPIX_EQUAL:
+            return "MPIX_EQUAL";
     }
     /* FIXME: default is not thread safe */
     snprintf(default_str, sizeof(default_str), "op=0x%x", o);

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -1852,6 +1852,7 @@ AC_OUTPUT(maint/testmerge \
           impls/mpich/Makefile \
           impls/mpich/testlist \
           impls/mpich/mpi_t/Makefile \
+          impls/mpich/coll/Makefile \
           impls/mpich/comm/Makefile \
           impls/mpich/comm/testlist \
           impls/mpich/threads/Makefile \

--- a/test/mpi/impls/mpich/coll/Makefile.am
+++ b/test/mpi/impls/mpich/coll/Makefile.am
@@ -5,7 +5,6 @@
 
 include $(top_srcdir)/Makefile_single.mtest
 
-EXTRA_DIST = testlist.in
-
-static_subdirs = mpi_t coll comm misc ulfm
-SUBDIRS      = $(static_subdirs) $(threadsdir) $(cudadir) $(hipdir)
+noinst_PROGRAMS = \
+    reduce_equal \
+    allreduce_equal

--- a/test/mpi/impls/mpich/coll/allreduce_equal.c
+++ b/test/mpi/impls/mpich/coll/allreduce_equal.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpitest.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm comm = MPI_COMM_WORLD;
+
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int is_equal;
+
+    MPI_Allreduce(&rank, &is_equal, 1, MPI_INT, MPIX_EQUAL, comm);
+    if (is_equal) {
+        errs++;
+        printf("Allreduce MPIX_EQUAL on rank resulted true!\n");
+    }
+
+    MPI_Allreduce(&size, &is_equal, 1, MPI_INT, MPIX_EQUAL, comm);
+    if (!is_equal) {
+        errs++;
+        printf("Allreduce MPIX_EQUAL on size resulted false!\n");
+    }
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/impls/mpich/coll/reduce_equal.c
+++ b/test/mpi/impls/mpich/coll/reduce_equal.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpitest.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm comm = MPI_COMM_WORLD;
+    int root = 0;
+
+    int rank, size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
+
+    int is_equal;
+
+    MPI_Reduce(&rank, &is_equal, 1, MPI_INT, MPIX_EQUAL, root, comm);
+    if (rank == root && is_equal) {
+        errs++;
+        printf("Reduce MPIX_EQUAL on rank resulted true!\n");
+    }
+
+    MPI_Reduce(&size, &is_equal, 1, MPI_INT, MPIX_EQUAL, root, comm);
+    if (rank == root && !is_equal) {
+        errs++;
+        printf("Reduce MPIX_EQUAL on size resulted false!\n");
+    }
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/impls/mpich/coll/testlist
+++ b/test/mpi/impls/mpich/coll/testlist
@@ -1,0 +1,2 @@
+reduce_equal 4
+allreduce_equal 4

--- a/test/mpi/impls/mpich/testlist.in
+++ b/test/mpi/impls/mpich/testlist.in
@@ -1,4 +1,5 @@
 mpi_t
+coll
 comm
 misc
 @threadsdir@


### PR DESCRIPTION
## Pull Request Description
It is a common reduction task to check whether data on each rank is equal. This can be achieved using custom derived datatype and user-defined op, or use allgather and manually compare the results. Neither is efficient or easy to write. Add the `MPIX_EQUAL` extension to allow a single reduction call for such purposes. 

ref: #5105
[skip warnings]

## Example usage
```
int data[NUM];
int is_equal;

MPI_Allreduce(data, &is_equal, NUM, MPI_INT, MPIX_EQUAL, comm);
```

MPICH internal usage:

```
MPIR_Reduce_equal(data, count, datatype, &is_equal, root, comm);
MPIR_Allreduce_equal(data, count, datatype, &is_equal, comm);
```


## Restrictions
* Only intra communicator
* Only blocking reduction
* limited algorithms

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
