### PR TITLE
pm/util: Allow duplicate keys in PMI KVS

### DIFF
--- a/src/pm/util/pmiserv.c
+++ b/src/pm/util/pmiserv.c
@@ -516,15 +516,15 @@ static int fPMIKVSAddPair(PMIKVSpace * kvs, const char key[], const char val[])
     PMIKVPair *pair, *p, **pprev;
     int rc;
 
-    /* Find the location in which to insert the pair (if the
-     * same key already exists, that is an error) */
+    /* Find the location in which to insert the pair */
     p = kvs->pairs;
     pprev = &(kvs->pairs);
     while (p) {
         rc = strcmp(p->key, key);
         if (rc == 0) {
-            /* Duplicate.  Indicate an error */
-            return 1;
+            /* Duplicate.  Replace the old one. */
+            MPL_strncpy(p->val, val, sizeof(p->val));
+            return 0;
         }
         if (rc > 0) {
             /* We've found the location (after pprev, before p) */


### PR DESCRIPTION
## Pull Request Description

Duplicate keys are already allowed in the Hydra PMI server. Update the utility PMI server used by gforker and remshell to also support them.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
