### PR TITLE
pt2pt/bsend: add comm/session buffer attach/detach

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 ===============================================================================
                                Changes in 4.2
 ===============================================================================
+# Complete support MPI 4.1 specification
+
 # CH4 shm is enabled by default with ucx netmod.
 
 # Use --with-{pmi,pmi2,pmix]=[path] to configure external PMI library.
@@ -30,6 +32,12 @@
   that supported kinds can also be found in MPI_INFO_ENV, but it was
   decided at the October 2023 meeting that this was a mistake and will
   be removed in an erratum.
+
+# New functions added in MPI-4.1: MPI_Comm_attach_buffer, MPI_Session_attach_buffer,
+  MPI_Comm_detach_buffer, MPI_Session_detach_buffer,
+  MPI_Buffer_flush, MPI_Comm_flush_buffer, MPI_Session_flush_buffer,
+  MPI_Buffer_iflush, MPI_Comm_iflush_buffer, and MPI_Session_iflush_buffer.
+  Also added constant MPI_BUFFER_AUTOMATIC to allow automatic buffers.
 
 ===============================================================================
                                Changes in 4.1

--- a/doc/mansrc/mpiconsts.txt
+++ b/doc/mansrc/mpiconsts.txt
@@ -271,6 +271,7 @@ datatypes for 'MPI_SUM', 'MPI_PROD', etc.  MPICH does allow these datatypes.
 . MPI_BOTTOM                     - May be used to indicate the bottom of the address space
 . MPI_IN_PLACE                   - Special location for buffer in some
   collective communication routines
+. MPI_BUFFER_AUTOMATIC           - Use automatic (unlimited) buffering in buffered send
 . MPI_VERSION                    - Numeric value of MPI version (e.g., 3)
 - MPI_SUBVERSION                 - Numeric value of MPI subversion (e.g., 1)
 

--- a/maint/local_python/binding_f77.py
+++ b/maint/local_python/binding_f77.py
@@ -93,6 +93,17 @@ def dump_f77_c_func(func):
         code_list_common.append("}")
         code_list_common.append("")
 
+    # MPI_Buffer_attach and family
+    def dump_buf_attach(buf):
+        # void *
+        c_param_list.append("void *%s" % buf)
+        c_arg_list_A.append(buf)
+        c_arg_list_B.append(buf)
+        code_list_common.append("if (%s == MPIR_F_MPI_BUFFER_AUTOMATIC) {" % buf)
+        code_list_common.append("    %s = MPI_BUFFER_AUTOMATIC;" % buf)
+        code_list_common.append("}")
+        code_list_common.append("")
+
     # MPI_Status
     def dump_status(v, is_in, is_out):
         c_param_list.append("MPI_Fint *%s" % v)
@@ -591,7 +602,10 @@ def dump_f77_c_func(func):
                 pass;
 
             elif p['kind'] == "BUFFER":
-                dump_buf(p['name'], False)
+                if re.match(r'MPI_Buffer_attach|MPI_\w+_buffer_attach', func['name'], re.IGNORECASE):
+                    dump_buf_attach(p['name'])
+                else:
+                    dump_buf(p['name'], False)
 
             elif p['kind'] == "STRING":
                 if p['param_direction'] == 'out':

--- a/src/binding/c/pt2pt_api.txt
+++ b/src/binding/c/pt2pt_api.txt
@@ -57,7 +57,7 @@ MPI_Bsend_init:
 
 MPI_Buffer_attach:
     .desc: Attaches a user-provided buffer for sending
-    .skip: ThreadSafe, validate-BUFFER
+    .skip: ThreadSafe
     .seealso: MPI_Buffer_detach, MPI_Bsend
 /*
     Notes:

--- a/src/binding/c/pt2pt_api.txt
+++ b/src/binding/c/pt2pt_api.txt
@@ -57,7 +57,7 @@ MPI_Bsend_init:
 
 MPI_Buffer_attach:
     .desc: Attaches a user-provided buffer for sending
-    .skip: ThreadSafe
+    .skip: ThreadSafe, validate-BUFFER
     .seealso: MPI_Buffer_detach, MPI_Bsend
 /*
     Notes:

--- a/src/binding/c/pt2pt_api.txt
+++ b/src/binding/c/pt2pt_api.txt
@@ -87,11 +87,6 @@ MPI_Buffer_attach:
     threads in a process, the user is responsible for ensuring that only
     one thread at a time calls this routine or 'MPI_Buffer_detach'.
 */
-{
-    mpi_errno = MPIR_Bsend_attach(buffer, size);
-    if (mpi_errno != MPI_SUCCESS)
-        goto fn_fail;
-}
 
 MPI_Buffer_detach:
     .desc: Removes an existing buffer (for use in MPI_Bsend etc)

--- a/src/binding/c/pt2pt_api.txt
+++ b/src/binding/c/pt2pt_api.txt
@@ -145,6 +145,10 @@ MPI_Buffer_detach:
         standard for more details.
 */
 
+MPI_Buffer_flush:
+    .desc: block until all messages currently in the globally shared buffer of the calling process have been transmitted
+    .seealso: MPI_Comm_flush_buffer, MPI_Session_flush_buffer
+
 MPI_Comm_attach_buffer:
     .desc: Attaches a user-provided buffer for buffered send in the communicator
     .skip: ThreadSafe
@@ -154,6 +158,10 @@ MPI_Comm_detach_buffer:
     .desc: Removes an existing buffer (for use in MPI_Bsend etc) in the communicator
     .skip: ThreadSafe
     .seealso: MPI_Comm_attach_buffer, MPI_Bsend
+
+MPI_Comm_flush_buffer:
+    .desc: block until all messages currently in the communicator-specific buffer of the calling process have been transmitted
+    .seealso: MPI_Buffer_flush, MPI_Session_flush_buffer
 
 MPI_Ibsend:
     .desc: Starts a nonblocking buffered send
@@ -485,6 +493,10 @@ MPI_Session_detach_buffer:
     .desc: Removes an existing buffer (for use in MPI_Bsend etc) in the session
     .skip: ThreadSafe
     .seealso: MPI_Session_attach_buffer, MPI_Bsend
+
+MPI_Session_flush_buffer:
+    .desc: block until all messages currently in the session-specific buffer of the calling process have been transmitted
+    .seealso: MPI_Buffer_flush, MPI_Comm_flush_buffer
 
 MPI_Ssend:
     .desc: Blocking synchronous send

--- a/src/binding/c/pt2pt_api.txt
+++ b/src/binding/c/pt2pt_api.txt
@@ -149,6 +149,10 @@ MPI_Buffer_flush:
     .desc: block until all messages currently in the globally shared buffer of the calling process have been transmitted
     .seealso: MPI_Comm_flush_buffer, MPI_Session_flush_buffer
 
+MPI_Buffer_iflush:
+    .desc: start a nonblocking flush in the globally shared buffer
+    .seealso: MPI_Buffer_flush
+
 MPI_Comm_attach_buffer:
     .desc: Attaches a user-provided buffer for buffered send in the communicator
     .skip: ThreadSafe
@@ -162,6 +166,10 @@ MPI_Comm_detach_buffer:
 MPI_Comm_flush_buffer:
     .desc: block until all messages currently in the communicator-specific buffer of the calling process have been transmitted
     .seealso: MPI_Buffer_flush, MPI_Session_flush_buffer
+
+MPI_Comm_iflush_buffer:
+    .desc: start a nonblocking flush in the communicator-specific buffer
+    .seealso: MPI_Comm_flush_buffer
 
 MPI_Ibsend:
     .desc: Starts a nonblocking buffered send
@@ -497,6 +505,10 @@ MPI_Session_detach_buffer:
 MPI_Session_flush_buffer:
     .desc: block until all messages currently in the session-specific buffer of the calling process have been transmitted
     .seealso: MPI_Buffer_flush, MPI_Comm_flush_buffer
+
+MPI_Session_iflush_buffer:
+    .desc: start a nonblocking flush in the session-specific buffer
+    .seealso: MPI_Session_flush_buffer
 
 MPI_Ssend:
     .desc: Blocking synchronous send

--- a/src/binding/c/pt2pt_api.txt
+++ b/src/binding/c/pt2pt_api.txt
@@ -145,6 +145,16 @@ MPI_Buffer_detach:
         standard for more details.
 */
 
+MPI_Comm_attach_buffer:
+    .desc: Attaches a user-provided buffer for buffered send in the communicator
+    .skip: ThreadSafe
+    .seealso: MPI_Buffer_attach, MPI_Bsend
+
+MPI_Comm_detach_buffer:
+    .desc: Removes an existing buffer (for use in MPI_Bsend etc) in the communicator
+    .skip: ThreadSafe
+    .seealso: MPI_Comm_attach_buffer, MPI_Bsend
+
 MPI_Ibsend:
     .desc: Starts a nonblocking buffered send
     .earlyreturn: pt2pt_proc_null
@@ -465,6 +475,16 @@ MPI_Sendrecv_replace:
     if (mpi_errno != MPI_SUCCESS)
         goto fn_fail;
 }
+
+MPI_Session_attach_buffer:
+    .desc: Attaches a user-provided buffer for buffered send in the session
+    .skip: ThreadSafe
+    .seealso: MPI_Buffer_attach, MPI_Bsend
+
+MPI_Session_detach_buffer:
+    .desc: Removes an existing buffer (for use in MPI_Bsend etc) in the session
+    .skip: ThreadSafe
+    .seealso: MPI_Session_attach_buffer, MPI_Bsend
 
 MPI_Ssend:
     .desc: Blocking synchronous send

--- a/src/binding/fortran/mpif_h/buildiface
+++ b/src/binding/fortran/mpif_h/buildiface
@@ -352,6 +352,7 @@ if ($write_mpif) {
     # Finally, the special symbols
     print MPIFFD "       INTEGER MPI_BOTTOM, MPI_IN_PLACE, MPI_UNWEIGHTED(1)\n";
     print MPIFFD "       INTEGER MPI_WEIGHTS_EMPTY(1)\n";
+    print MPIFFD "       INTEGER MPI_BUFFER_AUTOMATIC(1)\n";
 
     # And the external names.  This are necessary to
     # ensure that these are passed as routines, not implicitly-defined
@@ -417,6 +418,9 @@ if ($write_mpif) {
        SAVE /MPIFCMB5/
        SAVE /MPIFCMB9/
 
+       COMMON /MPIFCMBa/ MPI_BUFFER_AUTOMATIC
+       SAVE /MPIFCMBa/
+
        COMMON /MPIPRIV1/ MPI_BOTTOM, MPI_IN_PLACE, MPI_STATUS_IGNORE
 
        COMMON /MPIPRIV2/ MPI_STATUSES_IGNORE, MPI_ERRCODES_IGNORE
@@ -424,6 +428,7 @@ if ($write_mpif) {
 
        COMMON /MPIPRIVC/ MPI_ARGVS_NULL, MPI_ARGV_NULL
        SAVE   /MPIPRIVC/\n";
+
 
     close( MPIFFD );
     &ReplaceIfDifferent( "mpif.h.in", "mpif.h.in.new" );

--- a/src/binding/fortran/mpif_h/mpi_fortimpl.h
+++ b/src/binding/fortran/mpif_h/mpi_fortimpl.h
@@ -287,6 +287,7 @@ typedef MPI_Aint MPI_FAint;
 extern FORT_DLL_SPEC int MPIR_F_NeedInit;
 extern FORT_DLL_SPEC void *MPIR_F_MPI_BOTTOM;
 extern FORT_DLL_SPEC void *MPIR_F_MPI_IN_PLACE;
+extern FORT_DLL_SPEC void *MPIR_F_MPI_BUFFER_AUTOMATIC;
 extern FORT_DLL_SPEC void *MPIR_F_MPI_UNWEIGHTED;
 extern FORT_DLL_SPEC void *MPIR_F_MPI_WEIGHTS_EMPTY;
 /* MPI_F_STATUS(ES)_IGNORE are defined in mpi.h and are intended for C

--- a/src/binding/fortran/mpif_h/setbot.c.in
+++ b/src/binding/fortran/mpif_h/setbot.c.in
@@ -18,7 +18,7 @@
    we need to include the elements of the Fortran character "dope vector".
 */
 FORT_DLL_SPEC void FORT_CALL mpirinitc_(void *si, void *ssi,
-                                        void *bt, void *ip,
+                                        void *bt, void *ip, void *c_ba,
                                         void *uw, void *ecsi,
                                         void *an FORT_MIXED_LEN(d1),
                                         void *asn FORT_MIXED_LEN(d1),
@@ -31,6 +31,7 @@ FORT_DLL_SPEC void FORT_CALL mpirinitc_(void *si, void *ssi,
 int MPIR_F_NeedInit = 1;
 void *MPIR_F_MPI_BOTTOM = 0;
 void *MPIR_F_MPI_IN_PLACE = 0;
+void *MPIR_F_MPI_BUFFER_AUTOMATIC = 0;
 void *MPIR_F_MPI_UNWEIGHTED = 0;
 /* MPI_F_STATUS_IGNORE etc must be declared within mpi.h (MPI-2 standard
    requires this) */
@@ -44,7 +45,7 @@ void *MPI_F_ARGVS_NULL = 0;
 void *MPIR_F_MPI_WEIGHTS_EMPTY = 0;
 
 FORT_DLL_SPEC void FORT_CALL mpirinitc_(void *si, void *ssi,
-                                        void *bt, void *ip,
+                                        void *bt, void *ip, void *c_ba,
                                         void *uw, void *ecsi,
                                         void *an FORT_MIXED_LEN(d1),
                                         void *asn FORT_MIXED_LEN(d1),
@@ -54,6 +55,7 @@ FORT_DLL_SPEC void FORT_CALL mpirinitc_(void *si, void *ssi,
     MPI_F_STATUSES_IGNORE = (MPI_Fint *) ssi;
     MPIR_F_MPI_BOTTOM = bt;
     MPIR_F_MPI_IN_PLACE = ip;
+    MPIR_F_MPI_BUFFER_AUTOMATIC = c_ba;
     MPIR_F_MPI_UNWEIGHTED = uw;
     MPI_F_ERRCODES_IGNORE = (MPI_Fint *) ecsi;
     MPI_F_ARGV_NULL = an;

--- a/src/binding/fortran/mpif_h/setbotf.f.in
+++ b/src/binding/fortran/mpif_h/setbotf.f.in
@@ -8,20 +8,22 @@
 !      STATUS_IGNORE, STATUSES_IGNORE
        integer si(mpi_status_size), ssi(mpi_status_size,1)
 !      BOTTOM, IN_PLACE, UNWEIGHTED, WEIGHTED, ERRCODES_IGNORE
-       integer bt, ip, uw(1), we(1), ecsi(1)
+       integer bt, ip, c_ba(1), uw(1), we(1), ecsi(1)
 !      ARGVS_NULL, ARGV_NULL
        character*1 asn(1,1), an(1)
        common /MPIFCMB5/ uw
        common /MPIFCMB9/ we
+       common /MPIFCMBa/ c_ba
        common /MPIPRIV1/ bt, ip, si
        common /MPIPRIV2/ ssi, ecsi
        common /MPIPRIVC/ asn, an
        save /MPIFCMB5/
        save /MPIFCMB9/
+       save /MPIFCMBa/
        save /MPIPRIV1/, /MPIPRIV2/
        save /MPIPRIVC/
 !      MPI_ARGVS_NULL 
 !      (Fortran requires character data in a separate common block)
-       call mpirinitc(si, ssi, bt, ip, uw, ecsi, an, asn, we)
+       call mpirinitc(si, ssi, bt, ip, c_ba, uw, ecsi, an, asn, we)
        return
        end

--- a/src/binding/fortran/use_mpi_f08/mpi_f08_link_constants.f90
+++ b/src/binding/fortran/use_mpi_f08/mpi_f08_link_constants.f90
@@ -53,6 +53,14 @@ integer, dimension(1), target :: MPI_ERRCODES_IGNORE
 integer, dimension(1), target :: MPI_UNWEIGHTED
 integer, dimension(1), target :: MPI_WEIGHTS_EMPTY
 
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!
+!  MPI_BUFFER_AUTOMATIC
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+integer, dimension(1), target :: MPI_BUFFER_AUTOMATIC
+
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
 !  MPI_IN_PLACE
@@ -115,6 +123,13 @@ END FUNCTION
 
 FUNCTION MPIR_F08_get_MPI_WEIGHTS_EMPTY_c() &
     bind (C, name="MPIR_F08_get_MPI_WEIGHTS_EMPTY") result(p)
+    USE, intrinsic :: iso_c_binding, ONLY : c_ptr
+    IMPLICIT NONE
+    TYPE(c_ptr) :: p
+END FUNCTION
+
+FUNCTION MPIR_F08_get_MPI_BUFFER_AUTOMATIC_c() &
+    bind (C, name="MPIR_F08_get_MPI_BUFFER_AUTOMATIC") result(p)
     USE, intrinsic :: iso_c_binding, ONLY : c_ptr
     IMPLICIT NONE
     TYPE(c_ptr) :: p

--- a/src/binding/fortran/use_mpi_f08/wrappers_c/cdesc.h
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/cdesc.h
@@ -40,5 +40,6 @@ void *MPIR_F08_get_MPI_ARGVS_NULL(void);
 void *MPIR_F08_get_MPI_ERRCODES_IGNORE(void);
 void *MPIR_F08_get_MPI_UNWEIGHTED(void);
 void *MPIR_F08_get_MPI_WEIGHTS_EMPTY(void);
+void *MPIR_F08_get_MPI_BUFFER_AUTOMATIC(void);
 
 #endif /* CDESC_H_INCLUDED */

--- a/src/binding/fortran/use_mpi_f08/wrappers_c/utils.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/utils.c
@@ -140,3 +140,8 @@ void *MPIR_F08_get_MPI_WEIGHTS_EMPTY(void)
 {
     return (void *) MPI_WEIGHTS_EMPTY;
 }
+
+void *MPIR_F08_get_MPI_BUFFER_AUTOMATIC(void)
+{
+    return (void *) MPI_BUFFER_AUTOMATIC;
+}

--- a/src/binding/mpi_standard_api.txt
+++ b/src/binding/mpi_standard_api.txt
@@ -202,6 +202,7 @@ MPI_Buffer_attach:
 MPI_Buffer_detach:
     buffer_addr: C_BUFFER2, direction=out, [initial buffer address]
     size: POLYNUM_BYTES, direction=out, [buffer size, in bytes]
+MPI_Buffer_flush:
 MPI_COMM_DUP_FN:
     oldcomm: COMMUNICATOR
     comm_keyval: KEYVAL
@@ -364,6 +365,8 @@ MPI_Comm_errhandler_function:
 MPI_Comm_f2c:
     .return: COMMUNICATOR
     comm: F90_COMM, direction=in, pointer=False
+MPI_Comm_flush_buffer:
+    comm: COMMUNICATOR, [communicator]
 MPI_Comm_free:
     comm: COMMUNICATOR, direction=inout, [communicator to be destroyed]
 MPI_Comm_free_keyval:
@@ -1982,6 +1985,8 @@ MPI_Session_f2c:
     session: F90_SESSION, direction=in, pointer=False
 MPI_Session_finalize:
     session: SESSION, direction=inout, [session to be finalized]
+MPI_Session_flush_buffer:
+    session: SESSION, [session]
 MPI_Session_get_errhandler:
     session: SESSION, [session]
     errhandler: ERRHANDLER, direction=out, [error handler currently associated with session]

--- a/src/binding/mpi_standard_api.txt
+++ b/src/binding/mpi_standard_api.txt
@@ -283,6 +283,14 @@ MPI_Comm_accept:
     root: RANK, [rank in comm of root node]
     comm: COMMUNICATOR, [intra-communicator over which call is collective]
     newcomm: COMMUNICATOR, direction=out, [inter-communicator with client as remote group]
+MPI_Comm_attach_buffer:
+    comm: COMMUNICATOR, direction=in, pointer=False
+    buffer: BUFFER, asynchronous=True, suppress=f08_intent, [initial buffer address]
+    size: POLYNUM_BYTES_NNI, [buffer size, in bytes]
+MPI_Comm_detach_buffer:
+    comm: COMMUNICATOR, direction=in, pointer=False
+    buffer_addr: C_BUFFER2, direction=out, [initial buffer address]
+    size: POLYNUM_BYTES, direction=out, [buffer size, in bytes]
 MPI_Comm_c2f:
     .return: F90_COMM
     comm: COMMUNICATOR, direction=in, pointer=False
@@ -1947,6 +1955,14 @@ MPI_Sendrecv_replace:
     recvtag: TAG, [receive message tag or MPI_ANY_TAG]
     comm: COMMUNICATOR
     status: STATUS, direction=out
+MPI_Session_attach_buffer:
+    session: SESSION, [session]
+    buffer: BUFFER, asynchronous=True, suppress=f08_intent, [initial buffer address]
+    size: POLYNUM_BYTES_NNI, [buffer size, in bytes]
+MPI_Session_detach_buffer:
+    session: SESSION, [session]
+    buffer_addr: C_BUFFER2, direction=out, [initial buffer address]
+    size: POLYNUM_BYTES, direction=out, [buffer size, in bytes]
 MPI_Session_c2f:
     .return: F90_SESSION
     session: SESSION, direction=in, pointer=False

--- a/src/binding/mpi_standard_api.txt
+++ b/src/binding/mpi_standard_api.txt
@@ -203,6 +203,8 @@ MPI_Buffer_detach:
     buffer_addr: C_BUFFER2, direction=out, [initial buffer address]
     size: POLYNUM_BYTES, direction=out, [buffer size, in bytes]
 MPI_Buffer_flush:
+MPI_Buffer_iflush:
+    request: REQUEST, direction=out
 MPI_COMM_DUP_FN:
     oldcomm: COMMUNICATOR
     comm_keyval: KEYVAL
@@ -400,6 +402,9 @@ MPI_Comm_idup_with_info:
     info: INFO, [info object]
     newcomm: COMMUNICATOR, direction=out, asynchronous=True, [copy of comm]
     request: REQUEST, direction=out, [communication request]
+MPI_Comm_iflush_buffer:
+    comm: COMMUNICATOR, [communicator]
+    request: REQUEST, direction=out
 MPI_Comm_join:
     fd: FILE_DESCRIPTOR, suppress=lis_paren, [socket file descriptor]
     intercomm: COMMUNICATOR, direction=out, [new inter-communicator]
@@ -2007,6 +2012,9 @@ MPI_Session_get_pset_info:
     session: SESSION, [session]
     pset_name: STRING, constant=True, [name of process set]
     info: INFO, direction=OUT, [info object containing information about the given process set]
+MPI_Session_iflush_buffer:
+    session: SESSION, [session]
+    request: REQUEST, direction=out
 MPI_Session_init:
     info: INFO, [info object to specify thread support level and MPI implementation specific resources]
     errhandler: ERRHANDLER, [error handler to invoke in the event that an error is encountered during this function call]

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -506,6 +506,7 @@ extern int * const MPI_WEIGHTS_EMPTY MPICH_API_PUBLIC;
 
 #define MPI_BOTTOM      (void *)0
 #define MPI_IN_PLACE  (void *) -1
+#define MPI_BUFFER_AUTOMATIC (void *)0
 
 #define MPI_UNDEFINED      (-32766)
 

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -506,7 +506,7 @@ extern int * const MPI_WEIGHTS_EMPTY MPICH_API_PUBLIC;
 
 #define MPI_BOTTOM      (void *)0
 #define MPI_IN_PLACE  (void *) -1
-#define MPI_BUFFER_AUTOMATIC (void *)0
+#define MPI_BUFFER_AUTOMATIC (void *) -2
 
 #define MPI_UNDEFINED      (-32766)
 

--- a/src/include/mpir_bsend.h
+++ b/src/include/mpir_bsend.h
@@ -25,10 +25,8 @@
  *  BsendData_t - Describes a segment of the user buffer.  This data structure
  *                contains a BsendMsg_t for segments that contain a user
  *                message.  Each BsendData_t segment belongs to one of
- *                three lists: avail (unused and free), active (currently
- *                sending) and pending (contains a user message that has
- *                not begun sending because of some resource limit, such
- *                as no more MPID requests available).
+ *                two lists: avail (unused and free), and active (currently
+ *                sending).
  *  BsendBuffer - This global structure contains pointers to the user buffer
  *                and the three lists, along with the size of the user buffer.
  *

--- a/src/include/mpir_bsend.h
+++ b/src/include/mpir_bsend.h
@@ -67,6 +67,5 @@ typedef struct MPII_Bsend_data {
 int MPIR_Bsend_attach(void *, MPI_Aint);
 int MPIR_Bsend_detach(void *, MPI_Aint *);
 int MPIR_Bsend_isend(const void *, int, MPI_Datatype, int, int, MPIR_Comm *, MPIR_Request **);
-int MPIR_Bsend_free_req_seg(MPIR_Request *);
 
 #endif /* MPII_BSEND_H_INCLUDED */

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -200,6 +200,8 @@ struct MPIR_Comm {
                                          * communicators */
     struct MPII_Topo_ops *topo_fns;     /* Pointer to a table of functions
                                          * implementting the topology routines */
+    struct MPII_BsendBuffer *bsendbuffer;       /* for MPI_Comm_attach_buffer */
+
     int next_sched_tag;         /* used by the NBC schedule code to allocate tags */
 
     int revoked;                /* Flag to track whether the communicator

--- a/src/include/mpir_process.h
+++ b/src/include/mpir_process.h
@@ -52,6 +52,9 @@ typedef struct MPIR_Process_t {
     int tag_bits;               /* number of tag bits supported */
     char *memory_alloc_kinds;   /* memory kinds supported in the world model */
 
+    /* for MPI_Buffer_attach */
+    struct MPII_BsendBuffer *bsendbuffer;
+
     /* The topology routines dimsCreate is independent of any communicator.
      * If this pointer is null, the default routine is used */
     int (*dimsCreate) (int, int, int *);

--- a/src/include/mpir_session.h
+++ b/src/include/mpir_session.h
@@ -13,6 +13,7 @@ struct MPIR_Session {
     MPIR_OBJECT_HEADER;
     MPID_Thread_mutex_t mutex;
     MPIR_Errhandler *errhandler;
+    struct MPII_BsendBuffer *bsendbuffer;       /* for MPI_Session_attach_buffer */
     int thread_level;
     bool strict_finalize;
     char *memory_alloc_kinds;

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -279,6 +279,7 @@ int MPII_Comm_init(MPIR_Comm * comm_p)
     comm_p->remote_group = NULL;
     comm_p->local_group = NULL;
     comm_p->topo_fns = NULL;
+    comm_p->bsendbuffer = NULL;
     comm_p->name[0] = '\0';
     comm_p->seq = 0;    /* default to 0, to be updated at Comm_commit */
     comm_p->tainted = 0;
@@ -1178,6 +1179,9 @@ int MPIR_Comm_delete_internal(MPIR_Comm * comm_ptr)
         /* Notify the device that the communicator is about to be
          * destroyed */
         mpi_errno = MPID_Comm_free_hook(comm_ptr);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        mpi_errno = MPIR_Comm_bsend_finalize(comm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
 
         if (comm_ptr->session_ptr != NULL) {

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -110,8 +110,6 @@ also the value at index %d
 **bufexists:Buffer already attached with MPI_BUFFER_ATTACH.
 **bsendbufsmall:Buffer size is smaller than MPI_BSEND_OVERHEAD
 **bsendbufsmall %d %d:Buffer size of %d is smaller than MPI_BSEND_OVERHEAD (%d)
-**bsendpending:Internal error - completion of Bsend requests that were \
- deferred because of resource limits is not implemented
 **notgenreq:Attempt to complete a request with MPI_GREQUEST_COMPLETE that \
 was not started with MPI_GREQUEST_START
 **cancelinactive:Attempt to cancel an inactive persistent request

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -432,6 +432,9 @@ int MPII_Finalize(MPIR_Session * session_ptr)
     mpi_errno = MPIR_finalize_builtin_comms();
     MPIR_ERR_CHECK(mpi_errno);
 
+    mpi_errno = MPIR_Process_bsend_finalize();
+    MPIR_ERR_CHECK(mpi_errno);
+
     /* Signal the debugger that we are about to exit. */
     MPIR_Debugger_set_aborting(NULL);
 

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -110,20 +110,20 @@ static int MPIR_Bsend_detach(MPII_BsendBuffer ** bsendbuffer_p, void *bufferp, M
     goto fn_exit;
 }
 
-static int MPIR_Bsend_flush(MPII_BsendBuffer ** bsendbuffer_p)
+static int MPIR_Bsend_flush(MPII_BsendBuffer * bsendbuffer)
 {
     int mpi_errno = MPI_SUCCESS;
 
     MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_BSEND_MUTEX);
 
-    if (*bsendbuffer_p == NULL) {
+    if (bsendbuffer == NULL) {
         goto fn_exit;
     }
 
-    if ((*bsendbuffer_p)->is_automatic) {
-        mpi_errno = bsend_flush_auto(&((*bsendbuffer_p)->u.automatic));
+    if (bsendbuffer->is_automatic) {
+        mpi_errno = bsend_flush_auto(&(bsendbuffer->u.automatic));
     } else {
-        mpi_errno = bsend_flush_user(&((*bsendbuffer_p)->u.user));
+        mpi_errno = bsend_flush_user(&(bsendbuffer->u.user));
     }
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -814,6 +814,11 @@ int MPIR_Buffer_detach_impl(void *buffer_addr, MPI_Aint * size)
     return MPIR_Bsend_detach(&(MPIR_Process.bsendbuffer), buffer_addr, size);
 }
 
+int MPIR_Buffer_flush_impl(void)
+{
+    return MPIR_Bsend_flush(MPIR_Process.bsendbuffer);
+}
+
 int MPIR_Process_bsend_finalize(void)
 {
     return MPIR_Bsend_finalize(&(MPIR_Process.bsendbuffer));
@@ -829,6 +834,11 @@ int MPIR_Comm_detach_buffer_impl(MPIR_Comm * comm_ptr, void *buffer_addr, MPI_Ai
     return MPIR_Bsend_detach(&(comm_ptr->bsendbuffer), buffer_addr, size);
 }
 
+int MPIR_Comm_flush_buffer_impl(MPIR_Comm * comm_ptr)
+{
+    return MPIR_Bsend_flush(comm_ptr->bsendbuffer);
+}
+
 int MPIR_Comm_bsend_finalize(MPIR_Comm * comm_ptr)
 {
     return MPIR_Bsend_finalize(&(comm_ptr->bsendbuffer));
@@ -842,6 +852,11 @@ int MPIR_Session_attach_buffer_impl(MPIR_Session * session, void *buffer_addr, M
 int MPIR_Session_detach_buffer_impl(MPIR_Session * session, void *buffer_addr, MPI_Aint * size)
 {
     return MPIR_Bsend_detach(&(session->bsendbuffer), buffer_addr, size);
+}
+
+int MPIR_Session_flush_buffer_impl(MPIR_Session * session)
+{
+    return MPIR_Bsend_flush(session->bsendbuffer);
 }
 
 int MPIR_Session_bsend_finalize(MPIR_Session * session)

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -604,9 +604,29 @@ int MPIR_Process_bsend_finalize(void)
     return MPIR_Bsend_finalize(&(MPIR_Process.bsendbuffer));
 }
 
+int MPIR_Comm_attach_buffer_impl(MPIR_Comm * comm_ptr, void *buffer_addr, MPI_Aint size)
+{
+    return MPIR_Bsend_attach(&(comm_ptr->bsendbuffer), buffer_addr, size);
+}
+
+int MPIR_Comm_detach_buffer_impl(MPIR_Comm * comm_ptr, void *buffer_addr, MPI_Aint * size)
+{
+    return MPIR_Bsend_detach(&(comm_ptr->bsendbuffer), buffer_addr, size);
+}
+
 int MPIR_Comm_bsend_finalize(MPIR_Comm * comm_ptr)
 {
     return MPIR_Bsend_finalize(&(comm_ptr->bsendbuffer));
+}
+
+int MPIR_Session_attach_buffer_impl(MPIR_Session * session, void *buffer_addr, MPI_Aint size)
+{
+    return MPIR_Bsend_attach(&(session->bsendbuffer), buffer_addr, size);
+}
+
+int MPIR_Session_detach_buffer_impl(MPIR_Session * session, void *buffer_addr, MPI_Aint * size)
+{
+    return MPIR_Bsend_detach(&(session->bsendbuffer), buffer_addr, size);
 }
 
 int MPIR_Session_bsend_finalize(MPIR_Session * session)

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -322,35 +322,6 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
 }
 
 /*
- * The following routine looks up the segment used by request req
- * and frees it. The request is assumed to be completed. This routine
- * is called by only MPIR_Ibsend_cancel.
- */
-int MPIR_Bsend_free_req_seg(MPIR_Request * req)
-{
-    int mpi_errno = MPI_ERR_INTERN;
-    MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_BSEND_MUTEX);
-
-    MPII_Bsend_data_t *active = BsendBuffer.active;
-
-    MPL_DBG_MSG_P(MPIR_DBG_BSEND, TYPICAL, "Checking active starting at %p", active);
-    while (active) {
-
-        if (active->request == req) {
-            MPIR_Bsend_free_segment(active);
-            mpi_errno = MPI_SUCCESS;
-        }
-
-        active = active->next;;
-
-        MPL_DBG_MSG_P(MPIR_DBG_BSEND, TYPICAL, "Next active is %p", active);
-    }
-
-    MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_BSEND_MUTEX);
-    return mpi_errno;
-}
-
-/*
  * The following routines are used to manage the allocation of bsend segments
  * in the user buffer.  These routines handle, for example, merging segments
  * when an active segment that is adjacent to a free segment becomes free.

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -751,10 +751,7 @@ static int MPIR_Bsend_progress(struct MPII_BsendBuffer_user *user)
         MPIR_Request *req = active->request;
         if (MPIR_Request_is_complete(req)) {
             MPIR_Bsend_free_segment(user, active);
-            /* FIXME: how can req be persistent? Is this a left-over */
-            if (!MPIR_Request_is_persistent(req)) {
-                MPIR_Request_free(req);
-            }
+            MPIR_Request_free(req);
         }
         active = next_active;
     }

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -19,33 +19,28 @@
  *   MPIR_Bsend_isend  - Essentially performs an MPI_Ibsend.  Returns
  *                an MPIR_Request that is also stored internally in the
  *                corresponding MPII_Bsend_data_t entry
- *   MPIR_Bsend_free_segment - Free a buffer that is no longer needed,
- *                merging with adjacent segments
- *   MPIR_Bsend_check_active - Check for completion of any active sends
- *                for bsends (all bsends, both MPI_Ibsend and MPI_Bsend,
- *                are internally converted into Isends on the data
- *                in the Bsend buffer)
- *   MPIR_Bsend_find_buffer - Find a buffer in the bsend buffer large
- *                enough for the message.  However, does not acquire that
- *                buffer (see MPIR_Bsend_take_buffer)
- *   MPIR_Bsend_take_buffer - Find and acquire a buffer for a message
  *   MPIR_Bsend_finalize - Finalize bsendbuffer
- *   MPIR_Bsend_dump - Debugging routine to print the contents of the control
- *                information in the bsend buffer (the MPII_Bsend_data_t entries)
+ *
+ * Utilities for user buffer:
  */
-
-#ifdef MPL_USE_DBG_LOGGING
-static void MPIR_Bsend_dump(MPII_BsendBuffer * bsendbuffer);
-#endif
 
 #define BSENDDATA_HEADER_TRUE_SIZE (sizeof(MPII_Bsend_data_t) - sizeof(double))
 
 /* Forward references */
-static int MPIR_Bsend_check_active(MPII_BsendBuffer * bsendbuffer);
-static MPII_Bsend_data_t *MPIR_Bsend_find_buffer(MPII_BsendBuffer * bsendbuffer, size_t size);
-static void MPIR_Bsend_take_buffer(MPII_BsendBuffer * bsendbuffer,
-                                   MPII_Bsend_data_t * p, size_t size);
-static void MPIR_Bsend_free_segment(MPII_BsendBuffer * bsendbuffer, MPII_Bsend_data_t * p);
+static int bsend_attach_auto(struct MPII_BsendBuffer_auto *automatic,
+                             void *buffer, MPI_Aint buffer_size);
+static int bsend_detach_auto(struct MPII_BsendBuffer_auto *automatic,
+                             void *bufferp, MPI_Aint * size);
+static int bsend_isend_auto(struct MPII_BsendBuffer_auto *automatic, MPI_Aint packsize,
+                            const void *buf, int count, MPI_Datatype dtype, int dest, int tag,
+                            MPIR_Comm * comm_ptr, MPIR_Request ** request);
+
+static int bsend_attach_user(struct MPII_BsendBuffer_user *user,
+                             void *buffer, MPI_Aint buffer_size);
+static int bsend_detach_user(struct MPII_BsendBuffer_user *user, void *bufferp, MPI_Aint * size);
+static int bsend_isend_user(struct MPII_BsendBuffer_user *user, MPI_Aint packsize,
+                            const void *buf, int count, MPI_Datatype dtype,
+                            int dest, int tag, MPIR_Comm * comm_ptr, MPIR_Request ** request);
 
 /*
  * Attach a buffer.  This checks for the error conditions and then
@@ -53,72 +48,29 @@ static void MPIR_Bsend_free_segment(MPII_BsendBuffer * bsendbuffer, MPII_Bsend_d
  */
 static int MPIR_Bsend_attach(MPII_BsendBuffer ** bsendbuffer_p, void *buffer, MPI_Aint buffer_size)
 {
-    MPII_Bsend_data_t *p;
-    size_t offset, align_sz;
-    MPII_BsendBuffer *bsendbuffer;
-
-    if (*bsendbuffer_p == NULL) {
-        *bsendbuffer_p = MPL_calloc(1, sizeof(MPII_BsendBuffer), MPL_MEM_OTHER);
-        MPIR_Assert(*bsendbuffer_p);
-    }
-    bsendbuffer = *bsendbuffer_p;
-
-#ifdef HAVE_ERROR_CHECKING
-    {
-        MPID_BEGIN_ERROR_CHECKS;
-        {
-            if (bsendbuffer->buffer) {
-                return MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                            "MPIR_Bsend_attach", __LINE__, MPI_ERR_BUFFER,
-                                            "**bufexists", 0);
-            }
-            if (buffer_size < MPI_BSEND_OVERHEAD) {
-                /* MPI_ERR_OTHER is another valid choice for this error,
-                 * but the Intel test wants MPI_ERR_BUFFER, and it seems
-                 * to violate the principle of least surprise to not use
-                 * MPI_ERR_BUFFER for errors with the Buffer */
-                return MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                            "MPIR_Bsend_attach", __LINE__, MPI_ERR_BUFFER,
-                                            "**bsendbufsmall",
-                                            "**bsendbufsmall %d %d", buffer_size,
-                                            MPI_BSEND_OVERHEAD);
-            }
-        }
-        MPID_END_ERROR_CHECKS;
-    }
-#endif /* HAVE_ERROR_CHECKING */
+    int mpi_errno = MPI_SUCCESS;
 
     MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_BSEND_MUTEX);
 
-    bsendbuffer->origbuffer = buffer;
-    bsendbuffer->origbuffer_size = buffer_size;
-    bsendbuffer->buffer = buffer;
-    bsendbuffer->buffer_size = buffer_size;
+    MPIR_ERR_CHKANDJUMP((*bsendbuffer_p) != NULL, mpi_errno, MPI_ERR_OTHER, "**bufexists");
 
-    /* Make sure that the buffer that we use is aligned to align_sz.  Some other
-     * code assumes pointer-alignment, and some code assumes double alignment.
-     * Further, GCC 4.5.1 generates bad code on 32-bit platforms when this is
-     * only 4-byte aligned (see #1149). */
-    align_sz = MPL_MAX(sizeof(void *), sizeof(double));
-    offset = ((size_t) buffer) % align_sz;
-    if (offset) {
-        offset = align_sz - offset;
-        buffer = (char *) buffer + offset;
-        bsendbuffer->buffer = buffer;
-        bsendbuffer->buffer_size -= offset;
+    *bsendbuffer_p = MPL_calloc(1, sizeof(MPII_BsendBuffer), MPL_MEM_OTHER);
+    MPIR_ERR_CHKANDJUMP(!(*bsendbuffer_p), mpi_errno, MPI_ERR_OTHER, "**nomem");
+
+    if (0) {    /* MPI_BUFFER_AUTOMATIC */
+        (*bsendbuffer_p)->is_automatic = true;
+        mpi_errno = bsend_attach_auto(&((*bsendbuffer_p)->u.automatic), buffer, buffer_size);
+    } else {
+        (*bsendbuffer_p)->is_automatic = false;
+        mpi_errno = bsend_attach_user(&((*bsendbuffer_p)->u.user), buffer, buffer_size);
     }
-    bsendbuffer->avail = buffer;
-    bsendbuffer->active = 0;
+    MPIR_ERR_CHECK(mpi_errno);
 
-    /* Set the first block */
-    p = (MPII_Bsend_data_t *) buffer;
-    p->size = buffer_size - BSENDDATA_HEADER_TRUE_SIZE;
-    p->total_size = buffer_size;
-    p->next = p->prev = NULL;
-    p->msg.msgbuf = (char *) p + BSENDDATA_HEADER_TRUE_SIZE;
-
+  fn_exit:
     MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_BSEND_MUTEX);
-    return MPI_SUCCESS;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 /*
@@ -139,31 +91,15 @@ static int MPIR_Bsend_detach(MPII_BsendBuffer ** bsendbuffer_p, void *bufferp, M
         goto fn_exit;
     }
 
-    MPII_BsendBuffer *bsendbuffer;
-    bsendbuffer = *bsendbuffer_p;
-
-    if (bsendbuffer->active) {
-        /* Loop through each active element and wait on it */
-        MPII_Bsend_data_t *p = bsendbuffer->active;
-
-        while (p) {
-            MPIR_Request *r = p->request;
-            mpi_errno = MPID_Wait(r, MPI_STATUS_IGNORE);
-            MPIR_ERR_CHECK(mpi_errno);
-            MPIR_Request_free(r);
-            p = p->next;
-        }
+    if ((*bsendbuffer_p)->is_automatic) {
+        mpi_errno = bsend_detach_auto(&((*bsendbuffer_p)->u.automatic), bufferp, size);
+    } else {
+        mpi_errno = bsend_detach_user(&((*bsendbuffer_p)->u.user), bufferp, size);
     }
+    MPIR_ERR_CHECK(mpi_errno);
 
-    /* Note that this works even when the buffer does not exist */
-    *(void **) bufferp = bsendbuffer->origbuffer;
-    *size = (MPI_Aint) bsendbuffer->origbuffer_size;
-    bsendbuffer->origbuffer = NULL;
-    bsendbuffer->origbuffer_size = 0;
-    bsendbuffer->buffer = 0;
-    bsendbuffer->buffer_size = 0;
-    bsendbuffer->avail = 0;
-    bsendbuffer->active = 0;
+    MPL_free(*bsendbuffer_p);
+    *bsendbuffer_p = NULL;
 
   fn_exit:
     MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_BSEND_MUTEX);
@@ -179,9 +115,6 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
                      int dest, int tag, MPIR_Comm * comm_ptr, MPIR_Request ** request)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPII_Bsend_data_t *p = NULL;
-    MPII_Bsend_msg_t *msg;
-    int pass;
 
     MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_BSEND_MUTEX);
 
@@ -202,6 +135,175 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
     MPIR_ERR_CHKANDJUMP2(!bsendbuffer, mpi_errno, MPI_ERR_BUFFER, "**bufbsend",
                          "**bufbsend %d %d", packsize, 0);
 
+    if (bsendbuffer->is_automatic) {
+        mpi_errno = bsend_isend_auto(&(bsendbuffer->u.automatic), packsize,
+                                     buf, count, dtype, dest, tag, comm_ptr, request);
+    } else {
+        mpi_errno = bsend_isend_user(&(bsendbuffer->u.user), packsize,
+                                     buf, count, dtype, dest, tag, comm_ptr, request);
+    }
+
+  fn_exit:
+    MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_BSEND_MUTEX);
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIR_Bsend_finalize(MPII_BsendBuffer ** bsendbuffer_p)
+{
+    if (*bsendbuffer_p) {
+        /* No lock since this is inside MPI_Finalize */
+        void *b;
+        MPI_Aint s;
+
+        /* Use detach to complete any communication */
+        MPIR_Bsend_detach(bsendbuffer_p, &b, &s);
+    }
+
+    return MPI_SUCCESS;
+}
+
+/* -- routines for automatic buffer -- */
+
+static int bsend_attach_auto(struct MPII_BsendBuffer_auto *automatic,
+                             void *buffer, MPI_Aint buffer_size)
+{
+    return MPI_SUCCESS;
+}
+
+static int bsend_detach_auto(struct MPII_BsendBuffer_auto *automatic,
+                             void *bufferp, MPI_Aint * size)
+{
+    return MPI_SUCCESS;
+}
+
+static int bsend_isend_auto(struct MPII_BsendBuffer_auto *automatic, MPI_Aint packsize,
+                            const void *buf, int count, MPI_Datatype dtype,
+                            int dest, int tag, MPIR_Comm * comm_ptr, MPIR_Request ** request)
+{
+    return MPI_SUCCESS;
+}
+
+/* -- routines for user supplied buffer -- */
+/*
+ *   MPIR_Bsend_free_segment - Free a buffer that is no longer needed,
+ *                merging with adjacent segments
+ *   MPIR_Bsend_check_active - Check for completion of any active sends
+ *                for bsends (all bsends, both MPI_Ibsend and MPI_Bsend,
+ *                are internally converted into Isends on the data
+ *                in the Bsend buffer)
+ *   MPIR_Bsend_find_buffer - Find a buffer in the bsend buffer large
+ *                enough for the message.  However, does not acquire that
+ *                buffer (see mPIR_Bsend_take_buffer)
+ *   MPIR_Bsend_take_buffer - Find and acquire a buffer for a message
+ *   MPIR_Bsend_dump - Debugging routine to print the contents of the control
+ *                information in the bsend buffer (the MPII_Bsend_data_t entries)
+ */
+static int MPIR_Bsend_check_active(struct MPII_BsendBuffer_user *user);
+static MPII_Bsend_data_t *MPIR_Bsend_find_buffer(struct MPII_BsendBuffer_user *user, size_t size);
+static void MPIR_Bsend_take_buffer(struct MPII_BsendBuffer_user *user,
+                                   MPII_Bsend_data_t * p, size_t size);
+static void MPIR_Bsend_free_segment(struct MPII_BsendBuffer_user *user, MPII_Bsend_data_t * p);
+#ifdef MPL_USE_DBG_LOGGING
+static void MPIR_Bsend_dump(struct MPII_BsendBuffer_user *user);
+#endif
+
+static int bsend_attach_user(struct MPII_BsendBuffer_user *user, void *buffer, MPI_Aint buffer_size)
+{
+#ifdef HAVE_ERROR_CHECKING
+    {
+        MPID_BEGIN_ERROR_CHECKS;
+        {
+            if (buffer_size < MPI_BSEND_OVERHEAD) {
+                /* MPI_ERR_OTHER is another valid choice for this error,
+                 * but the Intel test wants MPI_ERR_BUFFER, and it seems
+                 * to violate the principle of least surprise to not use
+                 * MPI_ERR_BUFFER for errors with the Buffer */
+                return MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                            "MPIR_Bsend_attach", __LINE__, MPI_ERR_BUFFER,
+                                            "**bsendbufsmall",
+                                            "**bsendbufsmall %d %d", buffer_size,
+                                            MPI_BSEND_OVERHEAD);
+            }
+        }
+        MPID_END_ERROR_CHECKS;
+    }
+#endif /* HAVE_ERROR_CHECKING */
+
+
+    user->origbuffer = buffer;
+    user->origbuffer_size = buffer_size;
+    user->buffer = buffer;
+    user->buffer_size = buffer_size;
+
+    /* Make sure that the buffer that we use is aligned to align_sz.  Some other
+     * code assumes pointer-alignment, and some code assumes double alignment.
+     * Further, GCC 4.5.1 generates bad code on 32-bit platforms when this is
+     * only 4-byte aligned (see #1149). */
+    size_t offset, align_sz;
+    align_sz = MPL_MAX(sizeof(void *), sizeof(double));
+    offset = ((size_t) buffer) % align_sz;
+    if (offset) {
+        offset = align_sz - offset;
+        buffer = (char *) buffer + offset;
+        user->buffer = buffer;
+        user->buffer_size -= offset;
+    }
+    user->avail = buffer;
+    user->active = 0;
+
+    /* Set the first block */
+    MPII_Bsend_data_t *p;
+    p = (MPII_Bsend_data_t *) buffer;
+    p->size = buffer_size - BSENDDATA_HEADER_TRUE_SIZE;
+    p->total_size = buffer_size;
+    p->next = p->prev = NULL;
+    p->msg.msgbuf = (char *) p + BSENDDATA_HEADER_TRUE_SIZE;
+
+    return MPI_SUCCESS;
+}
+
+static int bsend_detach_user(struct MPII_BsendBuffer_user *user, void *bufferp, MPI_Aint * size)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    if (user->active) {
+        /* Loop through each active element and wait on it */
+        MPII_Bsend_data_t *p = user->active;
+
+        while (p) {
+            MPIR_Request *r = p->request;
+            mpi_errno = MPID_Wait(r, MPI_STATUS_IGNORE);
+            MPIR_ERR_CHECK(mpi_errno);
+            MPIR_Request_free(r);
+            p = p->next;
+        }
+    }
+
+    /* Note that this works even when the buffer does not exist */
+    *(void **) bufferp = user->origbuffer;
+    *size = (MPI_Aint) user->origbuffer_size;
+
+    user->origbuffer = NULL;
+    user->origbuffer_size = 0;
+    user->buffer = 0;
+    user->buffer_size = 0;
+    user->avail = 0;
+    user->active = 0;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int bsend_isend_user(struct MPII_BsendBuffer_user *user, MPI_Aint packsize,
+                            const void *buf, int count, MPI_Datatype dtype,
+                            int dest, int tag, MPIR_Comm * comm_ptr, MPIR_Request ** request)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPII_Bsend_data_t *p = NULL;
     /*
      * We may want to decide here whether we need to pack at all
      * or if we can just use (a MPIR_Memcpy) of the buffer.
@@ -210,7 +312,7 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
 
     /* We check the active buffer first.  This helps avoid storage
      * fragmentation */
-    mpi_errno = MPIR_Bsend_check_active(bsendbuffer);
+    mpi_errno = MPIR_Bsend_check_active(user);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPL_DBG_MSG_D(MPIR_DBG_BSEND, TYPICAL, "looking for buffer of size " MPI_AINT_FMT_DEC_SPEC,
@@ -221,15 +323,14 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
      *  If the message can be initiated in the first pass,
      * do not perform the second pass.
      */
-    for (pass = 0; pass < 2; pass++) {
-
-        p = MPIR_Bsend_find_buffer(bsendbuffer, packsize);
+    for (int pass = 0; pass < 2; pass++) {
+        p = MPIR_Bsend_find_buffer(user, packsize);
         if (p) {
             MPL_DBG_MSG_FMT(MPIR_DBG_BSEND, TYPICAL, (MPL_DBG_FDEST,
                                                       "found buffer of size " MPI_AINT_FMT_DEC_SPEC
                                                       " with address %p", packsize, p));
             /* Found a segment */
-
+            MPII_Bsend_msg_t *msg;
             msg = &p->msg;
 
             /* Pack the data into the buffer */
@@ -262,7 +363,7 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
                  * data has already been sent.  The original code
                  * to do this was commented out and probably did not match
                  * the current request internals */
-                MPIR_Bsend_take_buffer(bsendbuffer, p, p->msg.count);
+                MPIR_Bsend_take_buffer(user, p, p->msg.count);
                 if (request) {
                     /* Add 1 ref_count for MPI_Wait/Test */
                     MPIR_Request_add_ref(p->request);
@@ -278,7 +379,7 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
             break;
         MPL_DBG_MSG(MPIR_DBG_BSEND, TYPICAL, "Could not find storage, checking active");
         /* Try to complete some pending bsends */
-        MPIR_Bsend_check_active(bsendbuffer);
+        MPIR_Bsend_check_active(user);
     }
 
     if (!p) {
@@ -286,13 +387,12 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
         /* Generate a traceback of the allocated space, explaining why
          * packsize could not be found */
         MPL_DBG_MSG(MPIR_DBG_BSEND, TYPICAL, "Could not find space; dumping arena");
-        MPL_DBG_STMT(MPIR_DBG_BSEND, TYPICAL, MPIR_Bsend_dump(bsendbuffer));
+        MPL_DBG_STMT(MPIR_DBG_BSEND, TYPICAL, MPIR_Bsend_dump(user));
         MPIR_ERR_SETANDJUMP2(mpi_errno, MPI_ERR_BUFFER, "**bufbsend", "**bufbsend %d %d", packsize,
-                             bsendbuffer->buffer_size);
+                             user->buffer_size);
     }
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_BSEND_MUTEX);
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -308,9 +408,9 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
 /* Add block p to the free list. Merge into adjacent blocks.  Used only
    within the check_active */
 
-static void MPIR_Bsend_free_segment(MPII_BsendBuffer * bsendbuffer, MPII_Bsend_data_t * p)
+static void MPIR_Bsend_free_segment(struct MPII_BsendBuffer_user *user, MPII_Bsend_data_t * p)
 {
-    MPII_Bsend_data_t *prev = p->prev, *avail = bsendbuffer->avail, *avail_prev;
+    MPII_Bsend_data_t *prev = p->prev, *avail = user->avail, *avail_prev;
 
     MPL_DBG_MSG_FMT(MPIR_DBG_BSEND, TYPICAL, (MPL_DBG_FDEST,
                                               "Freeing bsend segment at %p of size %llu, next at %p",
@@ -320,7 +420,7 @@ static void MPIR_Bsend_free_segment(MPII_BsendBuffer * bsendbuffer, MPII_Bsend_d
     MPL_DBG_MSG_D(MPIR_DBG_BSEND, TYPICAL,
                   "At the beginning of free_segment with size %llu:",
                   (unsigned long long) p->total_size);
-    MPL_DBG_STMT(MPIR_DBG_BSEND, TYPICAL, MPIR_Bsend_dump(bsendbuffer));
+    MPL_DBG_STMT(MPIR_DBG_BSEND, TYPICAL, MPIR_Bsend_dump(user));
 
     /* Remove the segment from the active list */
     if (prev) {
@@ -329,14 +429,14 @@ static void MPIR_Bsend_free_segment(MPII_BsendBuffer * bsendbuffer, MPII_Bsend_d
     } else {
         /* p was at the head of the active list */
         MPL_DBG_MSG(MPIR_DBG_BSEND, TYPICAL, "free segment is head of active list");
-        bsendbuffer->active = p->next;
+        user->active = p->next;
         /* The next test sets the prev pointer to null */
     }
     if (p->next) {
         p->next->prev = prev;
     }
 
-    MPL_DBG_STMT(MPIR_DBG_BSEND, VERBOSE, MPIR_Bsend_dump(bsendbuffer));
+    MPL_DBG_STMT(MPIR_DBG_BSEND, VERBOSE, MPIR_Bsend_dump(user));
 
     /* Merge into the avail list */
     /* Find avail_prev, avail, such that p is between them.
@@ -380,12 +480,12 @@ static void MPIR_Bsend_free_segment(MPII_BsendBuffer * bsendbuffer, MPII_Bsend_d
         }
     } else {
         /* p is the new head of the list */
-        bsendbuffer->avail = p;
+        user->avail = p;
         p->prev = 0;
     }
 
     MPL_DBG_MSG(MPIR_DBG_BSEND, TYPICAL, "At the end of free_segment:");
-    MPL_DBG_STMT(MPIR_DBG_BSEND, TYPICAL, MPIR_Bsend_dump(bsendbuffer));
+    MPL_DBG_STMT(MPIR_DBG_BSEND, TYPICAL, MPIR_Bsend_dump(user));
 }
 
 /*
@@ -399,16 +499,16 @@ static void MPIR_Bsend_free_segment(MPII_BsendBuffer * bsendbuffer, MPII_Bsend_d
 
 /* TODO: make it as a progress_hook. The critical section need be made more granular.
  * Or, does it matter? */
-static int MPIR_Bsend_progress(MPII_BsendBuffer * bsendbuffer)
+static int MPIR_Bsend_progress(struct MPII_BsendBuffer_user *user)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPII_Bsend_data_t *active = bsendbuffer->active;
+    MPII_Bsend_data_t *active = user->active;
     while (active) {
         MPII_Bsend_data_t *next_active = active->next;
         MPIR_Request *req = active->request;
         if (MPIR_Request_is_complete(req)) {
-            MPIR_Bsend_free_segment(bsendbuffer, active);
+            MPIR_Bsend_free_segment(user, active);
             if (!MPIR_Request_is_persistent(req)) {
                 MPIR_Request_free(req);
             }
@@ -419,14 +519,14 @@ static int MPIR_Bsend_progress(MPII_BsendBuffer * bsendbuffer)
     return mpi_errno;
 }
 
-static int MPIR_Bsend_check_active(MPII_BsendBuffer * bsendbuffer)
+static int MPIR_Bsend_check_active(struct MPII_BsendBuffer_user *user)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    if (bsendbuffer->active) {
+    if (user->active) {
         mpi_errno = MPID_Progress_test(NULL);
         MPIR_ERR_CHECK(mpi_errno);
-        MPIR_Bsend_progress(bsendbuffer);
+        MPIR_Bsend_progress(user);
     }
 
   fn_exit:
@@ -439,9 +539,9 @@ static int MPIR_Bsend_check_active(MPII_BsendBuffer * bsendbuffer)
  * Find a slot in the avail buffer that can hold size bytes.  Does *not*
  * remove the slot from the avail buffer (see MPIR_Bsend_take_buffer)
  */
-static MPII_Bsend_data_t *MPIR_Bsend_find_buffer(MPII_BsendBuffer * bsendbuffer, size_t size)
+static MPII_Bsend_data_t *MPIR_Bsend_find_buffer(struct MPII_BsendBuffer_user *user, size_t size)
 {
-    MPII_Bsend_data_t *p = bsendbuffer->avail;
+    MPII_Bsend_data_t *p = user->avail;
 
     while (p) {
         if (p->size >= size) {
@@ -461,7 +561,7 @@ static MPII_Bsend_data_t *MPIR_Bsend_find_buffer(MPII_BsendBuffer * bsendbuffer,
  * If there isn't enough left of p, remove the entire segment from
  * the avail list.
  */
-static void MPIR_Bsend_take_buffer(MPII_BsendBuffer * bsendbuffer,
+static void MPIR_Bsend_take_buffer(struct MPII_BsendBuffer_user *user,
                                    MPII_Bsend_data_t * p, size_t size)
 {
     MPII_Bsend_data_t *prev;
@@ -514,53 +614,35 @@ static void MPIR_Bsend_take_buffer(MPII_BsendBuffer * bsendbuffer,
     if (prev) {
         prev->next = p->next;
     } else {
-        bsendbuffer->avail = p->next;
+        user->avail = p->next;
     }
 
     if (p->next) {
         p->next->prev = p->prev;
     }
 
-    if (bsendbuffer->active) {
-        bsendbuffer->active->prev = p;
+    if (user->active) {
+        user->active->prev = p;
     }
-    p->next = bsendbuffer->active;
+    p->next = user->active;
     p->prev = 0;
-    bsendbuffer->active = p;
+    user->active = p;
 
     MPL_DBG_MSG_P(MPIR_DBG_BSEND, VERBOSE, "segment %p now head of active", p);
     MPL_DBG_MSG(MPIR_DBG_BSEND, TYPICAL, "At end of take buffer");
-    MPL_DBG_STMT(MPIR_DBG_BSEND, TYPICAL, MPIR_Bsend_dump(bsendbuffer));
-}
-
-static int MPIR_Bsend_finalize(MPII_BsendBuffer ** bsendbuffer_p)
-{
-    if (*bsendbuffer_p) {
-        /* No lock since this is inside MPI_Finalize */
-        void *b;
-        MPI_Aint s;
-
-        if ((*bsendbuffer_p)->buffer) {
-            /* Use detach to complete any communication */
-            MPIR_Bsend_detach(bsendbuffer_p, &b, &s);
-        }
-        MPL_free(*bsendbuffer_p);
-        *bsendbuffer_p = NULL;
-    }
-
-    return MPI_SUCCESS;
+    MPL_DBG_STMT(MPIR_DBG_BSEND, TYPICAL, MPIR_Bsend_dump(user));
 }
 
 /*
  * These routines are defined only if debug logging is enabled
  */
 #ifdef MPL_USE_DBG_LOGGING
-static void MPIR_Bsend_dump(MPII_BsendBuffer * bsendbuffer)
+static void MPIR_Bsend_dump(struct MPII_BsendBuffer_user *user)
 {
-    MPII_Bsend_data_t *a = bsendbuffer->avail;
+    MPII_Bsend_data_t *a = user->avail;
 
     MPL_DBG_MSG_D(MPIR_DBG_BSEND, TYPICAL, "Total size is %llu",
-                  (unsigned long long) bsendbuffer->buffer_size);
+                  (unsigned long long) user->buffer_size);
     MPL_DBG_MSG(MPIR_DBG_BSEND, TYPICAL, "Avail list is:");
     while (a) {
         MPL_DBG_MSG_FMT(MPIR_DBG_BSEND, TYPICAL, (MPL_DBG_FDEST, "[%p] totalsize = %llu(%llx)",
@@ -574,7 +656,7 @@ static void MPIR_Bsend_dump(MPII_BsendBuffer * bsendbuffer)
     }
 
     MPL_DBG_MSG(MPIR_DBG_BSEND, TYPICAL, "Active list is:");
-    a = bsendbuffer->active;
+    a = user->active;
     while (a) {
         MPL_DBG_MSG_FMT(MPIR_DBG_BSEND, TYPICAL, (MPL_DBG_FDEST, "[%p] totalsize = %llu(%llx)",
                                                   a, (unsigned long long) a->total_size,
@@ -588,6 +670,8 @@ static void MPIR_Bsend_dump(MPII_BsendBuffer * bsendbuffer)
     MPL_DBG_MSG(MPIR_DBG_BSEND, TYPICAL, "end of list");
 }
 #endif
+
+/* -- Exposed wrapper functions -- */
 
 int MPIR_Buffer_attach_impl(void *buffer, MPI_Aint size)
 {

--- a/test/mpi/f77/pt2pt/Makefile.am
+++ b/test/mpi/f77/pt2pt/Makefile.am
@@ -22,6 +22,7 @@ noinst_PROGRAMS = sendf \
                   sendrecvf \
                   sendrecvreplf \
                   statusesf greqf \
+		  bsendf \
                   mprobef
 
 sendf_SOURCES = sendf.f utilsf.f
@@ -36,6 +37,7 @@ pssendf_SOURCES = pssendf.f utilsf.f
 sendrecvf_SOURCES = sendrecvf.f utilsf.f
 sendrecvreplf_SOURCES = sendrecvreplf.f utilsf.f
 greqf_SOURCES = greqf.f dummyf.f
+bsendf_SOURCES = bsendf.f
 
 ## attr1aints.h will be distributed because it's listed in AC_CONFIG_FILES/AC_OUTPUT
 

--- a/test/mpi/f77/pt2pt/bsendf.f
+++ b/test/mpi/f77/pt2pt/bsendf.f
@@ -1,0 +1,58 @@
+C
+C Copyright (C) by Argonne National Laboratory
+C     See COPYRIGHT in top-level directory
+C
+
+C Basic test for MPI_Bsend
+C     We test a basic buffered send of 10 INTEGERs and assume a buffer
+C     of 400 CHARACTERs are sufficient to account for MPI_BSEND_OVERHEAD
+
+      program bsend
+      implicit none
+      include 'mpif.h'
+      integer ierr, errs, comm
+      character dummy_buf(400)
+      INTEGER dummy_size
+C
+      errs = 0
+      comm = MPI_COMM_WORLD;
+      call MTest_Init( ierr )
+      call mpi_buffer_attach(dummy_buf, 400, ierr )
+      call test_bsend( comm, errs )
+      call mpi_buffer_detach(dummy_buf, dummy_size, ierr )
+      call MTest_Finalize( errs )
+      end
+C
+      subroutine test_bsend( comm, errs )
+      implicit none
+      include 'mpif.h'
+      integer comm, errs
+      integer rank, size, ierr, tag
+      integer i
+      integer N
+      parameter (N=10)
+      integer buf(N)
+
+      tag = 1123
+      call mpi_comm_rank( comm, rank, ierr )
+      call mpi_comm_size( comm, size, ierr )
+C
+      if (rank .eq. 0) then
+         do i = 1, N
+            buf(i) = i
+         end do
+         call MPI_Bsend(buf, N, MPI_REAL, 1, tag, comm, ierr)
+      else if (rank .eq. 1)  then
+         do i = 1, N
+            buf(i) = 0.0
+         end do
+         call MPI_Recv(buf, N, MPI_REAL, 0, tag, comm,
+     .                 MPI_STATUS_IGNORE, ierr)
+         do i = 1, N
+            if (buf(i) .ne. i) then
+                errs = errs + 1
+            end if
+         end do
+      end if
+C
+      end

--- a/test/mpi/f77/pt2pt/testlist
+++ b/test/mpi/f77/pt2pt/testlist
@@ -12,3 +12,4 @@ pssendf 2
 sendrecvf 2
 sendrecvreplf 2
 mprobef 2
+bsendf 2

--- a/test/mpi/session/Makefile.am
+++ b/test/mpi/session/Makefile.am
@@ -15,7 +15,8 @@ noinst_PROGRAMS = \
     session_mult_init \
     session_re_init \
     session_psets \
-    session_self
+    session_self \
+    session_bsend
 
 session_mult_init_SOURCES = session.c
 session_mult_init_CPPFLAGS = -DMULT_INIT $(AM_CPPFLAGS)

--- a/test/mpi/session/session_bsend.c
+++ b/test/mpi/session/session_bsend.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include <assert.h>
+#include "mpitest.h"
+
+int errs = 0;
+
+static int test_bsend(MPI_Comm comm);
+
+int main(int argc, char *argv[])
+{
+    MPI_Session session;
+    MPI_Group group;
+    MPI_Comm comm;
+
+    MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL, &session);
+
+    MPI_Group_from_session_pset(session, "mpi://world", &group);
+    MPI_Comm_create_from_group(group, "session_bsend", MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL, &comm);
+
+#define BUFSIZE 1024    /* assume it is sufficient to cover MPI_BSEND_OVERHEAD */
+    char buffer[BUFSIZE];
+    char *dummy_buf;
+    int dummy_size;
+
+    MPI_Buffer_attach(buffer, BUFSIZE);
+    errs += test_bsend(comm);
+    MPI_Buffer_detach(&dummy_buf, &dummy_size);
+    if (dummy_buf != buffer)
+        printf("MPI_Buffer_detach: dummy_buf = %p, expect %p\n", dummy_buf, buffer);
+    if (dummy_size != BUFSIZE)
+        printf("MPI_Buffer_detach: dummy_size = %d, expect %d\n", dummy_size, BUFSIZE);
+
+#if MTEST_HAVE_MIN_MPI_VERSION(4,1)
+    MPI_Session_attach_buffer(session, buffer, BUFSIZE);
+    errs += test_bsend(comm);
+    MPI_Session_detach_buffer(session, &dummy_buf, &dummy_size);
+    if (dummy_buf != buffer)
+        printf("MPI_Session_detach_buffer: dummy_buf = %p, expect %p\n", dummy_buf, buffer);
+    if (dummy_size != BUFSIZE)
+        printf("MPI_Session_detach_buffer: dummy_size = %d, expect %d\n", dummy_size, BUFSIZE);
+
+    MPI_Comm_attach_buffer(comm, buffer, BUFSIZE);
+    errs += test_bsend(comm);
+    MPI_Comm_detach_buffer(comm, &dummy_buf, &dummy_size);
+    if (dummy_buf != buffer)
+        printf("MPI_Comm_detach_buffer: dummy_buf = %p, expect %p\n", dummy_buf, buffer);
+    if (dummy_size != BUFSIZE)
+        printf("MPI_Comm_detach_buffer: dummy_size = %d, expect %d\n", dummy_size, BUFSIZE);
+
+    /* automatic buffer */
+
+    MPI_Buffer_attach(MPI_BUFFER_AUTOMATIC, 0);
+    errs += test_bsend(comm);
+    MPI_Buffer_detach(&dummy_buf, &dummy_size);
+    if (dummy_buf != MPI_BUFFER_AUTOMATIC)
+        printf("MPI_Buffer_detach: dummy_buf = %p, expect %p\n", dummy_buf, MPI_BUFFER_AUTOMATIC);
+    if (dummy_size != 0)
+        printf("MPI_Buffer_detach: dummy_size = %d, expect %d\n", dummy_size, 0);
+
+    MPI_Session_attach_buffer(session, MPI_BUFFER_AUTOMATIC, 0);
+    errs += test_bsend(comm);
+    MPI_Session_detach_buffer(session, &dummy_buf, &dummy_size);
+    if (dummy_buf != MPI_BUFFER_AUTOMATIC)
+        printf("MPI_Session_detach_buffer: dummy_buf = %p, expect %p\n", dummy_buf,
+               MPI_BUFFER_AUTOMATIC);
+    if (dummy_size != 0)
+        printf("MPI_Session_detach_buffer: dummy_size = %d, expect %d\n", dummy_size, 0);
+
+    MPI_Comm_attach_buffer(comm, MPI_BUFFER_AUTOMATIC, 0);
+    errs += test_bsend(comm);
+    MPI_Comm_detach_buffer(comm, &dummy_buf, &dummy_size);
+    if (dummy_buf != MPI_BUFFER_AUTOMATIC)
+        printf("MPI_Comm_detach_buffer: dummy_buf = %p, expect %p\n", dummy_buf,
+               MPI_BUFFER_AUTOMATIC);
+    if (dummy_size != 0)
+        printf("MPI_Comm_detach_buffer: dummy_size = %d, expect %d\n", dummy_size, 0);
+
+    /* large count variations */
+
+    MPI_Count dummy_size_c;
+    MPI_Buffer_attach_c(MPI_BUFFER_AUTOMATIC, 0);
+    errs += test_bsend(comm);
+    MPI_Buffer_detach_c(&dummy_buf, &dummy_size_c);
+    if (dummy_buf != MPI_BUFFER_AUTOMATIC)
+        printf("MPI_Buffer_detach_c: dummy_buf = %p, expect %p\n", dummy_buf, MPI_BUFFER_AUTOMATIC);
+    if (dummy_size != 0)
+        printf("MPI_Buffer_detach_c: dummy_size = %d, expect %d\n", (int) dummy_size, 0);
+
+    MPI_Session_attach_buffer_c(session, MPI_BUFFER_AUTOMATIC, 0);
+    errs += test_bsend(comm);
+    MPI_Session_detach_buffer_c(session, &dummy_buf, &dummy_size_c);
+    if (dummy_buf != MPI_BUFFER_AUTOMATIC)
+        printf("MPI_Session_detach_buffer_c: dummy_buf = %p, expect %p\n", dummy_buf,
+               MPI_BUFFER_AUTOMATIC);
+    if (dummy_size != 0)
+        printf("MPI_Session_detach_buffer_c: dummy_size = %d, expect %d\n", (int) dummy_size, 0);
+
+    MPI_Comm_attach_buffer_c(comm, MPI_BUFFER_AUTOMATIC, 0);
+    errs += test_bsend(comm);
+    MPI_Comm_detach_buffer_c(comm, &dummy_buf, &dummy_size_c);
+    if (dummy_buf != MPI_BUFFER_AUTOMATIC)
+        printf("MPI_Comm_detach_buffer_c: dummy_buf = %p, expect %p\n", dummy_buf,
+               MPI_BUFFER_AUTOMATIC);
+    if (dummy_size != 0)
+        printf("MPI_Comm_detach_buffer_c: dummy_size = %d, expect %d\n", (int) dummy_size, 0);
+#endif
+
+    int rank;
+    MPI_Comm_rank(comm, &rank);
+    if (rank == 0 && errs == 0) {
+        printf("No Errors\n");
+    }
+    MPI_Comm_free(&comm);
+    MPI_Group_free(&group);
+    MPI_Session_finalize(&session);
+    return MTestReturnValue(errs);
+}
+
+static int test_bsend(MPI_Comm comm)
+{
+    int rank, size;
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &size);
+
+    int src = 0;
+    int dst = size > 1 ? size - 1 : 0;
+    int tag = 1234;
+
+    int err = 0;
+#define N 10
+    int buf[N];
+    if (rank == src) {
+        for (int i = 0; i < N; i++) {
+            buf[i] = i;
+        }
+        MPI_Bsend(buf, N, MPI_INT, dst, tag, comm);
+
+        /* get err from dst */
+        int err;
+        MPI_Recv(&err, 1, MPI_INT, dst, tag, comm, MPI_STATUS_IGNORE);
+    }
+    if (rank == dst) {
+        for (int i = 0; i < N; i++) {
+            buf[i] = -1;
+        }
+        MPI_Recv(buf, N, MPI_INT, src, tag, comm, MPI_STATUS_IGNORE);
+
+        /* check err */
+        for (int i = 0; i < N; i++) {
+            if (buf[i] != i) {
+                err++;
+            }
+        }
+        MPI_Send(&err, 1, MPI_INT, src, tag, comm);
+    }
+    return err;
+}

--- a/test/mpi/session/testlist
+++ b/test/mpi/session/testlist
@@ -4,3 +4,4 @@ session_mult_init 4 arg=5
 session_re_init 4
 session_psets 1
 session_self 1
+session_bsend 2


### PR DESCRIPTION
## Pull Request Description
> B.1.2 Changes in MPI-4.1
1. Section 3.6 on page 55.
Automatic (unlimited) buffering is added, which can be enabled by using
MPI_BUFFER_AUTOMATIC in any of the buffer attach procedures. New procedures
MPI_COMM_ATTACH_BUFFER, MPI_SESSION_ATTACH_BUFFER,
MPI_COMM_DETACH_BUFFER and MPI_SESSION_DETACH_BUFFER to attach and
detach a buffer to a communicator or session, respectively, to be used for buffered
sends on that communicator or on communicators derived from groups derived from
process sets from that session. The buffers attached with the existing functions
MPI_BUFFER_ATTACH and MPI_BUFFER_DETACH now only apply to communi-
cators that have no buffer attached at the communicator or session level. New pro-
cedures MPI_COMM_FLUSH_BUFFER, MPI_SESSION_FLUSH_BUFFER, and
MPI_BUFFER_FLUSH were added as a combination of detach and attach



Fixes #6705
Fixes #6706

[skip warnings]
## TODO
* [x] Add tests
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
