### PR TITLE
test/xfails: fix typos and remove a working entry

### DIFF
--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -70,7 +70,7 @@
 * * * ch4:ofi freebsd64 /^dup_leak_test .*iter=1234.*/   xfail=issue4595        threads/comm/testlist
 * * * ch4:ofi freebsd64 /^alltoall/                      xfail=issue4595        threads/pt2pt/testlist
 # release-gather algorithm won't work with multithread
-* * async * *           /^.*_ALGORITHM=release_gather.*/ xfail=ticket0          coll/testlist.cvar
+* * async * *           /^.*_ALGORITHM=release_gather.*/ xfail=ticket0          coll/testlist.collalgo
 # freebsd failures
 * * debug ch3:tcp freebsd64     /^comm_create_group_threads/     xfail=issue4372        threads/comm/testlist
 
@@ -92,7 +92,7 @@
 mpich-.*-arm.* * * * * /^sendflood /          xfail=ticket0       pt2pt/testlist
 mpich-.*-arm.* * * * * /^nonblocking3 /       xfail=ticket0       coll/testlist
 mpich-.*-arm.* * * * * /^alltoall /           xfail=ticket0       threads/pt2pt/testlist
-mpich-.*-arm.* * * * * /^reduce 10/           xfail=ticket0       coll/testlist.cvar
+mpich-.*-arm.* * * * * /^reduce 10/           xfail=ticket0       coll/testlist.collalgo
 
 # pmix doesn't work well with ch3 under oversubscription, ref. PR5984
 * * pmix ch3:.* *       /^ic2 33/               xfail=ticket0       comm/testlist

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -69,8 +69,6 @@
 # more mutex unfairness on freebsd64. note: check these after upgrading freebsd64 hardware
 * * * ch4:ofi freebsd64 /^dup_leak_test .*iter=1234.*/   xfail=issue4595        threads/comm/testlist
 * * * ch4:ofi freebsd64 /^alltoall/                      xfail=issue4595        threads/pt2pt/testlist
-# release-gather algorithm won't work with multithread
-* * async * *           /^.*_ALGORITHM=release_gather.*/ xfail=ticket0          coll/testlist.collalgo
 # freebsd failures
 * * debug ch3:tcp freebsd64     /^comm_create_group_threads/     xfail=issue4372        threads/comm/testlist
 


### PR DESCRIPTION
## Pull Request Description
`testlist.cvar` has been renamed to `testlist.collalgo`. We neglected to fix the entries in `xfail.conf`.

Apparently the release-gather algorithm has been working with the `async` tests. Remove the xfail entry.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
