### PR TITLE
mpit: add MPI_T_BIND_MPI_SESSION

### DIFF
--- a/doc/mansrc/mpiconsts.txt
+++ b/doc/mansrc/mpiconsts.txt
@@ -384,6 +384,7 @@ Special value for error codes array:
 .    MPI_T_BIND_MPI_WIN             - MPI windows for one-sided communication
 .    MPI_T_BIND_MPI_MESSAGE         - MPI message object
 .    MPI_T_BIND_MPI_INFO            - MPI info object
+.    MPI_T_BIND_MPI_SESSION         - MPI session object
 .    MPI_T_SCOPE_CONSTANT           -read-only, value is constant
 .    MPI_T_SCOPE_READONLY           - read-only, cannot be written, but can
  change

--- a/src/env/mpivars.c
+++ b/src/env/mpivars.c
@@ -380,6 +380,9 @@ const char *mpit_bindingToStr(int binding)
         case MPI_T_BIND_MPI_INFO:
             p = "MPI_INFO";
             break;
+        case MPI_T_BIND_MPI_SESSION:
+            p = "MPI_SESSION";
+            break;
         default:
             p = "Unknown object binding";
     }

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -859,7 +859,8 @@ typedef enum MPIR_T_bind_t {
     MPI_T_BIND_MPI_REQUEST,
     MPI_T_BIND_MPI_WIN,
     MPI_T_BIND_MPI_MESSAGE,
-    MPI_T_BIND_MPI_INFO
+    MPI_T_BIND_MPI_INFO,
+    MPI_T_BIND_MPI_SESSION
 } MPIR_T_bind_t;
 
 typedef enum MPIR_T_scope_t {

--- a/test/mpi/mpi_t/mpit_vars.c
+++ b/test/mpi/mpi_t/mpit_vars.c
@@ -443,6 +443,9 @@ const char *mpit_bindingToStr(int binding)
         case MPI_T_BIND_MPI_INFO:
             p = "MPI_INFO";
             break;
+        case MPI_T_BIND_MPI_SESSION:
+            p = "MPI_SESSION";
+            break;
         default:
             p = "Unknown object binding";
     }

--- a/test/mpi/threads/mpi_t/mpit_threading.c
+++ b/test/mpi/threads/mpi_t/mpit_threading.c
@@ -394,6 +394,9 @@ const char *mpit_bindingToStr(int binding)
         case MPI_T_BIND_MPI_INFO:
             p = "MPI_INFO";
             break;
+        case MPI_T_BIND_MPI_SESSION:
+            p = "MPI_SESSION";
+            break;
         default:
             p = "Unknown object binding";
     }


### PR DESCRIPTION
## Pull Request Description
This bind constant was added in MPI 4.0, but we neglected to add in MPICH.


Fixes #6731

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
