### PR TITLE
pt2pt: fix the status for MPI_Irecv from MPI_PROC_NULL

### DIFF
--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -19,6 +19,13 @@ static void init_builtin_request(MPIR_Request * req, int handle, MPIR_Request_ki
     req->cc_ptr = &req->cc;
     req->status.MPI_ERROR = MPI_SUCCESS;
     MPIR_STATUS_SET_CANCEL_BIT(req->status, FALSE);
+    if (kind == MPIR_REQUEST_KIND__RECV) {
+        /* precompleted recv request is returned when source is MPI_PROC_NULL,
+         * or when we are certain status won't be needed. Thus, initialize the
+         * status for MPI_PROC_NULL. */
+        req->status.MPI_SOURCE = MPI_PROC_NULL;
+        req->status.MPI_TAG = MPI_ANY_TAG;
+    }
     req->comm = NULL;
 }
 

--- a/test/mpi/pt2pt/Makefile.am
+++ b/test/mpi/pt2pt/Makefile.am
@@ -46,6 +46,7 @@ noinst_PROGRAMS =  \
     waitany_null   \
     probe_unexp    \
     probenull      \
+    recvnull       \
     inactivereq    \
     waittestnull   \
     sendall        \

--- a/test/mpi/pt2pt/recvnull.c
+++ b/test/mpi/pt2pt/recvnull.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <stdio.h>
+#include "mpi.h"
+#include "mpitest.h"
+
+/*
+ * This program checks that MPI_Irecv and MPI_Recv correctly handle
+ * a source of MPI_PROC_NULL
+ */
+
+int main(int argc, char **argv)
+{
+    int flag;
+    int errs = 0;
+    MPI_Status status;
+    MPI_Request req;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Irecv(NULL, 0, MPI_DATATYPE_NULL, MPI_PROC_NULL, 10, MPI_COMM_WORLD, &req);
+    MPI_Waitall(1, &req, &status);
+    if (status.MPI_SOURCE != MPI_PROC_NULL) {
+        printf("Status.MPI_SOURCE was %d, should be MPI_PROC_NULL\n", status.MPI_SOURCE);
+        errs++;
+    }
+    if (status.MPI_TAG != MPI_ANY_TAG) {
+        printf("Status.MPI_TAG was %d, should be MPI_ANY_TAGL\n", status.MPI_TAG);
+        errs++;
+    }
+
+    /* If Irecv failed, Recv is likely to as well.  Avoid a possible hang
+     * by testing Recv only if Irecv test passed */
+    if (errs == 0) {
+        MPI_Recv(NULL, 0, MPI_DATATYPE_NULL, MPI_PROC_NULL, 10, MPI_COMM_WORLD, &status);
+        if (status.MPI_SOURCE != MPI_PROC_NULL) {
+            printf("Status.MPI_SOURCE was %d, should be MPI_PROC_NULL\n", status.MPI_SOURCE);
+            errs++;
+        }
+        if (status.MPI_TAG != MPI_ANY_TAG) {
+            printf("Status.MPI_TAG was %d, should be MPI_ANY_TAGL\n", status.MPI_TAG);
+            errs++;
+        }
+    }
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -39,6 +39,7 @@ probe_unexp 4 env=MPIR_CVAR_CH4_OFI_AM_LONG_FORCE_PIPELINE=true
 probenull 1
 probenull 1 env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=16384
 probenull 1 env=MPIR_CVAR_CH4_OFI_AM_LONG_FORCE_PIPELINE=true
+recvnull 1
 # For testing, scancel will run with 1 process as well
 scancel 2 xfail=ticket2266
 scancel2 2 xfail=ticket2266


### PR DESCRIPTION
## Pull Request Description
A pre-completed builtin request is returned for MPI_Irecv from
MPI_PROC_NULL. Initialize the status fields for this case. We should
never return pre-completed recv request for other cases since we won't be
able to set the status fields.

Also, add a test.

Fixes #6805
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
