### PR TITLE
ch3: Fix MPID_Startall for persistent collective requests

### DIFF
--- a/src/mpid/ch3/src/mpid_startall.c
+++ b/src/mpid/ch3/src/mpid_startall.c
@@ -55,15 +55,19 @@ int MPID_Startall(int count, MPIR_Request * requests[])
     {
 	MPIR_Request * const preq = requests[i];
 
-        /* continue if the source/dest is MPI_PROC_NULL */
-        if (preq->dev.match.parts.rank == MPI_PROC_NULL)
-            continue;
-
         if (preq->kind == MPIR_REQUEST_KIND__PREQUEST_COLL) {
             mpi_errno = MPIR_Persist_coll_start(preq);
             MPIR_ERR_CHECK(mpi_errno);
             continue;
         }
+
+        /* only pt2pt requests should reach here */
+        MPIR_Assert(preq->kind == MPIR_REQUEST_KIND__PREQUEST_SEND ||
+                    preq->kind == MPIR_REQUEST_KIND__PREQUEST_RECV);
+
+        /* continue if the source/dest is MPI_PROC_NULL */
+        if (preq->dev.match.parts.rank == MPI_PROC_NULL)
+            continue;
 
 	/* FIXME: The odd 7th arg (match.context_id - comm->context_id) 
 	   is probably to get the context offset.  Do we really need the


### PR DESCRIPTION
## Pull Request Description

Collective requests do not initialize the match parts used by pt2pt requests. Avoid reading an uninitialized value by first checking if a persistent request is collective. After that, we can assume the request is pt2pt since ch3 does not support partitioned communication requests.

Fixes pmodels/mpich#6738.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
