### PR TITLE
rma: add accumulate error checking for matching datatypes

### DIFF
--- a/src/binding/c/rma_api.txt
+++ b/src/binding/c/rma_api.txt
@@ -51,6 +51,16 @@ MPI_Accumulate:
     .seealso: MPI_Raccumulate
     .impl: mpid
     .earlyreturn: pt2pt_proc_null
+{ -- error_check --
+    MPI_Datatype origin_elem, target_elem;
+    MPIR_Datatype_get_basic_type(origin_datatype, origin_elem);
+    MPIR_Datatype_get_basic_type(target_datatype, target_elem);
+    if ((origin_count > 0 && origin_elem != MPI_DATATYPE_NULL) ||
+        (target_count > 0 && target_elem != MPI_DATATYPE_NULL)) {
+        MPIR_ERR_CHKANDJUMP(origin_elem != target_elem, mpi_errno, MPI_ERR_TYPE,
+                            "**dtypemismatch");
+    }
+}
 
 MPI_Compare_and_swap:
     .desc: Perform one-sided atomic compare-and-swap.


### PR DESCRIPTION
## Pull Request Description
The basic element type for origin_datatype and target_datatype must
match for MPI_Accumulate. We only check when the datatypes are not
compound types (with a single element type).

Commit https://github.com/pmodels/mpich/commit/e7db71295898ab5687a09f54f836d3d0089bce05 delayed PMI_Finalize to exit hook in order to allow
multiple session init/finalize. We should only call PMI_Finalize if
MPIR_pmi_finalize is called. Otherwise, an abnormal exit will look like
a normal exit to the process manager.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
