### PR TITLE
mpl: Limit pthread_setaffinity_np use to Linux

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -813,15 +813,7 @@ case $with_proc_mutex_package in
     AC_CHECK_FUNCS(pthread_mutexattr_setpshared)
 
     AC_CHECK_FUNCS(pthread_setaffinity_np)
-
-    #
-    # Check for the Linux functions for controlling processor affinity.
-    #
-    # LINUX: sched_setaffinity
-    # AIX:   bindprocessor
-    # OSX (Leopard): thread_policy_set
-    AC_CHECK_FUNCS([sched_setaffinity sched_getaffinity bindprocessor thread_policy_set])
-    if test "$ac_cv_func_sched_setaffinity" = "yes" ; then
+    if test "$ac_cv_func_pthread_setaffinity_np" = "yes" ; then
         # Test for the cpu process set type
         AC_CACHE_CHECK([whether cpu_set_t available],pac_cv_have_cpu_set_t,[
             AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sched.h>]],[[cpu_set_t t;]])],
@@ -842,13 +834,7 @@ case $with_proc_mutex_package in
 	    if test "$pac_cv_cpu_set_defined" = "yes" ; then
 	        AC_DEFINE(HAVE_CPU_SET_MACROS,1,[Define if CPU_SET and CPU_ZERO defined])
             fi
-        # FIXME: Some versions of sched_setaffinity return ENOSYS (!),
-	    # so we should test for the unfriendly and useless behavior
         fi
-    fi
-
-    if test "$ac_cv_func_pthread_setaffinity_np" = "yes" ; then
-      AC_DEFINE(HAVE_PTHREAD_SETAFFINITY_NP,1, [Define if pthread_setaffinity_np is available.])
     fi
 
     AC_MSG_NOTICE([POSIX will be used for interprocess mutex package.])

--- a/src/mpl/src/thread/mpl_thread_posix.c
+++ b/src/mpl/src/thread/mpl_thread_posix.c
@@ -86,7 +86,8 @@ void *MPLI_thread_start(void *arg)
 void MPL_thread_set_affinity(MPL_thread_id_t thread, int *affinity_arr, int affinity_size,
                              int *errp)
 {
-#if defined(MPL_HAVE_PTHREAD_SETAFFINITY_NP) && defined(MPL_HAVE_CPU_SET_MACROS)
+#if defined(MPL_HAVE_PTHREAD_SETAFFINITY_NP) && defined(MPL_HAVE_CPU_SET_MACROS) && defined(__linux__)
+    /* FIXME: this implementation uses Linux-specific types and macros */
     int err = MPL_SUCCESS;
     int proc_idx, set_size = 0;
     cpu_set_t cpuset;


### PR DESCRIPTION
## Pull Request Description

The implementation of MPL_thread_set_affinity using pthread_setaffinity_np uses Linux-specific types and macros. Make sure it is only compiled on Linux systems for now. Cleanup the configure logic to capture the current state of the implementation.

Fixes pmodels/mpich#6821.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
