### PR TITLE
ch3: revert changes in src/mpid/ch3/src/mpid_recv.c

### DIFF
--- a/src/mpid/ch3/src/mpid_recv.c
+++ b/src/mpid/ch3/src/mpid_recv.c
@@ -102,8 +102,11 @@ int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int t
 		/* The data is still being transferred across the net.  
 		   We'll leave it to the progress engine to handle once the
 		   entire message has arrived. */
-
-                MPIR_Datatype_add_ref_if_not_builtin(datatype);
+		if (!HANDLE_IS_BUILTIN(datatype))
+		{
+		    MPIR_Datatype_get_ptr(datatype, rreq->dev.datatype_ptr);
+            MPIR_Datatype_ptr_add_ref(rreq->dev.datatype_ptr);
+		}
 	    }
 	}
 	else if (MPIDI_Request_get_msg_type(rreq) == MPIDI_REQUEST_RNDV_MSG)
@@ -152,7 +155,11 @@ int MPID_Recv(void * buf, MPI_Aint count, MPI_Datatype datatype, int rank, int t
 	   of the actions that are taken when a request is freed. 
 	   (specifically, the datatype and comm both have their refs
 	   decremented, and are freed if the refs are zero) */
-        MPIR_Datatype_add_ref_if_not_builtin(datatype);
+	if (!HANDLE_IS_BUILTIN(datatype))
+	{
+	    MPIR_Datatype_get_ptr(datatype, rreq->dev.datatype_ptr);
+        MPIR_Datatype_ptr_add_ref(rreq->dev.datatype_ptr);
+	}
 
 	rreq->dev.recv_pending_count = 1;
 	/* We must wait until here to exit the msgqueue critical section


### PR DESCRIPTION

## Pull Request Description
Commit f7470a15 was incomplete in fixing ch3 mpid_recv.c. It neglected to update rreq->dev.datatype_ptr, which missed the corresponding MPIR_Datatype_release. Since the receive path does not have the original issue with MPI_DATATYPE_NULL as in the send path, we revert the changes.

This fixes the datatype handle leak caused by f7470a15.


[skip warnings]
## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
