### PR TITLE
ch4/ofi: Add CVAR to set a preferred NIC per rank

### DIFF
--- a/src/mpi/init/mpi_init.h
+++ b/src/mpi/init/mpi_init.h
@@ -28,13 +28,13 @@ cvars:
     - name        : MPIR_CVAR_DEBUG_SUMMARY
       category    : DEVELOPER
       alt-env     : MPIR_CVAR_MEM_CATEGORY_INFORMATION, MPIR_CVAR_CH4_OFI_CAPABILITY_SETS_DEBUG, MPIR_CVAR_CH4_UCX_CAPABILITY_DEBUG
-      type        : boolean
-      default     : false
+      type        : int
+      default     : 0
       class       : none
       verbosity   : MPI_T_VERBOSITY_MPIDEV_DETAIL
       scope       : MPI_T_SCOPE_LOCAL
       description : >-
-        If true, print internal summary of various debug information, such as memory allocation by category.
+        1: Print internal summary of various debug information, such as memory allocation by category.
         Each layer may print their own summary information. For example, ch4-ofi may print its provider
         capability settings.
 

--- a/src/mpi/init/mpi_init.h
+++ b/src/mpi/init/mpi_init.h
@@ -37,6 +37,7 @@ cvars:
         1: Print internal summary of various debug information, such as memory allocation by category.
         Each layer may print their own summary information. For example, ch4-ofi may print its provider
         capability settings.
+        2: Also print the preferred NIC for each rank
 
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -771,6 +771,15 @@ int MPIDI_OFI_init_local(int *tag_bits)
         dump_global_settings();
     }
 
+    if (MPIR_CVAR_DEBUG_SUMMARY >= 2) {
+        if (MPIR_Process.rank == 0) {
+            fprintf(stdout, "====== Rank to NIC assignment ========\n");
+        }
+        fprintf(stdout, "Rank: %d, Local_rank: %d, NIC: %s\n", MPIR_Process.rank,
+                MPIR_Process.local_rank, MPIDI_OFI_global.prov_use[0]->domain_attr->name);
+    }
+    fflush(stdout);
+
     /* Finally open the fabric */
     MPIDI_OFI_CALL(fi_fabric(MPIDI_OFI_global.prov_use[0]->fabric_attr,
                              &MPIDI_OFI_global.fabric, NULL), fabric);


### PR DESCRIPTION
## Pull Request Description

The PR is based on top of https://github.com/pmodels/mpich/pull/6732.

Adds a `MPIR_CVAR_CH4_OFI_PREF_NIC` to let the user select a NIC per rank.
Also extends `MPIR_CVAR_DEBUG_SUMMARY` to print the NIC assigned to a rank.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
