### PR TITLE
errhan: reference count dynamic error class/code

### DIFF
--- a/src/include/mpir_errcodes.h
+++ b/src/include/mpir_errcodes.h
@@ -52,6 +52,8 @@
 #define ERROR_SPECIFIC_SEQ_SIZE   16
 #define ERROR_SPECIFIC_SEQ_SHIFT  26
 #define ERROR_FATAL_MASK          0x00000080
+/* reuse the fatal mask for dynamic code with dynamic class */
+#define ERROR_DYN_CLASS           0x00000080
 #define ERROR_GET_CLASS(mpi_errno_) MPIR_ERR_GET_CLASS(mpi_errno_)
 
 /* These must correspond to the masks defined above */

--- a/src/mpi/errhan/dynerrutil.c
+++ b/src/mpi/errhan/dynerrutil.c
@@ -146,7 +146,7 @@ int MPIR_Add_error_string_impl(int code, const char *msg_string)
     errcode = (code & ERROR_GENERIC_MASK) >> ERROR_GENERIC_SHIFT;
 
     /* --BEGIN ERROR HANDLING-- */
-    if (code & ~(ERROR_CLASS_MASK | ERROR_DYN_MASK | ERROR_GENERIC_MASK)) {
+    if (code & ~(ERROR_CLASS_MASK | ERROR_DYN_MASK | ERROR_GENERIC_MASK | ERROR_DYN_CLASS)) {
         /* Check for invalid error code */
         return MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
                                     __func__, __LINE__,
@@ -384,6 +384,9 @@ int MPIR_Add_error_code_impl(int class, int *code)
 
     /* Create the full error code */
     new_code = class | (new_code << ERROR_GENERIC_SHIFT);
+    if (class & ERROR_DYN_MASK) {
+        new_code |= ERROR_DYN_CLASS;
+    }
 
     /* FIXME: For robustness, we should make sure that the associated string
      * is initialized to null */
@@ -413,7 +416,7 @@ int MPIR_Remove_error_code_impl(int code)
 
     struct intcnt *s;
 
-    if (class & ERROR_DYN_MASK) {
+    if (code & ERROR_DYN_CLASS) {
         /* increment ref_count for dynamic error class */
         int errclass = class & ~ERROR_DYN_MASK;
         HASH_FIND_INT(err_class.used, &errclass, s);
@@ -464,7 +467,7 @@ static const char *get_dynerr_string(int code)
     errclass = code & ERROR_CLASS_MASK;
     errcode = (code & ERROR_GENERIC_MASK) >> ERROR_GENERIC_SHIFT;
 
-    if (code & ~(ERROR_CLASS_MASK | ERROR_DYN_MASK | ERROR_GENERIC_MASK)) {
+    if (code & ~(ERROR_CLASS_MASK | ERROR_DYN_MASK | ERROR_GENERIC_MASK | ERROR_DYN_CLASS)) {
         /* Check for invalid error code */
         return 0;
     }

--- a/src/mpi/errhan/dynerrutil.c
+++ b/src/mpi/errhan/dynerrutil.c
@@ -415,14 +415,6 @@ int MPIR_Remove_error_code_impl(int code)
 
     struct intcnt *s;
 
-    if (code & ERROR_DYN_CLASS) {
-        /* increment ref_count for dynamic error class */
-        int errclass = class & ~ERROR_DYN_MASK;
-        HASH_FIND_INT(err_class.used, &errclass, s);
-        MPIR_Assert(s);
-        s->ref_count--;
-    }
-
     HASH_FIND_INT(err_code.used, &errcode, s);
 
     MPIR_ERR_CHKANDJUMP(s == NULL, mpi_errno, MPI_ERR_OTHER, "**invaliderrcode");
@@ -432,6 +424,13 @@ int MPIR_Remove_error_code_impl(int code)
     HASH_DEL(err_code.used, s);
     DL_APPEND(err_code.free, s);
     MPL_free((char *) user_code_msgs[s->val]);
+
+    if (code & ERROR_DYN_CLASS) {
+        /* decrement ref_count for dynamic error class */
+        HASH_FIND_INT(err_class.used, &class, s);
+        MPIR_Assert(s);
+        s->ref_count--;
+    }
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/errhan/dynerrutil.c
+++ b/src/mpi/errhan/dynerrutil.c
@@ -278,7 +278,8 @@ int MPIR_Add_error_class_impl(int *errorclass)
      * a string.  */
     user_class_msgs[new_class] = 0;
 
-    new_class |= ERROR_DYN_MASK;
+    /* set both ERROR_DYN_MASK and ERROR_DYN_CLASS so it behaves as a dynamic error code */
+    new_class |= (ERROR_DYN_MASK | ERROR_DYN_CLASS);
 
     if (new_class > MPIR_Process.attrs.lastusedcode) {
         MPIR_Process.attrs.lastusedcode = new_class;
@@ -315,7 +316,7 @@ int MPIR_Remove_error_class_impl(int user_errclass)
     MPIR_ERR_CHKANDJUMP(!(user_errclass & ERROR_DYN_MASK),
                         mpi_errno, MPI_ERR_OTHER, "**predeferrclass");
 
-    int errclass = user_errclass & ~ERROR_DYN_MASK;
+    int errclass = user_errclass & ~(ERROR_DYN_MASK | ERROR_DYN_CLASS);
     struct intcnt *s;
     HASH_FIND_INT(err_class.used, &errclass, s);
 
@@ -356,7 +357,7 @@ int MPIR_Add_error_code_impl(int class, int *code)
 
     if (class & ERROR_DYN_MASK) {
         /* increment ref_count for dynamic error class */
-        int errclass = class & ~ERROR_DYN_MASK;
+        int errclass = class & ~(ERROR_DYN_MASK | ERROR_DYN_CLASS);
         HASH_FIND_INT(err_class.used, &errclass, s);
         MPIR_ERR_CHKANDJUMP(s == NULL, mpi_errno, MPI_ERR_OTHER, "**invaliderrclass");
         s->ref_count++;

--- a/src/mpi/errhan/dynerrutil.c
+++ b/src/mpi/errhan/dynerrutil.c
@@ -380,7 +380,7 @@ int MPIR_Add_error_code_impl(int class, int *code)
     MPIR_ERR_CHKANDJUMP(new_code >= ERROR_MAX_NCODE, mpi_errno, MPI_ERR_OTHER, "**noerrcodes");
 
     /* Create the full error code */
-    new_code = class | (new_code << ERROR_GENERIC_SHIFT);
+    new_code = class | (new_code << ERROR_GENERIC_SHIFT) | ERROR_DYN_MASK;
     if (class & ERROR_DYN_MASK) {
         new_code |= ERROR_DYN_CLASS;
     }

--- a/src/mpi/errhan/errhan_impl.c
+++ b/src/mpi/errhan/errhan_impl.c
@@ -292,9 +292,13 @@ int MPIR_Errhandler_free_impl(MPIR_Errhandler * errhan_ptr)
 
 int MPIR_Error_class_impl(int errorcode, int *errorclass)
 {
-    /* We include the dynamic bit because this is needed to fully
-     * describe the dynamic error classes */
-    *errorclass = errorcode & (ERROR_CLASS_MASK | ERROR_DYN_MASK);
+    /* NOTE: MPIR_ERR_GET_CLASS is for internal use and only applies
+     *       to non-dynamic error code */
+    *errorclass = errorcode & (ERROR_CLASS_MASK);
+    if ((errorcode & ERROR_DYN_MASK) && (errorcode & ERROR_DYN_CLASS)) {
+        /* dynamic error code with dynamic error class */
+        *errorclass = *errorclass | (ERROR_DYN_MASK | ERROR_DYN_CLASS);
+    }
 
     return MPI_SUCCESS;
 }

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -58,6 +58,7 @@
 **errclassref %x %d:Error class %x still in use (ref_count = %d)
 **noerrcodes:No more user-defined error codes
 **predeferrcode:Predefined error code given
+**invaliderrcode:Invalid error code given
 **errcoderef:Error code still in use
 **errcoderef %x %d:Error code %x still in use (ref_count = %d)
 **rankdup:Duplicate ranks in rank array 

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -53,8 +53,13 @@
 **keyval:Invalid keyval
 **noerrclasses:No more user-defined error classes
 **predeferrclass:Predefined error class given
+**invaliderrclass:Invalid error class given
+**errclassref:Error class still in use
+**errclassref %x %d:Error class %x still in use (ref_count = %d)
 **noerrcodes:No more user-defined error codes
 **predeferrcode:Predefined error code given
+**errcoderef:Error code still in use
+**errcoderef %x %d:Error code %x still in use (ref_count = %d)
 **rankdup:Duplicate ranks in rank array 
 **rankdup %d %d %d:Duplicate ranks in rank array at index %d, has value %d which is \
 also the value at index %d

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -218,7 +218,11 @@ int MPIR_Errutil_is_initialized(void)
 /* Return true if the error code indicates a fatal error */
 int MPIR_Err_is_fatal(int errcode)
 {
-    return (errcode & ERROR_FATAL_MASK) ? TRUE : FALSE;
+    if (errcode & ERROR_DYN_MASK) {
+        return FALSE;
+    } else {
+        return (errcode & ERROR_FATAL_MASK) ? TRUE : FALSE;
+    }
 }
 
 /*

--- a/test/mpi/errhan/adderr.c
+++ b/test/mpi/errhan/adderr.c
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
 
     MTest_Init(&argc, &argv);
 
-#ifndef USE_STRICT_MPI
+#if MTEST_HAVE_MIN_MPI_VERSION(4,1)
     /* add and delete a bunch of times */
     for (int k = 0; k < 10000; k++) {
         for (i = 0; i < NCLASSES; i++) {


### PR DESCRIPTION
## Pull Request Description
Add reference count dynamic error class and dynamic error class code so we can detect errors when users try to remove an error class or code that has error string or error code still in use.

Improve the error messages. In specific, avoid just return `MPI_ERR_OTHER` since it produces error messages like:
```
internal_Remove_error_string(42743): MPI_Remove_error_string(errorcode=0) failed
(unknown)(): Other MPI error
```

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
