### PR TITLE
hydra: fix HYDU_str_to_strlist and hostlist_fn

### DIFF
--- a/src/pm/hydra/lib/utils/string.c
+++ b/src/pm/hydra/lib/utils/string.c
@@ -250,7 +250,7 @@ char **HYDU_str_to_strlist(char *str)
         if (len > 0) {
             char *s;
             HYDU_MALLOC_OR_JUMP(s, char *, len + 1, status);
-            MPL_strncpy(s, start, len);
+            MPL_strncpy(s, start, len + 1);
 
             strlist[argc] = s;
             argc++;

--- a/src/pm/hydra/mpiexec/options.c
+++ b/src/pm/hydra/mpiexec/options.c
@@ -345,7 +345,7 @@ static HYD_status hostlist_fn(char *arg, char ***argv)
     tok = strtok(**argv, ",");
     while (tok) {
         utarray_push_back(hosts, &tok, MPL_MEM_OTHER);
-        tok = strtok(**argv, ",");
+        tok = strtok(NULL, ",");
     }
 
     char **p = (char **) utarray_front(hosts);
@@ -359,6 +359,8 @@ static HYD_status hostlist_fn(char *arg, char ***argv)
 
         status = HYDU_add_to_node_list(h, np, &HYD_server_info.node_list);
         HYDU_ERR_POP(status, "unable to add to node list\n");
+
+        p = (char **) utarray_next(hosts, p);
     }
 
     utarray_free(hosts);


### PR DESCRIPTION
## Pull Request Description
Missing len+1 in MPL_strncpy resulted in chopping off the last character in HYDU_str_to_strlist.

In mpiexec hostlist_fn parsing, missing utarray_next resulted in dead loops.

The bugs are introduced in https://github.com/pmodels/mpich/pull/6682. We need to make sure to improve the test coverage.
Fixes #6719 

[skip warnings]
## TODO
* [ ] Add test coverage

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
