### PR TITLE
pmi: Unify code for connecting to process manager

### DIFF
--- a/src/pmi/src/pmi_util.h
+++ b/src/pmi/src/pmi_util.h
@@ -58,6 +58,7 @@ int PMIU_parse_keyvals(char *st);
 void PMIU_dump_keyvals(void);
 char *PMIU_getval(const char *keystr, char *valstr, int vallen);
 void PMIU_chgval(const char *keystr, char *valstr);
+int PMIU_get_pmi_fd(int *pmi_fd, bool * do_handshake);
 
 #define PMIU_Malloc(size_) MPL_malloc(size_, MPL_MEM_PM)
 #define PMIU_Realloc(ptr_, size_) MPL_realloc(ptr_, size_, MPL_MEM_PM)

--- a/src/pmi/src/pmi_v1.c
+++ b/src/pmi/src/pmi_v1.c
@@ -49,9 +49,6 @@ static int PMI_spawned = 0;
 /* Function prototypes for internal routines */
 static int PMII_getmaxes(int *kvsname_max, int *keylen_max, int *vallen_max);
 static int PMII_Set_from_port(int id);
-static int PMII_Connect_to_pm(char *, int);
-
-static int getPMIFD(int *);
 
 #ifdef USE_PMI_PORT
 static int PMII_singinit(void);
@@ -74,7 +71,6 @@ PMI_API_PUBLIC int PMI_Init(int *spawned)
 {
     int pmi_errno = PMI_SUCCESS;
     char *p;
-    int notset = 1;
     int rc;
 
     PMI_initialized = PMI_UNINITIALIZED;
@@ -94,7 +90,8 @@ PMI_API_PUBLIC int PMI_Init(int *spawned)
     }
 
     /* Get the fd for PMI commands; if none, we're a singleton */
-    rc = getPMIFD(&notset);
+    bool do_handshake;
+    rc = PMIU_get_pmi_fd(&PMI_fd, &do_handshake);
     if (rc) {
         return rc;
     }
@@ -115,9 +112,21 @@ PMI_API_PUBLIC int PMI_Init(int *spawned)
         return PMI_SUCCESS;
     }
 
-    /* If size, rank, and debug are not set from a communication port,
-     * use the environment */
-    if (notset) {
+    if (do_handshake) {
+        p = getenv("PMI_ID");
+        if (p) {
+            int id = atoi(p);
+            /* PMII_Set_from_port sets up the values that are delivered
+             * by environment variables when a separate port is not used */
+            pmi_errno = PMII_Set_from_port(id);
+            if (pmi_errno) {
+                PMIU_printf(1, "PMI_PORT initialization failed\n");
+                return pmi_errno;
+            }
+        }
+    } else {
+        /* If size, rank, and debug are not set from a communication port,
+         * use the environment */
         if ((p = getenv("PMI_SIZE")))
             PMI_size = atoi(p);
         else
@@ -690,66 +699,6 @@ static int PMIi_InitIfSingleton(void)
 }
 
 #else
-/*
- * This code allows a program to contact a host/port for the PMI socket.
- */
-
-/* stub for connecting to a specified host/port instead of using a
-   specified fd inherited from a parent process */
-static int PMII_Connect_to_pm(char *hostname, int portnum)
-{
-    MPL_sockaddr_t addr;
-    int ret;
-    int fd;
-    int optval = 1;
-    int q_wait = 1;
-
-    ret = MPL_get_sockaddr(hostname, &addr);
-    if (ret) {
-        PMIU_printf(1, "Unable to get host entry for %s\n", hostname);
-        return PMI_FAIL;
-    }
-
-    fd = MPL_socket();
-    if (fd < 0) {
-        PMIU_printf(1, "Unable to get AF_INET socket\n");
-        return PMI_FAIL;
-    }
-
-    if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char *) &optval, sizeof(optval))) {
-        perror("Error calling setsockopt:");
-    }
-
-    /* We wait here for the connection to succeed */
-    ret = MPL_connect(fd, &addr, portnum);
-    if (ret < 0) {
-        switch (errno) {
-            case ECONNREFUSED:
-                PMIU_printf(1, "connect failed with connection refused\n");
-                /* (close socket, get new socket, try again) */
-                if (q_wait)
-                    close(fd);
-                return PMI_FAIL;
-
-            case EINPROGRESS:  /*  (nonblocking) - select for writing. */
-                break;
-
-            case EISCONN:      /*  (already connected) */
-                break;
-
-            case ETIMEDOUT:    /* timed out */
-                PMIU_printf(1, "connect failed with timeout\n");
-                return PMI_FAIL;
-
-            default:
-                PMIU_printf(1, "connect failed with errno %d\n", errno);
-                return PMI_FAIL;
-        }
-    }
-
-    return fd;
-}
-
 static int PMII_Set_from_port(int id)
 {
     int pmi_errno = PMI_SUCCESS;
@@ -998,75 +947,6 @@ static int accept_one_connection(int list_sock)
 
 #endif
 /* end USE_PMI_PORT */
-
-/* Get the FD to use for PMI operations.  If a port is used, rather than
-   a pre-established FD (i.e., via pipe), this routine will handle the
-   initial handshake.
-*/
-static int getPMIFD(int *notset)
-{
-    char *p;
-
-    /* Set the default */
-    PMI_fd = -1;
-
-    p = getenv("PMI_FD");
-
-    if (p) {
-        PMI_fd = atoi(p);
-        return PMI_SUCCESS;
-    }
-#ifdef USE_PMI_PORT
-    p = getenv("PMI_PORT");
-    if (p) {
-        int portnum;
-        char hostname[MAXHOSTNAME + 1];
-        char *pn, *ph;
-        int id = 0;
-
-        /* Connect to the indicated port (in format hostname:portnumber)
-         * and get the fd for the socket */
-
-        /* Split p into host and port */
-        pn = p;
-        ph = hostname;
-        while (*pn && *pn != ':' && (ph - hostname) < MAXHOSTNAME) {
-            *ph++ = *pn++;
-        }
-        *ph = 0;
-
-        if (*pn == ':') {
-            portnum = atoi(pn + 1);
-            /* FIXME: Check for valid integer after : */
-            /* This routine only gets the fd to use to talk to
-             * the process manager. The handshake below is used
-             * to setup the initial values */
-            PMI_fd = PMII_Connect_to_pm(hostname, portnum);
-            if (PMI_fd < 0) {
-                PMIU_printf(1, "Unable to connect to %s on %d\n", hostname, portnum);
-                return PMI_FAIL;
-            }
-        } else {
-            PMIU_printf(1, "unable to decode hostport from %s\n", p);
-            return PMI_FAIL;
-        }
-
-        /* We should first handshake to get size, rank, debug. */
-        p = getenv("PMI_ID");
-        if (p) {
-            id = atoi(p);
-            /* PMII_Set_from_port sets up the values that are delivered
-             * by environment variables when a separate port is not used */
-            PMII_Set_from_port(id);
-            *notset = 0;
-        }
-        return PMI_SUCCESS;
-    }
-#endif
-
-    /* Singleton init case - its ok to return success with no fd set */
-    return PMI_SUCCESS;
-}
 
 static int expect_pmi_cmd(const char *key)
 {

--- a/src/pmi/src/pmi_v2.c
+++ b/src/pmi/src/pmi_v2.c
@@ -29,7 +29,6 @@ static bool cached_singinit_inuse;
 static char cached_singinit_key[PMI2_MAX_KEYLEN];
 static char cached_singinit_val[PMI2_MAX_VALLEN];
 
-static int getPMIFD(void);
 static int PMIi_InitIfSingleton(void);
 
 /* ------------------------------------------------------------------------- */
@@ -80,7 +79,8 @@ PMI_API_PUBLIC int PMI2_Init(int *spawned, int *size, int *rank, int *appnum)
     }
 
     /* Get the fd for PMI commands; if none, we're a singleton */
-    pmi_errno = getPMIFD();
+    bool do_handshake ATTRIBUTE((unused));
+    pmi_errno = PMIU_get_pmi_fd(&PMI_fd, &do_handshake);
     PMIU_ERR_POP(pmi_errno);
 
     if (PMI_fd == -1) {
@@ -644,62 +644,6 @@ PMI_API_PUBLIC int PMI2_Nameserv_unpublish(const char service_name[],
     goto fn_exit;
 }
 
-/* stub for connecting to a specified host/port instead of using a
-   specified fd inherited from a parent process */
-static int PMII_Connect_to_pm(char *hostname, int portnum)
-{
-    int ret;
-    MPL_sockaddr_t addr;
-    int fd;
-    int optval = 1;
-    int q_wait = 1;
-
-    ret = MPL_get_sockaddr(hostname, &addr);
-    if (ret) {
-        PMIU_printf(1, "Unable to get host entry for %s\n", hostname);
-        return -1;
-    }
-
-    fd = MPL_socket();
-    if (fd < 0) {
-        PMIU_printf(1, "Unable to get AF_INET socket\n");
-        return -1;
-    }
-
-    if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char *) &optval, sizeof(optval))) {
-        perror("Error calling setsockopt:");
-    }
-
-    ret = MPL_connect(fd, &addr, portnum);
-    /* We wait here for the connection to succeed */
-    if (ret) {
-        switch (errno) {
-            case ECONNREFUSED:
-                PMIU_printf(1, "connect failed with connection refused\n");
-                /* (close socket, get new socket, try again) */
-                if (q_wait)
-                    close(fd);
-                return -1;
-
-            case EINPROGRESS:  /*  (nonblocking) - select for writing. */
-                break;
-
-            case EISCONN:      /*  (already connected) */
-                break;
-
-            case ETIMEDOUT:    /* timed out */
-                PMIU_printf(1, "connect failed with timeout\n");
-                return -1;
-
-            default:
-                PMIU_printf(1, "connect failed with errno %d\n", errno);
-                return -1;
-        }
-    }
-
-    return fd;
-}
-
 /* ------------------------------------------------------------------------- */
 /*
  * Singleton Init.
@@ -752,61 +696,6 @@ static int PMII_Connect_to_pm(char *hostname, int portnum)
 static int PMIi_InitIfSingleton(void)
 {
     return 0;
-}
-
-/* Get the FD to use for PMI operations.  If a port is used, rather than
-   a pre-established FD (i.e., via pipe), this routine will handle the
-   initial handshake.
-*/
-static int getPMIFD(void)
-{
-    int pmi_errno = PMI2_SUCCESS;
-    char *p;
-
-    /* Set the default */
-    PMI_fd = -1;
-
-    p = getenv("PMI_FD");
-    if (p) {
-        PMI_fd = atoi(p);
-        goto fn_exit;
-    }
-
-    p = getenv("PMI_PORT");
-    if (p) {
-        int portnum;
-        char hostname[MAXHOSTNAME + 1];
-        char *pn, *ph;
-
-        /* Connect to the indicated port (in format hostname:portnumber)
-         * and get the fd for the socket */
-
-        /* Split p into host and port */
-        pn = p;
-        ph = hostname;
-        while (*pn && *pn != ':' && (ph - hostname) < MAXHOSTNAME) {
-            *ph++ = *pn++;
-        }
-        *ph = 0;
-
-        PMIU_ERR_CHKANDJUMP1(*pn != ':', pmi_errno, PMI2_ERR_OTHER, "**pmi2_port %s", p);
-
-        portnum = atoi(pn + 1);
-        /* FIXME: Check for valid integer after : */
-        /* This routine only gets the fd to use to talk to
-         * the process manager. The handshake below is used
-         * to setup the initial values */
-        PMI_fd = PMII_Connect_to_pm(hostname, portnum);
-        PMIU_ERR_CHKANDJUMP2(PMI_fd < 0, pmi_errno, PMI2_ERR_OTHER,
-                             "**connect_to_pm %s %d", hostname, portnum);
-    }
-
-    /* OK to return success for singleton init */
-
-  fn_exit:
-    return pmi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 #endif /* DISABLE_PMI2 */

--- a/src/pmi/src/pmi_wire.c
+++ b/src/pmi/src/pmi_wire.c
@@ -952,8 +952,6 @@ int PMIU_cmd_send(int fd, struct PMIU_cmd *pmicmd)
  * return from this routine, the response is parsed into the pmicmd object.
  * It can be queried for attributes.
  */
-static int GetResponse_set_int(const char *key, int *val_out);
-
 int PMIU_cmd_get_response(int fd, struct PMIU_cmd *pmicmd)
 {
     int pmi_errno = PMIU_SUCCESS;
@@ -985,39 +983,7 @@ int PMIU_cmd_get_response(int fd, struct PMIU_cmd *pmicmd)
         PMIU_ERR_SETANDJUMP2(pmi_errno, PMIU_FAIL, "server responded with rc=%d - %s\n", rc, msg);
     }
 
-    if (cmd_id == PMIU_CMD_FULLINIT && pmicmd->version == PMIU_WIRE_V1) {
-        /* weird 3 additional set commands */
-        pmi_errno = GetResponse_set_int("size", &PMI_size);
-        PMIU_ERR_POP(pmi_errno);
-        pmi_errno = GetResponse_set_int("rank", &PMI_rank);
-        PMIU_ERR_POP(pmi_errno);
-        pmi_errno = GetResponse_set_int("debug", &PMIU_verbose);
-        PMIU_ERR_POP(pmi_errno);
-    }
-
   fn_exit:
-    return pmi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-static int GetResponse_set_int(const char *key, int *val_out)
-{
-    int pmi_errno = PMIU_SUCCESS;
-
-    struct PMIU_cmd pmicmd;
-
-    pmi_errno = PMIU_cmd_read(PMI_fd, &pmicmd);
-    PMIU_ERR_POP(pmi_errno);
-
-    if (strcmp("set", pmicmd.cmd) != 0) {
-        PMIU_ERR_SETANDJUMP1(pmi_errno, PMIU_FAIL, "expecting cmd=set, got %s\n", pmicmd.cmd);
-    }
-
-    PMIU_CMD_GET_INTVAL(&pmicmd, key, *val_out);
-
-  fn_exit:
-    PMIU_cmd_free_buf(&pmicmd);
     return pmi_errno;
   fn_fail:
     goto fn_exit;


### PR DESCRIPTION
## Pull Request Description

Both PMI1 and PMI2 clients have similar utilities for connecting to the process manager. Add common utility functions that both can use.

While moving this code around, it was noticed that the `-pmi-port` option with PMI1 was broken. #6715 fixed the underlying issue, but the code from doing a "fullinit" command in the PMI1 client remained misleading. An additional commit cleans it up.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
