### PR TITLE
comm: fix intercomm split

### DIFF
--- a/src/mpi/comm/comm_split_type.c
+++ b/src/mpi/comm/comm_split_type.c
@@ -162,6 +162,11 @@ static int split_type_hw_guided(MPIR_Comm * comm_ptr, int key, const char *resou
     mpi_errno = split_type_by_node(comm_ptr, key, &node_comm);
     MPIR_ERR_CHECK(mpi_errno);
 
+    if (comm_ptr == NULL) {
+        /* it is possible with intercomm split */
+        goto fn_exit;
+    }
+
     if (!MPIR_hwtopo_is_initialized()) {
         /* if hwtopo is not available, return MPI_COMM_NULL */
         *newcomm_ptr = NULL;
@@ -206,6 +211,11 @@ static int split_type_hw_unguided(MPIR_Comm * comm_ptr, int key, MPIR_Info * inf
      */
     mpi_errno = split_type_by_node(comm_ptr, key, &subcomm);
     MPIR_ERR_CHECK(mpi_errno);
+
+    if (comm_ptr == NULL) {
+        /* it is possible with intercomm split */
+        goto fn_exit;
+    }
 
     if (MPIR_Comm_size(subcomm) < orig_size) {
         resource_type = "node";
@@ -278,6 +288,11 @@ int MPIR_Comm_split_type_node_topo(MPIR_Comm * user_comm_ptr, int key,
     MPIR_Comm *comm_ptr;
     mpi_errno = split_type_by_node(user_comm_ptr, key, &comm_ptr);
     MPIR_ERR_CHECK(mpi_errno);
+
+    if (comm_ptr == NULL) {
+        /* it is possible with intercomm split */
+        goto fn_exit;
+    }
 
     const char *shmem_topo;
     mpi_errno = MPII_collect_info_key(comm_ptr, info_ptr, SHMEM_INFO_KEY, &shmem_topo);

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -1283,6 +1283,15 @@ int MPII_collect_info_key(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr, const char
         }
     }
 
+    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) {
+        /* just ensure consistency on the local group */
+        /* TODO: check consistency between local and remote processes */
+        if (!comm_ptr->local_comm) {
+            MPII_Setup_intercomm_localcomm(comm_ptr);
+        }
+        comm_ptr = comm_ptr->local_comm;
+    }
+
     int is_equal;
     mpi_errno = MPIR_Allreduce_equal(&hint_str_size, 1, MPI_INT, &is_equal, comm_ptr);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -1067,6 +1067,12 @@ int MPID_Get_node_id(MPIR_Comm * comm, int rank, int *id_p)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
+    if (comm->comm_kind == MPIR_COMM_KIND__INTERCOMM) {
+        if (!comm->local_comm) {
+            MPII_Setup_intercomm_localcomm(comm);
+        }
+        comm = comm->local_comm;
+    }
     MPIDIU_get_node_id(comm, rank, id_p);
 
     MPIR_FUNC_EXIT;


### PR DESCRIPTION
## Pull Request Description
Some code paths along the comm split by type does not consider inter communicator, and the best is work by accident.
In particular, the ch4 av manager does not work with intercomm and may return garbage node_id in `MPID_get_node_id`.

Intercomm split may result in NULL communicator when local and remote groups do not have the same color value. Immediately return rather than continue splitting with a NULL communicator.

[skip warnings]
Fixes #6783 


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
