### PR TITLE
hydra: slurm hostlist_t should be used as pointer

### DIFF
--- a/src/pm/hydra/lib/tools/bootstrap/external/slurm_query_node_list.c
+++ b/src/pm/hydra/lib/tools/bootstrap/external/slurm_query_node_list.c
@@ -26,7 +26,7 @@ static struct HYD_node *global_node_list = NULL;
 #if defined(HAVE_SLURM)
 static HYD_status list_to_nodes(char *str)
 {
-    hostlist_t hostlist;
+    hostlist_t *hostlist;
     char *host;
     int k = 0;
     HYD_status status = HYD_SUCCESS;


### PR DESCRIPTION
## Pull Request Description
It appears Slurm changed the signature and usage of its hostlist function and hostlist_t type. `hostlist_t` is an opaque struct, and should be used in its pointer form.

Fixes #6806
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
