### PR TITLE
fortran/use_mpi: add missing dependency on pmip_base.mod

### DIFF
--- a/src/binding/fortran/use_mpi/Makefile.mk
+++ b/src/binding/fortran/use_mpi/Makefile.mk
@@ -68,7 +68,7 @@ mpi_fc_sources += \
 # We need the MPI constants in a separate module for some of the
 # interface definitions (the ones that need MPI_ADDRESS_KIND or
 # MPI_OFFSET_KIND)
-src/binding/fortran/use_mpi/mpi.$(MOD)-stamp: src/binding/fortran/use_mpi/$(MPICONSTMOD).$(MOD) src/binding/fortran/use_mpi/$(MPISIZEOFMOD).$(MOD) src/binding/fortran/use_mpi/$(MPIBASEMOD).$(MOD) $(srcdir)/src/binding/fortran/use_mpi/mpi.f90 src/binding/fortran/use_mpi/mpifnoext.h
+src/binding/fortran/use_mpi/mpi.$(MOD)-stamp: src/binding/fortran/use_mpi/$(MPICONSTMOD).$(MOD) src/binding/fortran/use_mpi/$(MPISIZEOFMOD).$(MOD) src/binding/fortran/use_mpi/$(MPIBASEMOD).$(MOD) src/binding/fortran/use_mpi/$(PMPIBASEMOD).$(MOD) $(srcdir)/src/binding/fortran/use_mpi/mpi.f90 src/binding/fortran/use_mpi/mpifnoext.h
 	@rm -f src/binding/fortran/use_mpi/mpi-tmp
 	@touch src/binding/fortran/use_mpi/mpi-tmp
 	@( cd src/binding/fortran/use_mpi && \


### PR DESCRIPTION
## Pull Request Description
Neglected to add pmpi_base.mod to mpi.mod's dependency list.

This may not trigger build error if make happen to build the mod files in order, which is the reason it skipped CI check.

Fixes #6811 
[skip warnings]



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
