### PR TITLE
test/xfail: xfail coll/reduce 10 for arm testing

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -92,6 +92,7 @@
 mpich-.*-arm.* * * * * /^sendflood /          xfail=ticket0       pt2pt/testlist
 mpich-.*-arm.* * * * * /^nonblocking3 /       xfail=ticket0       coll/testlist
 mpich-.*-arm.* * * * * /^alltoall /           xfail=ticket0       threads/pt2pt/testlist
+mpich-.*-arm.* * * * * /^reduce 10/           xfail=ticket0       coll/testlist.cvar
 
 # pmix doesn't work well with ch3 under oversubscription, ref. PR5984
 * * pmix ch3:.* *       /^ic2 33/               xfail=ticket0       comm/testlist


### PR DESCRIPTION
## Pull Request Description
The reduce test iterates the count up to 130000. At 10 processes, this is too much memory for the Arm machines (esp. for the release gather algorithms) and results in timeouts.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
