### PR TITLE
mpir_pmi: Use namespace returned in PMIx_Init as world_id

### DIFF
--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -175,6 +175,7 @@ void MPIR_pmi_finalize(void)
     /* Finalize of PM interface happens in exit handler,
      * here: free allocated memory */
     MPL_free(pmi_kvs_name);
+    pmi_kvs_name = NULL;
 
     MPL_free(MPIR_Process.node_map);
     MPL_free(MPIR_Process.node_root_map);

--- a/src/util/mpir_pmi1.inc
+++ b/src/util/mpir_pmi1.inc
@@ -154,7 +154,9 @@ static int pmi1_get_universe_size(int *universe_size)
     goto fn_exit;
 }
 
-static int pmi1_spawn(int count, char *commands[], char **argvs[], const int maxprocs[], MPIR_Info * info_ptrs[], int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+static int pmi1_spawn(int count, char *commands[], char **argvs[], const int maxprocs[],
+                      MPIR_Info * info_ptrs[], int num_preput_keyval,
+                      struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
 {
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
@@ -233,7 +235,7 @@ static int pmi1_unpublish(const char name[])
     goto fn_exit;
 }
 
-#else  /* ENABLE_PMI1 */
+#else /* ENABLE_PMI1 */
 
 static int pmi1_init(int *has_parent, int *rank, int *size, int *appnum)
 {
@@ -296,7 +298,9 @@ static int pmi1_get_universe_size(int *universe_size)
     return MPI_ERR_INTERN;
 }
 
-static int pmi1_spawn(int count, char *commands[], char **argvs[], const int maxprocs[], MPIR_Info * info_ptrs[], int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+static int pmi1_spawn(int count, char *commands[], char **argvs[], const int maxprocs[],
+                      MPIR_Info * info_ptrs[], int num_preput_keyval,
+                      struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
 {
     return MPI_ERR_INTERN;
 }

--- a/src/util/mpir_pmi2.inc
+++ b/src/util/mpir_pmi2.inc
@@ -74,7 +74,8 @@ static bool pmi2_get_jobattr(const char *key, char *valbuf)
 {
     if (strcmp(key, "PMI_dead_processes") == 0) {
         int out_len;
-        int pmi_errno = PMI2_KVS_Get(pmi_kvs_name, PMI2_ID_NULL, key, valbuf, pmi_max_val_size, &out_len);
+        int pmi_errno =
+            PMI2_KVS_Get(pmi_kvs_name, PMI2_ID_NULL, key, valbuf, pmi_max_val_size, &out_len);
         if (pmi_errno != PMI2_SUCCESS || out_len == 0) {
             return false;
         }
@@ -181,7 +182,9 @@ static int pmi2_get_universe_size(int *universe_size)
     goto fn_exit;
 }
 
-static int pmi2_spawn(int count, char *commands[], char **argvs[], const int maxprocs[], MPIR_Info * info_ptrs[], int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+static int pmi2_spawn(int count, char *commands[], char **argvs[], const int maxprocs[],
+                      MPIR_Info * info_ptrs[], int num_preput_keyval,
+                      struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
 {
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
@@ -282,7 +285,7 @@ static int pmi2_unpublish(const char name[])
     goto fn_exit;
 }
 
-#else  /* ENABLE_PMI2 */
+#else /* ENABLE_PMI2 */
 
 static int pmi2_init(int *has_parent, int *rank, int *size, int *appnum)
 {
@@ -345,7 +348,9 @@ static int pmi2_get_universe_size(int *universe_size)
     return MPI_ERR_INTERN;
 }
 
-static int pmi2_spawn(int count, char *commands[], char **argvs[], const int maxprocs[], MPIR_Info * info_ptrs[], int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+static int pmi2_spawn(int count, char *commands[], char **argvs[], const int maxprocs[],
+                      MPIR_Info * info_ptrs[], int num_preput_keyval,
+                      struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
 {
     return MPI_ERR_INTERN;
 }

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -285,7 +285,9 @@ static int pmix_get_universe_size(int *universe_size)
     goto fn_exit;
 }
 
-static int pmix_spawn(int count, char *commands[], char **argvs[], const int maxprocs[], MPIR_Info * info_ptrs[], int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+static int pmix_spawn(int count, char *commands[], char **argvs[], const int maxprocs[],
+                      MPIR_Info * info_ptrs[], int num_preput_keyval,
+                      struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
 {
     /* not supported yet */
     return MPI_ERR_INTERN;
@@ -339,7 +341,7 @@ static int pmix_unpublish(const char name[])
     return MPI_SUCCESS;
 }
 
-#else  /* ENABLE_PMIX */
+#else /* ENABLE_PMIX */
 
 static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
 {
@@ -412,7 +414,9 @@ static int pmix_get_universe_size(int *universe_size)
     return MPI_ERR_INTERN;
 }
 
-static int pmix_spawn(int count, char *commands[], char **argvs[], const int maxprocs[], MPIR_Info * info_ptrs[], int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+static int pmix_spawn(int count, char *commands[], char **argvs[], const int maxprocs[],
+                      MPIR_Info * info_ptrs[], int num_preput_keyval,
+                      struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
 {
     return MPI_ERR_INTERN;
 }
@@ -472,4 +476,3 @@ static int pmix_build_nodemap(int *nodemap, int sz)
     goto fn_exit;
 #endif
 }
-

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -34,6 +34,8 @@ static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
         PMIX_PROC_CONSTRUCT(&pmix_wcproc);
         MPL_strncpy(pmix_wcproc.nspace, pmix_proc.nspace, PMIX_MAX_NSLEN);
         pmix_wcproc.rank = PMIX_RANK_WILDCARD;
+
+        pmi_kvs_name = MPL_strdup(pmix_proc.nspace);
     }
 
     *rank = pmix_proc.rank;
@@ -42,14 +44,6 @@ static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
     MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                          "**pmix_get", "**pmix_get %d", pmi_errno);
     *size = pvalue->data.uint32;
-    PMIX_VALUE_RELEASE(pvalue);
-
-    /* PMIX_JOBID seems to be more supported than PMIX_NSPACE */
-    /* TODO: fallback in case the key is not supported */
-    pmi_errno = PMIx_Get(&pmix_wcproc, PMIX_JOBID, NULL, 0, &pvalue);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_get", "**pmix_get %d", pmi_errno);
-    pmi_kvs_name = MPL_strdup(pvalue->data.string);
     PMIX_VALUE_RELEASE(pvalue);
 
   fn_exit:


### PR DESCRIPTION
## Pull Request Description

The pmix_proc_t returned by PMIx_Init contains the namespace information already. No need to get it separately.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
