### PR TITLE
test: Avoid MPI_DATATYPE_NULL in send/recv calls

### DIFF
--- a/test/mpi/pt2pt/pssend.c
+++ b/test/mpi/pt2pt/pssend.c
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
     }
 
     if (rank == 0) {
-        MPI_Ssend_init(NULL, 0, MPI_DATATYPE_NULL, 1, 0, MPI_COMM_WORLD, &req);
+        MPI_Ssend_init(NULL, 0, MPI_INT, 1, 0, MPI_COMM_WORLD, &req);
         MPI_Start(&req);
 
         /* ssend cannot be complete at this point */
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
         MPI_Wait(&req, MPI_STATUS_IGNORE);
         MPI_Request_free(&req);
     } else if (rank == 1) {
-        MPI_Recv(NULL, 0, MPI_DATATYPE_NULL, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        MPI_Recv(NULL, 0, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
     }
 
     MTest_Finalize(errs);


### PR DESCRIPTION
## Pull Request Description

This is questionable usage and not relevant to the test. Change it to MPI_INT and fix a bunch of Jenkins failures.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
