### PR TITLE
util: use dynamic num_nodes in MPIR_Find_external

### DIFF
--- a/src/util/mpir_localproc.c
+++ b/src/util/mpir_localproc.c
@@ -161,6 +161,9 @@ int MPIR_Find_external(MPIR_Comm * comm, int *external_size_p, int *external_ran
                         "internode_table", MPL_MEM_COMM);
 
     int num_nodes = MPIR_Process.num_nodes;
+    if (MPIR_Process.node_hostnames) {
+        num_nodes = utarray_len(MPIR_Process.node_hostnames);
+    }
     MPIR_CHKLMEM_MALLOC(nodes, int *, sizeof(int) * num_nodes, mpi_errno, "nodes", MPL_MEM_COMM);
 
     /* nodes maps node_id to rank in external_ranks of leader for that node */


### PR DESCRIPTION
## Pull Request Description
The node_id from dynamic processes may exceed MPIR_Process.num_nodes, which is the initial environment. Update it with the dynamic size instead.


Fixes #6603 
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
