### PR TITLE
mpl/gpu: enable re-init of MPL GPU module

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -383,6 +383,9 @@ int MPL_gpu_finalize(void)
         MPL_free(prev);
     }
 
+    /* Reset initialization state */
+    gpu_initialized = 0;
+
   fn_exit:
     return MPL_SUCCESS;
 }

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -369,6 +369,9 @@ int MPL_gpu_finalize(void)
         MPL_free(prev);
     }
 
+    /* Reset initialization state */
+    gpu_initialized = 0;
+
   fn_exit:
     return MPL_SUCCESS;
 }

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -1274,6 +1274,9 @@ int MPL_gpu_finalize(void)
     MPL_free(mask_contents.dev_id);
     MPL_free(mask_contents.subdev_id);
 
+    /* Reset initialization state */
+    gpu_initialized = 0;
+
     return MPL_SUCCESS;
 }
 


### PR DESCRIPTION
## Pull Request Description

For MPI Session re-init with enabled CUDA/GPU awareness we need to re-init the MPL GPU module. Therefore, it is required to reset the initialization state to 0 in `MPL_gpu_finalize`.

Probably something that was overlooked in https://github.com/pmodels/mpich/pull/6337


## Author Checklist
* [X] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [X] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [X] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
