### PR TITLE
[4.1.x] ch4/ucx: Limit IOV recv to UCX >= 1.16

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_recv.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_recv.h
@@ -158,7 +158,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_UCX_recv(void *buf,
             MPI_Aint density;
             MPIR_Datatype_get_density(datatype, density);
 
-            if (density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
+            if (UCP_VERSION(UCP_API_MAJOR, UCP_API_MINOR) >= UCP_VERSION(1, 16) &&
+                density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
                 MPI_Aint iov_len, actual_iov_len;
                 MPIR_Typerep_get_iov_len(count, datatype, &iov_len);
                 ucp_dt_iov_t *iov = MPL_malloc(sizeof(ucp_dt_iov_t) * iov_len, MPL_MEM_BUFFER);


### PR DESCRIPTION
## Pull Request Description

There is a bug in older versions that will cause this path to segfault with GPU buffers. Avoid it unless we are using a known good version.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
