### PR TITLE
info: Add support for "command" and "argv" keys in MPI_INFO_ENV

### DIFF
--- a/src/include/mpir_info.h
+++ b/src/include/mpir_info.h
@@ -99,7 +99,7 @@ extern MPIR_Info MPIR_Info_builtin[MPIR_INFO_N_BUILTIN];
 extern MPIR_Info MPIR_Info_direct[];
 
 int MPIR_Info_alloc(MPIR_Info ** info_p_p);
-void MPIR_Info_setup_env(MPIR_Info * info_ptr);
+void MPIR_Info_setup_env(MPIR_Info * info_ptr, int argc, char **argv);
 int MPIR_Info_push(MPIR_Info * info_ptr, const char *key, const char *val);
 const char *MPIR_Info_lookup(MPIR_Info * info_ptr, const char *key);
 

--- a/src/mpi/info/info_impl.c
+++ b/src/mpi/info/info_impl.c
@@ -199,7 +199,7 @@ int MPIR_Info_create_env_impl(int argc, char **argv, MPIR_Info ** new_info_ptr)
     mpi_errno = MPIR_Info_alloc(&info_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     /* Set up the info value. */
-    MPIR_Info_setup_env(info_ptr);
+    MPIR_Info_setup_env(info_ptr, argc, argv);
 
     *new_info_ptr = info_ptr;
 

--- a/src/mpi/info/infoutil.c
+++ b/src/mpi/info/infoutil.c
@@ -62,11 +62,22 @@ int MPIR_Info_alloc(MPIR_Info ** info_p_p)
 
 /* Set up MPI_INFO_ENV.  This may be called before initialization and after
  * finalization by MPI_Info_create_env().  This routine must be thread-safe. */
-void MPIR_Info_setup_env(MPIR_Info * info_ptr)
+void MPIR_Info_setup_env(MPIR_Info * info_ptr, int argc, char **argv)
 {
     info_init(info_ptr);
     /* FIXME: Currently this info object is missing some data as
      * defined by the standard. */
+
+    if (argc > 0) {
+        MPIR_Info_push(info_ptr, "command", argv[0]);
+    }
+
+    if (argc > 1) {
+        /* space-separated arguments to command */
+        char *command_args = MPL_strjoin(&argv[1], argc - 1, ' ');
+        MPIR_Info_push(info_ptr, "argv", command_args);
+        MPL_free(command_args);
+    }
 }
 
 #define INFO_INITIAL_SIZE 10

--- a/src/mpi/init/local_proc_attrs.c
+++ b/src/mpi/init/local_proc_attrs.c
@@ -102,7 +102,7 @@ int MPII_init_tag_ub(void)
     return MPI_SUCCESS;
 }
 
-int MPII_init_builtin_infos(void)
+int MPII_init_builtin_infos(int *argc, char ***argv)
 {
     /* Init MPI_INFO_ENV object */
     MPIR_Info *info_ptr;
@@ -110,7 +110,7 @@ int MPII_init_builtin_infos(void)
     info_ptr->handle = MPI_INFO_ENV;
     MPIR_Object_set_ref(info_ptr, 1);
     /* Add data to MPI_INFO_ENV. */
-    MPIR_Info_setup_env(info_ptr);
+    MPIR_Info_setup_env(info_ptr, argc ? *argc : 0, argv ? *argv : NULL);
 
     return MPI_SUCCESS;
 }

--- a/src/mpi/init/mpi_init.h
+++ b/src/mpi/init/mpi_init.h
@@ -53,7 +53,7 @@ const char *MPII_threadlevel_name(int threadlevel);
 
 int MPII_init_local_proc_attrs(int *p_thread_required);
 int MPII_init_tag_ub(void);
-int MPII_init_builtin_infos(void);
+int MPII_init_builtin_infos(int *argc, char ***argv);
 int MPII_finalize_builtin_infos(void);
 
 void MPII_init_windows(void);

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -199,7 +199,7 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     mpi_errno = MPII_init_local_proc_attrs(&required);
     MPIR_ERR_CHECK(mpi_errno);
 
-    mpi_errno = MPII_init_builtin_infos();
+    mpi_errno = MPII_init_builtin_infos(argc, argv);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPII_Coll_init();


### PR DESCRIPTION
## Pull Request Description

If available, allow users to query for the command and arguments used when starting MPI processes.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
