### PR TITLE
ch3/nemesis: fix re-init leak in nemesis

### DIFF
--- a/src/mpid/ch3/channels/nemesis/src/ch3_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_init.c
@@ -16,7 +16,7 @@ void *MPIDI_CH3_packet_buffer = NULL;
 int MPIDI_CH3I_my_rank = -1;
 MPIDI_PG_t *MPIDI_CH3I_my_pg = NULL;
 
-static int nemesis_initialized = 0;
+int MPIDI_nemesis_initialized = 0;
 
 static int split_type(MPIR_Comm * user_comm_ptr, int stype, int key,
                       MPIR_Info *info_ptr, MPIR_Comm ** newcomm_ptr)
@@ -83,7 +83,7 @@ int MPIDI_CH3_Init(int has_parent, MPIDI_PG_t *pg_p, int pg_rank)
     mpi_errno = MPID_nem_init (pg_rank, pg_p, has_parent);
     if (mpi_errno) MPIR_ERR_POP (mpi_errno);
 
-    nemesis_initialized = 1;
+    MPIDI_nemesis_initialized = 1;
 
     MPIDI_CH3I_my_rank = pg_rank;
     MPIDI_CH3I_my_pg = pg_p;
@@ -160,7 +160,7 @@ int MPIDI_CH3_VC_Init( MPIDI_VC_t *vc )
 	called before MPIDI_CH3_Init, and call MPIDI_CH3_VC_Init from
 	inside MPIDI_CH3_Init after initializing nemesis
     */
-    if (!nemesis_initialized)
+    if (!MPIDI_nemesis_initialized)
         goto fn_exit;
 
     /* no need to initialize vc to self */
@@ -218,7 +218,7 @@ int MPIDI_CH3_Connect_to_root (const char *port_name, MPIDI_VC_t **new_vc)
     MPIDI_VC_Init (vc, NULL, 0);
 
     /* init channel portion of vc */
-    MPIR_ERR_CHKINTERNAL(!nemesis_initialized, mpi_errno, "Nemesis not initialized");
+    MPIR_ERR_CHKINTERNAL(!MPIDI_nemesis_initialized, mpi_errno, "Nemesis not initialized");
     vc->ch.recv_active = NULL;
     MPIDI_CHANGE_VC_STATE(vc, ACTIVE);
 

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_finalize.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_finalize.c
@@ -10,6 +10,8 @@
 #include "mpidu_init_shm.h"
 #include "mpidi_ch3_impl.h"
 
+extern int MPIDI_nemesis_initialized;
+
 int MPID_nem_finalize(void)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -57,6 +59,7 @@ int MPID_nem_finalize(void)
     }
 
     memset(&MPID_nem_mem_region, 0, sizeof(MPID_nem_mem_region));
+    MPIDI_nemesis_initialized = 0;
 
  fn_exit:
     MPIR_FUNC_EXIT;


### PR DESCRIPTION

## Pull Request Description
Nemesis uses a static global nemesis_initialized that needs to be re-initialized to 0 or it will cause an extra call to MPID_nem_vc_init and allocates extra memory that ultimately leaks. It is really a tricky design.

This fixes the `/session/session_re_init` ch3-nemesis-debug` test (memory leak):
```
not ok 2327 - ./session/session_re_init 4
  ---
  Directory: ./session
  File: session_re_init
  Num-procs: 4
  Timeout: 180
  Date: "Fri Oct 13 06:52:37 2023"
  ...
## Test output (expected 'No Errors'):
## [2] 56 at [0x28172f48], c/mpid/ch3/channels/nemesis/src/mpid_nem_init.c[457]
## [2] 56 at [0x28173028], c/mpid/ch3/channels/nemesis/src/mpid_nem_init.c[457]
## [2] 56 at [0x28173108], c/mpid/ch3/channels/nemesis/src/mpid_nem_init.c[457]
## [3] 56 at [0x28172f48], c/mpid/ch3/channels/nemesis/src/mpid_nem_init.c[457]
## [3] 56 at [0x28173028], c/mpid/ch3/channels/nemesis/src/mpid_nem_init.c[457]
## [3] 56 at [0x28173108], c/mpid/ch3/channels/nemesis/src/mpid_nem_init.c[457]
## [0] 56 at [0x28172f48], c/mpid/ch3/channels/nemesis/src/mpid_nem_init.c[457]
## [0] 56 at [0x28173028], c/mpid/ch3/channels/nemesis/src/mpid_nem_init.c[457]
## [0] 56 at [0x28173108], c/mpid/ch3/channels/nemesis/src/mpid_nem_init.c[457]
## No Errors
## [1] 56 at [0x28172f48], c/mpid/ch3/channels/nemesis/src/mpid_nem_init.c[457]
## [1] 56 at [0x28173028], c/mpid/ch3/channels/nemesis/src/mpid_nem_init.c[457]
## [1] 56 at [0x28173108], c/mpid/ch3/channels/nemesis/src/mpid_nem_init.c[457]
```
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
