### PR TITLE
ch4/ofi: fix bits allocation for providers without CQ data

### DIFF
--- a/src/mpid/ch4/netmod/ofi/init_settings.c
+++ b/src/mpid/ch4/netmod/ofi/init_settings.c
@@ -407,9 +407,9 @@ void MPIDI_OFI_update_global_settings(struct fi_info *prov)
     /* if CQ data is disabled, make sure we have sufficient source_bits */
     if (!MPIDI_OFI_global.settings.enable_data) {
         if (MPIDI_OFI_global.settings.source_bits == 0) {
-            MPIDI_OFI_global.settings.context_bits = 16;
-            MPIDI_OFI_global.settings.source_bits = 24;
-            MPIDI_OFI_global.settings.tag_bits = 20;
+            MPIDI_OFI_global.settings.context_bits = MPIDI_OFI_CONTEXT_BITS_b;
+            MPIDI_OFI_global.settings.source_bits = MPIDI_OFI_SOURCE_BITS_b;
+            MPIDI_OFI_global.settings.tag_bits = MPIDI_OFI_TAG_BITS_b;
         }
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_capability_sets.h
@@ -139,9 +139,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_ENABLE_HMEM_PSM2               MPIDI_OFI_OFF
 #define MPIDI_OFI_NUM_AM_BUFFERS_PSM2            MPIDI_OFI_MAX_NUM_AM_BUFFERS
 #define MPIDI_OFI_NUM_OPTIMIZED_MEMORY_REGIONS_PSM2 (0)
-#define MPIDI_OFI_CONTEXT_BITS_PSM2              (20)
-#define MPIDI_OFI_SOURCE_BITS_PSM2               (0)
-#define MPIDI_OFI_TAG_BITS_PSM2                  (31)
+#define MPIDI_OFI_CONTEXT_BITS_PSM2              MPIDI_OFI_CONTEXT_BITS_a
+#define MPIDI_OFI_SOURCE_BITS_PSM2               MPIDI_OFI_SOURCE_BITS_a
+#define MPIDI_OFI_TAG_BITS_PSM2                  MPIDI_OFI_TAG_BITS_a
 #define MPIDI_OFI_COUNTER_WAIT_OBJECTS_PSM2      MPIDI_OFI_ON
 #define MPIDI_OFI_MAJOR_VERSION_PSM2             1
 #define MPIDI_OFI_MINOR_VERSION_PSM2             6
@@ -211,9 +211,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_ENABLE_HMEM_PSM3               MPIDI_OFI_ON
 #define MPIDI_OFI_NUM_AM_BUFFERS_PSM3            MPIDI_OFI_MAX_NUM_AM_BUFFERS
 #define MPIDI_OFI_NUM_OPTIMIZED_MEMORY_REGIONS_PSM3 (0)
-#define MPIDI_OFI_CONTEXT_BITS_PSM3              (20)
-#define MPIDI_OFI_SOURCE_BITS_PSM3               (0)
-#define MPIDI_OFI_TAG_BITS_PSM3                  (31)
+#define MPIDI_OFI_CONTEXT_BITS_PSM3              MPIDI_OFI_CONTEXT_BITS_a
+#define MPIDI_OFI_SOURCE_BITS_PSM3               MPIDI_OFI_SOURCE_BITS_a
+#define MPIDI_OFI_TAG_BITS_PSM3                  MPIDI_OFI_TAG_BITS_a
 #define MPIDI_OFI_COUNTER_WAIT_OBJECTS_PSM3      MPIDI_OFI_ON
 #define MPIDI_OFI_MAJOR_VERSION_PSM3             1
 #define MPIDI_OFI_MINOR_VERSION_PSM3             6
@@ -283,9 +283,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_ENABLE_HMEM_SOCKETS               MPIDI_OFI_OFF
 #define MPIDI_OFI_NUM_AM_BUFFERS_SOCKETS            MPIDI_OFI_MAX_NUM_AM_BUFFERS
 #define MPIDI_OFI_NUM_OPTIMIZED_MEMORY_REGIONS_SOCKETS  (0)
-#define MPIDI_OFI_CONTEXT_BITS_SOCKETS              (20)
-#define MPIDI_OFI_SOURCE_BITS_SOCKETS               (0)
-#define MPIDI_OFI_TAG_BITS_SOCKETS                  (31)
+#define MPIDI_OFI_CONTEXT_BITS_SOCKETS              MPIDI_OFI_CONTEXT_BITS_a
+#define MPIDI_OFI_SOURCE_BITS_SOCKETS               MPIDI_OFI_SOURCE_BITS_a
+#define MPIDI_OFI_TAG_BITS_SOCKETS                  MPIDI_OFI_TAG_BITS_a
 #define MPIDI_OFI_COUNTER_WAIT_OBJECTS_SOCKETS      MPIDI_OFI_ON
 #define MPIDI_OFI_MAJOR_VERSION_SOCKETS             1
 #define MPIDI_OFI_MINOR_VERSION_SOCKETS             5
@@ -355,9 +355,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_ENABLE_HMEM_BGQ               MPIDI_OFI_OFF
 #define MPIDI_OFI_NUM_AM_BUFFERS_BGQ            MPIDI_OFI_MAX_NUM_AM_BUFFERS
 #define MPIDI_OFI_NUM_OPTIMIZED_MEMORY_REGIONS_BGQ  (0)
-#define MPIDI_OFI_CONTEXT_BITS_BGQ              (20)
-#define MPIDI_OFI_SOURCE_BITS_BGQ               (0)
-#define MPIDI_OFI_TAG_BITS_BGQ                  (31)
+#define MPIDI_OFI_CONTEXT_BITS_BGQ              MPIDI_OFI_CONTEXT_BITS_a
+#define MPIDI_OFI_SOURCE_BITS_BGQ               MPIDI_OFI_SOURCE_BITS_a
+#define MPIDI_OFI_TAG_BITS_BGQ                  MPIDI_OFI_TAG_BITS_a
 #define MPIDI_OFI_COUNTER_WAIT_OBJECTS_BGQ      MPIDI_OFI_ON
 #define MPIDI_OFI_MAJOR_VERSION_BGQ             1
 #define MPIDI_OFI_MINOR_VERSION_BGQ             5
@@ -431,6 +431,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
                                                          * RMA support is fixed. */
 #define MPIDI_OFI_CONTEXT_BITS_CXI                  (20)
 #define MPIDI_OFI_SOURCE_BITS_CXI                   (0)
+/* FIXME: What is the actual bit space? We need make sure to account for
+ * MPIDI_OFI_PROTOCOL_BITS. */
 #define MPIDI_OFI_TAG_BITS_CXI                      (20)        /* The CXI provider has a smaller tag space
                                                                  * than other providers so the number of
                                                                  * tag bits exposed to the user is
@@ -511,9 +513,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_ENABLE_HMEM_RXM                  MPIDI_OFI_OFF
 #define MPIDI_OFI_NUM_AM_BUFFERS_RXM               MPIDI_OFI_MAX_NUM_AM_BUFFERS
 #define MPIDI_OFI_NUM_OPTIMIZED_MEMORY_REGIONS_RXM (0)
-#define MPIDI_OFI_CONTEXT_BITS_RXM                 (20)
-#define MPIDI_OFI_SOURCE_BITS_RXM                  (0)
-#define MPIDI_OFI_TAG_BITS_RXM                     (31)
+#define MPIDI_OFI_CONTEXT_BITS_RXM                 MPIDI_OFI_CONTEXT_BITS_a
+#define MPIDI_OFI_SOURCE_BITS_RXM                  MPIDI_OFI_SOURCE_BITS_a
+#define MPIDI_OFI_TAG_BITS_RXM                     MPIDI_OFI_TAG_BITS_a
 #define MPIDI_OFI_COUNTER_WAIT_OBJECTS_RXM         MPIDI_OFI_ON
 #define MPIDI_OFI_MAJOR_VERSION_RXM                 1
 #define MPIDI_OFI_MINOR_VERSION_RXM                 6
@@ -582,9 +584,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_ENABLE_HMEM_VERBS_RXM               MPIDI_OFI_OFF
 #define MPIDI_OFI_NUM_AM_BUFFERS_VERBS_RXM            MPIDI_OFI_MAX_NUM_AM_BUFFERS
 #define MPIDI_OFI_NUM_OPTIMIZED_MEMORY_REGIONS_VERBS_RXM  (0)
-#define MPIDI_OFI_CONTEXT_BITS_VERBS_RXM              (20)
-#define MPIDI_OFI_SOURCE_BITS_VERBS_RXM               (0)
-#define MPIDI_OFI_TAG_BITS_VERBS_RXM                  (31)
+#define MPIDI_OFI_CONTEXT_BITS_VERBS_RXM              MPIDI_OFI_CONTEXT_BITS_a
+#define MPIDI_OFI_SOURCE_BITS_VERBS_RXM               MPIDI_OFI_SOURCE_BITS_a
+#define MPIDI_OFI_TAG_BITS_VERBS_RXM                  MPIDI_OFI_TAG_BITS_a
 #define MPIDI_OFI_COUNTER_WAIT_OBJECTS_VERBS_RXM      MPIDI_OFI_ON
 #define MPIDI_OFI_MAJOR_VERSION_VERBS_RXM             1
 #define MPIDI_OFI_MINOR_VERSION_VERBS_RXM             5
@@ -655,9 +657,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_ENABLE_HMEM_GNI               MPIDI_OFI_OFF
 #define MPIDI_OFI_NUM_AM_BUFFERS_GNI            MPIDI_OFI_MAX_NUM_AM_BUFFERS
 #define MPIDI_OFI_NUM_OPTIMIZED_MEMORY_REGIONS_GNI (0)
-#define MPIDI_OFI_CONTEXT_BITS_GNI              (16)
-#define MPIDI_OFI_SOURCE_BITS_GNI               (24)
-#define MPIDI_OFI_TAG_BITS_GNI                  (20)
+#define MPIDI_OFI_CONTEXT_BITS_GNI              MPIDI_OFI_CONTEXT_BITS_b
+#define MPIDI_OFI_SOURCE_BITS_GNI               MPIDI_OFI_SOURCE_BITS_b
+#define MPIDI_OFI_TAG_BITS_GNI                  MPIDI_OFI_TAG_BITS_b
 #define MPIDI_OFI_COUNTER_WAIT_OBJECTS_GNI      MPIDI_OFI_ON
 #define MPIDI_OFI_MAJOR_VERSION_GNI             1
 #define MPIDI_OFI_MINOR_VERSION_GNI             5
@@ -735,9 +737,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_SOURCE_MASK_DEFAULT               (0x0000000000000000ULL)     /* We require support for immediate data
                                                                                  * so this field is zeroed */
 #define MPIDI_OFI_TAG_MASK_DEFAULT                  (0x000000007FFFFFFFULL)
-#define MPIDI_OFI_CONTEXT_BITS_DEFAULT              (20)
-#define MPIDI_OFI_SOURCE_BITS_DEFAULT               (0)
-#define MPIDI_OFI_TAG_BITS_DEFAULT                  (31)
+#define MPIDI_OFI_CONTEXT_BITS_DEFAULT              MPIDI_OFI_CONTEXT_BITS_a
+#define MPIDI_OFI_SOURCE_BITS_DEFAULT               MPIDI_OFI_SOURCE_BITS_a
+#define MPIDI_OFI_TAG_BITS_DEFAULT                  MPIDI_OFI_TAG_BITS_a
 #define MPIDI_OFI_COUNTER_WAIT_OBJECTS_DEFAULT      MPIDI_OFI_ON
 #define MPIDI_OFI_SYNC_SEND_ACK_DEFAULT             (0x0010000000000000ULL)
 #define MPIDI_OFI_DYNPROC_SEND_DEFAULT              (0x0020000000000000ULL)
@@ -775,9 +777,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_get_set_number(const char *set_name)
 #define MPIDI_OFI_SOURCE_MASK_MINIMAL               (0x00000FFFFFF00000ULL)     /* assume that provider does not support immediate data
                                                                                  * so this field needs to be available */
 #define MPIDI_OFI_TAG_MASK_MINIMAL                  (0x00000000000FFFFFULL)
-#define MPIDI_OFI_CONTEXT_BITS_MINIMAL              (16)
-#define MPIDI_OFI_SOURCE_BITS_MINIMAL               (24)
-#define MPIDI_OFI_TAG_BITS_MINIMAL                  (20)
+#define MPIDI_OFI_CONTEXT_BITS_MINIMAL              MPIDI_OFI_CONTEXT_BITS_b
+#define MPIDI_OFI_SOURCE_BITS_MINIMAL               MPIDI_OFI_SOURCE_BITS_b
+#define MPIDI_OFI_TAG_BITS_MINIMAL                  MPIDI_OFI_SOURCE_BITS_b
 #define MPIDI_OFI_COUNTER_WAIT_OBJECTS_MINIMAL      MPIDI_OFI_ON
 #define MPIDI_OFI_SYNC_SEND_MINIMAL                 (0x1000000000000000ULL)
 #define MPIDI_OFI_DYNPROC_SEND_MINIMAL              (0x2000000000000000ULL)

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -110,6 +110,18 @@ static inline uint32_t MPIDI_OFI_idata_get_gpuchunk_bits(uint64_t idata)
 #define MPIDI_OFI_PROTOCOL_BITS (5)
 #define MPIDI_OFI_PROTOCOL_MASK_BITS (2)
 
+/* Define constants for default bits allocation. The actual bits are defined in
+ * ofi_capability_sets.h, which may use these defaults or define its own.
+ */
+/* with CQ data */
+#define MPIDI_OFI_CONTEXT_BITS_a 20
+#define MPIDI_OFI_SOURCE_BITS_a  0
+#define MPIDI_OFI_TAG_BITS_a     31
+/* without CQ data */
+#define MPIDI_OFI_CONTEXT_BITS_b 16
+#define MPIDI_OFI_SOURCE_BITS_b  24
+#define MPIDI_OFI_TAG_BITS_b     20
+
 #if MPIDI_OFI_ENABLE_RUNTIME_CHECKS == MPIDI_OFI_ON
 #define MPIDI_OFI_SYNC_SEND_ACK      (1ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))
 #define MPIDI_OFI_DYNPROC_SEND       (2ULL << (MPIDI_OFI_CONTEXT_BITS + MPIDI_OFI_SOURCE_BITS + MPIDI_OFI_TAG_BITS))

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -119,7 +119,7 @@ static inline uint32_t MPIDI_OFI_idata_get_gpuchunk_bits(uint64_t idata)
 #define MPIDI_OFI_TAG_BITS_a     31
 /* without CQ data */
 #define MPIDI_OFI_CONTEXT_BITS_b 16
-#define MPIDI_OFI_SOURCE_BITS_b  24
+#define MPIDI_OFI_SOURCE_BITS_b  23
 #define MPIDI_OFI_TAG_BITS_b     20
 
 #if MPIDI_OFI_ENABLE_RUNTIME_CHECKS == MPIDI_OFI_ON


### PR DESCRIPTION
## Pull Request Description

MPIDI_OFI_PROTOCOL_BITS is defined in ofi_types.h, but the rest of the
bits are defined in ofi_capabilities.h. This allows inconsistency to
easily creep in. This is the case as in commit https://github.com/pmodels/mpich/commit/32e5db5a98e95d002df2f3841a6a5f2e2eb14b89 when we modified
MPIDI_OFI_PROTOCOL_BITS without checking against *all* providers.
Refactor by defining bit patterns in ofi_types.h and use the predefined
constants in ofi_capabilities.h. We still can overwrite them, such is
the case for CXI provider, but at least the default will be consistent.

Fixes nightly tests for `verbs` provider.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
