### PR TITLE
[4.1.x] Revert "mpir: fix memory leak in mpir_hwtopo.c"

### DIFF
--- a/src/util/mpir_hwtopo.c
+++ b/src/util/mpir_hwtopo.c
@@ -210,7 +210,6 @@ int MPII_hwtopo_init(void)
              * file is really the underlying system. */
             hwloc_topology_set_flags(hwloc_topology, HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM);
         }
-        MPL_free(xmlfile);
     }
 
     hwloc_topology_set_io_types_filter(hwloc_topology, HWLOC_TYPE_FILTER_KEEP_ALL);


### PR DESCRIPTION
## Pull Request Description

This reverts commit 03c37b628b3d98141d1de43541e56446923a05c1. This commit is not needed in this branch, since the leak was the result of additional refactoring.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
