### PR TITLE
ch3: skip win_free on allocate error for now

### DIFF
--- a/src/mpid/ch3/src/mpid_rma.c
+++ b/src/mpid/ch3/src/mpid_rma.c
@@ -171,9 +171,6 @@ int MPID_Win_allocate_shared(MPI_Aint size, MPI_Aint disp_unit, MPIR_Info * info
 
     mpi_errno =
         MPIDI_CH3U_Win_fns.allocate_shared(size, my_disp_unit, info, comm_ptr, base_ptr, win_ptr);
-    if (mpi_errno) {
-        MPID_Win_free(win_ptr);
-    }
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_fail:


### PR DESCRIPTION
## Pull Request Description
Ideally upon error in win_allocate_shared, we need free the window to prevent resource leaks. However, we need be careful since there may have unclean fields in the windown structure and the current window free is causing double free error, likely due to trying to free an uninitialed pointer.

Because ch3 is in legacy mode and this only affects resource leak under an error condition, let's omit the win_free for now to prevent errors in win_free.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
