### PR TITLE
mpi4.1: MPI_Win_shared_query on more window flavors

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -2048,7 +2048,7 @@ def dump_validate_handle_ptr(func, p):
             G.out.append("MPIR_ERRTEST_PARRIVEDREQ(%s, mpi_errno);" % ptr_name)
 
         if kind == "WINDOW" and RE.match(r'mpi_win_shared_query', func_name, re.IGNORECASE):
-            G.out.append("MPIR_ERRTEST_WIN_FLAVOR(win_ptr, MPI_WIN_FLAVOR_SHARED, mpi_errno);")
+            G.out.append("MPIR_ERRTEST_WIN_NOT_DYNAMIC(win_ptr, mpi_errno);")
 
         if G.handle_error_codes[kind]:
             G.err_codes[G.handle_error_codes[kind]] = 1

--- a/src/include/mpir_err.h
+++ b/src/include/mpir_err.h
@@ -473,6 +473,15 @@ cvars:
         }                                                       \
     } while (0)
 
+#define MPIR_ERRTEST_WIN_NOT_DYNAMIC(win_, err_)                \
+    do {                                                        \
+        if ((win_)->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {  \
+            MPIR_ERR_SETANDSTMT1((err_), MPI_ERR_RMA_FLAVOR,    \
+                                 goto fn_fail, "**winflavor",   \
+                                 "**winflavor %s", "!MPI_WIN_FLAVOR_DYNAMIC");   \
+        }                                                       \
+    } while (0)
+
 #define MPIR_ERRTEST_WIN_SIZE(size_, err_)                      \
     do {                                                        \
         if (size_ < 0) {                                        \

--- a/src/mpid/ch3/channels/nemesis/src/ch3_rma_shm.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_rma_shm.c
@@ -47,11 +47,16 @@ int MPIDI_CH3_SHM_Win_shared_query(MPIR_Win * win_ptr, int target_rank, MPI_Aint
     }
     else {
         int local_target_rank = win_ptr->comm_ptr->intranode_table[target_rank];
-        MPIR_Assert(local_target_rank >= 0 &&
-                    local_target_rank < win_ptr->comm_ptr->node_comm->local_size);
-        *size = win_ptr->basic_info_table[target_rank].size;
-        *disp_unit = win_ptr->basic_info_table[target_rank].disp_unit;
-        *((void **) baseptr) = win_ptr->shm_base_addrs[local_target_rank];
+        if (local_target_rank >= 0) {
+            MPIR_Assert(local_target_rank < win_ptr->comm_ptr->node_comm->local_size);
+            *size = win_ptr->basic_info_table[target_rank].size;
+            *disp_unit = win_ptr->basic_info_table[target_rank].disp_unit;
+            *((void **) baseptr) = win_ptr->shm_base_addrs[local_target_rank];
+        } else {
+            *size = 0;
+            *disp_unit = 0;
+            *((void **) baseptr) = NULL;
+        }
     }
 
   fn_exit:

--- a/src/mpid/ch3/channels/nemesis/src/ch3_rma_shm.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_rma_shm.c
@@ -47,11 +47,15 @@ int MPIDI_CH3_SHM_Win_shared_query(MPIR_Win * win_ptr, int target_rank, MPI_Aint
     }
     else {
         int local_target_rank = win_ptr->comm_ptr->intranode_table[target_rank];
-        if (local_target_rank >= 0) {
+        if (local_target_rank >= 0 && win_ptr->shm_base_addrs) {
             MPIR_Assert(local_target_rank < win_ptr->comm_ptr->node_comm->local_size);
             *size = win_ptr->basic_info_table[target_rank].size;
             *disp_unit = win_ptr->basic_info_table[target_rank].disp_unit;
             *((void **) baseptr) = win_ptr->shm_base_addrs[local_target_rank];
+        } else if (target_rank == win_ptr->comm_ptr->rank) {
+            *size = win_ptr->size;;
+            *disp_unit = win_ptr->disp_unit;
+            *((void **) baseptr) = win_ptr->base;
         } else {
             *size = 0;
             *disp_unit = 0;

--- a/src/mpid/ch3/src/ch3u_win_fns.c
+++ b/src/mpid/ch3/src/ch3u_win_fns.c
@@ -228,9 +228,21 @@ int MPIDI_CH3U_Win_shared_query(MPIR_Win * win_ptr, int target_rank, MPI_Aint * 
 
     MPIR_FUNC_ENTER;
 
-    *(void **) baseptr = win_ptr->base;
-    *size = win_ptr->size;
-    *disp_unit = win_ptr->disp_unit;
+    /* We don't really support shared memory, only return local process' info
+     * if the window size is 1 or it is querying its own rank */
+    if (target_rank == MPI_PROC_NULL && win_ptr->comm_ptr->local_size == 1) {
+        *(void **) baseptr = win_ptr->base;
+        *size = win_ptr->size;
+        *disp_unit = win_ptr->disp_unit;
+    } else if (target_rank == win_ptr->comm_ptr->rank) {
+        *(void **) baseptr = win_ptr->base;
+        *size = win_ptr->size;
+        *disp_unit = win_ptr->disp_unit;
+    } else {
+        *(void **) baseptr = NULL;
+        *size = 0;
+        *disp_unit = 0;
+    }
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/src/ch4_proc.h
+++ b/src/mpid/ch4/src/ch4_proc.h
@@ -52,6 +52,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIU_comm_rank_to_pid(MPIR_Comm * comm, int rank,
     MPIR_FUNC_ENTER;
 
     *avtid = 0;
+    *idx = 0;
 
     switch (MPIDI_COMM(comm, map).mode) {
         case MPIDI_RANK_MAP_DIRECT:

--- a/src/mpid/ch4/src/mpidig_win.h
+++ b/src/mpid/ch4/src/mpidig_win.h
@@ -556,7 +556,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_win_shared_query_part(MPIR_Win * win, int ra
         *size = win->size;
         *disp_unit = win->disp_unit;
         *((void **) baseptr) = win->base;
-    } else if (rank == MPI_PROC_NULL || !MPIDI_rank_is_local(rank, win->comm_ptr)) {
+    } else if (rank == MPI_PROC_NULL || !MPIDI_rank_is_local(rank, win->comm_ptr) ||
+               MPIDIG_WIN(win, shared_table) == NULL) {
         *size = 0;
         *disp_unit = 0;
         *((void **) baseptr) = NULL;

--- a/src/mpid/ch4/src/mpidig_win.h
+++ b/src/mpid/ch4/src/mpidig_win.h
@@ -534,6 +534,55 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_fence(int massert, MPIR_Win * win)
     goto fn_exit;
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIDIG_win_shared_query_self(MPIR_Win * win, int rank, MPI_Aint * size,
+                                                          int *disp_unit, void *baseptr)
+{
+    if (rank == win->comm_ptr->rank) {
+        *size = win->size;
+        *disp_unit = win->disp_unit;
+        *((void **) baseptr) = win->base;
+    } else {
+        *size = 0;
+        *disp_unit = 0;
+        *((void **) baseptr) = NULL;
+    }
+    return MPI_SUCCESS;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDIG_win_shared_query_part(MPIR_Win * win, int rank, MPI_Aint * size,
+                                                          int *disp_unit, void *baseptr)
+{
+    if (rank == win->comm_ptr->rank) {
+        *size = win->size;
+        *disp_unit = win->disp_unit;
+        *((void **) baseptr) = win->base;
+    } else if (rank == MPI_PROC_NULL || !MPIDI_rank_is_local(rank, win->comm_ptr)) {
+        *size = 0;
+        *disp_unit = 0;
+        *((void **) baseptr) = NULL;
+    } else {
+        int shm_rank = -1;
+        /* find shm_rank in node_comm. Q: can we rely on comm_ptr->intranode_table? */
+        int avtid, idx;
+        MPIDIU_comm_rank_to_pid(win->comm_ptr, rank, &idx, &avtid);
+        for (int i = 0; i < win->comm_ptr->node_comm->local_size; i++) {
+            int tmp_avtid, tmp_idx;
+            MPIDIU_comm_rank_to_pid(win->comm_ptr->node_comm, i, &tmp_idx, &tmp_avtid);
+            if (tmp_avtid == avtid && tmp_idx == idx) {
+                shm_rank = i;
+                break;
+            }
+        }
+        MPIR_Assert(shm_rank >= 0);
+
+        MPIDIG_win_shared_info_t *shared_table = MPIDIG_WIN(win, shared_table);
+        *size = shared_table[shm_rank].size;
+        *disp_unit = shared_table[shm_rank].disp_unit;
+        *(void **) baseptr = shared_table[shm_rank].shm_base_addr;
+    }
+    return MPI_SUCCESS;
+}
+
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_shared_query(MPIR_Win * win, int rank, MPI_Aint * size,
                                                          int *disp_unit, void *baseptr)
 {
@@ -542,6 +591,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_shared_query(MPIR_Win * win, int ran
     MPIDIG_win_shared_info_t *shared_table = MPIDIG_WIN(win, shared_table);
 
     MPIR_FUNC_ENTER;
+
+    bool whole_shared = false;
+    if (win->comm_ptr->node_comm == NULL) {
+        whole_shared = (win->comm_ptr->local_size == 1);
+    } else {
+        whole_shared = (win->comm_ptr->local_size == win->comm_ptr->node_comm->local_size);
+    }
+
+    if (!whole_shared) {
+        if (win->comm_ptr->node_comm == NULL) {
+            mpi_errno = MPIDIG_win_shared_query_self(win, rank, size, disp_unit, baseptr);
+        } else {
+            mpi_errno = MPIDIG_win_shared_query_part(win, rank, size, disp_unit, baseptr);
+        }
+        goto fn_exit;
+    }
 
     /* When only single process exists on the node or shared memory allocation fails,
      * should only query MPI_PROC_NULL or local process. Thus, return local window's info. */

--- a/test/mpi/rma/Makefile.am
+++ b/test/mpi/rma/Makefile.am
@@ -90,6 +90,7 @@ noinst_PROGRAMS =          \
     win_shared_zerobyte    \
     win_shared_create_allocshm    \
     win_shared_create_no_allocshm \
+    win_shared_query       \
     win_zero               \
     win_large_shm          \
     win_dynamic_acc        \

--- a/test/mpi/rma/testlist.in
+++ b/test/mpi/rma/testlist.in
@@ -78,6 +78,9 @@ win_shared_create_allocshm 4
 win_shared_create_no_allocshm 4
 win_shared_noncontig 4
 win_shared_noncontig_put 4
+win_shared_query 4 arg=-flavor=create
+win_shared_query 4 arg=-flavor=allocate
+win_shared_query 4 arg=-flavor=allocate_shared
 win_zero 4
 @largetest@win_large_shm 4
 @largetest@win_large_shm 3

--- a/test/mpi/rma/win_shared_query.c
+++ b/test/mpi/rma/win_shared_query.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <mpi.h>
+#include "mpitest.h"
+
+#define ELEM_PER_PROC 100
+#define ELEM_SIZE sizeof(int)
+#define SIZE (ELEM_PER_PROC * ELEM_SIZE)
+
+const int verbose = 0;
+
+enum {
+    CREATE,
+    ALLOCATE,
+    ALLOCATE_SHARED,
+} opt_win_flavor = ALLOCATE;
+
+int main(int argc, char **argv)
+{
+    int errors = 0;
+    MPI_Comm comm;
+    MPI_Win win;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "-flavor=create") == 0) {
+            opt_win_flavor = CREATE;
+        } else if (strcmp(argv[i], "-flavor=allocate") == 0) {
+            opt_win_flavor = ALLOCATE;
+        } else if (strcmp(argv[i], "-flavor=allocate_shared") == 0) {
+            opt_win_flavor = ALLOCATE_SHARED;
+        }
+    }
+
+    MTest_Init(&argc, &argv);
+
+    if (opt_win_flavor == CREATE) {
+        MTestPrintfMsg(1, "TEST MPI_Win_create\n");
+        comm = MPI_COMM_WORLD;
+    } else if (opt_win_flavor == ALLOCATE) {
+        MTestPrintfMsg(1, "TEST MPI_Win_allocate\n");
+        comm = MPI_COMM_WORLD;
+    } else if (opt_win_flavor == ALLOCATE_SHARED) {
+        MTestPrintfMsg(1, "TEST MPI_Win_allocate_shared\n");
+        MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &comm);
+    } else {
+        printf("Invalid opt_win_flavor: %d\n", opt_win_flavor);
+        goto fn_exit;
+    }
+
+    int rank, nproc;
+    MPI_Comm_rank(comm, &rank);
+    MPI_Comm_size(comm, &nproc);
+
+    int *my_base;
+    if (opt_win_flavor == CREATE) {
+        my_base = malloc(SIZE);
+        MPI_Win_create(my_base, SIZE, ELEM_SIZE, MPI_INFO_NULL, comm, &win);
+    } else if (opt_win_flavor == ALLOCATE) {
+        MPI_Win_allocate(SIZE, ELEM_SIZE, MPI_INFO_NULL, comm, &my_base, &win);
+    } else if (opt_win_flavor == ALLOCATE_SHARED) {
+        MPI_Win_allocate_shared(SIZE, ELEM_SIZE, MPI_INFO_NULL, comm, &my_base, &win);
+    }
+
+    for (int i = 0; i < nproc; i++) {
+        MPI_Aint size;
+        int disp_unit;
+        void *base;
+        MPI_Win_shared_query(win, i, &size, &disp_unit, &base);
+        MTestPrintfMsg(1, "[%d] query [%d / %d]: %p - size=%ld, disp_unit=%d\n",
+                       rank, i, nproc, base, (long) size, disp_unit);
+    }
+
+    MPI_Win_free(&win);
+
+    if (opt_win_flavor == CREATE) {
+        free(my_base);
+    } else if (opt_win_flavor == ALLOCATE_SHARED) {
+        MPI_Comm_free(&comm);
+    }
+
+  fn_exit:
+    MTest_Finalize(errors);
+
+    return MTestReturnValue(errors);
+}


### PR DESCRIPTION
## Pull Request Description
MPI 4.1 allow MPI_Win_shared_query to be called on windows created by
MPI_Win_create and MPI_Win_allocate.

Because in ch4 we will create partial shared memory domain in a window if part of the processes are on a same node, we enhance the implementation to support such partial queries. The old code will return garbage or share_table memory access error if used on partially shared windows.

[skip warnings]

Fixes #6771


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
