### PR TITLE
mpi4.1: add split_type MPI_COMM_TYPE_RESOURCE_GUIDED

### DIFF
--- a/src/binding/c/topo_api.txt
+++ b/src/binding/c/topo_api.txt
@@ -189,6 +189,9 @@ MPI_Dist_graph_neighbors_count:
     .desc: Provides adjacency information for a distributed graph topology
     .extra: ignore_revoked_comm
 
+MPI_Get_hw_resource_info:
+    .desc: returns an info object containing information pertaining to the hardware platform on which the calling MPI process is executing at the moment of the call.
+
 MPI_Graph_get:
     .desc: Retrieves graph topology information associated with a communicator
     .skip: global_cs

--- a/src/binding/mpi_standard_api.txt
+++ b/src/binding/mpi_standard_api.txt
@@ -966,6 +966,8 @@ MPI_Get_elements_x:
     status: STATUS, constant=True, [return status of receive operation]
     datatype: DATATYPE, [datatype used by receive operation]
     count: NUM_BYTES, direction=out, [number of received basic elements]
+MPI_Get_hw_resource_info:
+    hw_info: INFO, direction=out, [info object created]
 MPI_Get_library_version:
     version: STRING, length=MPI_MAX_LIBRARY_VERSION_STRING, direction=OUT, [version number]
     resultlen: STRING_LENGTH, direction=out, [Length (in printable characters) of the result returned in version]

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -576,9 +576,10 @@ enum MPIR_Combiner_enum {
 #define MPI_COMM_TYPE_SHARED    1
 #define MPI_COMM_TYPE_HW_GUIDED 2
 #define MPI_COMM_TYPE_HW_UNGUIDED 3
+#define MPI_COMM_TYPE_RESOURCE_GUIDED 4
 
 /* MPICH-specific types */
-#define MPIX_COMM_TYPE_NEIGHBORHOOD 4
+#define MPIX_COMM_TYPE_NEIGHBORHOOD 5
 
 /* For supported thread levels */
 #define MPI_THREAD_SINGLE 0

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -408,11 +408,6 @@ int MPIR_Comm_connect_impl(const char *port_name, MPIR_Info * info_ptr, int root
                            MPIR_Comm * comm_ptr, MPIR_Comm ** newcomm_ptr);
 
 int MPIR_Comm_split_type_self(MPIR_Comm * comm_ptr, int key, MPIR_Comm ** newcomm_ptr);
-int MPIR_Comm_split_type_hw_guided(MPIR_Comm * comm_ptr, int key, MPIR_Info * info_ptr,
-                                   MPIR_Comm ** newcomm_ptr);
-int MPIR_Comm_split_type_hw_unguided(MPIR_Comm * comm_ptr, int key, MPIR_Info * info_ptr,
-                                     MPIR_Comm ** newcomm_ptr);
-int MPIR_Comm_split_type_by_node(MPIR_Comm * comm_ptr, int key, MPIR_Comm ** newcomm_ptr);
 int MPIR_Comm_split_type_node_topo(MPIR_Comm * comm_ptr, int key,
                                    MPIR_Info * info_ptr, MPIR_Comm ** newcomm_ptr);
 int MPIR_Comm_split_type(MPIR_Comm * comm_ptr, int split_type, int key, MPIR_Info * info_ptr,
@@ -420,10 +415,6 @@ int MPIR_Comm_split_type(MPIR_Comm * comm_ptr, int split_type, int key, MPIR_Inf
 
 int MPIR_Comm_split_type_neighborhood(MPIR_Comm * comm_ptr, int split_type, int key,
                                       MPIR_Info * info_ptr, MPIR_Comm ** newcomm_ptr);
-int MPIR_Comm_split_type_nbhd_common_dir(MPIR_Comm * user_comm_ptr, int key, const char *hintval,
-                                         MPIR_Comm ** newcomm_ptr);
-int MPIR_Comm_split_type_network_topo(MPIR_Comm * user_comm_ptr, int key, const char *hintval,
-                                      MPIR_Comm ** newcomm_ptr);
 
 /* Preallocated comm objects.  There are 3: comm_world, comm_self, and
    a private (non-user accessible) dup of comm world that is provided

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -1260,77 +1260,42 @@ int MPIR_Comm_delete_internal(MPIR_Comm * comm_ptr)
     goto fn_exit;
 }
 
-/* This function collectively compares hint_str to see whether all processes are having
- * the same string. The result is set in output pointer info_args_are_equal.
- */
-/* TODO: it is certainly not ideal that we have to run 4 Allreduce to do this check.
- * Once we have an OP_EQUAL operator, a single Allreduce would suffice.
+/* This function retrieves info key and collectively compares hint_str to see
+ * hether all processes are having the same string.
  */
 int MPII_collect_info_key(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr, const char *key,
                           const char **value_ptr)
 {
+    int mpi_errno = MPI_SUCCESS;
+
     const char *hint_str = NULL;
     if (info_ptr) {
         hint_str = MPIR_Info_lookup(info_ptr, key);
     }
 
-    /* TODO: convert to use MPIR_Allreduce_equal */
     int hint_str_size;
-    int hint_str_size_max;
-    int hint_str_equal;
-    int hint_str_equal_global = 0;
-    char *hint_str_global = NULL;
-    int mpi_errno = MPI_SUCCESS;
-
     if (!hint_str) {
         hint_str_size = 0;
     } else {
         hint_str_size = strlen(hint_str);
-    }
-    /* Find the maximum hint_str size.  Each process locally compares
-     * its hint_str size to the global max, and makes sure that this
-     * comparison is successful on all processes. */
-    mpi_errno =
-        MPIR_Allreduce(&hint_str_size, &hint_str_size_max, 1, MPI_INT, MPI_MAX, comm_ptr,
-                       MPIR_ERR_NONE);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    hint_str_equal = (hint_str_size == hint_str_size_max);
-
-    mpi_errno =
-        MPIR_Allreduce(&hint_str_equal, &hint_str_equal_global, 1, MPI_INT, MPI_LAND,
-                       comm_ptr, MPIR_ERR_NONE);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    MPIR_ERR_CHKANDJUMP1(!hint_str_equal_global, mpi_errno, MPI_ERR_OTHER, "**infonoteq",
-                         "**infonoteq %s", key);
-
-    if (hint_str_size == 0) {
-        goto fn_exit;
+        if (hint_str_size == 0) {
+            hint_str = NULL;
+        }
     }
 
-    /* Now that the sizes of the hint_strs match, check to make sure
-     * the actual hint_strs themselves are the equal */
-    hint_str_global = (char *) MPL_malloc(strlen(hint_str), MPL_MEM_OTHER);
-
-    mpi_errno =
-        MPIR_Allreduce(hint_str, hint_str_global, strlen(hint_str), MPI_CHAR,
-                       MPI_MAX, comm_ptr, MPIR_ERR_NONE);
+    int is_equal;
+    mpi_errno = MPIR_Allreduce_equal(&hint_str_size, 1, MPI_INT, &is_equal, comm_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    hint_str_equal = !memcmp(hint_str, hint_str_global, strlen(hint_str));
+    if (is_equal && hint_str_size > 0) {
+        mpi_errno = MPIR_Allreduce_equal(&hint_str, hint_str_size, MPI_CHAR, &is_equal, comm_ptr);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
 
-    mpi_errno =
-        MPIR_Allreduce(&hint_str_equal, &hint_str_equal_global, 1, MPI_INT, MPI_LAND,
-                       comm_ptr, MPIR_ERR_NONE);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    MPIR_ERR_CHKANDJUMP1(!hint_str_equal_global, mpi_errno, MPI_ERR_OTHER, "**infonoteq",
-                         "**infonoteq %s", key);
+    MPIR_ERR_CHKANDJUMP1(!is_equal, mpi_errno, MPI_ERR_OTHER, "**infonoteq", "**infonoteq %s", key);
 
   fn_exit:
     *value_ptr = hint_str;
-    MPL_free(hint_str_global);
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -1288,16 +1288,19 @@ int MPII_collect_info_key(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr, const char
     MPIR_ERR_CHECK(mpi_errno);
 
     if (is_equal && hint_str_size > 0) {
-        mpi_errno = MPIR_Allreduce_equal(&hint_str, hint_str_size, MPI_CHAR, &is_equal, comm_ptr);
+        mpi_errno = MPIR_Allreduce_equal(hint_str, hint_str_size, MPI_CHAR, &is_equal, comm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
     MPIR_ERR_CHKANDJUMP1(!is_equal, mpi_errno, MPI_ERR_OTHER, "**infonoteq", "**infonoteq %s", key);
 
-  fn_exit:
     *value_ptr = hint_str;
-    return mpi_errno;
+
+  fn_exit:
+    return MPI_SUCCESS;
   fn_fail:
+    /* inconsistent info keys are ignored */
+    *value_ptr = NULL;
     goto fn_exit;
 }
 

--- a/src/mpi/comm/mpicomm.h
+++ b/src/mpi/comm/mpicomm.h
@@ -9,6 +9,8 @@
 /* Function prototypes for communicator helper functions */
 int MPIR_Get_intercomm_contextid(MPIR_Comm *, MPIR_Context_id_t *, MPIR_Context_id_t *);
 
-int MPII_compare_info_hint(const char *hint_str, MPIR_Comm * comm_ptr, int *info_args_are_equal);
+/* Utitlity function that retrieves an info key and ensures it is collectively equal */
+int MPII_collect_info_key(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr, const char *key,
+                          const char **value_ptr);
 
 #endif /* MPICOMM_H_INCLUDED */

--- a/src/mpi/topo/topo_impl.c
+++ b/src/mpi/topo/topo_impl.c
@@ -681,3 +681,19 @@ int MPIR_Topo_test_impl(MPIR_Comm * comm_ptr, int *status)
     }
     return MPI_SUCCESS;
 }
+
+int MPIR_Get_hw_resource_info_impl(MPIR_Info ** hw_info_ptr)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_Info *info_ptr = NULL;
+    mpi_errno = MPIR_Info_alloc(&info_ptr);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    *hw_info_ptr = info_ptr;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}


### PR DESCRIPTION
## Pull Request Description
Add `MPI_Get_hw_resource_info` and new split_type `MPI_COMM_TYPE_RESOURCE_GUIDED`.
Refactor code `MPII_collect_info_key` that retrieves info key and collectively verifies they are equal. Internally use `MPIR_Allreduce_equal`.

[skip warnings]

Fixes #6763 
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
