### PR TITLE
test: fix displs type in threadcomm_coll tests

### DIFF
--- a/test/mpi/impls/mpich/threads/threadcomm/threadcomm_coll.c
+++ b/test/mpi/impls/mpich/threads/threadcomm/threadcomm_coll.c
@@ -494,7 +494,8 @@ static void test_gatherv_c(MPI_Comm comm)
     MPI_Comm_rank(comm, &rank);
 
     int allranks[size];
-    MPI_Count counts[size], displs[size];
+    MPI_Count counts[size];
+    MPI_Aint displs[size];
 
     if (rank == root) {
         for (int i = 0; i < size; i++) {
@@ -551,7 +552,8 @@ static void test_scatterv_c(MPI_Comm comm)
     MPI_Comm_rank(comm, &rank);
 
     int data_out[size];
-    MPI_Count counts[size], displs[size];
+    MPI_Count counts[size];
+    MPI_Aint displs[size];
 
     if (rank == root) {
         for (int i = 0; i < size; i++) {
@@ -599,7 +601,8 @@ static void test_allgatherv_c(MPI_Comm comm)
     MPI_Comm_rank(comm, &rank);
 
     int allranks[size];
-    MPI_Count counts[size], displs[size];
+    MPI_Count counts[size];
+    MPI_Aint displs[size];
 
     for (int i = 0; i < size; i++) {
         counts[i] = 1;
@@ -643,7 +646,8 @@ static void test_alltoallv_c(MPI_Comm comm)
     MPI_Comm_rank(comm, &rank);
 
     int data_out[size], data_in[size];
-    MPI_Count counts[size], displs[size];
+    MPI_Count counts[size];
+    MPI_Aint displs[size];
     for (int i = 0; i < size; i++) {
         data_out[i] = i * 1000 + rank;
         data_in[i] = -1;
@@ -667,7 +671,8 @@ static void test_alltoallw_c(MPI_Comm comm)
     MPI_Comm_rank(comm, &rank);
 
     int data_out[size], data_in[size];
-    MPI_Count counts[size], displs[size];
+    MPI_Count counts[size];
+    MPI_Aint displs[size];
     MPI_Datatype types[size];
     for (int i = 0; i < size; i++) {
         data_out[i] = i * 1000 + rank;


### PR DESCRIPTION
## Pull Request Description
The type for displs in large count v-collectives is MPI_Aint, not MPI_Count. The test fails on 32-bit systems where the size of MPI_Aint is not the same as MPI_Count. It also gave warnings during compile on 64-bit linux (but we failed to notice them in the console log).


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
