### PR TITLE
pmi: remove maximum limit on PMI messages

### DIFF
--- a/src/pmi/src/pmi_util.c
+++ b/src/pmi/src/pmi_util.c
@@ -210,6 +210,95 @@ int PMIU_readline(int fd, char *buf, int maxlen)
     return curlen - 1;
 }
 
+/* Read and return the next full PMI message in a buffer */
+/* NOTE: no race detection. We assume PMI is only called serailly */
+
+int PMIU_read_cmd(int fd, char **buf_out, int *buflen_out)
+{
+    int pmi_errno = PMIU_SUCCESS;
+
+    int buflen = 0;
+    int bufsize = 0;
+    char *buf;
+    bufsize = MAX_READLINE;
+    PMIU_CHK_MALLOC(buf, char *, bufsize, pmi_errno, PMIU_ERR_NOMEM, "buf");
+
+    int wire_version = 0;
+    int pmi2_cmd_len = 0;
+    while (1) {
+        int n;
+        /* -- read more -- */
+        do {
+            if (bufsize - buflen - 1 < 100) {
+                bufsize += MAX_READLINE;
+                PMIU_REALLOC_ORJUMP(buf, bufsize, pmi_errno);
+            }
+            n = read(fd, buf + buflen, bufsize - buflen - 1);
+        } while (n == -1 && errno == EINTR);
+        if (n == 0) {
+            /* EOF */
+            break;
+        } else if (n < 0) {
+            PMIU_ERR_SETANDJUMP(pmi_errno, PMI_FAIL, "Error in PMIU_read_cmd.\n");
+        }
+
+        char *s = buf + buflen;
+        buflen += n;
+        if (wire_version == 0) {
+            /* -- check wire protocol -- */
+            if (buflen > 6) {
+                if (strncmp(buf, "cmd=", 4) == 0) {
+                    wire_version = 1;
+                } else {
+                    wire_version = 2;
+                    char len_str[7];
+                    memcpy(len_str, buf, 6);
+                    len_str[6] = '\0';
+                    pmi2_cmd_len = atoi(len_str);
+                    PMIU_Assert(pmi2_cmd_len > 10);
+                    if (bufsize < pmi2_cmd_len + 1) {
+                        bufsize = pmi2_cmd_len + 1;
+                        PMIU_REALLOC_ORJUMP(buf, bufsize, pmi_errno);
+                    }
+                }
+            }
+        }
+        /* -- check whether we have the full message -- */
+        int got_full_cmd = 0;
+        if (wire_version == 1) {
+            /* newline marks the end of a PMI-1 message */
+            /* Q: can we take shortcut and just check the end? */
+            for (int i = 0; i < n; i++) {
+                if (s[i] == '\n') {
+                    got_full_cmd = 1;
+                }
+            }
+        } else {
+            if (buflen >= pmi2_cmd_len) {
+                got_full_cmd = 1;
+            }
+        }
+        if (got_full_cmd) {
+            break;
+        }
+    }
+
+    if (buflen == 0) {
+        PMIU_Free(buf);
+        *buf_out = NULL;
+        *buflen_out = 0;
+    } else {
+        buf[buflen] = '\0';
+        *buf_out = buf;
+        *buflen_out = buflen;
+    }
+
+  fn_exit:
+    return pmi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 int PMIU_write(int fd, char *buf, int buflen)
 {
     char *p = buf;

--- a/src/pmi/src/pmi_util.h
+++ b/src/pmi/src/pmi_util.h
@@ -51,6 +51,7 @@ void PMIU_Set_rank_kvsname(int rank, const char *kvsname);
 void PMIU_SetServer(void);
 void PMIU_printf(int print_flag, const char *fmt, ...);
 int PMIU_readline(int fd, char *buf, int max);
+int PMIU_read_cmd(int fd, char **buf_out, int *buflen_out);
 int PMIU_write(int fd, char *buf, int buflen);
 int PMIU_writeline(int fd, char *buf);
 int PMIU_parse_keyvals(char *st);

--- a/src/pmi/src/pmi_util.h
+++ b/src/pmi/src/pmi_util.h
@@ -59,6 +59,7 @@ char *PMIU_getval(const char *keystr, char *valstr, int vallen);
 void PMIU_chgval(const char *keystr, char *valstr);
 
 #define PMIU_Malloc(size_) MPL_malloc(size_, MPL_MEM_PM)
+#define PMIU_Realloc(ptr_, size_) MPL_realloc(ptr_, size_, MPL_MEM_PM)
 #define PMIU_Free MPL_free
 #define PMIU_Strdup MPL_strdup
 #define PMIU_Strnapp MPL_strnapp
@@ -186,6 +187,8 @@ extern int PMIU_verbose;        /* Set this to true to print PMI debugging info 
         } \
     } while (0)
 
+#define PMIU_QUOTE(x) #x
+
 /* Provides a easy way to use realloc safely and avoid the temptation to use
  * realloc unsafely (direct ptr assignment).  Zero-size reallocs returning NULL
  * are handled and are not considered an error. */
@@ -193,8 +196,8 @@ extern int PMIU_verbose;        /* Set this to true to print PMI debugging info 
         void *realloc_tmp_ = PMIU_Realloc((ptr_), (size_));                                    \
         if ((size_) && !realloc_tmp_) {                                                         \
             PMIU_Free(ptr_);                                                                   \
-            PMIU_ERR_SETANDJUMP2(rc_,PMIU_CHKMEM_ISFATAL,                                     \
-                                  "**nomem2","**nomem2 %d %s",(size_),PMIU_QUOTE(ptr_));       \
+            PMIU_ERR_SETANDJUMP2(rc_,PMIU_FAIL,                                     \
+                                 "**nomem2 %d %s",(size_),PMIU_QUOTE(ptr_));       \
         }                                                                                       \
         (ptr_) = realloc_tmp_;                                                                  \
     } while (0)
@@ -202,8 +205,8 @@ extern int PMIU_verbose;        /* Set this to true to print PMI debugging info 
 #define PMIU_REALLOC_ORJUMP(ptr_,size_,rc_) do {                                               \
         void *realloc_tmp_ = PMIU_Realloc((ptr_), (size_));                                    \
         if (size_)                                                                              \
-            PMIU_ERR_CHKANDJUMP2(!realloc_tmp_,rc_,PMIU_CHKMEM_ISFATAL,\                      \
-                                  "**nomem2","**nomem2 %d %s",(size_),PMIU_QUOTE(ptr_));       \
+            PMIU_ERR_CHKANDJUMP2(!realloc_tmp_,rc_,PMIU_FAIL,                      \
+                                 "**nomem2 %d %s",(size_),PMIU_QUOTE(ptr_));       \
         (ptr_) = realloc_tmp_;                                                                  \
     } while (0)
 

--- a/src/pmi/src/pmi_v1.c
+++ b/src/pmi/src/pmi_v1.c
@@ -151,16 +151,6 @@ PMI_API_PUBLIC int PMI_Init(int *spawned)
 #endif
 
     PMII_getmaxes(&PMI_kvsname_max, &PMI_keylen_max, &PMI_vallen_max);
-    /* we need construct a cmd like "cmd=put kvsname=%s key=%s value=%s\n",
-     * make sure it fits in PMIU_MAXLINE.
-     */
-    if (PMI_kvsname_max + PMI_keylen_max + PMI_vallen_max + 30 > PMIU_MAXLINE) {
-        if (PMI_keylen_max > 256) {
-            PMI_keylen_max = 256;
-        }
-        PMI_vallen_max = PMIU_MAXLINE - PMI_kvsname_max - PMI_keylen_max - 30;
-        assert(PMI_vallen_max > 256);
-    }
 
     /* FIXME: This is something that the PM should tell the process,
      * rather than deliver it through the environment */

--- a/src/pmi/src/pmi_wire.c
+++ b/src/pmi/src/pmi_wire.c
@@ -869,11 +869,9 @@ int PMIU_cmd_read(int fd, struct PMIU_cmd *pmicmd)
     pmicmd->buf = NULL;
     while (pmicmd->buf == NULL) {
         char *recvbuf;
-        PMIU_CHK_MALLOC(recvbuf, char *, PMIU_MAXLINE, pmi_errno, PMIU_ERR_NOMEM, "recvbuf");
-
         int n;
-        n = PMIU_readline(fd, recvbuf, PMIU_MAXLINE);
-        PMIU_ERR_CHKANDJUMP(n <= 0, pmi_errno, PMIU_FAIL, "readline failed\n");
+        pmi_errno = PMIU_read_cmd(fd, &recvbuf, &n);
+        PMIU_ERR_POP(pmi_errno);
 
         if (recvbuf[n - 1] == '\n') {
             PMIU_printf(PMIU_verbose, "got pmi response: %s", recvbuf);


### PR DESCRIPTION
## Pull Request Description

Add and use a new routine, PMIU_read_cmd, that reads the next full PMI
message into a dynamically allocated buffer. This allows PMI messages
with arbitrary length. Previously we use PMIU_readline, which restricts
PMI message to PMIU_MAXLINE (1024) limit.

Hydra uses its own reading routine, which use a static buffer with size
HYD_TMPBUF_SIZE, but at a much higher limit (64K).

[skip warnings]

## TODO
Hydra uses fixed sizes for keyval keys and values. It needs to be changed to use dynamic allocation instead.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
