### PR TITLE
stream: fix wrong size in malloc

### DIFF
--- a/src/mpi/stream/stream_enqueue.c
+++ b/src/mpi/stream/stream_enqueue.c
@@ -412,7 +412,7 @@ static void waitall_enqueue_cb(void *data)
 {
     struct waitall_data *p = data;
 
-    MPIR_Request **reqs = MPL_malloc(p->count * sizeof(MPIR_Request), MPL_MEM_OTHER);
+    MPIR_Request **reqs = MPL_malloc(p->count * sizeof(MPIR_Request *), MPL_MEM_OTHER);
     MPIR_Assert(reqs);
 
     for (int i = 0; i < p->count; i++) {


### PR DESCRIPTION
## Pull Request Description
It should be sizeof(MPIR_Request *) instead of sizeof(MPIR_Request). Caught by coverity scan.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
