### PR TITLE
groups: Improve error return of MPI Group routines in combination with MPI Sessions

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -543,6 +543,8 @@ def process_func_parameters(func):
             func['_has_win'] = name
         elif name == "session":
             func['_has_session'] = name
+        elif name == "group":
+            func['_has_group'] = name
 
         if 'ANY' in func['_skip_validate'] or kind in func['_skip_validate'] or name in func['_skip_validate']:
             # -- user bypass --
@@ -1741,6 +1743,8 @@ def dump_mpi_fn_fail(func):
             G.out.append("mpi_errno = MPIR_Err_return_session_init(errhandler_ptr, __func__, mpi_errno);")
         elif '_has_session' in func:
             G.out.append("mpi_errno = MPIR_Err_return_session(session_ptr, __func__, mpi_errno);")
+        elif '_has_group' in func:
+            G.out.append("mpi_errno = MPIR_Err_return_group(%s_ptr, __func__, mpi_errno);" % func['_has_group'])
         else:
             G.out.append("mpi_errno = MPIR_Err_return_comm(0, __func__, mpi_errno);")
 

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -1743,6 +1743,8 @@ def dump_mpi_fn_fail(func):
             G.out.append("mpi_errno = MPIR_Err_return_session_init(errhandler_ptr, __func__, mpi_errno);")
         elif '_has_session' in func:
             G.out.append("mpi_errno = MPIR_Err_return_session(session_ptr, __func__, mpi_errno);")
+        elif RE.match(r'mpi_comm_create_from_group', func['name'], re.IGNORECASE):
+            G.out.append("mpi_errno = MPIR_Err_return_comm_create_from_group(errhandler_ptr, __func__, mpi_errno);")
         elif '_has_group' in func:
             G.out.append("mpi_errno = MPIR_Err_return_group(%s_ptr, __func__, mpi_errno);" % func['_has_group'])
         else:

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -22,6 +22,8 @@ MPICH_API_PUBLIC int MPIR_Err_return_win(struct MPIR_Win *, const char[], int);
 MPICH_API_PUBLIC int MPIR_Err_return_session(struct MPIR_Session *, const char[], int);
 MPICH_API_PUBLIC int MPIR_Err_return_session_init(struct MPIR_Errhandler *, const char[], int);
 MPICH_API_PUBLIC int MPIR_Err_return_group(struct MPIR_Group *, const char[], int);
+MPICH_API_PUBLIC int MPIR_Err_return_comm_create_from_group(struct MPIR_Errhandler *, const char[],
+                                                            int);
 #ifdef MPI__FILE_DEFINED
 /* Only define if we have MPI_File */
 MPICH_API_PUBLIC int MPIR_Err_return_file(MPI_File, const char[], int); /* Romio version */

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -14,12 +14,14 @@ struct MPIR_Comm;
 struct MPIR_Win;
 struct MPIR_Session;
 struct MPIR_Errhandler;
+struct MPIR_Group;
 
 /* Bindings for internal routines */
 MPICH_API_PUBLIC int MPIR_Err_return_comm(struct MPIR_Comm *, const char[], int);
 MPICH_API_PUBLIC int MPIR_Err_return_win(struct MPIR_Win *, const char[], int);
 MPICH_API_PUBLIC int MPIR_Err_return_session(struct MPIR_Session *, const char[], int);
 MPICH_API_PUBLIC int MPIR_Err_return_session_init(struct MPIR_Errhandler *, const char[], int);
+MPICH_API_PUBLIC int MPIR_Err_return_group(struct MPIR_Group *, const char[], int);
 #ifdef MPI__FILE_DEFINED
 /* Only define if we have MPI_File */
 MPICH_API_PUBLIC int MPIR_Err_return_file(MPI_File, const char[], int); /* Romio version */

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -592,6 +592,20 @@ int MPIR_Err_return_session_init(MPIR_Errhandler * errhandler_ptr, const char fc
 
 }
 
+int MPIR_Err_return_group(struct MPIR_Group *group_ptr, const char fcname[], int errcode)
+{
+    if (group_ptr == NULL) {
+        /* If no group provided, fallback to MPIR_Err_return_comm */
+        return MPIR_Err_return_comm(NULL, fcname, errcode);
+    } else if (group_ptr->session_ptr == NULL) {
+        /* If group does not belong to session, fallback to MPIR_Err_return_comm */
+        return MPIR_Err_return_comm(NULL, fcname, errcode);
+    } else {
+        /* Group belongs to session, use MPIR_Err_return_session */
+        return MPIR_Err_return_session(group_ptr->session_ptr, fcname, errcode);
+    }
+}
+
 /* ------------------------------------------------------------------------- */
 /* Group 3: Routines to handle error messages.  These are organized into
  * several subsections:

--- a/test/mpi/errors/session/Makefile.am
+++ b/test/mpi/errors/session/Makefile.am
@@ -10,4 +10,4 @@ EXTRA_DIST = testlist
 ## for all programs that are just built from the single corresponding source
 ## file, we don't need per-target _SOURCES rules, automake will infer them
 ## correctly
-noinst_PROGRAMS = sessioninit getpsetinfo getnthpset
+noinst_PROGRAMS = sessioninit getpsetinfo getnthpset comm_create_from_group

--- a/test/mpi/errors/session/comm_create_from_group.c
+++ b/test/mpi/errors/session/comm_create_from_group.c
@@ -1,0 +1,103 @@
+/*
+ * ParaStation
+ *
+ * Copyright (C) 2023 ParTec AG, Munich
+ *
+ * This file may be distributed under the terms of the Q Public License
+ * as defined in the file LICENSE.QPL included in the packaging of this
+ * file.
+ */
+
+#include <stdio.h>
+#include "mpi.h"
+#include "mpitest.h"
+
+int errs = 0;
+int calls = 0;
+
+void eh(MPI_Comm * comm, int *err, ...)
+{
+    calls++;
+    return;
+}
+
+/* Test for the errhandler arg of MPI_Comm_create_from_group */
+
+int main(int argc, char *argv[])
+{
+    int rc;
+    char *pset_name = "mpi://WORLD";
+
+    MPI_Session shandle = MPI_SESSION_NULL;
+    MPI_Group ghandle = MPI_GROUP_NULL;
+    MPI_Comm comm = MPI_COMM_NULL;
+    MPI_Errhandler errhandler = MPI_ERRHANDLER_NULL;
+
+    rc = MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &shandle);
+    if (rc != MPI_SUCCESS) {
+        errs++;
+        fprintf(stderr, "MPI_Session_init returned error code: %i\n", rc);
+        goto fn_exit;
+    }
+
+    MPI_Comm_create_errhandler(eh, &errhandler);
+
+    MPI_Session_set_errhandler(shandle, MPI_ERRORS_RETURN);
+
+    /* create a group from the WORLD process set */
+    rc = MPI_Group_from_session_pset(shandle, pset_name, &ghandle);
+    if (rc != MPI_SUCCESS) {
+        errs++;
+        goto fn_exit;
+    }
+
+    /* try to get a communicator with NULL comm as arg */
+    rc = MPI_Comm_create_from_group(ghandle, "org.mpi-forum.mpi-v4_0.example-ex10_8",
+                                    MPI_INFO_NULL, errhandler, NULL);
+    if (rc == MPI_SUCCESS) {
+        errs++;
+        goto fn_exit;
+    }
+
+    /* get a communicator */
+    rc = MPI_Comm_create_from_group(ghandle, "org.mpi-forum.mpi-v4_0.example-ex10_8",
+                                    MPI_INFO_NULL, errhandler, &comm);
+    if (rc != MPI_SUCCESS) {
+        errs++;
+        goto fn_exit;
+    }
+
+    if (calls != 1) {
+        /* errhandler should have been called exactly once at this point */
+        errs++;
+        fprintf(stderr, "Errhandler of MPI_Comm_create_from_group called %i times (expected 1)\n",
+                calls);
+    }
+
+  fn_exit:
+
+    if (ghandle != MPI_GROUP_NULL) {
+        MPI_Group_free(&ghandle);
+    }
+
+    if (comm != MPI_COMM_NULL) {
+        MPI_Comm_free(&comm);
+    }
+
+    if (errhandler != MPI_ERRHANDLER_NULL) {
+        MPI_Errhandler_free(&errhandler);
+    }
+
+    rc = MPI_Session_finalize(&shandle);
+    if (rc != MPI_SUCCESS) {
+        errs++;
+        fprintf(stderr, "MPI_Session_finalize returned error code: %i\n", rc);
+    }
+
+    if (errs == 0) {
+        fprintf(stdout, " No Errors\n");
+    } else {
+        fprintf(stderr, "%d Errors\n", errs);
+    }
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/errors/session/testlist
+++ b/test/mpi/errors/session/testlist
@@ -1,3 +1,4 @@
 sessioninit 1
 getnthpset 1
 getpsetinfo 1
+comm_create_from_group 1


### PR DESCRIPTION

**Remark:** This PR is based on https://github.com/pmodels/mpich/pull/6578 (Session reference counting). Only the last three commits add additional content. To avoid confusion, https://github.com/pmodels/mpich/pull/6578 should be reviewed and merged first, before we continue with this PR.

## Pull Request Description

For a better error reporting of MPI Group routines in the context of MPI Sessions, this PR enables MPI  Group routines that operate on one group, to use the error handler provided to the MPI Session to which they belong (if any). If we are in the world model and the group does not belong to any session, the error return is done as before.

The routine `MPI_Comm_create_from_group` is a somewhat special case in this regard as it has an error handler as parameter. This PR adds an error return function just for this case so that the provided error handler is used (if any).
The PR adds a new test for the error return behaviour of `MPI_Comm_create_from_group`.

The error return of MPI group routines that operate on multiple groups (e.g. `MPI_Group_compare`) is not touched by this PR. It is unclear whether or not MPI Groups that originate from different MPI Sessions can be combined in such operations and which error handler should be used. The MPI standard should provide some clarity here first.


## Author Checklist
* [X] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [X] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [X] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
