### PR TITLE
Draft: Session: Do not rely on built-in comms, decouple from world model

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -855,10 +855,6 @@ export device_name
 export device_args
 export devicedir
 
-if test "$device_name" = "ch4" ; then
-    AC_DEFINE([ENABLE_LOCAL_SESSION_INIT], 1, [Define to skip initializing builtin world comm during MPI_Session_init])
-fi
-
 # expand all of the prereq macros in the correct order
 m4_map([PAC_SUBCFG_DO_PREREQ], [PAC_SUBCFG_MODULE_LIST])
 

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -463,5 +463,9 @@ int MPIR_init_icomm_world(void);
 #endif
 int MPIR_finalize_builtin_comms(void);
 
+#define MPIR_COMM_TMP_SESSION_CTXID (3 << MPIR_CONTEXT_PREFIX_SHIFT)
+
 void MPIR_Comm_set_session_ptr(MPIR_Comm * comm_ptr, MPIR_Session * session_ptr);
+int MPIR_Comm_create_group_session(MPIR_Group * group_ptr, int tag, MPIR_Comm ** newcomm_ptr);
+
 #endif /* MPIR_COMM_H_INCLUDED */

--- a/src/mpi/comm/contextid.c
+++ b/src/mpi/comm/contextid.c
@@ -161,11 +161,12 @@ void MPIR_context_id_init(void)
     }
     /* The first two values are already used (comm_world, comm_self).
      * The third value is also used for the internal-only copy of
-     * comm_world, if needed by mpid. */
+     * comm_world, if needed by mpid.
+     * The fourth value is reserved for MPIR_Comm_create_group_session */
 #ifdef MPID_NEEDS_ICOMM_WORLD
-    context_mask[0] = 0xFFFFFFF8;
+    context_mask[0] = 0xFFFFFFF0;
 #else
-    context_mask[0] = 0xFFFFFFFC;
+    context_mask[0] = 0xFFFFFFF4;
 #endif
 
 #ifdef MPICH_DEBUG_HANDLEALLOC

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -259,11 +259,7 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     mpi_errno = MPIR_pmi_barrier();
     MPIR_ERR_CHECK(mpi_errno);
 
-    bool need_init_builtin_comms = true;
-#ifdef ENABLE_LOCAL_SESSION_INIT
-    need_init_builtin_comms = is_world_model;
-#endif
-    if (need_init_builtin_comms) {
+    if (is_world_model) {
         mpi_errno = MPIR_init_comm_world();
         MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -417,6 +417,9 @@ int MPII_Finalize(MPIR_Session * session_ptr)
     mpi_errno = MPIR_Process_bsend_finalize();
     MPIR_ERR_CHECK(mpi_errno);
 
+    /* Free context id reserved for creating comm from group in sessions */
+    MPIR_Free_contextid(MPIR_COMM_TMP_SESSION_CTXID);
+
     /* Signal the debugger that we are about to exit. */
     MPIR_Debugger_set_aborting(NULL);
 

--- a/test/mpi/session/Makefile.am
+++ b/test/mpi/session/Makefile.am
@@ -17,7 +17,8 @@ noinst_PROGRAMS = \
     session_re_init \
     session_psets \
     session_self \
-    session_bsend
+    session_bsend \
+    session_self_with_world
 
 session_mult_init_SOURCES = session.c
 session_mult_init_CPPFLAGS = -DMULT_INIT $(AM_CPPFLAGS)
@@ -25,3 +26,5 @@ session_mult_init_with_world_SOURCES = session.c
 session_mult_init_with_world_CPPFLAGS = -DMULT_INIT -DWITH_WORLD $(AM_CPPFLAGS)
 session_re_init_SOURCES = session.c
 session_re_init_CPPFLAGS = -DRE_INIT $(AM_CPPFLAGS)
+session_self_with_world_SOURCES = session_self.c
+session_self_with_world_CPPFLAGS = -DWITH_WORLD $(AM_CPPFLAGS)

--- a/test/mpi/session/Makefile.am
+++ b/test/mpi/session/Makefile.am
@@ -13,6 +13,7 @@ EXTRA_DIST = testlist
 noinst_PROGRAMS = \
     session       \
     session_mult_init \
+    session_mult_init_with_world \
     session_re_init \
     session_psets \
     session_self \
@@ -20,5 +21,7 @@ noinst_PROGRAMS = \
 
 session_mult_init_SOURCES = session.c
 session_mult_init_CPPFLAGS = -DMULT_INIT $(AM_CPPFLAGS)
+session_mult_init_with_world_SOURCES = session.c
+session_mult_init_with_world_CPPFLAGS = -DMULT_INIT -DWITH_WORLD $(AM_CPPFLAGS)
 session_re_init_SOURCES = session.c
 session_re_init_CPPFLAGS = -DRE_INIT $(AM_CPPFLAGS)

--- a/test/mpi/session/Makefile.am
+++ b/test/mpi/session/Makefile.am
@@ -15,6 +15,7 @@ noinst_PROGRAMS = \
     session_mult_init \
     session_mult_init_with_world \
     session_re_init \
+    session_mod_group \
     session_psets \
     session_self \
     session_bsend \
@@ -28,3 +29,5 @@ session_re_init_SOURCES = session.c
 session_re_init_CPPFLAGS = -DRE_INIT $(AM_CPPFLAGS)
 session_self_with_world_SOURCES = session_self.c
 session_self_with_world_CPPFLAGS = -DWITH_WORLD $(AM_CPPFLAGS)
+session_mod_group_SOURCES = session.c
+session_mod_group_CPPFLAGS = -DMOD_GROUP $(AM_CPPFLAGS)

--- a/test/mpi/session/session.c
+++ b/test/mpi/session/session.c
@@ -43,12 +43,16 @@ int main(int argc, char *argv[])
 #else
     int rank = library_foo_test();
 #ifdef RE_INIT
+    if (errs > 0) {
+        goto fn_exit;
+    }
     library_foo_test();
 #endif
 #endif
     if (rank == 0 && errs == 0) {
         printf("No Errors\n");
     }
+  fn_exit:
     return MTestReturnValue(errs);
 }
 

--- a/test/mpi/session/session.c
+++ b/test/mpi/session/session.c
@@ -32,14 +32,24 @@ int main(int argc, char *argv[])
         /* basic sanity check */
         assert(num_repeat > 0 && num_repeat < 100);
     }
-
+#ifdef WITH_WORLD
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+#endif
     for (int i = 0; i < num_repeat; i++) {
+#ifdef WITH_WORLD
         library_foo_test();
+#else
+        rank = library_foo_test();
+#endif
+        if (errs > 0) {
+            break;
+        }
     }
+#ifdef WITH_WORLD
     MPI_Finalize();
+#endif
 #else
     int rank = library_foo_test();
 #ifdef RE_INIT

--- a/test/mpi/session/session.c
+++ b/test/mpi/session/session.c
@@ -93,6 +93,12 @@ int library_foo_test(void)
         rank = -1;
         goto fn_exit;
     }
+#ifdef MOD_GROUP
+    if (lib_comm == MPI_COMM_NULL) {
+        /* Skip the reduce operation for rank that is not in smaller group/ comm */
+        goto fn_exit;
+    }
+#endif
 
     int sum;
     rc = MPI_Reduce(&rank, &sum, 1, MPI_INT, MPI_SUM, 0, lib_comm);
@@ -157,7 +163,68 @@ void library_foo_init(int *rank, int *size)
         errs++;
         goto fn_exit;
     }
+#ifdef MOD_GROUP
+    int grp_size, grp_rank, newgrp_size, newgrp_rank, comm_size = 0;
+    MPI_Group newgroup = MPI_GROUP_NULL;
+    MPI_Group_size(wgroup, &grp_size);
+    MPI_Group_rank(wgroup, &grp_rank);
+    *rank = grp_rank;
+    *size = grp_size;
+    int excl[1];
 
+    if (grp_size >= 2) {
+        /* Create a new group where the highest rank is excluded */
+        excl[0] = grp_size - 1;
+        rc = MPI_Group_excl(wgroup, 1, excl, &newgroup);
+        if (rc != MPI_SUCCESS) {
+            printf("Error on MPI_Group_excl\n");
+            errs++;
+            goto fn_exit;
+        }
+
+        MPI_Group_size(newgroup, &newgrp_size);
+        MPI_Group_rank(newgroup, &newgrp_rank);
+        if (newgrp_size != grp_size - 1) {
+            errs++;
+            goto fn_exit;
+        }
+        /* Use the new smaller group to create the lib_comm */
+        if (newgrp_rank == MPI_UNDEFINED) {
+            rc = MPI_Comm_create_from_group(MPI_GROUP_EMPTY,
+                                            "org.mpi-forum.mpi-v4_0.example-ex10_8", MPI_INFO_NULL,
+                                            MPI_ERRORS_RETURN, &lib_comm);
+        } else {
+            rc = MPI_Comm_create_from_group(newgroup, "org.mpi-forum.mpi-v4_0.example-ex10_8",
+                                            MPI_INFO_NULL, MPI_ERRORS_RETURN, &lib_comm);
+        }
+        if (rc != MPI_SUCCESS) {
+            errs++;
+            goto fn_exit;
+        }
+        if (lib_comm != MPI_COMM_NULL) {
+            MPI_Comm_size(lib_comm, &comm_size);
+            if (comm_size != newgrp_size) {
+                printf("Error: communicator for smaller group has size %d (expected %d)\n",
+                       comm_size, newgrp_size);
+                errs++;
+                goto fn_exit;
+            }
+            /* set size to size of smaller comm to enable
+             * result check of reduce operation */
+            *size = newgrp_size;
+        } else {
+            /* Only for the rank that has been excluded from the group it is ok to have MPI_COMM_NULL */
+            if (grp_rank != grp_size - 1) {
+                errs++;
+                printf("Error: communicator for smaller group is MPI_COMM_NULL\n");
+                goto fn_exit;
+            }
+        }
+    } else {
+        printf("This test has to be started with at least 2 processes!\n");
+        goto fn_exit;
+    }
+#else
     /* get a communicator */
     rc = MPI_Comm_create_from_group(wgroup, "org.mpi-forum.mpi-v4_0.example-ex10_8",
                                     MPI_INFO_NULL, MPI_ERRORS_RETURN, &lib_comm);
@@ -167,12 +234,18 @@ void library_foo_init(int *rank, int *size)
     }
     MPI_Comm_size(lib_comm, size);
     MPI_Comm_rank(lib_comm, rank);
+#endif
 
     /* free group, library doesn’t need it. */
   fn_exit:
     if (wgroup != MPI_GROUP_NULL) {
         MPI_Group_free(&wgroup);
     }
+#ifdef MOD_GROUP
+    if (newgroup != MPI_GROUP_NULL) {
+        MPI_Group_free(&newgroup);
+    }
+#endif
     if (sinfo != MPI_INFO_NULL) {
         MPI_Info_free(&sinfo);
     }

--- a/test/mpi/session/session_psets.c
+++ b/test/mpi/session/session_psets.c
@@ -23,6 +23,7 @@ int main(int argc, char *argv[])
     int n_psets, psetlen, rc;
     int valuelen;
     int flag = 0;
+    int rank;
     char *info_val = NULL;
     char *pset_name = NULL;
     char **all_pset_names;
@@ -95,6 +96,10 @@ int main(int argc, char *argv[])
             errs++;
         }
 
+        if (strcmp("mpi://WORLD", all_pset_names[i]) == 0) {
+            MPI_Group_rank(pgroup, &rank);
+        }
+
         free(all_pset_names[i]);
         MPI_Group_free(&pgroup);
         MPI_Info_free(&sinfo);
@@ -111,10 +116,12 @@ int main(int argc, char *argv[])
         errs++;
     }
 
-    if (errs == 0) {
-        printf("No Errors\n");
-    } else {
-        printf("%d Errors\n", errs);
+    if (rank == 0) {
+        if (errs == 0) {
+            printf("No Errors\n");
+        } else {
+            printf("%d Errors\n", errs);
+        }
     }
     return MTestReturnValue(errs);
 }

--- a/test/mpi/session/session_self.c
+++ b/test/mpi/session/session_self.c
@@ -8,14 +8,27 @@
 #include <assert.h>
 #include "mpitest.h"
 
+void get_world_rank(MPI_Session session, int *rank)
+{
+    MPI_Group group = MPI_GROUP_NULL;
+    MPI_Comm comm = MPI_COMM_NULL;
+    int my_rank = 0;
+    MPI_Group_from_session_pset(session, "mpi://WORLD", &group);
+    MPI_Comm_create_from_group(group, "foo", MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL, &comm);
+    MPI_Comm_rank(comm, &my_rank);
+    MPI_Group_free(&group);
+    MPI_Comm_free(&comm);
+    *rank = my_rank;
+}
+
 int main(int argc, char *argv[])
 {
     int errs = 0;
 
-    int ret;
-    MPI_Session session;
-    MPI_Group group;
-    MPI_Comm comm;
+    int ret, world_rank, grp_size, comm_size;
+    MPI_Session session = MPI_SESSION_NULL;
+    MPI_Group group = MPI_GROUP_NULL;
+    MPI_Comm comm = MPI_COMM_NULL;
 
     ret = MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &session);
     if (ret != MPI_SUCCESS) {
@@ -23,9 +36,20 @@ int main(int argc, char *argv[])
         goto fn_exit;
     }
 
-    ret = MPI_Group_from_session_pset(session, "mpi://self", &group);
+    /* Get the world rank of the process */
+    get_world_rank(session, &world_rank);
+
+    ret = MPI_Group_from_session_pset(session, "mpi://SELF", &group);
     if (ret != MPI_SUCCESS) {
         errs++;
+    }
+
+    MPI_Group_size(group, &grp_size);
+    if (grp_size != 1) {
+        printf("Error: Size of group generated from pset mpi://SELF is %d (expected size 1)\n",
+               grp_size);
+        errs++;
+        goto fn_exit;
     }
 
     ret = MPI_Comm_create_from_group(group, "tag", MPI_INFO_NULL, MPI_ERRORS_RETURN, &comm);
@@ -33,9 +57,17 @@ int main(int argc, char *argv[])
         errs++;
     }
 
-    ret = MPI_Group_free(&group);
-    if (ret != MPI_SUCCESS) {
+    if (comm == MPI_COMM_NULL) {
+        printf("Error: communicator for pset mpi://SELF is MPI_COMM_NULL\n");
         errs++;
+        goto fn_exit;
+    }
+
+    MPI_Comm_size(comm, &comm_size);
+    if (comm_size != grp_size) {
+        printf("Error: Comm for pset mpi://SELF has size %d (expected size 1)\n", comm_size);
+        errs++;
+        goto fn_exit;
     }
 
     MPI_Request req;
@@ -56,20 +88,35 @@ int main(int argc, char *argv[])
         errs++;
     }
 
-    ret = MPI_Comm_free(&comm);
-    if (ret != MPI_SUCCESS) {
-        errs++;
-    }
-
-    ret = MPI_Session_finalize(&session);
-    if (ret != MPI_SUCCESS) {
-        errs++;
-    }
-
-    if (errs == 0) {
-        printf("No Errors\n");
-    }
-
   fn_exit:
+    if (group != MPI_GROUP_NULL) {
+        ret = MPI_Group_free(&group);
+        if (ret != MPI_SUCCESS) {
+            errs++;
+        }
+    }
+
+    if (comm != MPI_COMM_NULL) {
+        ret = MPI_Comm_free(&comm);
+        if (ret != MPI_SUCCESS) {
+            errs++;
+        }
+    }
+
+    if (session != MPI_SESSION_NULL) {
+        ret = MPI_Session_finalize(&session);
+        if (ret != MPI_SUCCESS) {
+            errs++;
+        }
+    }
+
+    if (world_rank == 0) {
+        if (errs == 0) {
+            printf("No Errors\n");
+        } else {
+            printf("%d Errors\n", errs);
+        }
+    }
+
     return errs;
 }

--- a/test/mpi/session/session_self.c
+++ b/test/mpi/session/session_self.c
@@ -29,6 +29,11 @@ int main(int argc, char *argv[])
     MPI_Session session = MPI_SESSION_NULL;
     MPI_Group group = MPI_GROUP_NULL;
     MPI_Comm comm = MPI_COMM_NULL;
+#ifdef WITH_WORLD
+    int provided;
+
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+#endif
 
     ret = MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &session);
     if (ret != MPI_SUCCESS) {
@@ -117,6 +122,8 @@ int main(int argc, char *argv[])
             printf("%d Errors\n", errs);
         }
     }
-
+#ifdef WITH_WORLD
+    MPI_Finalize();
+#endif
     return errs;
 }

--- a/test/mpi/session/testlist
+++ b/test/mpi/session/testlist
@@ -7,3 +7,4 @@ session_re_init 4
 session_psets 1
 session_self 1
 session_bsend 2
+session_self 4

--- a/test/mpi/session/testlist
+++ b/test/mpi/session/testlist
@@ -4,6 +4,8 @@ session_mult_init 4 arg=5
 session_mult_init_with_world 4
 session_mult_init_with_world 4 arg=5
 session_re_init 4
+session_mod_group 2
+session_mod_group 4
 session_psets 1
 session_psets 4
 session_self 1

--- a/test/mpi/session/testlist
+++ b/test/mpi/session/testlist
@@ -1,6 +1,8 @@
 session 4
 session_mult_init 4
 session_mult_init 4 arg=5
+session_mult_init_with_world 4
+session_mult_init_with_world 4 arg=5
 session_re_init 4
 session_psets 1
 session_self 1

--- a/test/mpi/session/testlist
+++ b/test/mpi/session/testlist
@@ -5,6 +5,7 @@ session_mult_init_with_world 4
 session_mult_init_with_world 4 arg=5
 session_re_init 4
 session_psets 1
+session_psets 4
 session_self 1
 session_bsend 2
 session_self 4

--- a/test/mpi/session/testlist
+++ b/test/mpi/session/testlist
@@ -8,3 +8,5 @@ session_psets 1
 session_self 1
 session_bsend 2
 session_self 4
+session_self_with_world 1
+session_self_with_world 4


### PR DESCRIPTION
Remark: This PR is based on https://github.com/pmodels/mpich/pull/6578 (Session reference counting).  To avoid confusion, https://github.com/pmodels/mpich/pull/6578 should be reviewed and merged first, before we continue with this PR.

## Pull Request Description

For a malleable MPI library, it is essential to remove any dependency of the MPI Session implementation on the static built-in communicators `MPI_COMM_WORLD` and `MPI_COMM_SELF`. This is needed to be flexible with the number of processes of an MPI application. The built-in communicators are static (see MPI standard) and must not change. For malleability, the MPI library should be capable of operating without them in MPI Session-only situations.

This PR attempts to achieve this for `MPI_Comm_create_from_group` by using a temporary reserved context id to negotiate a free context id for the new communicator without using the built-in communicators.

In MPI Session-only situations, `MPI_COMM_WORLD` and `MPI_COMM_SELF` are no longer initialized and are not available - neither in the MPI lib nor to users.

This PR improves and adds several MPI Session-related tests to cover more potential error cases.

I need help of a CH4 expert to get this PR working for CH4. For ParaStation MPI we had to make some modifications in our PSP device layer so I perhaps something must be changed in CH4 as well? At the moment a segfault is thrown in `MPI_Comm_create_from_group`. Any ideas are welcome. Feel free to add/ modify commits.


## Author Checklist
* [X] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [X] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [X] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
