### PR TITLE
ch4/comm: call commit_post_hook after comm_create

### DIFF
--- a/src/mpi/coll/src/csel.c
+++ b/src/mpi/coll/src/csel.c
@@ -696,6 +696,7 @@ int MPIR_Csel_prune(void *root_csel, MPIR_Comm * comm_ptr, void **comm_csel_)
     MPIR_Assert(comm_ptr);
 
     comm_csel = (csel_s *) MPL_malloc(sizeof(csel_s), MPL_MEM_COLL);
+    MPIR_Assert(comm_csel);
 
     comm_csel->type = CSEL_TYPE__PRUNED;
     for (int i = 0; i < MPIR_CSEL_COLL_TYPE__END; i++)

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -780,6 +780,10 @@ int MPIDI_Comm_create_multi_leaders(MPIR_Comm * comm)
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
 
+            mpi_errno = MPID_Comm_commit_post_hook(MPIDI_COMM(comm, multi_leads_comm));
+            if (mpi_errno)
+                MPIR_ERR_CHECK(mpi_errno);
+
             MPIR_Comm_map_free(MPIDI_COMM(comm, multi_leads_comm));
         }
     }


### PR DESCRIPTION
## Pull Request Description

Without the MPID_Comm_commit_post_hook, the csel_comm in the multi_leaders comm does not get pruned correctly and causes error during comm release and eventually csel_free.


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
