### PR TITLE
mpi4.1: add `mpi_accumulate_granularity` info hint

### DIFF
--- a/src/binding/c/rma_api.txt
+++ b/src/binding/c/rma_api.txt
@@ -271,6 +271,15 @@ MPI_Win_create:
         operation or 'MPI_NO_OP'. This can eliminate the need to protect access for
         certain operation types where the hardware can guarantee atomicity. The default
         is same_op_no_op.
+
+    . mpi_accumulate_granularity - Controls the desired synchronization granularity
+        for accumulate ops. It sets the size of memory range in bytes for which the
+        MPI library should acquire a synchronization primitive to ensure the atomicity
+        of updates. The default is 0 which let the MPI library decides the granularity.
+        When the info hint is set to a positive value, the actual range of synchroniation
+        is round-up to the next size that fits the Datatype used in the accumulate
+        operation (see MPI standard 4.1). All processes in the group of a windows must
+        set to the same value.
 */
 
 MPI_Win_create_dynamic:

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -293,6 +293,7 @@ struct MPIDI_Win_info_args {
     int same_disp_unit;
     int alloc_shared_noncontig;
     int alloc_shm;
+    int accumulate_granularity;
 };
 
 struct MPIDI_RMA_op;            /* forward decl from mpidrma.h */

--- a/src/mpid/ch3/src/ch3u_win_fns.c
+++ b/src/mpid/ch3/src/ch3u_win_fns.c
@@ -354,6 +354,20 @@ int MPID_Win_set_info(MPIR_Win * win, MPIR_Info * info)
             if (!strncmp(info_value, "false", sizeof("false")))
                 win->info_args.same_disp_unit = FALSE;
         }
+
+        /********************************************************/
+        /*******  check for info mpi_accumualte_granularity *****/
+        /********************************************************/
+        info_flag = 0;
+        MPIR_Info_get_impl(info, "mpi_acumulate_granularity", MPI_MAX_INFO_VAL, info_value, &info_flag);
+        if (info_flag) {
+            int value = atoi(info_value);
+            if (value > 0) {
+                win->info_args.accumulate_granularity = value;
+            } else {
+                win->info_args.accumulate_granularity = 0;
+            }
+        }
     }
 
 

--- a/src/mpid/ch3/src/mpid_rma.c
+++ b/src/mpid/ch3/src/mpid_rma.c
@@ -272,6 +272,7 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
         (*win_ptr)->create_flavor == MPI_WIN_FLAVOR_SHARED) {
         (*win_ptr)->info_args.alloc_shm = TRUE;
     }
+    (*win_ptr)->info_args.accumulate_granularity = 0;
 
     /* Set info_args on window based on info provided by user */
     mpi_errno = MPID_Win_set_info((*win_ptr), info);

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -377,6 +377,7 @@ typedef struct MPIDIG_win_info_args_t {
     int accumulate_ordering;
     int alloc_shared_noncontig;
     MPIDIG_win_info_accumulate_ops accumulate_ops;
+    int accumulate_granularity;
 
     /* hints to tradeoff atomicity support */
     uint32_t which_accumulate_ops;      /* Arbitrary combination of {1<<max|1<<min|1<<sum|...}

--- a/src/mpid/ch4/src/mpidig_win.c
+++ b/src/mpid/ch4/src/mpidig_win.c
@@ -245,6 +245,16 @@ static int win_set_info(MPIR_Win * win, MPIR_Info * info, bool is_init)
         parse_info_perf_preference_str(val, &MPIDIG_WIN(win, info_args).perf_preference);
     }
 
+    val = MPIR_Info_lookup(info, "mpi_accumulate_granularity");
+    if (val) {
+        int value = atoi(val);
+        if (value > 0) {
+            MPIDIG_WIN(win, info_args).accumulate_granularity = value;
+        } else {
+            MPIDIG_WIN(win, info_args).accumulate_granularity = 0;
+        }
+    }
+
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -322,6 +332,7 @@ static int win_init(MPI_Aint length, int disp_unit, MPIR_Win ** win_ptr, MPIR_In
     MPIDIG_WIN(win, info_args).disable_shm_accumulate = false;
     MPIDIG_WIN(win, info_args).coll_attach = false;
     MPIDIG_WIN(win, info_args).optimized_mr = false;
+    MPIDIG_WIN(win, info_args).accumulate_granularity = 0;
 
     if ((info != NULL) && ((int *) info != (int *) MPI_INFO_NULL)) {
         mpi_errno = win_set_info(win, info, TRUE /* is_init */);

--- a/test/mpi/impls/mpich/rma/win_info.c
+++ b/test/mpi/impls/mpich/rma/win_info.c
@@ -160,6 +160,14 @@ int main(int argc, char **argv)
     errors += check_win_info_get(win, "alloc_shared_noncontig", "false");
     MPI_Comm_free(&shm_comm);
 
+    /* Test#9: setting/getting "mpi_accumulate_granularity" */
+    /*   #9.1: "mpi_accumulate_granularity" must default to "0" */
+    errors += check_win_info_get(win, "mpi_accumulate_granularity", "0");
+
+    /*   #9.2: setting "mpi_accumulate_granularity" to "8" */
+    win_info_set(win, "mpi_accumulate_granularity", "8");
+    errors += check_win_info_get(win, "mpi_accumulate_granularity", "8");
+
     MPI_Win_free(&win);
 
     MTest_Finalize(errors);


### PR DESCRIPTION
## Pull Request Description
fixes #6773 

`mpi_accumulate_granularity` provides a hint to implementations about the desired synchronization granularity for accumulate operations, i.e., the size of memory ranges in bytes for which the implementation should acquire a synchronization primitive to ensure atomicity of updates.
If the specified granularity is not divisible by the size of the type used in an accumulate operation, it should be treated as if it was the next multiple of the element size.
For example, a granularity of 1 byte  should be treated as 8 in an accumulate operation using `MPI_UINT64_T`.
By default, this info key is set to 0, which leaves the choice of synchronization granularity to the implementation.
If specified, all mpi processes in the group of a window must supply the same value.

### User Advice
Small synchronization granularities may provide improved latencies for accumulate operations with few elements and potentially increase concurrency of updates, at the cost of lower throughput.
For example, a value matching the size of a type involved in an accumulate operation may enable implementations to use atomic memory operations instead of mutual exclusion devices.
Larger synchronization granularities may yield higher throughput of accumulate operation with large numbers of elements due to lower synchronization costs, potentially at the expense of higher latency for accumulate operations with few elements, e.g., if atomic memory operations are not employed.
By dividing larger accumulate operations into smaller segments, concurrent accumulate operations to the same window memory may update different segments in parallel.

### implementors Advice
Implementations are encouraged to avoid mutual exclusion devices in cases where the granularity is small enough to warrant the use of atomic memory operations.
For larger granularities, implementations should use this info value as a hint to partition the window memory into zones of mutual exclusion to enable segmentation of large accumulate operations.


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
