### PR TITLE
test/runtests: singleton tests skip those require mpiexecarg

### DIFF
--- a/test/mpi/runtests
+++ b/test/mpi/runtests
@@ -406,10 +406,6 @@ sub LoadTests {
 
             if ($#args >= 1) { $np = $args[1]; }
 
-            if ($g_opt{mpitest_singleton} and $np != 1) {
-                # skip multiple process tests if we need test singleton init
-                next;
-            }
             # Process the key=value arguments
             for (my $i=2; $i <= $#args; $i++) {
                 if ($args[$i] =~ /([^=]+)=(.*)/) {
@@ -434,6 +430,11 @@ sub LoadTests {
                         print STDERR "Unrecognized key $key in $listfileSource\n";
                     }
                 }
+            }
+
+            if ($g_opt{mpitest_singleton} and ($np != 1 or @{$test_opt->{mpiexecargs}})) {
+                # skip if we need test singleton init and the test require multiple processes or mpiexec argument
+                next;
             }
 
             if ($g_opt{has_gpu_test}) {


### PR DESCRIPTION
## Pull Request Description
Singleton tests can't apply mpiexec argument, thus we need skip.

This fixes the singleton test impls/mpich/info/memory_alloc_kinds.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
