### PR TITLE
coll: fix a bug when getting a tree_type

### DIFF
--- a/src/mpi/coll/allreduce/allreduce_intra_tree.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_tree.c
@@ -68,15 +68,15 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
     if (tree_type == MPIR_TREE_TYPE_TOPOLOGY_AWARE || tree_type == MPIR_TREE_TYPE_TOPOLOGY_AWARE_K) {
         mpi_errno =
             MPIR_Treealgo_tree_create_topo_aware(comm_ptr, tree_type, k, root,
-                                                 MPIR_CVAR_BCAST_TOPO_REORDER_ENABLE, &my_tree);
+                                                 MPIR_CVAR_ALLREDUCE_TOPO_REORDER_ENABLE, &my_tree);
     } else if (tree_type == MPIR_TREE_TYPE_TOPOLOGY_WAVE) {
         mpi_errno =
             MPIR_Treealgo_tree_create_topo_wave(comm_ptr, k, root,
-                                                MPIR_CVAR_BCAST_TOPO_REORDER_ENABLE,
-                                                MPIR_CVAR_BCAST_TOPO_OVERHEAD,
-                                                MPIR_CVAR_BCAST_TOPO_DIFF_GROUPS,
-                                                MPIR_CVAR_BCAST_TOPO_DIFF_SWITCHES,
-                                                MPIR_CVAR_BCAST_TOPO_SAME_SWITCHES, &my_tree);
+                                                MPIR_CVAR_ALLREDUCE_TOPO_REORDER_ENABLE,
+                                                MPIR_CVAR_ALLREDUCE_TOPO_OVERHEAD,
+                                                MPIR_CVAR_ALLREDUCE_TOPO_DIFF_GROUPS,
+                                                MPIR_CVAR_ALLREDUCE_TOPO_DIFF_SWITCHES,
+                                                MPIR_CVAR_ALLREDUCE_TOPO_SAME_SWITCHES, &my_tree);
     } else {
         mpi_errno = MPIR_Treealgo_tree_create(rank, comm_size, tree_type, k, root, &my_tree);
     }

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree.c
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree.c
@@ -71,15 +71,16 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
     my_tree.children = NULL;
     if (tree_type == MPIR_TREE_TYPE_TOPOLOGY_AWARE || tree_type == MPIR_TREE_TYPE_TOPOLOGY_AWARE_K) {
         mpi_errno =
-            MPIR_Treealgo_tree_create_topo_aware(comm, tree_type, k, root,
-                                                 MPIR_CVAR_BCAST_TOPO_REORDER_ENABLE, &my_tree);
+            MPIR_Treealgo_tree_create_topo_aware(comm, tree_type, k, tree_root,
+                                                 MPIR_CVAR_IREDUCE_TOPO_REORDER_ENABLE, &my_tree);
     } else if (tree_type == MPIR_TREE_TYPE_TOPOLOGY_WAVE) {
         mpi_errno =
-            MPIR_Treealgo_tree_create_topo_wave(comm, k, root, MPIR_CVAR_BCAST_TOPO_REORDER_ENABLE,
-                                                MPIR_CVAR_BCAST_TOPO_OVERHEAD,
-                                                MPIR_CVAR_BCAST_TOPO_DIFF_GROUPS,
-                                                MPIR_CVAR_BCAST_TOPO_DIFF_SWITCHES,
-                                                MPIR_CVAR_BCAST_TOPO_SAME_SWITCHES, &my_tree);
+            MPIR_Treealgo_tree_create_topo_wave(comm, k, tree_root,
+                                                MPIR_CVAR_IREDUCE_TOPO_REORDER_ENABLE,
+                                                MPIR_CVAR_IREDUCE_TOPO_OVERHEAD,
+                                                MPIR_CVAR_IREDUCE_TOPO_DIFF_GROUPS,
+                                                MPIR_CVAR_IREDUCE_TOPO_DIFF_SWITCHES,
+                                                MPIR_CVAR_IREDUCE_TOPO_SAME_SWITCHES, &my_tree);
     } else {
         mpi_errno = MPIR_Treealgo_tree_create(rank, size, tree_type, k, tree_root, &my_tree);
     }

--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -111,11 +111,11 @@ void *MPIR_Csel_root = NULL;
 static MPIR_Tree_type_t get_tree_type_from_string(const char *tree_str)
 {
     MPIR_Tree_type_t tree_type = MPIR_TREE_TYPE_KARY;
-    if (0 == strcmp(MPIR_CVAR_BCAST_TREE_TYPE, "kary"))
+    if (0 == strcmp(tree_str, "kary"))
         tree_type = MPIR_TREE_TYPE_KARY;
-    else if (0 == strcmp(MPIR_CVAR_BCAST_TREE_TYPE, "knomial_1"))
+    else if (0 == strcmp(tree_str, "knomial_1"))
         tree_type = MPIR_TREE_TYPE_KNOMIAL_1;
-    else if (0 == strcmp(MPIR_CVAR_BCAST_TREE_TYPE, "knomial_2"))
+    else if (0 == strcmp(tree_str, "knomial_2"))
         tree_type = MPIR_TREE_TYPE_KNOMIAL_2;
     else
         tree_type = MPIR_TREE_TYPE_KARY;
@@ -125,17 +125,17 @@ static MPIR_Tree_type_t get_tree_type_from_string(const char *tree_str)
 static MPIR_Tree_type_t get_tree_type_from_string_with_topo(const char *tree_str)
 {
     MPIR_Tree_type_t tree_type = MPIR_TREE_TYPE_KARY;
-    if (0 == strcmp(MPIR_CVAR_BCAST_TREE_TYPE, "kary"))
+    if (0 == strcmp(tree_str, "kary"))
         tree_type = MPIR_TREE_TYPE_KARY;
-    else if (0 == strcmp(MPIR_CVAR_BCAST_TREE_TYPE, "knomial_1"))
+    else if (0 == strcmp(tree_str, "knomial_1"))
         tree_type = MPIR_TREE_TYPE_KNOMIAL_1;
-    else if (0 == strcmp(MPIR_CVAR_BCAST_TREE_TYPE, "knomial_2"))
+    else if (0 == strcmp(tree_str, "knomial_2"))
         tree_type = MPIR_TREE_TYPE_KNOMIAL_2;
-    else if (0 == strcmp(MPIR_CVAR_BCAST_TREE_TYPE, "topology_aware"))
+    else if (0 == strcmp(tree_str, "topology_aware"))
         tree_type = MPIR_TREE_TYPE_TOPOLOGY_AWARE;
-    else if (0 == strcmp(MPIR_CVAR_BCAST_TREE_TYPE, "topology_aware_k"))
+    else if (0 == strcmp(tree_str, "topology_aware_k"))
         tree_type = MPIR_TREE_TYPE_TOPOLOGY_AWARE_K;
-    else if (0 == strcmp(MPIR_CVAR_BCAST_TREE_TYPE, "topology_wave"))
+    else if (0 == strcmp(tree_str, "topology_wave"))
         tree_type = MPIR_TREE_TYPE_TOPOLOGY_WAVE;
     else
         tree_type = MPIR_TREE_TYPE_KARY;


### PR DESCRIPTION
## Pull Request Description
1. Fix a bug in get_tree_type_from_string and get_tree_type_from_string_with_topo. The bug causes the tree_types to be set to the wrong values.
2. Fix typos when building topology-aware trees in Ireduce and Allreduce.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
