### PR TITLE
coll: enable topology-aware CVARs in json

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -235,10 +235,16 @@ struct MPIR_Comm {
         int nbrs_defined[MAX_RADIX - 1];
         void **recexch_allreduce_nbr_buffer;
         int topo_aware_tree_root;
+        int topo_aware_tree_k;
         MPIR_Treealgo_tree_t *topo_aware_tree;
         int topo_aware_k_tree_root;
+        int topo_aware_k_tree_k;
         MPIR_Treealgo_tree_t *topo_aware_k_tree;
         int topo_wave_tree_root;
+        int topo_wave_tree_overhead;
+        int topo_wave_tree_lat_diff_groups;
+        int topo_wave_tree_lat_diff_switches;
+        int topo_wave_tree_lat_same_switches;
         MPIR_Treealgo_tree_t *topo_wave_tree;
     } coll;
 

--- a/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
+++ b/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
@@ -27,11 +27,17 @@ int MPII_Recexchalgo_comm_init(MPIR_Comm * comm)
     comm->coll.recexch_allreduce_nbr_buffer = NULL;
 
     comm->coll.topo_aware_tree_root = -1;
+    comm->coll.topo_aware_tree_k = 0;
     comm->coll.topo_aware_tree = NULL;
     comm->coll.topo_aware_k_tree_root = -1;
+    comm->coll.topo_aware_k_tree_k = 0;
     comm->coll.topo_aware_k_tree = NULL;
     comm->coll.topo_wave_tree_root = -1;
     comm->coll.topo_wave_tree = NULL;
+    comm->coll.topo_wave_tree_overhead = 0;
+    comm->coll.topo_wave_tree_lat_diff_groups = 0;
+    comm->coll.topo_wave_tree_lat_diff_switches = 0;
+    comm->coll.topo_wave_tree_lat_same_switches = 0;
 
     return mpi_errno;
 }

--- a/src/mpi/coll/algorithms/treealgo/treealgo.c
+++ b/src/mpi/coll/algorithms/treealgo/treealgo.c
@@ -84,7 +84,8 @@ int MPIR_Treealgo_tree_create_topo_aware(MPIR_Comm * comm, int tree_type, int k,
 
     switch (tree_type) {
         case MPIR_TREE_TYPE_TOPOLOGY_AWARE:
-            if (!comm->coll.topo_aware_tree || root != comm->coll.topo_aware_tree_root) {
+            if (!comm->coll.topo_aware_tree || root != comm->coll.topo_aware_tree_root
+                || k != comm->coll.topo_aware_tree_k) {
                 if (comm->coll.topo_aware_tree) {
                     MPIR_Treealgo_tree_free(comm->coll.topo_aware_tree);
                 } else {
@@ -98,6 +99,7 @@ int MPIR_Treealgo_tree_create_topo_aware(MPIR_Comm * comm, int tree_type, int k,
                 MPIR_ERR_CHECK(mpi_errno);
                 *ct = *comm->coll.topo_aware_tree;
                 comm->coll.topo_aware_tree_root = root;
+                comm->coll.topo_aware_tree_k = k;
             }
             *ct = *comm->coll.topo_aware_tree;
             utarray_new(ct->children, &ut_int_icd, MPL_MEM_COLL);
@@ -109,7 +111,8 @@ int MPIR_Treealgo_tree_create_topo_aware(MPIR_Comm * comm, int tree_type, int k,
             break;
 
         case MPIR_TREE_TYPE_TOPOLOGY_AWARE_K:
-            if (!comm->coll.topo_aware_k_tree || root != comm->coll.topo_aware_k_tree_root) {
+            if (!comm->coll.topo_aware_k_tree || root != comm->coll.topo_aware_k_tree_root
+                || k != comm->coll.topo_aware_k_tree_k) {
                 if (comm->coll.topo_aware_k_tree) {
                     MPIR_Treealgo_tree_free(comm->coll.topo_aware_k_tree);
                 } else {
@@ -123,6 +126,7 @@ int MPIR_Treealgo_tree_create_topo_aware(MPIR_Comm * comm, int tree_type, int k,
                 MPIR_ERR_CHECK(mpi_errno);
                 *ct = *comm->coll.topo_aware_k_tree;
                 comm->coll.topo_aware_k_tree_root = root;
+                comm->coll.topo_aware_k_tree_k = k;
             }
             *ct = *comm->coll.topo_aware_k_tree;
             utarray_new(ct->children, &ut_int_icd, MPL_MEM_COLL);
@@ -160,7 +164,11 @@ int MPIR_Treealgo_tree_create_topo_wave(MPIR_Comm * comm, int k, int root,
 
     MPIR_FUNC_ENTER;
 
-    if (!comm->coll.topo_wave_tree || root != comm->coll.topo_wave_tree_root) {
+    if (!comm->coll.topo_wave_tree || root != comm->coll.topo_wave_tree_root
+        || overhead != comm->coll.topo_wave_tree_overhead
+        || lat_diff_groups != comm->coll.topo_wave_tree_lat_diff_groups
+        || lat_diff_switches != comm->coll.topo_wave_tree_lat_diff_switches
+        || lat_same_switches != comm->coll.topo_wave_tree_lat_same_switches) {
         if (comm->coll.topo_wave_tree) {
             MPIR_Treealgo_tree_free(comm->coll.topo_wave_tree);
         } else {
@@ -174,6 +182,10 @@ int MPIR_Treealgo_tree_create_topo_wave(MPIR_Comm * comm, int k, int root,
         MPIR_ERR_CHECK(mpi_errno);
         *ct = *comm->coll.topo_wave_tree;
         comm->coll.topo_wave_tree_root = root;
+        comm->coll.topo_wave_tree_overhead = overhead;
+        comm->coll.topo_wave_tree_lat_diff_groups = lat_diff_groups;
+        comm->coll.topo_wave_tree_lat_diff_switches = lat_diff_switches;
+        comm->coll.topo_wave_tree_lat_same_switches = lat_same_switches;
     }
     *ct = *comm->coll.topo_wave_tree;
     utarray_new(ct->children, &ut_int_icd, MPL_MEM_COLL);

--- a/src/mpi/coll/allreduce/allreduce_intra_tree.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_tree.c
@@ -70,13 +70,36 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
             MPIR_Treealgo_tree_create_topo_aware(comm_ptr, tree_type, k, root,
                                                  MPIR_CVAR_ALLREDUCE_TOPO_REORDER_ENABLE, &my_tree);
     } else if (tree_type == MPIR_TREE_TYPE_TOPOLOGY_WAVE) {
+        MPIR_Csel_coll_sig_s coll_sig = {
+            .coll_type = MPIR_CSEL_COLL_TYPE__ALLREDUCE,
+            .comm_ptr = comm_ptr,
+            .u.allreduce.sendbuf = sendbuf,
+            .u.allreduce.recvbuf = recvbuf,
+            .u.allreduce.count = count,
+            .u.allreduce.datatype = datatype,
+            .u.allreduce.op = op,
+        };
+
+        int overhead = MPIR_CVAR_ALLREDUCE_TOPO_OVERHEAD;
+        int lat_diff_groups = MPIR_CVAR_ALLREDUCE_TOPO_DIFF_GROUPS;
+        int lat_diff_switches = MPIR_CVAR_ALLREDUCE_TOPO_DIFF_SWITCHES;
+        int lat_same_switches = MPIR_CVAR_ALLREDUCE_TOPO_SAME_SWITCHES;
+
+        MPII_Csel_container_s *cnt = MPIR_Csel_search(comm_ptr->csel_comm, coll_sig);
+        MPIR_Assert(cnt);
+
+        if (cnt->id == MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Allreduce_intra_tree) {
+            overhead = cnt->u.allreduce.intra_tree.topo_overhead;
+            lat_diff_groups = cnt->u.allreduce.intra_tree.topo_diff_groups;
+            lat_diff_switches = cnt->u.allreduce.intra_tree.topo_diff_switches;
+            lat_same_switches = cnt->u.allreduce.intra_tree.topo_same_switches;
+        }
+
         mpi_errno =
             MPIR_Treealgo_tree_create_topo_wave(comm_ptr, k, root,
                                                 MPIR_CVAR_ALLREDUCE_TOPO_REORDER_ENABLE,
-                                                MPIR_CVAR_ALLREDUCE_TOPO_OVERHEAD,
-                                                MPIR_CVAR_ALLREDUCE_TOPO_DIFF_GROUPS,
-                                                MPIR_CVAR_ALLREDUCE_TOPO_DIFF_SWITCHES,
-                                                MPIR_CVAR_ALLREDUCE_TOPO_SAME_SWITCHES, &my_tree);
+                                                overhead, lat_diff_groups, lat_diff_switches,
+                                                lat_same_switches, &my_tree);
     } else {
         mpi_errno = MPIR_Treealgo_tree_create(rank, comm_size, tree_type, k, root, &my_tree);
     }

--- a/src/mpi/coll/bcast/bcast_intra_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_tree.c
@@ -80,13 +80,36 @@ int MPIR_Bcast_intra_tree(void *buffer,
                 MPIR_Treealgo_tree_create_topo_aware(comm_ptr, tree_type, branching_factor, root,
                                                      MPIR_CVAR_BCAST_TOPO_REORDER_ENABLE, &my_tree);
         } else if (tree_type == MPIR_TREE_TYPE_TOPOLOGY_WAVE) {
+            MPIR_Csel_coll_sig_s coll_sig = {
+                .coll_type = MPIR_CSEL_COLL_TYPE__BCAST,
+                .comm_ptr = comm_ptr,
+                .u.bcast.buffer = buffer,
+                .u.bcast.count = count,
+                .u.bcast.datatype = datatype,
+                .u.bcast.root = root,
+            };
+
+            int overhead = MPIR_CVAR_BCAST_TOPO_OVERHEAD;
+            int lat_diff_groups = MPIR_CVAR_BCAST_TOPO_DIFF_GROUPS;
+            int lat_diff_switches = MPIR_CVAR_BCAST_TOPO_DIFF_SWITCHES;
+            int lat_same_switches = MPIR_CVAR_BCAST_TOPO_SAME_SWITCHES;
+
+            MPII_Csel_container_s *cnt = MPIR_Csel_search(comm_ptr->csel_comm, coll_sig);
+            MPIR_Assert(cnt);
+
+            if (cnt->id == MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Bcast_intra_tree) {
+                overhead = cnt->u.bcast.intra_tree.topo_overhead;
+                lat_diff_groups = cnt->u.bcast.intra_tree.topo_diff_groups;
+                lat_diff_switches = cnt->u.bcast.intra_tree.topo_diff_switches;
+                lat_same_switches = cnt->u.bcast.intra_tree.topo_same_switches;
+            }
+
             mpi_errno =
                 MPIR_Treealgo_tree_create_topo_wave(comm_ptr, branching_factor, root,
                                                     MPIR_CVAR_BCAST_TOPO_REORDER_ENABLE,
-                                                    MPIR_CVAR_BCAST_TOPO_OVERHEAD,
-                                                    MPIR_CVAR_BCAST_TOPO_DIFF_GROUPS,
-                                                    MPIR_CVAR_BCAST_TOPO_DIFF_SWITCHES,
-                                                    MPIR_CVAR_BCAST_TOPO_SAME_SWITCHES, &my_tree);
+                                                    overhead, lat_diff_groups, lat_diff_switches,
+                                                    lat_same_switches, &my_tree);
+
         } else {
             mpi_errno =
                 MPIR_Treealgo_tree_create(rank, comm_size, tree_type, branching_factor, root,

--- a/src/mpi/coll/include/csel_container.h
+++ b/src/mpi/coll/include/csel_container.h
@@ -311,6 +311,10 @@ typedef struct {
                 int tree_type;
                 int k;
                 int is_non_blocking;
+                int topo_overhead;
+                int topo_diff_groups;
+                int topo_diff_switches;
+                int topo_same_switches;
             } intra_tree;
             struct {
                 int tree_type;
@@ -349,6 +353,10 @@ typedef struct {
                 int k;
                 int chunk_size;
                 int buffer_per_child;
+                int topo_overhead;
+                int topo_diff_groups;
+                int topo_diff_switches;
+                int topo_same_switches;
             } intra_tsp_tree;
             struct {
                 int chunk_size;
@@ -371,6 +379,10 @@ typedef struct {
                 int k;
                 int chunk_size;
                 int buffer_per_child;
+                int topo_overhead;
+                int topo_diff_groups;
+                int topo_diff_switches;
+                int topo_same_switches;
             } intra_tree;
             struct {
                 int k;

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree.c
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree.c
@@ -74,13 +74,37 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
             MPIR_Treealgo_tree_create_topo_aware(comm, tree_type, k, tree_root,
                                                  MPIR_CVAR_IREDUCE_TOPO_REORDER_ENABLE, &my_tree);
     } else if (tree_type == MPIR_TREE_TYPE_TOPOLOGY_WAVE) {
+        MPIR_Csel_coll_sig_s coll_sig = {
+            .coll_type = MPIR_CSEL_COLL_TYPE__IREDUCE,
+            .comm_ptr = comm,
+            .u.ireduce.sendbuf = sendbuf,
+            .u.ireduce.recvbuf = recvbuf,
+            .u.ireduce.count = count,
+            .u.ireduce.datatype = datatype,
+            .u.ireduce.op = op,
+            .u.ireduce.root = tree_root,
+        };
+
+        int overhead = MPIR_CVAR_IREDUCE_TOPO_OVERHEAD;
+        int lat_diff_groups = MPIR_CVAR_IREDUCE_TOPO_DIFF_GROUPS;
+        int lat_diff_switches = MPIR_CVAR_IREDUCE_TOPO_DIFF_SWITCHES;
+        int lat_same_switches = MPIR_CVAR_IREDUCE_TOPO_SAME_SWITCHES;
+
+        MPII_Csel_container_s *cnt = MPIR_Csel_search(comm->csel_comm, coll_sig);
+        MPIR_Assert(cnt);
+
+        if (cnt->id == MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ireduce_intra_tsp_tree) {
+            overhead = cnt->u.ireduce.intra_tsp_tree.topo_overhead;
+            lat_diff_groups = cnt->u.ireduce.intra_tsp_tree.topo_diff_groups;
+            lat_diff_switches = cnt->u.ireduce.intra_tsp_tree.topo_diff_switches;
+            lat_same_switches = cnt->u.ireduce.intra_tsp_tree.topo_same_switches;
+        }
+
         mpi_errno =
             MPIR_Treealgo_tree_create_topo_wave(comm, k, tree_root,
                                                 MPIR_CVAR_IREDUCE_TOPO_REORDER_ENABLE,
-                                                MPIR_CVAR_IREDUCE_TOPO_OVERHEAD,
-                                                MPIR_CVAR_IREDUCE_TOPO_DIFF_GROUPS,
-                                                MPIR_CVAR_IREDUCE_TOPO_DIFF_SWITCHES,
-                                                MPIR_CVAR_IREDUCE_TOPO_SAME_SWITCHES, &my_tree);
+                                                overhead, lat_diff_groups, lat_diff_switches,
+                                                lat_same_switches, &my_tree);
     } else {
         mpi_errno = MPIR_Treealgo_tree_create(rank, size, tree_type, k, tree_root, &my_tree);
     }

--- a/src/mpi/coll/src/csel_container.c
+++ b/src/mpi/coll/src/csel_container.c
@@ -53,6 +53,18 @@ static void parse_container_params(struct json_object *obj, MPII_Csel_container_
                     else if (!strncmp(ckey, "is_non_blocking=", strlen("is_non_blocking=")))
                         cnt->u.bcast.intra_tree.is_non_blocking =
                             atoi(ckey + strlen("is_non_blocking="));
+                    else if (!strncmp(ckey, "topo_overhead=", strlen("topo_overhead=")))
+                        cnt->u.bcast.intra_tree.topo_overhead =
+                            atoi(ckey + strlen("topo_overhead="));
+                    else if (!strncmp(ckey, "topo_diff_groups=", strlen("topo_diff_groups=")))
+                        cnt->u.bcast.intra_tree.topo_diff_groups =
+                            atoi(ckey + strlen("topo_diff_groups="));
+                    else if (!strncmp(ckey, "topo_diff_switches=", strlen("topo_diff_switches=")))
+                        cnt->u.bcast.intra_tree.topo_diff_switches =
+                            atoi(ckey + strlen("topo_diff_switches="));
+                    else if (!strncmp(ckey, "topo_same_switches=", strlen("topo_same_switches=")))
+                        cnt->u.bcast.intra_tree.topo_same_switches =
+                            atoi(ckey + strlen("topo_same_switches="));
                     MPL_free(ckey);
                 }
             }
@@ -95,6 +107,18 @@ static void parse_container_params(struct json_object *obj, MPII_Csel_container_
                     else if (!strncmp(ckey, "chunk_size=", strlen("chunk_size=")))
                         cnt->u.ireduce.intra_tsp_tree.chunk_size =
                             atoi(ckey + strlen("chunk_size="));
+                    else if (!strncmp(ckey, "topo_overhead=", strlen("topo_overhead=")))
+                        cnt->u.ireduce.intra_tsp_tree.topo_overhead =
+                            atoi(ckey + strlen("topo_overhead="));
+                    else if (!strncmp(ckey, "topo_diff_groups=", strlen("topo_diff_groups=")))
+                        cnt->u.ireduce.intra_tsp_tree.topo_diff_groups =
+                            atoi(ckey + strlen("topo_diff_groups="));
+                    else if (!strncmp(ckey, "topo_diff_switches=", strlen("topo_diff_switches=")))
+                        cnt->u.ireduce.intra_tsp_tree.topo_diff_switches =
+                            atoi(ckey + strlen("topo_diff_switches="));
+                    else if (!strncmp(ckey, "topo_same_switches=", strlen("topo_same_switches=")))
+                        cnt->u.ireduce.intra_tsp_tree.topo_same_switches =
+                            atoi(ckey + strlen("topo_same_switches="));
                     MPL_free(ckey);
                 }
             }
@@ -148,6 +172,18 @@ static void parse_container_params(struct json_object *obj, MPII_Csel_container_
                         cnt->u.allreduce.intra_tree.tree_type = atoi(ckey + strlen("tree_type="));
                     else if (!strncmp(ckey, "chunk_size=", strlen("chunk_size=")))
                         cnt->u.allreduce.intra_tree.chunk_size = atoi(ckey + strlen("chunk_size="));
+                    else if (!strncmp(ckey, "topo_overhead=", strlen("topo_overhead=")))
+                        cnt->u.allreduce.intra_tree.topo_overhead =
+                            atoi(ckey + strlen("topo_overhead="));
+                    else if (!strncmp(ckey, "topo_diff_groups=", strlen("topo_diff_groups=")))
+                        cnt->u.allreduce.intra_tree.topo_diff_groups =
+                            atoi(ckey + strlen("topo_diff_groups="));
+                    else if (!strncmp(ckey, "topo_diff_switches=", strlen("topo_diff_switches=")))
+                        cnt->u.allreduce.intra_tree.topo_diff_switches =
+                            atoi(ckey + strlen("topo_diff_switches="));
+                    else if (!strncmp(ckey, "topo_same_switches=", strlen("topo_same_switches=")))
+                        cnt->u.allreduce.intra_tree.topo_same_switches =
+                            atoi(ckey + strlen("topo_same_switches="));
                     MPL_free(ckey);
                 }
             }


### PR DESCRIPTION
## Pull Request Description
Allow setting up topology-aware CVARs in collective tuning json file for bcast, reduce, and allreduce.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
