### PR TITLE
mpir_pmi: Avoid calling PMI2_Set_threaded on old Cray systems

### DIFF
--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -253,7 +253,7 @@ void MPIR_pmi_abort(int exit_code, const char *error_msg)
 int MPIR_pmi_set_threaded(int is_threaded)
 {
     if (MPIR_CVAR_PMI_VERSION == MPIR_CVAR_PMI_VERSION_2) {
-#if ENABLE_PMI2
+#if ENABLE_PMI2 && !defined(USE_PMI2_CRAY)
         PMI2_Set_threaded(is_threaded);
 #endif
     }

--- a/test/mpi/pt2pt/pssend.c
+++ b/test/mpi/pt2pt/pssend.c
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
     }
 
     if (rank == 0) {
-        MPI_Ssend_init(NULL, 0, MPI_DATATYPE_NULL, 1, 0, MPI_COMM_WORLD, &req);
+        MPI_Ssend_init(NULL, 0, MPI_INT, 1, 0, MPI_COMM_WORLD, &req);
         MPI_Start(&req);
 
         /* ssend cannot be complete at this point */
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
         MPI_Wait(&req, MPI_STATUS_IGNORE);
         MPI_Request_free(&req);
     } else if (rank == 1) {
-        MPI_Recv(NULL, 0, MPI_DATATYPE_NULL, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+        MPI_Recv(NULL, 0, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
     }
 
     MTest_Finalize(errs);


### PR DESCRIPTION
## Pull Request Description

While PMI2_Set_threaded is defined in the Cray pmi2.h header file, there is no symbol provided in libpmi2.so as of version 6.1.6. Thus, MPICH fails to link at the end of the build.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
