### PR TITLE
init: add cvar MPIR_CVAR_FINALIZE_WAIT

### DIFF
--- a/src/mpi/comm/builtin_comms.c
+++ b/src/mpi/comm/builtin_comms.c
@@ -131,11 +131,13 @@ static int finalize_builtin_comm(MPIR_Comm * comm)
 
     int ref_count = MPIR_Object_get_ref(comm);
     if (ref_count != 1) {
-        MPL_internal_error_printf
-            ("WARNING: Builtin communicator %x has pending %d references, polling progress until all references clears.\n",
-             comm->handle, ref_count - 1);
-        while (MPIR_Object_get_ref(comm) > 1) {
-            MPID_Stream_progress(NULL);
+        MPL_internal_error_printf("WARNING: Builtin communicator %x has pending %d references.\n",
+                                  comm->handle, ref_count - 1);
+        if (MPIR_CVAR_FINALIZE_WAIT) {
+            MPL_internal_error_printf("WARNING: polling progress until all references clears.\n");
+            while (MPIR_Object_get_ref(comm) > 1) {
+                MPID_Stream_progress(NULL);
+            }
         }
     }
     mpi_errno = MPIR_Comm_release(comm);

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -79,6 +79,19 @@ cvars:
         in leaking memory or losing messages due to pre-mature exiting. The
         default is false, which may invoke collective behaviors at finalize.
 
+    - name        : MPIR_CVAR_FINALIZE_WAIT
+      category    : COLLECTIVE
+      type        : boolean
+      default     : false
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        If true, poll progress at MPI_Finalize until reference count on
+        MPI_COMM_WORLD and MPI_COMM_SELF reaches zero. This may be necessary
+        to prevent remote processes hanging if it has pending communication
+        protocols, e.g. a rendezvous send.
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 

--- a/test/mpi/comm/testlist.in
+++ b/test/mpi/comm/testlist.in
@@ -48,4 +48,4 @@ idup_with_info 8
 comm_info 6
 comm_info2 1
 comm_create_group_idup 4
-inactive_reqs 1 resultTest=TestAllowWarnings
+inactive_reqs 1 resultTest=TestAllowWarnings env=MPIR_CVAR_FINALIZE_WAIT=1

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -31,7 +31,7 @@ icsend 4 arg=-randomize=1
 icprobe 4
 icprobe 4 arg=-randomize=1
 rqstatus 2
-rqfree 4 resultTest=TestAllowWarnings
+rqfree 4 resultTest=TestAllowWarnings env=MPIR_CVAR_FINALIZE_WAIT=1
 greq1 1
 probe_unexp 4
 probe_unexp 4 env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=16384


### PR DESCRIPTION
## Pull Request Description
When the communicator have outstanding reference count at finalize, in some cases this is due to pending progress and we need continue poll progress to prevent blocking other processes. But sometime it is simply due to missing a free call, e.g. MPI_Request_free, and polling progress will not resolve the reference and will enter a dead loop. Unfortunately, the latter is by far the more common case. Thus, add a cvar, MPIR_CVAR_FINALIZE_WAIT, and by default, we don't enter progress loop if we encounter outstanding reference count, only issue WARNING. For applications that known to result in pending progress at finalize, they can set MPIR_CVAR_FINALIZE_WAIT=true to prevent deadlocks.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
