### PR TITLE
mpi41: Support for mpi_memory_alloc_kinds info hint

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,15 @@
 # Yaksa updated to auto detect the GPU architecture and only build for
   the detected arch. This applies to CUDA and HIP support.
 
+# Support for "mpi_memory_alloc_kinds" info key. Memory allocation kind
+  requests can be made via argument to mpiexec, or as info during
+  session creation. Kinds supported are "mpi" (with standard defined
+  restrictors) and "system". Queries for supported kinds can be made on
+  MPI objects such as sessions, comms, windows, or files. MPI 4.1 states
+  that supported kinds can also be found in MPI_INFO_ENV, but it was
+  decided at the October 2023 meeting that this was a mistake and will
+  be removed in an erratum.
+
 ===============================================================================
                                Changes in 4.1
 ===============================================================================

--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -125,4 +125,6 @@ int MPIR_Get_intranode_rank(MPIR_Comm * comm_ptr, int r);
      : (MPI_Aint) (val))
 #endif
 
+int MPIR_get_supported_memory_kinds(char *requested_kinds, char **out_kinds);
+
 #endif /* MPIR_MISC_H_INCLUDED */

--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -126,5 +126,6 @@ int MPIR_Get_intranode_rank(MPIR_Comm * comm_ptr, int r);
 #endif
 
 int MPIR_get_supported_memory_kinds(char *requested_kinds, char **out_kinds);
+void MPIR_get_memory_kinds_from_comm(MPIR_Comm * comm_ptr, char **out_kinds);
 
 #endif /* MPIR_MISC_H_INCLUDED */

--- a/src/include/mpir_process.h
+++ b/src/include/mpir_process.h
@@ -50,6 +50,7 @@ typedef struct MPIR_Process_t {
                                          * versions */
     PreDefined_attrs attrs;     /* Predefined attribute values */
     int tag_bits;               /* number of tag bits supported */
+    char *memory_alloc_kinds;   /* memory kinds supported in the world model */
 
     /* The topology routines dimsCreate is independent of any communicator.
      * If this pointer is null, the default routine is used */

--- a/src/include/mpir_session.h
+++ b/src/include/mpir_session.h
@@ -15,6 +15,7 @@ struct MPIR_Session {
     MPIR_Errhandler *errhandler;
     int thread_level;
     bool strict_finalize;
+    char *memory_alloc_kinds;
 };
 
 extern MPIR_Object_alloc_t MPIR_Session_mem;
@@ -38,6 +39,9 @@ int MPIR_Session_get_thread_level_from_info(MPIR_Info * info_ptr, int *threadlev
 
 /* strict finalize util */
 int MPIR_Session_get_strict_finalize_from_info(MPIR_Info * info_ptr, bool * strict_finalize);
+
+/* memory allocation kinds util */
+int MPIR_Session_get_memory_kinds_from_info(MPIR_Info * info_ptr, char **out_kinds);
 
 /* API Implementations */
 

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -153,6 +153,10 @@ int MPII_Comm_get_hints(MPIR_Comm * comm_ptr, MPIR_Info * info)
         }
     }
 
+    char *memory_alloc_kinds;
+    MPIR_get_memory_kinds_from_comm(comm_ptr, &memory_alloc_kinds);
+    MPIR_Info_set_impl(info, "mpi_memory_alloc_kinds", memory_alloc_kinds);
+
   fn_exit:
     return mpi_errno;
   fn_fail:
@@ -1407,5 +1411,14 @@ void MPIR_Comm_set_session_ptr(MPIR_Comm * comm_ptr, MPIR_Session * session_ptr)
         comm_ptr->session_ptr = session_ptr;
         /* Add ref counter of session */
         MPIR_Session_add_ref(session_ptr);
+    }
+}
+
+void MPIR_get_memory_kinds_from_comm(MPIR_Comm * comm_ptr, char **kinds)
+{
+    if (comm_ptr->session_ptr) {
+        *kinds = comm_ptr->session_ptr->memory_alloc_kinds;
+    } else {
+        *kinds = MPIR_Process.memory_alloc_kinds;
     }
 }

--- a/src/mpi/info/infoutil.c
+++ b/src/mpi/info/infoutil.c
@@ -67,10 +67,6 @@ void MPIR_Info_setup_env(MPIR_Info * info_ptr)
     info_init(info_ptr);
     /* FIXME: Currently this info object is missing some data as
      * defined by the standard. */
-
-    if (MPIR_Process.memory_alloc_kinds != NULL) {
-        MPIR_Info_push(info_ptr, "mpi_memory_alloc_kinds", MPIR_Process.memory_alloc_kinds);
-    }
 }
 
 #define INFO_INITIAL_SIZE 10

--- a/src/mpi/info/infoutil.c
+++ b/src/mpi/info/infoutil.c
@@ -65,9 +65,12 @@ int MPIR_Info_alloc(MPIR_Info ** info_p_p)
 void MPIR_Info_setup_env(MPIR_Info * info_ptr)
 {
     info_init(info_ptr);
-    /* FIXME: Currently this info object is left empty, we need to add data to
-     * this as defined by the standard. */
-    (void) info_ptr;
+    /* FIXME: Currently this info object is missing some data as
+     * defined by the standard. */
+
+    if (MPIR_Process.memory_alloc_kinds != NULL) {
+        MPIR_Info_push(info_ptr, "mpi_memory_alloc_kinds", MPIR_Process.memory_alloc_kinds);
+    }
 }
 
 #define INFO_INITIAL_SIZE 10

--- a/src/mpi/init/globals.c
+++ b/src/mpi/init/globals.c
@@ -10,7 +10,8 @@
 MPL_initlock_t MPIR_init_lock = MPL_INITLOCK_INITIALIZER;
 
 MPIR_Process_t MPIR_Process = {
-    .mpich_state = MPL_ATOMIC_INT_T_INITIALIZER(MPICH_MPI_STATE__UNINITIALIZED)
+    .mpich_state = MPL_ATOMIC_INT_T_INITIALIZER(MPICH_MPI_STATE__UNINITIALIZED),
+    .memory_alloc_kinds = NULL
 };
 
 MPIR_Thread_info_t MPIR_ThreadInfo;

--- a/src/mpi/init/local_proc_attrs.c
+++ b/src/mpi/init/local_proc_attrs.c
@@ -79,8 +79,9 @@ int MPII_init_local_proc_attrs(int *p_thread_required)
     /* Set the number of tag bits. The device may override this value. */
     MPIR_Process.tag_bits = MPIR_TAG_BITS_DEFAULT;
 
-    /* FIXME: we should support requested kinds via mpiexec */
-    MPIR_get_supported_memory_kinds(NULL, &MPIR_Process.memory_alloc_kinds);
+    char *requested_kinds = MPIR_pmi_get_jobattr("PMI_mpi_memory_alloc_kinds");
+    MPIR_get_supported_memory_kinds(requested_kinds, &MPIR_Process.memory_alloc_kinds);
+    MPL_free(requested_kinds);
 
     return mpi_errno;
 }

--- a/src/mpi/init/local_proc_attrs.c
+++ b/src/mpi/init/local_proc_attrs.c
@@ -79,6 +79,9 @@ int MPII_init_local_proc_attrs(int *p_thread_required)
     /* Set the number of tag bits. The device may override this value. */
     MPIR_Process.tag_bits = MPIR_TAG_BITS_DEFAULT;
 
+    /* FIXME: we should support requested kinds via mpiexec */
+    MPIR_get_supported_memory_kinds(NULL, &MPIR_Process.memory_alloc_kinds);
+
     return mpi_errno;
 }
 

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -476,6 +476,9 @@ int MPII_Finalize(MPIR_Session * session_ptr)
         MPIR_ERR_CHECK(mpi_errno);
     }
 
+    MPL_free(MPIR_Process.memory_alloc_kinds);
+    MPIR_Process.memory_alloc_kinds = NULL;
+
     /* All memory should be freed at this point */
     MPII_finalize_memory_tracing();
 

--- a/src/mpi/misc/Makefile.mk
+++ b/src/mpi/misc/Makefile.mk
@@ -4,4 +4,5 @@
 ##
 
 mpi_core_sources += \
-    src/mpi/misc/utils.c
+    src/mpi/misc/utils.c \
+    src/mpi/misc/memory_alloc_kinds.c

--- a/src/mpi/misc/memory_alloc_kinds.c
+++ b/src/mpi/misc/memory_alloc_kinds.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+
+static const char *memory_alloc_kinds[3][5] = {
+    /* mpi 4.1 kinds */
+    {"mpi", "alloc_mem", "win_allocate", "win_allocate_shared", NULL},
+    {"system", NULL},
+    {NULL}
+};
+
+static bool is_supported(const char *kind);
+
+int MPIR_get_supported_memory_kinds(char *requested_kinds, char **out_kinds)
+{
+    char *tmp_strs[1024];
+    int num = 2;
+    /* mpi and system kinds are always supported */
+    tmp_strs[0] = MPL_strdup("mpi");
+    tmp_strs[1] = MPL_strdup("system");
+
+    /* match user kinds with supported kinds */
+    if (requested_kinds != NULL) {
+        char *tmp = MPL_strdup(requested_kinds);
+        char *save_tmp = tmp;
+        for (char *kind = MPL_strsep(&tmp, ","); kind; kind = MPL_strsep(&tmp, ",")) {
+            if (!MPL_stricmp(kind, "mpi") || !MPL_stricmp(kind, "system")) {
+                continue;
+            } else if (is_supported(kind)) {
+                tmp_strs[num++] = MPL_strdup(kind);
+                /* FIXME: use dynamic storage */
+                MPIR_Assert(num < 1024);
+            }
+        }
+        MPL_free(save_tmp);
+    }
+
+    /* build return string */
+    *out_kinds = MPL_strjoin(tmp_strs, num, ',');
+
+    for (int i = 0; i < num; i++) {
+        MPL_free(tmp_strs[i]);
+    }
+
+    return MPI_SUCCESS;
+}
+
+/*** static functions ***/
+
+static bool is_supported(const char *kind)
+{
+    bool ret = false;
+    char *tmp = MPL_strdup(kind);
+    char *save_tmp = tmp;
+
+    char *k = MPL_strsep(&tmp, ":");
+    for (int i = 0; memory_alloc_kinds[i][0]; i++) {
+        if (!MPL_stricmp(k, memory_alloc_kinds[i][0])) {
+            ret = true;
+
+            /* check that any restrictors are also supported */
+            char *res;
+            while ((res = MPL_strsep(&tmp, ":")) != NULL) {
+                bool res_supported = false;
+
+                for (int j = 1; memory_alloc_kinds[i][j]; j++) {
+                    if (!MPL_stricmp(res, memory_alloc_kinds[i][j])) {
+                        res_supported = true;
+                    }
+                }
+
+                ret = ret && res_supported;
+            }
+        }
+    }
+
+    MPL_free(save_tmp);
+    return ret;
+}

--- a/src/mpi/session/session_impl.c
+++ b/src/mpi/session/session_impl.c
@@ -50,6 +50,9 @@ int MPIR_Session_init_impl(MPIR_Info * info_ptr, MPIR_Errhandler * errhandler_pt
         MPIR_Session_get_strict_finalize_from_info(info_ptr, &(session_ptr->strict_finalize));
     MPIR_ERR_CHECK(mpi_errno);
 
+    /* Get memory allocation kinds requested by the user (if any) */
+    mpi_errno = MPIR_Session_get_memory_kinds_from_info(info_ptr, &session_ptr->memory_alloc_kinds);
+
     *p_session_ptr = session_ptr;
 
   fn_exit:
@@ -141,6 +144,11 @@ int MPIR_Session_get_info_impl(MPIR_Session * session_ptr, MPIR_Info ** info_p_p
 
     /* Set strict finalize */
     mpi_errno = MPIR_Info_set_impl(*info_p_p, "strict_finalize", buf_strict_finalize);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* Set memory allocation kinds */
+    mpi_errno =
+        MPIR_Info_set_impl(*info_p_p, "mpi_memory_alloc_kinds", session_ptr->memory_alloc_kinds);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch3/src/ch3u_win_fns.c
+++ b/src/mpid/ch3/src/ch3u_win_fns.c
@@ -440,6 +440,13 @@ int MPID_Win_get_info(MPIR_Win * win, MPIR_Info ** info_used)
         mpi_errno = MPIR_Info_set_impl(*info_used, "same_disp_unit", "false");
     MPIR_ERR_CHECK(mpi_errno);
 
+    if (win->comm_ptr) {
+        char *memory_alloc_kinds;
+        MPIR_get_memory_kinds_from_comm(win->comm_ptr, &memory_alloc_kinds);
+        mpi_errno = MPIR_Info_set_impl(*info_used, "mpi_memory_alloc_kinds", memory_alloc_kinds);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/src/mpidig_win.c
+++ b/src/mpid/ch4/src/mpidig_win.c
@@ -822,6 +822,13 @@ int MPIDIG_mpi_win_get_info(MPIR_Win * win, MPIR_Info ** info_p_p)
     }
     MPIR_ERR_CHECK(mpi_errno);
 
+    if (win->comm_ptr) {
+        char *memory_alloc_kinds;
+        MPIR_get_memory_kinds_from_comm(win->comm_ptr, &memory_alloc_kinds);
+        mpi_errno = MPIR_Info_set_impl(*info_p_p, "mpi_memory_alloc_kinds", memory_alloc_kinds);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpl/include/mpl_str.h
+++ b/src/mpl/include/mpl_str.h
@@ -43,6 +43,8 @@ void MPL_create_pathname(char *dest_filename, const char *dirname,
 
 int MPL_stricmp(const char *a, const char *b);
 
+char *MPL_strjoin(char *strs[], int num, char sep);
+
 /* *INDENT-ON* */
 #if defined(__cplusplus)
 }

--- a/src/mpl/src/str/mpl_str.c
+++ b/src/mpl/src/str/mpl_str.c
@@ -305,3 +305,39 @@ int MPL_stricmp(const char *s1, const char *s2)
         return 1;
     }
 }
+
+/*@ MPL_strjoin - Join an array of strings with a separator
+
++ strs - Array of strings
+. num  - Number of strings in the array
+- sep  - Character separator
+
+Return:
+  Joined string.
+
+Module:
+  Utility
+@*/
+char *MPL_strjoin(char *strs[], int num, char sep)
+{
+    if (num <= 0) {
+        return MPL_strdup("");
+    }
+
+    int len = 0;
+    for (int i = 0; i < num; i++) {
+        len += strlen(strs[i]);
+    }
+
+    char *outstr = MPL_malloc(len + num, MPL_MEM_OTHER);
+    char *p = outstr;
+    for (int i = 0; i < num; i++) {
+        strcpy(p, strs[i]);
+        if (i < num - 1) {
+            p += strlen(strs[i]);
+            *p++ = sep;
+        }
+    }
+
+    return outstr;
+}

--- a/src/pm/hydra/lib/hydra.h
+++ b/src/pm/hydra/lib/hydra.h
@@ -373,6 +373,9 @@ struct HYD_user_global {
     /* Network interface */
     char *iface;
 
+    /* requested memory allocation kinds */
+    char *memory_alloc_kinds;
+
     /* Other random parameters */
     int enablex;
     int debug;

--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -17,6 +17,8 @@ void HYDU_init_user_global(struct HYD_user_global *user_global)
     user_global->demux = NULL;
     user_global->iface = NULL;
 
+    user_global->memory_alloc_kinds = NULL;
+
     user_global->enablex = -1;
     user_global->usize = HYD_USIZE_UNSET;
 
@@ -38,6 +40,7 @@ void HYDU_finalize_user_global(struct HYD_user_global *user_global)
     MPL_free(user_global->topolib);
     MPL_free(user_global->demux);
     MPL_free(user_global->iface);
+    MPL_free(user_global->memory_alloc_kinds);
 
     HYDU_finalize_global_env(&user_global->global_env);
 }

--- a/src/pm/hydra/mpiexec/options.c
+++ b/src/pm/hydra/mpiexec/options.c
@@ -65,6 +65,15 @@ static void help_help_fn(void)
     printf("\n");
     printf("\n");
 
+    printf("MPI specific options (treated as global):\n");
+
+    printf("\n");
+    printf("  MPI settings:\n");
+    printf("    -memory-alloc-kinds              request support for memory allocation kinds\n");
+
+    printf("\n");
+    printf("\n");
+
     printf("Hydra specific options (treated as global):\n");
 
     printf("\n");
@@ -803,6 +812,27 @@ static HYD_status np_fn(char *arg, char ***argv)
     ASSERT_ARGV;
     status = HYDU_set_int(arg, &exec->proc_count, atoi(**argv));
     HYDU_ERR_POP(status, "error getting executable process count\n");
+
+  fn_exit:
+    (*argv)++;
+    return status;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static void memory_alloc_kinds_help_fn(void)
+{
+    printf("\n");
+    printf("-memory-alloc-kinds: Request support from MPI for memory allocation kinds\n\n");
+}
+
+static HYD_status memory_alloc_kinds_fn(char *arg, char ***argv)
+{
+    HYD_status status = HYD_SUCCESS;
+
+    status = HYDU_set_str(arg, &HYD_server_info.user_global.memory_alloc_kinds, **argv);
+    HYDU_ERR_POP(status, "error setting memory alloc kinds\n");
 
   fn_exit:
     (*argv)++;
@@ -1640,6 +1670,9 @@ struct HYD_arg_match_table HYD_mpiexec_match_table[] = {
     /* Other local options */
     {"n", np_fn, np_help_fn},
     {"np", np_fn, np_help_fn},
+
+    /* MPI specific options */
+    {"memory-alloc-kinds", memory_alloc_kinds_fn, memory_alloc_kinds_help_fn},
 
     /* Hydra specific options */
 

--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -118,6 +118,12 @@ HYD_status HYD_pmcd_pmi_fill_in_proxy_args(struct HYD_string_stash *proxy_stash,
     HYD_STRING_STASH(*proxy_stash,
                      HYDU_int_to_str(HYD_server_info.user_global.gpu_subdevs_per_proc), status);
 
+    if (HYD_server_info.user_global.memory_alloc_kinds != NULL) {
+        HYD_STRING_STASH(*proxy_stash, MPL_strdup("--memory-alloc-kinds"), status);
+        HYD_STRING_STASH(*proxy_stash, MPL_strdup(HYD_server_info.user_global.memory_alloc_kinds),
+                         status);
+    }
+
     if (pgid == 0 && HYD_server_info.is_singleton) {
         HYD_STRING_STASH(*proxy_stash, MPL_strdup("--singleton-port"), status);
         HYD_STRING_STASH(*proxy_stash, HYDU_int_to_str(HYD_server_info.singleton_port), status);

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -404,6 +404,8 @@ static const char *get_jobattr(struct pmip_downstream *p, const char *key)
         int universe_size = get_universe_size(p);
         snprintf(universe_str, 64, "%d", universe_size);
         return universe_str;
+    } else if (!strcmp(key, "PMI_mpi_memory_alloc_kinds")) {
+        return HYD_pmcd_pmip.user_global.memory_alloc_kinds;
     }
     return NULL;
 }

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -226,6 +226,18 @@ static HYD_status retries_fn(char *arg, char ***argv)
     return status;
 }
 
+static HYD_status memory_alloc_kinds_fn(char *arg, char ***argv)
+{
+    HYD_status status = HYD_SUCCESS;
+
+    status = HYDU_set_str(arg, &HYD_pmcd_pmip.user_global.memory_alloc_kinds, **argv);
+
+    (*argv)++;
+
+    return status;
+}
+
+
 static HYD_status pmi_kvsname_fn(char *arg, char ***argv)
 {
     HYD_status status = HYD_SUCCESS;
@@ -627,6 +639,7 @@ struct HYD_arg_match_table HYD_pmip_args_match_table[] = {
     {"topolib", topolib_fn, NULL},
     {"iface", iface_fn, NULL},
     {"retries", retries_fn, NULL},
+    {"memory-alloc-kinds", memory_alloc_kinds_fn, NULL},
     {"\0", NULL, NULL}
 };
 

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1148,6 +1148,7 @@
 /impls/mpich/comm/comm_dup
 /impls/mpich/comm/comm_info_hint
 /impls/mpich/comm/testlist
+/impls/mpich/info/memory_alloc_kinds
 /impls/mpich/mpi_t/collparmt
 /impls/mpich/mpi_t/recvq_events
 /impls/mpich/misc/gpu_query

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -1864,5 +1864,6 @@ AC_OUTPUT(maint/testmerge \
           impls/mpich/hip/Makefile \
           impls/mpich/misc/Makefile \
           impls/mpich/ulfm/Makefile \
+          impls/mpich/info/Makefile \
           )
 

--- a/test/mpi/impls/mpich/Makefile.am
+++ b/test/mpi/impls/mpich/Makefile.am
@@ -7,5 +7,5 @@ include $(top_srcdir)/Makefile_single.mtest
 
 EXTRA_DIST = testlist.in
 
-static_subdirs = mpi_t coll comm misc ulfm session
+static_subdirs = mpi_t coll comm misc ulfm session info
 SUBDIRS      = $(static_subdirs) $(threadsdir) $(cudadir) $(hipdir)

--- a/test/mpi/impls/mpich/info/Makefile.am
+++ b/test/mpi/impls/mpich/info/Makefile.am
@@ -1,0 +1,9 @@
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+include $(top_srcdir)/Makefile_single.mtest
+
+noinst_PROGRAMS = \
+    memory_alloc_kinds

--- a/test/mpi/impls/mpich/info/memory_alloc_kinds.c
+++ b/test/mpi/impls/mpich/info/memory_alloc_kinds.c
@@ -21,16 +21,27 @@ int main(int argc, char *argv[])
 
     MPI_Info_get(MPI_INFO_ENV, key, MPI_MAX_INFO_VAL, value, &flag);
     if (flag) {
-        /* MPICH will return the default kinds plus any user requests
-         * that are also supported. As of MPI-4.1, that only includes the
-         * mpi kind with restrictors. */
-        errs += check_value(value, "mpi,system,mpi:alloc_mem");
-    } else {
-        /* MPICH supports this key since MPICH 4.2.0 */
+        /* It was discussed in the October 2023 MPI Forum meeting that
+         * if a value for mpi_memory_alloc_kinds is returned from
+         * MPI_INFO_ENV, it should be the requested value. This is
+         * consistent with the other keys defined in MPI_INFO_ENV. Like
+         * those keys, returning a value for mpi_memory_alloc_kind is
+         * optional, and MPICH does not support it at this time. */
         errs++;
     }
 
-    /* test if session gets the same default */
+    /* test if MPI_COMM_WORLD gets the right value */
+    MPI_Info cinfo;
+    MPI_Comm_get_info(MPI_COMM_WORLD, &cinfo);
+    MPI_Info_get(cinfo, key, MPI_MAX_INFO_VAL, value, &flag);
+    MPI_Info_free(&cinfo);
+    if (flag) {
+        errs += check_value(value, "mpi,system,mpi:alloc_mem");
+    } else {
+        errs++;
+    }
+
+    /* test if session gets the right value */
     MPI_Info sinfo;
     MPI_Session session;
     MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL, &session);

--- a/test/mpi/impls/mpich/info/memory_alloc_kinds.c
+++ b/test/mpi/impls/mpich/info/memory_alloc_kinds.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include "mpitest.h"
+
+static int verbose = 0;
+static int check_value(const char *value, const char *expected);
+
+int main(int argc, char *argv[])
+{
+    char value[MPI_MAX_INFO_VAL];
+    const char *key = "mpi_memory_alloc_kinds";
+    int flag;
+    int errs = 0;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Info_get(MPI_INFO_ENV, key, MPI_MAX_INFO_VAL, value, &flag);
+    if (flag) {
+        /* MPICH will return the default kinds plus any user requests
+         * that are also supported. As of MPI-4.1, that only includes the
+         * mpi kind with restrictors. */
+        errs += check_value(value, "mpi,system,mpi:alloc_mem");
+    } else {
+        /* MPICH supports this key since MPICH 4.2.0 */
+        errs++;
+    }
+
+    /* test if session gets the same default */
+    MPI_Info sinfo;
+    MPI_Session session;
+    MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL, &session);
+    MPI_Session_get_info(session, &sinfo);
+    MPI_Info_get(sinfo, key, MPI_MAX_INFO_VAL, value, &flag);
+    MPI_Info_free(&sinfo);
+    if (flag) {
+        errs += check_value(value, "mpi,system,mpi:alloc_mem");
+    } else {
+        errs++;
+    }
+    MPI_Session_finalize(&session);
+
+    /* test if session info overrides the default */
+    MPI_Info info_in;
+    MPI_Info_create(&info_in);
+    MPI_Info_set(info_in, key, "mpi:win_allocate:alloc_mem");
+    MPI_Session_init(info_in, MPI_ERRORS_ARE_FATAL, &session);
+    MPI_Session_get_info(session, &sinfo);
+    MPI_Info_get(sinfo, key, MPI_MAX_INFO_VAL, value, &flag);
+    if (flag) {
+        errs += check_value(value, "mpi,system,mpi:win_allocate:alloc_mem");
+    } else {
+        errs++;
+    }
+    MPI_Info_free(&info_in);
+    MPI_Info_free(&sinfo);
+    MPI_Session_finalize(&session);
+
+    MTest_Finalize(errs);
+    return 0;
+}
+
+static int check_value(const char *value, const char *expected)
+{
+    if (strcmp(value, expected)) {
+        MTestPrintfMsg(verbose, "mpi_memory_alloc_kinds value is \"%s\", expected \"%s\"\n",
+                       value, expected);
+        return 1;
+    }
+
+    return 0;
+}

--- a/test/mpi/impls/mpich/info/testlist
+++ b/test/mpi/impls/mpich/info/testlist
@@ -1,0 +1,1 @@
+memory_alloc_kinds 1 mpiexecarg=-memory-alloc-kinds=mpi:alloc_mem

--- a/test/mpi/impls/mpich/testlist.in
+++ b/test/mpi/impls/mpich/testlist.in
@@ -3,6 +3,7 @@ coll
 comm
 misc
 session
+info
 @threadsdir@
 @cudadir@
 @hipdir@


### PR DESCRIPTION
## Pull Request Description

~Draft implementation.~ Supports kind and restrictor hints defined in MPI 4.1. The session models supports requesting support for memory kinds during MPI_SESSION_INIT. ~The first commit in the series is just adding support for `command` and `argv` keys in MPI_INFO_ENV, which I did to familiarize myself with the infrastructure. This can easily be split out to a separate PR is desired.~ (moved to separate PR)

TODO:
~1. Add option for `mpiexec` to pass requested kinds to MPI for the world model.~
~2. Support retrieving supported kinds from MPI_FILE objects.~
~3. Add tests.~

See #6707

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
