### PR TITLE
mpi4.1: MPI_Remove_error_{class,code,string}

### DIFF
--- a/src/binding/c/errhan_api.txt
+++ b/src/binding/c/errhan_api.txt
@@ -1,9 +1,5 @@
 # vim: set ft=c:
 
-# Note: MPIX_Delete_error_{code,class,string} are MPI 4.1 APIs, so we are using MPIX_
-#       prefixes and supplying the parameter information since they are not in the
-#       official standards yet
-
 MPI_Add_error_class:
     .desc: Add an MPI error class to the known classes
 
@@ -21,25 +17,6 @@ MPI_Add_error_string:
     specify it that way.
 
     According to the MPI-2 standard, it is erroneous to call 'MPI_Add_error_string'
-    for an error code or class with a value less than or equal
-    to 'MPI_ERR_LASTCODE'.  Thus, you cannot replace the predefined error messages
-    with this routine.
-*/
-
-MPI_Delete_error_class:
-    errorclass: ERROR_CLASS, [value of the error class to be remoed]
-    .desc: Delete an MPI error class from the known classes
-
-MPI_Delete_error_code:
-    errorcode: ERROR_CODE, [value of the error code to be remoed]
-    .desc: Delete an MPI error code
-
-MPI_Delete_error_string:
-    errorcode: ERROR_CODE, [value of the error code whose string is to be remoed]
-    .desc: Delete the error string associated with an MPI error code or class
-/*
-    Notes:
-    According to the MPI 4.1 standard, it is erroneous to call 'MPI_Delete_error_string'
     for an error code or class with a value less than or equal
     to 'MPI_ERR_LASTCODE'.  Thus, you cannot replace the predefined error messages
     with this routine.
@@ -146,6 +123,22 @@ MPI_File_set_errhandler:
         goto fn_fail;
     }
 }
+
+MPI_Remove_error_class:
+    .desc: Remove an MPI error class from the known classes
+
+MPI_Remove_error_code:
+    .desc: Remove an MPI error code
+
+MPI_Remove_error_string:
+    .desc: Remove the error string associated with an MPI error code or class
+/*
+    Notes:
+    According to the MPI 4.1 standard, it is erroneous to call 'MPI_Remove_error_string'
+    for an error code or class with a value less than or equal
+    to 'MPI_ERR_LASTCODE'.  Thus, you cannot replace the predefined error messages
+    with this routine.
+*/
 
 MPI_Win_call_errhandler:
     .desc: Call the error handler installed on a window

--- a/src/binding/mpi_standard_api.txt
+++ b/src/binding/mpi_standard_api.txt
@@ -1767,6 +1767,12 @@ MPI_Register_datarep:
     write_conversion_fn: POLYFUNCTION, func_type=MPI_Datarep_conversion_function, [function invoked to convert from native representation to file representation]
     dtype_file_extent_fn: FUNCTION, func_type=MPI_Datarep_extent_function, [function invoked to get the extent of a datatype as represented in the file]
     extra_state: EXTRA_STATE, [extra state]
+MPI_Remove_error_class:
+    errorclass: ERROR_CLASS, [value of the error class to be removed]
+MPI_Remove_error_code:
+    errorcode: ERROR_CODE, [value of the error code to be removed]
+MPI_Remove_error_string:
+    errorcode: ERROR_CODE, [value of the error code whose string is to be removed]
 MPI_Request_c2f:
     .return: F90_REQUEST
     request: REQUEST, direction=in, pointer=False

--- a/src/binding/mpix.txt
+++ b/src/binding/mpix.txt
@@ -16,7 +16,3 @@
 # side effects to run the script multiple times.
 
 # MPI functions
-
-MPI_Delete_error_class
-MPI_Delete_error_code
-MPI_Delete_error_string

--- a/src/include/mpir_errcodes.h
+++ b/src/include/mpir_errcodes.h
@@ -6,14 +6,6 @@
 #ifndef MPIR_ERRCODES_H_INCLUDED
 #define MPIR_ERRCODES_H_INCLUDED
 
-/* Prototypes for internal routines for the errhandling module */
-int MPIR_Add_error_string_impl(int errorcode, const char *string);
-int MPIR_Delete_error_string_impl(int errorcode);
-int MPIR_Add_error_class_impl(int *errorclass);
-int MPIR_Delete_error_class_impl(int errorclass);
-int MPIR_Add_error_code_impl(int errorclass, int *errorcode);
-int MPIR_Delete_error_code_impl(int code);
-
 /*
    This file contains the definitions of the error code fields
 

--- a/src/mpi/errhan/dynerrutil.c
+++ b/src/mpi/errhan/dynerrutil.c
@@ -193,13 +193,13 @@ int MPIR_Add_error_string_impl(int code, const char *msg_string)
 }
 
 /*
-  MPIR_Delete_error_string_impl - Delete the string associated with an error code or class
+  MPIR_Remove_error_string_impl - Delete the string associated with an error code or class
 
   Notes:
-  This is used to implement 'MPI_Delete_error_string'; it may also be used by a
+  This is used to implement 'MPI_Remove_error_string'; it may also be used by a
   device to delete device-specific error strings.
 */
-int MPIR_Delete_error_string_impl(int code)
+int MPIR_Remove_error_string_impl(int code)
 {
     int mpi_errno = MPI_SUCCESS;
     int errcode = (int) (((unsigned int) code & ERROR_GENERIC_MASK) >> ERROR_GENERIC_SHIFT);
@@ -292,10 +292,10 @@ int MPIR_Add_error_class_impl(int *errorclass)
 }
 
 /*
-  MPIR_Delete_error_class_impl - Delete an error class
+  MPIR_Remove_error_class_impl - Delete an error class
 
   Notes:
-  This is used to implement 'MPI_Delete_error_class'; it may also be used by a
+  This is used to implement 'MPI_Remove_error_class'; it may also be used by a
   device to delete device-specific error classes.
 
   Predefined classes are handled directly; this routine is not used to
@@ -304,7 +304,7 @@ int MPIR_Add_error_class_impl(int *errorclass)
 
   This routine should be run within a SINGLE_CS in the multithreaded case.
 */
-int MPIR_Delete_error_class_impl(int user_errclass)
+int MPIR_Remove_error_class_impl(int user_errclass)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -376,13 +376,13 @@ int MPIR_Add_error_code_impl(int class, int *code)
 }
 
 /*
-  MPIR_Delete_error_code_impl - Delete an error code
+  MPIR_Remove_error_code_impl - Delete an error code
 
   Notes:
-  This is used to implement 'MPI_Delete_error_code'; it may also be used by a
+  This is used to implement 'MPI_Remove_error_code'; it may also be used by a
   device to delete device-specific error codes.
 */
-int MPIR_Delete_error_code_impl(int code)
+int MPIR_Remove_error_code_impl(int code)
 {
     int mpi_errno = MPI_SUCCESS;
     int errcode = (int) (((unsigned int) code & ERROR_GENERIC_MASK) >> ERROR_GENERIC_SHIFT);

--- a/test/mpi/errhan/adderr.c
+++ b/test/mpi/errhan/adderr.c
@@ -38,10 +38,10 @@ int main(int argc, char *argv[])
         }
         for (i = 0; i < NCLASSES; i++) {
             for (j = 0; j < NCODES; j++) {
-                MPI_Delete_error_string(newcode[i][j]);
-                MPI_Delete_error_code(newcode[i][j]);
+                MPI_Remove_error_string(newcode[i][j]);
+                MPI_Remove_error_code(newcode[i][j]);
             }
-            MPI_Delete_error_class(newclass[i]);
+            MPI_Remove_error_class(newclass[i]);
         }
     }
 #endif


### PR DESCRIPTION

## Pull Request Description
These routines were implemented as
MPIX_Delete_error_{class,code,string}. Now they are in official MPI 4.1 as MPI_Remove_error_{class,code,string}.

Fixes #6760

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
