### PR TITLE
ch4:ucx: revert "configure: enable shmmod"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,8 +3,6 @@
 ===============================================================================
 # Complete support MPI 4.1 specification
 
-# CH4 shm is enabled by default with ucx netmod.
-
 # Use --with-{pmi,pmi2,pmix]=[path] to configure external PMI library.
   Convenience options for Slurm and cray deprecated. Use --with-pmi=oldcray
   for older Cray environment.

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -275,6 +275,13 @@ AC_ARG_WITH(ch4-shmmods,
 ch4_shm="`echo $with_ch4_shmmods | sed -e 's/,/ /g'`"
 export ch4_shm
 
+# setup default direct communication routine
+if test "${with_ch4_shmmods}" = "auto" -a "${ch4_netmods}" = "ucx" ; then
+    # ucx can only choose direct netmod because it does not handle any_src
+    # receive when both nemod and shared memory are used.
+    with_ch4_shmmods=none
+fi
+
 if test "${with_ch4_shmmods}" = "none" -o "${with_ch4_shmmods}" = "no" ; then
     AC_DEFINE(MPIDI_CH4_DIRECT_NETMOD, 1, [CH4 Directly transfers data through the chosen netmode])
 fi


### PR DESCRIPTION
## Pull Request Description

A report shows that the ucx shm performance is superior to the ch4 shm. Thus, we revert the configuration default for ch4:ucx until we resolve the ch4 shm performance issues.

This reverts commit 29c31f8d1ccf533e7932ed579b2e65bf0098e4d8.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
