### PR TITLE
binding/f90: fix ierr as ierror

### DIFF
--- a/maint/local_python/binding_f90.py
+++ b/maint/local_python/binding_f90.py
@@ -92,8 +92,8 @@ def dump_f90_func(func):
     G.out.append("")
     if 'return' not in func:
         if not len(f_param_list) or not RE.match(r'ierr(or)?', f_param_list[-1]):
-            f_param_list.append('ierr')
-            decl_list.append("INTEGER :: ierr")
+            f_param_list.append('ierror')
+            decl_list.append("INTEGER :: ierror")
         dump_fortran_line("SUBROUTINE %s(%s)" % (func_name, ', '.join(f_param_list)))
     else:
         dump_fortran_line("FUNCTION %s(%s) result(res)" % (func_name, ', '.join(f_param_list)))


### PR DESCRIPTION
## Pull Request Description
The fortran interface uses ierror for the return argument rather than ierr. This matters if user call with explicit keyword e.g.
```
    call MPI_Init(ierror=status)
```
, where status is the actual variable to use.

Fixes #6693 
[skip warnings]



## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
