### PR TITLE
request: return error code from free_fn of a generalized request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -379,6 +379,7 @@ Makefile.am-stamp
 # /src/
 
 # /src/binding/
+/src/binding/c/c_binding.c
 
 # /src/binding/cxx/
 /src/binding/cxx/Makefile.sm

--- a/configure.ac
+++ b/configure.ac
@@ -2140,6 +2140,7 @@ MPIMODNAME=mpi
 MPICONSTMODNAME=mpi_constants
 MPISIZEOFMODNAME=mpi_sizeofs
 MPIBASEMODNAME=mpi_base
+PMPIBASEMODNAME=pmpi_base
 
 # F08 binding stuff
 MPI_F08_LINK_CONSTANTS_NAME=mpi_f08_link_constants
@@ -2200,6 +2201,7 @@ if test "$enable_f90" = "yes" -o "$enable_f08" = "yes"; then
         MPICONSTMODNAME=MPI_CONSTANTS
 	MPISIZEOFMODNAME=MPI_SIZEOFS
 	MPIBASEMODNAME=MPI_BASE
+	PMPIBASEMODNAME=PMPI_BASE
         MPI_F08_NAME=MPI_F08
         MPI_F08_LINK_CONSTANTS_NAME=MPI_F08_LINK_CONSTANTS
         MPI_F08_CALLBACKS_NAME=MPI_F08_CALLBACKS
@@ -2216,6 +2218,7 @@ if test "$enable_f90" = "yes" -o "$enable_f08" = "yes"; then
         MPICONSTMODNAME=mpi_constants
 	MPISIZEOFMODNAME=mpi_sizeofs
 	MPIBASEMODNAME=mpi_base
+	PMPIBASEMODNAME=pmpi_base
         MPI_F08_NAME=mpi_f08
         MPI_F08_LINK_CONSTANTS_NAME=mpi_f08_link_constants
         MPI_F08_CALLBACKS_NAME=mpi_f08_callbacks
@@ -2232,6 +2235,7 @@ if test "$enable_f90" = "yes" -o "$enable_f08" = "yes"; then
     AC_SUBST(MPICONSTMODNAME)
     AC_SUBST(MPISIZEOFMODNAME)
     AC_SUBST(MPIBASEMODNAME)
+    AC_SUBST(PMPIBASEMODNAME)
 
     AC_SUBST(MPI_F08_NAME)
     AC_SUBST(MPI_F08_LINK_CONSTANTS_NAME)

--- a/src/binding/c/request_api.txt
+++ b/src/binding/c/request_api.txt
@@ -266,9 +266,20 @@ MPI_Testall:
             if (request_ptrs[i] && !MPIR_Request_is_persistent(request_ptrs[i])) {
                 int rc = MPIR_Request_free_return(request_ptrs[i]);
                 array_of_requests[i] = MPI_REQUEST_NULL;
-                if (rc && array_of_statuses != MPI_STATUSES_IGNORE) {
-                    array_of_statuses[i].MPI_ERROR = rc;
-                    mpi_errno = MPI_ERR_IN_STATUS;
+                if (rc) {
+                    if (array_of_statuses == MPI_STATUSES_IGNORE) {
+                        mpi_errno = MPI_ERR_IN_STATUS;
+                    } else if (mpi_errno == MPI_ERR_IN_STATUS) {
+                        array_of_statuses[i].MPI_ERROR = rc;
+                    } else {
+                        MPIR_Assert(mpi_errno == MPI_SUCCESS);
+                        /* init all statuses' MPI_ERROR fields first */
+                        for (int j = 0; j < count; j++) {
+                            array_of_statuses[j].MPI_ERROR = MPI_SUCCESS;
+                        }
+                        mpi_errno = MPI_ERR_IN_STATUS;
+                        array_of_statuses[i].MPI_ERROR = rc;
+                    }
                 }
             }
         }
@@ -328,9 +339,20 @@ MPI_Testsome:
         if (request_ptrs[idx] && !MPIR_Request_is_persistent(request_ptrs[idx])) {
             int rc = MPIR_Request_free_return(request_ptrs[idx]);
             array_of_requests[idx] = MPI_REQUEST_NULL;
-            if (rc && array_of_statuses != MPI_STATUSES_IGNORE) {
-                array_of_statuses[i].MPI_ERROR = rc;
-                mpi_errno = MPI_ERR_IN_STATUS;
+            if (rc) {
+                if (array_of_statuses == MPI_STATUSES_IGNORE) {
+                    mpi_errno = MPI_ERR_IN_STATUS;
+                } else if (mpi_errno == MPI_ERR_IN_STATUS) {
+                    array_of_statuses[i].MPI_ERROR = rc;
+                } else {
+                    MPIR_Assert(mpi_errno == MPI_SUCCESS);
+                    /* init all statuses' MPI_ERROR fields first */
+                    for (int j = 0; j < *outcount; j++) {
+                        array_of_statuses[j].MPI_ERROR = MPI_SUCCESS;
+                    }
+                    mpi_errno = MPI_ERR_IN_STATUS;
+                    array_of_statuses[i].MPI_ERROR = rc;
+                }
             }
         }
     }
@@ -389,9 +411,20 @@ MPI_Waitall:
         if (request_ptrs[i] && !MPIR_Request_is_persistent(request_ptrs[i])) {
             int rc = MPIR_Request_free_return(request_ptrs[i]);
             array_of_requests[i] = MPI_REQUEST_NULL;
-            if (rc && array_of_statuses != MPI_STATUSES_IGNORE) {
-                array_of_statuses[i].MPI_ERROR = rc;
-                mpi_errno = MPI_ERR_IN_STATUS;
+            if (rc) {
+                if (array_of_statuses == MPI_STATUSES_IGNORE) {
+                    mpi_errno = MPI_ERR_IN_STATUS;
+                } else if (mpi_errno == MPI_ERR_IN_STATUS) {
+                    array_of_statuses[i].MPI_ERROR = rc;
+                } else {
+                    MPIR_Assert(mpi_errno == MPI_SUCCESS);
+                    /* init all statuses' MPI_ERROR fields first */
+                    for (int j = 0; j < count; j++) {
+                        array_of_statuses[j].MPI_ERROR = MPI_SUCCESS;
+                    }
+                    mpi_errno = MPI_ERR_IN_STATUS;
+                    array_of_statuses[i].MPI_ERROR = rc;
+                }
             }
         }
     }
@@ -467,9 +500,20 @@ MPI_Waitsome:
         if (request_ptrs[idx] && !MPIR_Request_is_persistent(request_ptrs[idx])) {
             int rc = MPIR_Request_free_return(request_ptrs[idx]);
             array_of_requests[idx] = MPI_REQUEST_NULL;
-            if (rc && array_of_statuses != MPI_STATUSES_IGNORE) {
-                array_of_statuses[i].MPI_ERROR = rc;
-                mpi_errno = MPI_ERR_IN_STATUS;
+            if (rc) {
+                if (array_of_statuses == MPI_STATUSES_IGNORE) {
+                    mpi_errno = MPI_ERR_IN_STATUS;
+                } else if (mpi_errno == MPI_ERR_IN_STATUS) {
+                    array_of_statuses[i].MPI_ERROR = rc;
+                } else {
+                    MPIR_Assert(mpi_errno == MPI_SUCCESS);
+                    /* init all statuses' MPI_ERROR fields first */
+                    for (int j = 0; j < *outcount; j++) {
+                        array_of_statuses[j].MPI_ERROR = MPI_SUCCESS;
+                    }
+                    mpi_errno = MPI_ERR_IN_STATUS;
+                    array_of_statuses[i].MPI_ERROR = rc;
+                }
             }
         }
     }

--- a/src/binding/c/request_api.txt
+++ b/src/binding/c/request_api.txt
@@ -223,8 +223,11 @@ MPI_Test:
     mpi_errno = MPIR_Test(request_ptr, flag, status);
     if (*flag) {
         if (!MPIR_Request_is_persistent(request_ptr)) {
-            MPIR_Request_free(request_ptr);
+            int rc = MPIR_Request_free_return(request_ptr);
             *request = MPI_REQUEST_NULL;
+            if (rc) {
+                mpi_errno = rc;
+            }
         }
     }
     if (mpi_errno)
@@ -261,8 +264,12 @@ MPI_Testall:
                 continue;
             }
             if (request_ptrs[i] && !MPIR_Request_is_persistent(request_ptrs[i])) {
-                MPIR_Request_free(request_ptrs[i]);
+                int rc = MPIR_Request_free_return(request_ptrs[i]);
                 array_of_requests[i] = MPI_REQUEST_NULL;
+                if (rc && array_of_statuses != MPI_STATUSES_IGNORE) {
+                    array_of_statuses[i].MPI_ERROR = rc;
+                    mpi_errno = MPI_ERR_IN_STATUS;
+                }
             }
         }
     }
@@ -285,8 +292,11 @@ MPI_Testany:
     mpi_errno = MPIR_Testany(count, request_ptrs, indx, flag, status);
     if (*indx != MPI_UNDEFINED) {
         if (request_ptrs[*indx] && !MPIR_Request_is_persistent(request_ptrs[*indx])) {
-            MPIR_Request_free(request_ptrs[*indx]);
+            int rc = MPIR_Request_free_return(request_ptrs[*indx]);
             array_of_requests[*indx] = MPI_REQUEST_NULL;
+            if (rc) {
+                mpi_errno = rc;
+            }
         }
     }
     if (mpi_errno != MPI_SUCCESS)
@@ -316,8 +326,12 @@ MPI_Testsome:
     for (int i = 0; i < *outcount; i++) {
         int idx = array_of_indices[i];
         if (request_ptrs[idx] && !MPIR_Request_is_persistent(request_ptrs[idx])) {
-            MPIR_Request_free(request_ptrs[idx]);
+            int rc = MPIR_Request_free_return(request_ptrs[idx]);
             array_of_requests[idx] = MPI_REQUEST_NULL;
+            if (rc && array_of_statuses != MPI_STATUSES_IGNORE) {
+                array_of_statuses[i].MPI_ERROR = rc;
+                mpi_errno = MPI_ERR_IN_STATUS;
+            }
         }
     }
     if (mpi_errno != MPI_SUCCESS)
@@ -336,8 +350,11 @@ MPI_Wait:
 {
     mpi_errno = MPIR_Wait(request_ptr, status);
     if (!MPIR_Request_is_persistent(request_ptr)) {
-        MPIR_Request_free(request_ptr);
+        int rc = MPIR_Request_free_return(request_ptr);
         *request = MPI_REQUEST_NULL;
+        if (rc) {
+            mpi_errno = rc;
+        }
     }
     if (mpi_errno)
         goto fn_fail;
@@ -370,8 +387,12 @@ MPI_Waitall:
             continue;
         }
         if (request_ptrs[i] && !MPIR_Request_is_persistent(request_ptrs[i])) {
-            MPIR_Request_free(request_ptrs[i]);
+            int rc = MPIR_Request_free_return(request_ptrs[i]);
             array_of_requests[i] = MPI_REQUEST_NULL;
+            if (rc && array_of_statuses != MPI_STATUSES_IGNORE) {
+                array_of_statuses[i].MPI_ERROR = rc;
+                mpi_errno = MPI_ERR_IN_STATUS;
+            }
         }
     }
     if (mpi_errno)
@@ -395,8 +416,11 @@ MPI_Waitany:
     mpi_errno = MPIR_Waitany(count, request_ptrs, indx, status);
     if (*indx != MPI_UNDEFINED) {
         if (request_ptrs[*indx] && !MPIR_Request_is_persistent(request_ptrs[*indx])) {
-            MPIR_Request_free(request_ptrs[*indx]);
+            int rc = MPIR_Request_free_return(request_ptrs[*indx]);
             array_of_requests[*indx] = MPI_REQUEST_NULL;
+            if (rc) {
+                mpi_errno = rc;
+            }
         }
     }
     if (mpi_errno)
@@ -441,8 +465,12 @@ MPI_Waitsome:
     for (int i = 0; i < *outcount; i++) {
         int idx = array_of_indices[i];
         if (request_ptrs[idx] && !MPIR_Request_is_persistent(request_ptrs[idx])) {
-            MPIR_Request_free(request_ptrs[idx]);
+            int rc = MPIR_Request_free_return(request_ptrs[idx]);
             array_of_requests[idx] = MPI_REQUEST_NULL;
+            if (rc && array_of_statuses != MPI_STATUSES_IGNORE) {
+                array_of_statuses[i].MPI_ERROR = rc;
+                mpi_errno = MPI_ERR_IN_STATUS;
+            }
         }
     }
     if (mpi_errno)

--- a/src/binding/fortran/mpif_h/mpi_fortimpl.h
+++ b/src/binding/fortran/mpif_h/mpi_fortimpl.h
@@ -382,4 +382,7 @@ typedef void (FORT_CALL F90_DeleteFunction) (MPI_Fint *, MPI_Fint *, MPI_Aint *,
 
 void MPII_Keyval_set_f90_proxy(int keyval);
 
+extern FORT_DLL_SPEC void FORT_CALL mpi_alloc_mem_cptr_(MPI_Aint * size, MPI_Fint * info,
+                                                        void **baseptr, MPI_Fint * ierr);
+
 #endif /* MPI_FORTIMPL_H_INCLUDED */

--- a/src/binding/fortran/use_mpi/Makefile.mk
+++ b/src/binding/fortran/use_mpi/Makefile.mk
@@ -8,6 +8,7 @@ MPIMOD           = @MPIMODNAME@
 MPICONSTMOD      = @MPICONSTMODNAME@
 MPISIZEOFMOD     = @MPISIZEOFMODNAME@
 MPIBASEMOD       = @MPIBASEMODNAME@
+PMPIBASEMOD       = @PMPIBASEMODNAME@
 FC_COMPILE_MODS  = $(LTFCCOMPILE)
 
 # ensure that the buildiface script ends up in the release tarball
@@ -225,7 +226,7 @@ src/binding/fortran/use_mpi/pmpi_base.$(MOD)-stamp: src/binding/fortran/use_mpi/
 	   fi )
 	@mv src/binding/fortran/use_mpi/pmpi_base-tmp src/binding/fortran/use_mpi/pmpi_base.$(MOD)-stamp
 
-src/binding/fortran/use_mpi/pmpi_base.lo src/binding/fortran/use_mpi/$(MPIBASEMOD).$(MOD): src/binding/fortran/use_mpi/pmpi_base.$(MOD)-stamp
+src/binding/fortran/use_mpi/pmpi_base.lo src/binding/fortran/use_mpi/$(PMPIBASEMOD).$(MOD): src/binding/fortran/use_mpi/pmpi_base.$(MOD)-stamp
 ## Recover from the removal of $@
 	@if test -f $@; then :; else \
 	  trap 'rm -rf src/binding/fortran/use_mpi/pmpi_base-lock src/binding/fortran/use_mpi/pmpi_base.$(MOD)-stamp' 1 2 13 15; \
@@ -243,14 +244,15 @@ src/binding/fortran/use_mpi/pmpi_base.lo src/binding/fortran/use_mpi/$(MPIBASEMO
 	  fi; \
 	fi
 
-CLEANFILES += src/binding/fortran/use_mpi/pmpi_base.$(MOD)-stamp src/binding/fortran/use_mpi/$(MPIBASEMOD).$(MOD) src/binding/fortran/use_mpi/pmpi_base.lo src/binding/fortran/use_mpi/pmpi_base-tmp
+CLEANFILES += src/binding/fortran/use_mpi/pmpi_base.$(MOD)-stamp src/binding/fortran/use_mpi/$(PMPIBASEMOD).$(MOD) src/binding/fortran/use_mpi/pmpi_base.lo src/binding/fortran/use_mpi/pmpi_base-tmp
 
 
 mpi_fc_modules += \
     src/binding/fortran/use_mpi/$(MPIMOD).$(MOD) \
     src/binding/fortran/use_mpi/$(MPISIZEOFMOD).$(MOD) \
     src/binding/fortran/use_mpi/$(MPICONSTMOD).$(MOD) \
-    src/binding/fortran/use_mpi/$(MPIBASEMOD).$(MOD)
+    src/binding/fortran/use_mpi/$(MPIBASEMOD).$(MOD) \
+    src/binding/fortran/use_mpi/$(PMPIBASEMOD).$(MOD)
 
 # We need a free-format version of mpif.h with no external commands,
 # including no wtime/wtick (removing MPI_WTICK also removes MPI_WTIME,

--- a/src/mpi/request/request_impl.c
+++ b/src/mpi/request/request_impl.c
@@ -227,7 +227,7 @@ int MPIR_Request_free_impl(MPIR_Request * request_ptr)
             break;
     }
 
-    MPIR_Request_free(request_ptr);
+    mpi_errno = MPIR_Request_free_return(request_ptr);
 
     return mpi_errno;
 }

--- a/test/mpi/f77/pt2pt/irsendf.f
+++ b/test/mpi/f77/pt2pt/irsendf.f
@@ -82,12 +82,13 @@ C
          do while (completed .lt. 2)
             call MPI_Waitany(2, requests, index, status, ierr)
             completed = completed + 1
+            if (index .eq. 1) then
+                call msg_check( recv_buf, next, tag, count, status,
+     .                          TEST_SIZE, 'irsend and irecv', errs )
+            endif
          end do
 C
          call rq_check( requests(1), 1, 'irsend and irecv' )
-C
-         call msg_check( recv_buf, next, tag, count, status,
-     .           TEST_SIZE, 'irsend and irecv', errs )
 C
       else if (prev .eq. 0) then
 C


### PR DESCRIPTION
## Pull Request Description

We are supposed to return the error code from the `free_fn` of a generalized request. This was broken in PR https://github.com/pmodels/mpich/pull/6718

Also add to .gitignore the missing entry `src/binding/c/c_binding.c`.

Also fix a warning of missing prototypes in mpif_h binding.

Fixes #6747
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
