### PR TITLE
part: Fix bindings for MPI_Psend_init and MPI_Precv_init

### DIFF
--- a/src/binding/mpi_standard_api.txt
+++ b/src/binding/mpi_standard_api.txt
@@ -1641,7 +1641,7 @@ MPI_Pready_range:
 MPI_Precv_init:
     buf: BUFFER, direction=IN, [initial address of recv buffer (choice)]
     partitions: PARTITION, direction=IN, [number of partitions]
-    count: XFER_NUM_ELEM_NNI, direction=IN, [number of elements send per partition]
+    count: POLYXFER_NUM_ELEM_NNI, direction=IN, [number of elements per partition]
     datatype: DATATYPE, direction=IN, [type of each element]
     dest: RANK, direction=IN, [rank of destination]
     tag: TAG, direction=IN, [message tag]
@@ -1656,7 +1656,7 @@ MPI_Probe:
 MPI_Psend_init:
     buf: BUFFER, constant=True, direction=IN, [initial address of send buffer (choice)]
     partitions: PARTITION, direction=IN, [number of partitions]
-    count: XFER_NUM_ELEM_NNI, direction=IN, [number of elements send per partition]
+    count: POLYXFER_NUM_ELEM_NNI, direction=IN, [number of elements per partition]
     datatype: DATATYPE, direction=IN, [type of each element]
     dest: RANK, direction=IN, [rank of destination]
     tag: TAG, direction=IN, [message tag]

--- a/test/mpi/part/pingping.c
+++ b/test/mpi/part/pingping.c
@@ -48,7 +48,7 @@ static void send_test(void *sbuf, int partitions, MPI_Count count, MPI_Datatype 
 {
     MPI_Request req = MPI_REQUEST_NULL;
 
-    MPI_Psend_init(sbuf, partitions, count, stype, dest, 0, comm, MPI_INFO_NULL, &req);
+    MPI_Psend_init_c(sbuf, partitions, count, stype, dest, 0, comm, MPI_INFO_NULL, &req);
     MPI_Start(&req);
 
     /* Set partition ready separately to test partial data transfer */
@@ -64,7 +64,7 @@ static void recv_test(void *rbuf, int partitions, MPI_Count count, MPI_Datatype 
 {
     MPI_Request req = MPI_REQUEST_NULL;
 
-    MPI_Precv_init(rbuf, partitions, count, rtype, source, 0, comm, MPI_INFO_NULL, &req);
+    MPI_Precv_init_c(rbuf, partitions, count, rtype, source, 0, comm, MPI_INFO_NULL, &req);
     MPI_Start(&req);
 
     MPI_Wait(&req, p_status);


### PR DESCRIPTION
## Pull Request Description

An errata defined these bindings to use integer count and added separate large count versions. See mpi-forum/mpi-issues#765.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
