### PR TITLE
mpi: add feature macro MPICH_ENABLE_EXTENSION

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,12 @@
 ===============================================================================
+                               Changes in 4.3
+===============================================================================
+# MPIX extensions are now guarded in mpi.h. Define MPICH_ENABLE_EXTENSION before
+  including mpi.h to enable MPIX extensions. Enable extension will also define
+  MPI_MAX_PORT_NAME to 1024, a larger value than defined in the current MPICH ABI.
+
+
+===============================================================================
                                Changes in 4.2
 ===============================================================================
 # Complete support MPI 4.1 specification

--- a/configure.ac
+++ b/configure.ac
@@ -208,6 +208,8 @@ AH_TOP([/*
 #define MPICHCONF_H_INCLUDED
 ])
 
+AC_DEFINE(MPICH_ENABLE_EXTENSION, 1, [define to expose mpix in mpi.h])
+
 # We use an #include strategy here because all of the alternative strategies for
 # quashing these variables have various drawbacks.  The alternatives are listed
 # here to avoid rediscovery of these problems by someone else in the future:

--- a/maint/version.m4
+++ b/maint/version.m4
@@ -14,7 +14,7 @@
 # changing this by playing with diversions, but then we would probably be
 # playing with autotools-fire.
 
-m4_define([MPICH_VERSION_m4],[4.2.0b1])dnl
+m4_define([MPICH_VERSION_m4],[4.3.0a1])dnl
 m4_define([MPICH_RELEASE_DATE_m4],[unreleased development copy])dnl
 
 # For libtool ABI versioning rules see:

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -9,6 +9,12 @@
 
 /* user include file for MPI programs */
 
+/* NOTE: some of the features are not visible by default.
+ *       Define MPICH_ENABLE_EXTENSION to enable them.
+ *       *  increased MPI_MAX_PORT_NAME to accommodate certain architecture.
+ *       *  MPIX features
+ */
+
 #if defined(HAVE_VISIBILITY)
 #define MPICH_API_PUBLIC __attribute__((visibility ("default")))
 #else
@@ -135,7 +141,9 @@ extern "C" {
 #define MPI_ERRHANDLER_NULL ((MPI_Errhandler)0x14000000)
 #define MPI_MESSAGE_NULL   ((MPI_Message)0x2c000000)
 #define MPI_MESSAGE_NO_PROC ((MPI_Message)0x6c000000)
+#ifdef MPICH_ENABLE_EXTENSION
 #define MPIX_STREAM_NULL   ((MPIX_Stream)0x3c000000)
+#endif
 
 typedef int MPI_Datatype;
 #define MPI_CHAR           ((MPI_Datatype)@MPI_CHAR@)
@@ -217,7 +225,9 @@ typedef int MPI_Datatype;
 #define MPI_C_DOUBLE_COMPLEX       ((MPI_Datatype)@MPI_C_DOUBLE_COMPLEX@)
 #define MPI_C_LONG_DOUBLE_COMPLEX  ((MPI_Datatype)@MPI_C_LONG_DOUBLE_COMPLEX@)
 /* other extension types */
+#ifdef MPICH_ENABLE_EXTENSION
 #define MPIX_C_FLOAT16             ((MPI_Datatype)@MPIX_C_FLOAT16@)
+#endif
 
 /* address/offset types */
 #define MPI_AINT          ((MPI_Datatype)@MPI_AINT_DATATYPE@)
@@ -272,7 +282,9 @@ typedef int MPI_Op;
 #define MPI_MAXLOC  (MPI_Op)(0x5800000c)
 #define MPI_REPLACE (MPI_Op)(0x5800000d)
 #define MPI_NO_OP   (MPI_Op)(0x5800000e)
+#ifdef MPICH_ENABLE_EXTENSION
 #define MPIX_EQUAL  (MPI_Op)(0x5800000f)
+#endif
 
 /* MPI errhandler objects */
 typedef int MPI_Errhandler;
@@ -294,11 +306,13 @@ typedef int MPI_Request;
 /* MPI message objects for Mprobe and related functions */
 typedef int MPI_Message;
 
+#ifdef MPICH_ENABLE_EXTENSION
 /* Generalized requests extensions */
 typedef int MPIX_Grequest_class;
 
 /* MPI stream objects */
 typedef int MPIX_Stream;
+#endif
 
 /* for info */
 typedef int MPI_Info;
@@ -469,7 +483,11 @@ extern MPI_F08_status *MPI_F08_STATUSES_IGNORE;
 #define MPI_MAX_PROCESSOR_NAME @MPI_MAX_PROCESSOR_NAME@
 #define MPI_MAX_LIBRARY_VERSION_STRING @MPI_MAX_LIBRARY_VERSION_STRING@
 #define MPI_MAX_ERROR_STRING   @MPI_MAX_ERROR_STRING@
+#ifdef MPICH_ENABLE_EXTENSION
+#define MPI_MAX_PORT_NAME      1024
+#else
 #define MPI_MAX_PORT_NAME      256
+#endif
 #define MPI_MAX_OBJECT_NAME    128
 #define MPI_MAX_STRINGTAG_LEN  256
 #define MPI_MAX_PSET_NAME_LEN  256
@@ -579,7 +597,9 @@ enum MPIR_Combiner_enum {
 #define MPI_COMM_TYPE_RESOURCE_GUIDED 4
 
 /* MPICH-specific types */
+#ifdef MPICH_ENABLE_EXTENSION
 #define MPIX_COMM_TYPE_NEIGHBORHOOD 5
+#endif
 
 /* For supported thread levels */
 #define MPI_THREAD_SINGLE 0
@@ -703,6 +723,7 @@ enum MPIR_Combiner_enum {
 #define MPICH_ERR_LAST_CLASS 80     /* It is also helpful to know the
 				       last valid class */
 
+#ifdef MPICH_ENABLE_EXTENSION
 #define MPICH_ERR_FIRST_MPIX 100 /* Define a gap here because sock is
                                   * already using some of the values in this
                                   * range. All MPIX error codes will be
@@ -718,13 +739,16 @@ enum MPIR_Combiner_enum {
 #define MPIX_ERR_TIMEOUT              MPICH_ERR_FIRST_MPIX+7 /* Operation timed out */
 
 #define MPICH_ERR_LAST_MPIX           MPICH_ERR_FIRST_MPIX+7
+#endif  /* MPICH_ENABLE_EXTENSION */
 
 /* End of MPI's error classes */
 
 /* GPU extensions */
+#ifdef MPICH_ENABLE_EXTENSION
 #define MPIX_GPU_SUPPORT_CUDA  (0)
 #define MPIX_GPU_SUPPORT_ZE    (1)
 #define MPIX_GPU_SUPPORT_HIP   (2)
+#endif
 
 /* feature advertisement */
 #define MPIIMPL_ADVERTISES_FEATURES 1
@@ -772,8 +796,10 @@ typedef void (MPI_User_function_c) ( void *, void *, MPI_Count *, MPI_Datatype *
 typedef int (MPI_Grequest_cancel_function)(void *, int);
 typedef int (MPI_Grequest_free_function)(void *);
 typedef int (MPI_Grequest_query_function)(void *, MPI_Status *);
+#ifdef MPICH_ENABLE_EXTENSION
 typedef int (MPIX_Grequest_poll_function)(void *, MPI_Status *);
 typedef int (MPIX_Grequest_wait_function)(int, void **, double, MPI_Status *);
+#endif
 
 /* Function type defs */
 typedef int (MPI_Datarep_conversion_function)(void *, MPI_Datatype, int,
@@ -943,11 +969,13 @@ int QMPI_Get_calling_address(QMPI_Context context, void **address) MPICH_API_PUB
 */
 /* --Insert Additional Definitions Here-- */
 
+#ifdef MPICH_ENABLE_EXTENSION
 /* same as struct iovec, provided to avoid header dependency */
 typedef struct MPIX_Iov {
     void *iov_base;
     MPI_Aint iov_len;
 } MPIX_Iov;
+#endif
 
 /*
  * Normally, we provide prototypes for all MPI routines.  In a few weird

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -153,6 +153,8 @@ else
     # just set mpl_includedir and source mpl/localdefs if any.
     pac_skip_mpl_lib=yes
     PAC_CONFIG_MPL
+    # enable MPICH extensions
+    AC_DEFINE(MPICH_ENABLE_EXTENSION, 1, [define to enable MPICH mpix extensions])
 fi
 
 CFLAGS=${CFLAGS:-""}

--- a/src/mpid/ch4/src/ch4_spawn.c
+++ b/src/mpid/ch4/src/ch4_spawn.c
@@ -238,7 +238,7 @@ int MPID_Open_port(MPIR_Info * info_ptr, char *port_name)
 
     int len;
     int err;
-    len = MPI_MAX_PORT_NAME;    /* FIXME: currently at 256, probably too short for ucx */
+    len = MPI_MAX_PORT_NAME;
     err = MPL_str_add_int_arg(&port_name, &len, PORT_NAME_TAG_KEY, tag);
     MPIR_ERR_CHKANDJUMP(err, mpi_errno, MPI_ERR_OTHER, "**argstr_port_name_tag");
     err = MPL_str_add_binary_arg(&port_name, &len, CONNENTR_TAG_KEY, addrname, addrname_size[0]);

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -441,6 +441,9 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include "mpi.h"],[return 1 + MPICH;])],
 AC_MSG_RESULT($MPI_IS_MPICH)
 
 if test "$MPI_IS_MPICH" = "yes" ; then
+    if test "$enable_strictmpi" = "no" then
+        AC_DEFINE(MPICH_ENABLE_EXTENSION, 1, [define to enable mpich mpix features])
+    fi
     # try mpichversion
     AC_PATH_PROG(MPICHVERSION, mpichversion, [], [$PATH:$with_mpi/bin])
     if test -n "$MPICHVERSION" ; then

--- a/test/mpi/impls/mpich/misc/gpu_query.c
+++ b/test/mpi/impls/mpich/misc/gpu_query.c
@@ -3,14 +3,15 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#include "mpi.h"
+#include "mpitest.h"
 #include <stdio.h>
 
 int main(int argc, char **argv)
 {
     int errors = 0;
     int cuda_support, ze_support, hip_support;
-    MPI_Init(NULL, NULL);
+
+    MTest_Init(&argc, &argv);
 
     MPIX_GPU_query_support(MPIX_GPU_SUPPORT_CUDA, &cuda_support);
     MPIX_GPU_query_support(MPIX_GPU_SUPPORT_ZE, &ze_support);
@@ -47,11 +48,7 @@ int main(int argc, char **argv)
     }
 #endif
 
-    if (errors == 0) {
-        printf("No Errors\n");
-    }
-
-    MPI_Finalize();
+    MTest_Finalize(errors);
 
     return 0;
 }

--- a/test/mpi/impls/mpich/misc/type_iov.c
+++ b/test/mpi/impls/mpich/misc/type_iov.c
@@ -3,9 +3,8 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#include "mpi.h"
-#include <stdio.h>
 #include "mpitest.h"
+#include <stdio.h>
 #include "stdlib.h"
 #include "dtpools.h"
 #include <assert.h>

--- a/test/mpi/impls/mpich/ulfm/get_failed.c
+++ b/test/mpi/impls/mpich/ulfm/get_failed.c
@@ -3,7 +3,7 @@
  *     See COPYRIGHT in top-level directory
  */
 
-#include <mpi.h>
+#include <mpitest.h>
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
## Pull Request Description
The goal is to protect all public features that are outside the MPICH
ABI with this macro. Users need to explicitly define MPICH_ENABLE_EXTENSION
before #include "mpi.h" in order to use extended features.

A strict mpi program does not need define `MPICH_ENABLE_EXTENSION` --
```
#include "mpi.h"
void main(void)
{
    int is_supported;
    MPIX_GPU_query_support(MPIX_GPU_SUPPORT_CUDA, &is_supported);  /* !!! compilation error */
}
```
To use `MPIX`-feature, define `MPICH_ENABLE_EXTENSION`:
```
#define MPICH_ENABLE_EXTENSION
#include "mpi.h"
void main(void)
{
    int is_supported;
    MPIX_GPU_query_support(MPIX_GPU_SUPPORT_CUDA, &is_supported);  /* ok if mpich is used */
}
```
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
