### PR TITLE
romio/gpfs: fix typecast and check for integer overflow 

### DIFF
--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
@@ -870,12 +870,19 @@ MY_Alltoallv(void *sbuf, int *scounts, MPI_Aint * sdisps, MPI_Datatype stype,
 
     void *sbuf_copy;
     void *rbuf_copy;
-    int scount_total = 0;
-    int rcount_total = 0;
+    size_t scount_total = 0;
+    size_t rcount_total = 0;
     for (i = 0; i < nranks; i++) {
-        sdisps_int[i] = scount_total;
+        if ((scount_total != (int) scount_total) || (rcount_total != (int) rcount_total)) {
+            FPRINTF(stderr,
+                    "Error in %s: integer overflow / scount_total(%zu) != (int)scount_total(%d)"
+                    " || rcount_total(%zu) != (int)rcount_total(%d)\n",
+                    __func__, scount_total, (int) scount_total, rcount_total, (int) rcount_total);
+            MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+        sdisps_int[i] = (int) scount_total;
+        rdisps_int[i] = (int) rcount_total;
         scount_total += scounts[i];
-        rdisps_int[i] = rcount_total;
         rcount_total += rcounts[i];
     }
     sbuf_copy = (void *) ADIOI_Malloc(scount_total * sizeof_stype);

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
@@ -850,7 +850,7 @@ MY_Alltoallv(void *sbuf, int *scounts, MPI_Aint * sdisps, MPI_Datatype stype,
         }
     }
     for (i = 0; i < nranks && disps_are_small_enough; ++i) {
-        if (rdisps[i] != (int) sdisps[i]) {
+        if (rdisps[i] != (int) rdisps[i]) {
             disps_are_small_enough = 0;
         }
     }

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_aggrs.c
@@ -768,7 +768,7 @@ void ADIOI_GPFS_Calc_others_req(ADIO_File fd, int count_my_req_procs,
         if (scounts[i] == 0)
             sdispls[i] = 0;
         else
-            sdispls[i] = (int)
+            sdispls[i] = (MPI_Aint)
                 (((uintptr_t) my_req[i].offsets -
                   (uintptr_t) sendBuf) / (uintptr_t) sizeof(ADIO_Offset));
 
@@ -777,7 +777,7 @@ void ADIOI_GPFS_Calc_others_req(ADIO_File fd, int count_my_req_procs,
         if (rcounts[i] == 0)
             rdispls[i] = 0;
         else
-            rdispls[i] = (int)
+            rdispls[i] = (MPI_Aint)
                 (((uintptr_t) others_req[i].offsets -
                   (uintptr_t) recvBuf) / (uintptr_t) sizeof(ADIO_Offset));
     }


### PR DESCRIPTION
## Pull Request Description

On the supercomputing systems at FZ Jülich (JUWELS and JURECA), users reported segmentation faults when certain large applications with large amounts of data were run with ROMIO's GPFS support by the MPICH-based ParaStation MPI.

Investigations by ParTec's MPI team have shown that an incorrect typecast in `ADIOI_GPFS_Calc_others_req()` caused an integer overflow, which then caused the crashes. (The corresponding fix in the ROMIO part of ParaStation MPI can be found [here](https://github.com/ParaStation/psmpi/commit/1de1919a5ff8cb560a3cac452c4bc63529351d9a).)
In addition, two further shortcomings were fixed (the addition of a [check](https://github.com/ParaStation/psmpi/commit/e9d08cc1f0aee3899c0afa2acb20b5754e736ed6) as well as the fix of a copy/paste [bug](https://github.com/ParaStation/psmpi/commit/844c5280fdf06d1449005cc538e93e7f7746a717)), but which only came into play when `MPI_Alltoallc_c()` was not available (i.e, in the case of MPICH3) and where the related commits therefore may only serve for potential backports – as we did it for [psmpi-5.7.1](https://github.com/ParaStation/psmpi/commits/5.7.1-1), which was still MPICH3-based.

On customer's request, we provide these three ROMIO/GPFS commits now also upstream with this PR.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
