### PR TITLE
mpi4.1: add new error class MPI_ERR_ERRHANDLER

### DIFF
--- a/doc/mansrc/mpiconsts.txt
+++ b/doc/mansrc/mpiconsts.txt
@@ -522,6 +522,10 @@ Special value for error codes array:
 .   MPI_ERR_RMA_SHARED        - Memory cannot be shared (e.g., some process in
  the group of the specified communicator cannot expose shared memory)
 .   MPI_ERR_RMA_FLAVOR        - Passed window has the wrong flavor for the
+.   MPI_ERR_SESSION           - Invalid session argument
+.   MPI_ERR_PROC_ABORTED      - Trying to communicate with aborted processes
+.   MPI_ERR_VALUE_TOO_LARGE   - Value is too large to store
+.   MPI_ERR_ERRHANDLER        - Invalid error handler argument
  called function
 -   MPI_ERR_LASTCODE          - Last error code -- always at end
 

--- a/maint/local_python/__init__.py
+++ b/maint/local_python/__init__.py
@@ -82,7 +82,7 @@ class MPI_API_Global:
         'COMMUNICATOR': "MPI_ERR_COMM",
         'GROUP': "MPI_ERR_GROUP",
         'DATATYPE': "MPI_ERR_TYPE",
-        'ERRHANDLER': "MPI_ERR_ARG",
+        'ERRHANDLER': "MPI_ERR_ERRHANDLER",
         'OPERATION': "MPI_ERR_OP",
         'INFO': "MPI_ERR_INFO",
         'WINDOW': "MPI_ERR_WIN",

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -1885,7 +1885,7 @@ def dump_validate_handle(func, p):
         G.err_codes['MPI_ERR_WIN'] = 1
         G.out.append("MPIR_ERRTEST_WIN(%s, mpi_errno);" % name)
     elif kind == "ERRHANDLER":
-        G.err_codes['MPI_ERR_ARG'] = 1
+        G.err_codes['MPI_ERR_ERRHANDLER'] = 1
         G.out.append("MPIR_ERRTEST_ERRHANDLER(%s, mpi_errno);" % name)
     elif kind == "REQUEST":
         G.err_codes['MPI_ERR_REQUEST'] = 1

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -693,9 +693,11 @@ enum MPIR_Combiner_enum {
 #define MPI_T_ERR_NOT_SUPPORTED    78  /* Requested functionality not supported */
 #define MPI_T_ERR_NOT_ACCESSIBLE   79  /* Requested functionality not accessible */
 
+#define MPI_ERR_ERRHANDLER         80  /* Invalid errhandler handle */
+
 #define MPI_ERR_LASTCODE    0x3fffffff  /* Last valid error code for a
 					   predefined error class */
-#define MPICH_ERR_LAST_CLASS 79     /* It is also helpful to know the
+#define MPICH_ERR_LAST_CLASS 80     /* It is also helpful to know the
 				       last valid class */
 
 #define MPICH_ERR_FIRST_MPIX 100 /* Define a gap here because sock is

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -692,11 +692,11 @@ cvars:
 
 #define MPIR_ERRTEST_ERRHANDLER(errhandler_,err_)                       \
     if (errhandler_ == MPI_ERRHANDLER_NULL) {                           \
-        MPIR_ERR_SETANDSTMT(err_,MPI_ERR_ARG,goto fn_fail,"**errhandlernull"); \
+        MPIR_ERR_SETANDSTMT(err_,MPI_ERR_ERRHANDLER,goto fn_fail,"**errhandlernull"); \
     }                                                                   \
     else {                                                              \
         MPIR_ERRTEST_VALID_HANDLE(errhandler_,MPIR_ERRHANDLER,          \
-                                  err_,MPI_ERR_ARG,"**errhandler");     \
+                                  err_,MPI_ERR_ERRHANDLER,"**errhandler");     \
     }
 
 #define MPIR_ERRTEST_INFO(info_, err_)                                  \

--- a/src/mpi/errhan/baseerrnames.txt
+++ b/src/mpi/errhan/baseerrnames.txt
@@ -83,3 +83,7 @@ MPIX_ERR_REVOKED     **revoked
 MPIX_ERR_EAGAIN      **eagain
 MPIX_ERR_NOREQ       **nomemreq
 MPIX_ERR_TIMEOUT     **timeout
+MPI_ERR_SESSION      **session
+MPI_ERR_PROC_ABORTED **proc_aborted
+MPI_ERR_VALUE_TOO_LARGE **valuetoolarge
+MPI_ERR_ERRHANDLER   **errhandler

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -488,6 +488,7 @@ unexpected messages queued.
 **badcase:INTERNAL ERROR: unexpected value in case statement
 **badcase %d:INTERNAL ERROR: unexpected value in case statement (value=%d)
 **node_root_rank:Unable to get the node root rank
+**proc_aborted:Process was aborted
 **proc_failed:Process failed
 **failure_pending:Request pending due to failure
 **revoked:Communication object revoked
@@ -899,6 +900,7 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **procnamefailed:Failed to get processor name
 
 **notsuppmultithread:this functionality is not supported when the thread level is greater than MPI_THREAD_SINGLE
+**valuetoolarge:Value is too large to store
 
 #
 # mpi functions


### PR DESCRIPTION
## Pull Request Description

MPI 4.1 added a new error class `MPI_ERR_ERRHANDLER` for invalid errhandler argument.
We also added documentation and error string support for some newly added error classes, including `MPI_ERR_SESSION`, `MPI_ERR_PROC_ABORTED`, and `MPI_ERR_VALUE_TOO_LARGE`.

Fixes #6748 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
