### PR TITLE
datatype: add MPI_Type_get_value_index

### DIFF
--- a/src/binding/c/datatype_api.txt
+++ b/src/binding/c/datatype_api.txt
@@ -305,6 +305,9 @@ MPI_Type_get_true_extent_x:
     .desc: Get the true lower bound and extent as MPI_Count values for a datatype
     .skip: global_cs
 
+MPI_Type_get_value_index:
+    .desc: returns a handle to a predefined datatype suitable for the use with MPI_MINLOC and MPI_MAXLOC if such a predefined type exists
+
 MPI_Type_size:
     .desc: Return the number of bytes occupied by entries in the datatype
     .skip: global_cs

--- a/src/binding/mpi_standard_api.txt
+++ b/src/binding/mpi_standard_api.txt
@@ -2475,6 +2475,10 @@ MPI_Type_get_true_extent_x:
     datatype: DATATYPE, [datatype to get information on]
     true_lb: XFER_NUM_ELEM, direction=out, [true lower bound of datatype]
     true_extent: XFER_NUM_ELEM, direction=out, [true size of datatype]
+MPI_Type_get_value_index:
+    value_type: DATATYPE, [datatype of the value in pair]
+    index_type: DATATYPE, [datatype of the index in pair]
+    pair_type: DATATYPE, direction=out, [datatype of the value-index pair]
 MPI_Type_indexed:
     count: POLYDTYPE_NUM_ELEM_NNI, [number of blocks -- also number of entries in array_of_displacements and array_of_blocklengths]
     array_of_blocklengths: POLYDTYPE_NUM_ELEM_NNI, length=count, constant=True, [number of elements per block]

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -552,7 +552,8 @@ enum MPIR_Combiner_enum {
     MPI_COMBINER_F90_COMPLEX      = 16,
     MPI_COMBINER_F90_INTEGER      = 17,
     MPI_COMBINER_RESIZED          = 18,
-    MPI_COMBINER_HINDEXED_BLOCK   = 19
+    MPI_COMBINER_HINDEXED_BLOCK   = 19,
+    MPI_COMBINER_VALUE_INDEX      = 20
 };
 
 /* for subarray and darray constructors */

--- a/src/mpi/datatype/datatype_impl.c
+++ b/src/mpi/datatype/datatype_impl.c
@@ -263,6 +263,34 @@ int MPIR_Type_get_true_extent_x_impl(MPI_Datatype datatype, MPI_Count * true_lb,
     return MPI_SUCCESS;
 }
 
+int MPIR_Type_get_value_index_impl(MPI_Datatype value_type, MPI_Datatype index_type,
+                                   MPI_Datatype * pair_type)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    if (index_type == MPI_INT) {
+        if (value_type == MPI_FLOAT) {
+            *pair_type = MPI_FLOAT_INT;
+        } else if (value_type == MPI_DOUBLE) {
+            *pair_type = MPI_DOUBLE_INT;
+        } else if (value_type == MPI_LONG) {
+            *pair_type = MPI_LONG_INT;
+        } else if (value_type == MPI_SHORT) {
+            *pair_type = MPI_SHORT_INT;
+        } else if (value_type == MPI_INT) {
+            *pair_type = MPI_2INT;
+        } else if (value_type == MPI_LONG_DOUBLE) {
+            *pair_type = MPI_LONG_DOUBLE_INT;
+        } else {
+            *pair_type = MPI_DATATYPE_NULL;
+        }
+    } else {
+        *pair_type = MPI_DATATYPE_NULL;
+    }
+
+    return mpi_errno;
+}
+
 int MPIR_Type_size_impl(MPI_Datatype datatype, MPI_Aint * size)
 {
     int mpi_errno = MPI_SUCCESS;


### PR DESCRIPTION
## Pull Request Description

For initial implementation, we only return the six predefined pair types
if the input is matching and return MPI_DATATYPE_NULL otherwise.
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
