### PR TITLE
mpir_pmi: Reset pmi_kvs_name during reinitialization

### DIFF
--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -46,6 +46,12 @@ static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
     *size = pvalue->data.uint32;
     PMIX_VALUE_RELEASE(pvalue);
 
+    /* sessions: pmi_kvs_name is freed during finalize, so we need to set it
+     * again in the reinitialization case */
+    if (pmi_kvs_name == NULL) {
+        pmi_kvs_name = MPL_strdup(pmix_proc.nspace);
+    }
+
   fn_exit:
     /* FIXME: support spawn and appnum */
     *has_parent = 0;


### PR DESCRIPTION
## Pull Request Description

PMIx support for reinitialization does not call PMIx_Init again, so we need to make sure all the appropriate information is provided from the first init. Set pmi_kvs_name from the stored pmix_proc_t struct.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
