### PR TITLE
ch4/ipc: do not block sender on ipc copy errors

### DIFF
--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -130,6 +130,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_copy_data(MPIDI_IPC_hdr * ipc_hdr, MPIR_
                                         MPIDIG_REQUEST(rreq, datatype), 0, &actual_unpack_bytes,
                                         MPIR_TYPEREP_FLAG_NONE);
         MPIR_ERR_CHECK(mpi_errno);
+        if (actual_unpack_bytes < src_data_sz) {
+            MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_TYPE, "**dtypemismatch");
+        }
         MPIR_Assert(actual_unpack_bytes == src_data_sz);
     } else {
         void *flattened_type = ipc_hdr + 1;

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
@@ -114,6 +114,7 @@ int MPIDI_POSIX_iqueue_post_init(void)
             max_vcis = num;
         }
     }
+    MPIDU_Init_shm_barrier();
 
     MPIDI_POSIX_eager_iqueue_global.max_vcis = max_vcis;
 


### PR DESCRIPTION
## Pull Request Description
IPC copy errors, including handle mapping errors, should be treated as a receive error. We need make sure to always reply sender ack message so we don't block senders on error.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
