### PR TITLE
mpi4.1: allow passing null handles into get_name functions

### DIFF
--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -851,7 +851,11 @@ int MPIR_Comm_get_info_impl(MPIR_Comm * comm_ptr, MPIR_Info ** info_p_p)
 int MPIR_Comm_get_name_impl(MPIR_Comm * comm_ptr, char *comm_name, int *resultlen)
 {
     /* The user must allocate a large enough section of memory */
-    MPL_strncpy(comm_name, comm_ptr->name, MPI_MAX_OBJECT_NAME);
+    if (comm_ptr == NULL) {
+        MPL_strncpy(comm_name, "MPI_COMM_NULL", MPI_MAX_OBJECT_NAME);
+    } else {
+        MPL_strncpy(comm_name, comm_ptr->name, MPI_MAX_OBJECT_NAME);
+    }
     *resultlen = (int) strlen(comm_name);
     return MPI_SUCCESS;
 }

--- a/src/mpi/datatype/datatype_impl.c
+++ b/src/mpi/datatype/datatype_impl.c
@@ -430,8 +430,12 @@ int MPIR_Type_match_size_impl(int typeclass, int size, MPI_Datatype * datatype)
 
 int MPIR_Type_get_name_impl(MPIR_Datatype * datatype_ptr, char *type_name, int *resultlen)
 {
-    /* Include the null in MPI_MAX_OBJECT_NAME */
-    MPL_strncpy(type_name, datatype_ptr->name, MPI_MAX_OBJECT_NAME);
+    if (datatype_ptr == NULL) {
+        MPL_strncpy(type_name, "MPI_DATATYPE_NULL", MPI_MAX_OBJECT_NAME);
+    } else {
+        /* Include the null in MPI_MAX_OBJECT_NAME */
+        MPL_strncpy(type_name, datatype_ptr->name, MPI_MAX_OBJECT_NAME);
+    }
     *resultlen = (int) strlen(type_name);
 
     return MPI_SUCCESS;

--- a/src/mpi/rma/rma_impl.c
+++ b/src/mpi/rma/rma_impl.c
@@ -7,7 +7,11 @@
 
 int MPIR_Win_get_name_impl(MPIR_Win * win_ptr, char *win_name, int *resultlen)
 {
-    MPL_strncpy(win_name, win_ptr->name, MPI_MAX_OBJECT_NAME);
+    if (win_ptr == NULL) {
+        MPL_strncpy(win_name, "MPI_WIN_NULL", MPI_MAX_OBJECT_NAME);
+    } else {
+        MPL_strncpy(win_name, win_ptr->name, MPI_MAX_OBJECT_NAME);
+    }
     *resultlen = (int) strlen(win_name);
 
     return MPI_SUCCESS;

--- a/test/mpi/comm/commname.c
+++ b/test/mpi/comm/commname.c
@@ -34,6 +34,14 @@ int main(int argc, char *argv[])
         errs++;
         printf("Name of comm self is %s, should be MPI_COMM_SELF\n", nameout);
     }
+#if MTEST_HAVE_MIN_MPI_VERSION(4,1)
+    nameout[0] = 0;
+    MPI_Comm_get_name(MPI_COMM_NULL, nameout, &rlen);
+    if (strcmp(nameout, "MPI_COMM_NULL")) {
+        errs++;
+        printf("Name of comm null is %s, should be MPI_COMM_NULL\n", nameout);
+    }
+#endif
 
     /* Now, handle other communicators, including world/self */
     cnt = 0;

--- a/test/mpi/datatype/typename.c
+++ b/test/mpi/datatype/typename.c
@@ -125,6 +125,9 @@ static mpi_names_t mpi_names[] = {
     /* added in MPI 3 */
     {MPI_COUNT, "MPI_COUNT"},
 #endif
+#if MTEST_HAVE_MIN_MPI_VERSION(4,1)
+    {MPI_DATATYPE_NULL, "MPI_DATATYPE_NULL"},
+#endif
     {0, (char *) 0},    /* Sentinel used to indicate the last element */
 };
 

--- a/test/mpi/rma/winname.c
+++ b/test/mpi/rma/winname.c
@@ -21,6 +21,16 @@ int main(int argc, char *argv[])
 
     MTest_Init(&argc, &argv);
 
+#if MTEST_HAVE_MIN_MPI_VERSION(4,1)
+    int rlen;
+    nameout[0] = 0;
+    MPI_Win_get_name(MPI_WIN_NULL, nameout, &rlen);
+    if (strcmp(nameout, "MPI_WIN_NULL")) {
+        errs++;
+        printf("Name of win null is %s, should be MPI_WIN_NULL\n", nameout);
+    }
+#endif
+
     cnt = 0;
     while (MTestGetWin(&win, 1)) {
         if (win == MPI_WIN_NULL)


### PR DESCRIPTION
## Pull Request Description
MPI 4.1 allows passing `MPI_COMM_NULL` to `MPI_Comm_get_name`, `MPI_WIN_NULL` to `MPI_Win_get_name`, and `MPI_DATATYPE_NULL` to `MPI_Type_get_name`.

Fixes #6769 
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
