### PR TITLE
pmi: Add configure options to exclude certain PMI protocols

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1498,6 +1498,7 @@ case "$with_pmi" in
   default|pmi1|pmi2|pmix)
     ;;
   slurm)
+    with_pmi=pmi1
     with_pmilib=slurm
     with_pm=no
     ;;
@@ -1513,7 +1514,9 @@ PAC_CHECK_HEADER_LIB_EXPLICIT(pmi1, pmi.h, pmi, PMI_Init)
 PAC_CHECK_HEADER_LIB_EXPLICIT(pmi2, pmi2.h, pmi2, PMI2_Init)
 PAC_CHECK_HEADER_LIB_EXPLICIT(pmix, pmix.h, pmix, PMIx_Init)
 
+pac_3rd_party_pmi=no
 if test "$pac_have_pmi" = "yes" -o "$pac_have_pmi1" = "yes" -o "$pac_have_pmi2" = "yes" -o "$pac_have_pmix" = "yes"; then
+    pac_3rd_party_pmi=yes
     if test "$with_pmilib" = "default" ; then
         with_pmilib=no
     fi
@@ -1625,6 +1628,12 @@ case "$with_pmilib" in
     if test "$with_pmilib" != "install" ; then
         pmi_subdir_args="--enable-embedded"
     fi
+    if test "$pac_have_pmi1" = "yes" -o "$pac_have_pmi2" = "yes" ; then
+        pmi_subdir_args="$pmi_subdir_args --disable-pmi1 --disable-pmi2"
+    fi
+    if test "$pac_have_pmix" = "yes" ; then
+        pmi_subdir_args="$pmi_subdir_args --disable-pmix"
+    fi
     PAC_CONFIG_SUBDIR_ARGS([src/pmi], [$pmi_subdir_args])
 
     PAC_APPEND_FLAG([-I${use_top_srcdir}/src/pmi/include], [CPPFLAGS])
@@ -1672,14 +1681,19 @@ elif test "$with_pmi" = "pmi2" ; then
 elif test "$with_pmi" = "pmix" ; then
     enable_pmix="yes"
 elif test "$with_pmilib" = "default" -o "$with_pmilib" = "mpich" -o "$with_pmilib" = "install"; then
-    # mpich's libpmi support both PMI1 and PMI2
     enable_pmi1="yes"
     enable_pmi2="yes"
-    # HACK: also enable pmix if both --with-pmilib and --with-pmix options are given
-    if test "$pac_have_pmix" = "yes" ; then
-        enable_pmix="yes"
+    # mpich's libpmi support both PMI1 and PMI2 unless 3rd party pmi is loaded
+    if test "$pac_have_pmi1" = "yes" -o "$pac_have_pmi2" = "yes" ; then
+        enable_pmi1="no"
+        enable_pmi2="no"
     fi
-else
+    if test "$pac_have_pmix" = "yes" ; then
+        enable_pmix="no"
+    fi
+fi
+
+if test "$pac_3rd_party_pmi" = "yes" ; then
     # detect
     PAC_PUSH_FLAG([LIBS])
     LIBS=$WRAPPER_LIBS
@@ -1694,10 +1708,12 @@ else
             AC_DEFINE([HAVE_PMI2_SET_THREADED], 1, [Define if PMI2_Set_threaded exist])
         ])
     fi
-    if test "$enable_pmi1" != "yes" -a "$enable_pmi2" != "yes" -a "$enable_pmix" != "yes"; then
-        AC_MSG_ERROR([Neither PMI, nor PMI2, nor PMIx is enabled.])
-    fi
     PAC_POP_FLAG([LIBS])
+fi
+
+# sanity check
+if test "$enable_pmi1" != "yes" -a "$enable_pmi2" != "yes" -a "$enable_pmix" != "yes"; then
+    AC_MSG_ERROR([Neither PMI, nor PMI2, nor PMIx is enabled.])
 fi
 
 if test "$enable_pmi1" = "yes"; then

--- a/src/pmi/configure.ac
+++ b/src/pmi/configure.ac
@@ -52,6 +52,25 @@ AH_BOTTOM([
 #endif
 ])
 
+AC_ARG_ENABLE([pmi1],
+    AS_HELP_STRING([--disable-pmi1], [disable PMI-v1 protocol])
+    [if test "$enableval" = "no" ; then
+         AC_DEFINE(DISABLE_PMI1, 1, [Disable PMI-v1 protocol])
+     fi
+    ])
+AC_ARG_ENABLE([pmi2],
+    AS_HELP_STRING([--disable-pmi2], [disable PMI2 protocol])
+    [if test "$enableval" = "no" ; then
+         AC_DEFINE(DISABLE_PMI2, 1, [Disable PMI2 protocol])
+     fi
+    ])
+AC_ARG_ENABLE([pmix],
+    AS_HELP_STRING([--disable-pmix], [disable PMIx protocol])
+    [if test "$enableval" = "no" ; then
+         AC_DEFINE(DISABLE_PMIX, 1, [Disable PMIx protocol])
+     fi
+    ])
+
 AC_ARG_WITH([thread-package],
     AS_HELP_STRING([--with-thread-package], [whether to enable threads]))
 

--- a/src/pmi/src/pmi_v1.c
+++ b/src/pmi/src/pmi_v1.c
@@ -16,6 +16,8 @@
  */
 /***************************************************************************/
 
+#ifndef DISABLE_PMI1
+
 #include "pmi_config.h"
 #include "mpl.h"
 
@@ -1092,3 +1094,5 @@ static int expect_pmi_cmd(const char *key)
   fn_fail:
     goto fn_exit;
 }
+
+#endif /* DISABLE_PMI1 */

--- a/src/pmi/src/pmi_v2.c
+++ b/src/pmi/src/pmi_v2.c
@@ -3,6 +3,8 @@
  *     See COPYRIGHT in top-level directory
  */
 
+#ifndef DISABLE_PMI2
+
 #include "pmi_config.h"
 #include "mpl.h"
 
@@ -806,3 +808,5 @@ static int getPMIFD(void)
   fn_fail:
     goto fn_exit;
 }
+
+#endif /* DISABLE_PMI2 */


### PR DESCRIPTION
## Pull Request Description
To support configuring with both builtin libpmi and external pmi library such as libpmix, add options to disable certain protocols in the builtin libpmi

Fixes #6669
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
