### PR TITLE
request: add --enable-g=progress

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -403,6 +403,7 @@ AC_ARG_ENABLE(g,
         mutex    - Enable error checking on pthread mutexes
         most     - Most of the above options, excluding some with severe
                    performance impacts.  Recommended for typical development.
+        progress - Enable debugging progress status
         yes      - synonym for "most" (*not* "all")
         all      - All of the above choices
 ],,enable_g=none)
@@ -1323,6 +1324,9 @@ for option in $enable_g ; do
         perform_handlealloc=yes
         perform_handle=yes
         ;;
+        progress)
+        perform_dbgprogress=yes
+        ;;
 	all)
         perform_memarena=yes
 	perform_memtracing=yes
@@ -1393,6 +1397,10 @@ fi
 
 if test -n "$perform_dbgmutex" ; then
    AC_DEFINE(MPICH_DEBUG_MUTEX,1,[Define to enable mutex debugging])
+fi
+
+if test -n "$perform_dbgprogress" ; then
+   AC_DEFINE(MPICH_DEBUG_PROGRESS,1,[Define to enable mutex debugging])
 fi
 
 pac_cross_compiling=no

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -457,3 +457,27 @@ int MPIR_Grequest_free(MPIR_Request * request_ptr)
 
     return mpi_errno;
 }
+
+void MPIR_Request_debug(void)
+{
+    for (int i = 0; i < MPIR_REQUEST_NUM_POOLS; i++) {
+        int n_pending = MPIR_Request_mem[i].num_allocated - MPIR_Request_mem[i].num_avail;
+        if (n_pending > 0) {
+            printf("%d pending requests in pool %d\n", n_pending, i);
+#ifdef MPICH_DEBUG_PROGRESS
+            if (i == 0) {
+                MPIR_Request *pool = MPIR_Request_direct;
+                for (int j = 0; j < MPIR_Request_mem[0].direct_size; j++) {
+                    MPIR_REQUEST_DEBUG(&pool[j]);
+                }
+            }
+            for (int k = 0; k < MPIR_Request_mem[i].indirect_size; k++) {
+                MPIR_Request *pool = MPIR_Request_mem[i].indirect[k];
+                for (int j = 0; j < REQUEST_NUM_INDICES; j++) {
+                    MPIR_REQUEST_DEBUG(&pool[j]);
+                }
+            }
+#endif
+        }
+    }
+}


### PR DESCRIPTION
## Pull Request Description
How do we debug a "livelock" situation when MPI processes are stuck inside a progress loop?

This PR adds configure option `--enable-g=progress` and combined with `MPIR_CVAR_DEBUG_PROGRESS_TIMEOUT=1` will show pending requests during progress after we are stuck in the progress for a while.

There are legitimate situations when certain MPI processes are supposed to be spinning progress, thus only enable this for a debugging session.

To make the debug info more useful, we can inject status info to individual request objects using `MPIR_REQUEST_SET_INFO`. This is useful when we want to track the precise stages a request is hanging on. 

[skip warnings]
```
~/work/pull_requests/debug_requests/test/mpi/pt2pt$ MPIR_CVAR_DEBUG_PROGRESS_TIMEOUT=1 mpirun -n 3 ./test_deadlock
1 pending requests in pool 0
    ac000000:
1 pending requests in pool 0
    ac000001:
1 pending requests in pool 0
    ac000000:
^C[mpiexec@Tiger] Sending Ctrl-C to processes as requested
```
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
