### PR TITLE
ch4: Fix recv side free cell allocation

### DIFF
--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -57,7 +57,8 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
      * queuing. */
     MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell,
                                      MPIR_CVAR_GENQ_SHMEM_POOL_FREE_QUEUE_SENDER_SIDE ?
-                                     MPIR_Process.local_rank : grank, buf);
+                                     MPIR_Process.local_rank :
+                                     MPIDI_POSIX_global.local_ranks[grank], buf);
 
     /* If a cell wasn't available, let the caller know that we weren't able to send the message
      * immediately. */

--- a/src/mpid/common/genq/mpidu_genq_shmem_queue.h
+++ b/src/mpid/common/genq/mpidu_genq_shmem_queue.h
@@ -188,6 +188,7 @@ static inline int MPIDU_genqi_nem_mpmc_dequeue(MPIDU_genqi_shmem_pool_s * pool_o
                     MPL_atomic_store_ptr(&queue->q.head.m, next_handle);
                 }
             }
+            break;
         }
     }
 

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -10,6 +10,7 @@ sendrecv3 2
 sendrecv3 2 arg=-isendrecv
 sendflood 8
 sendall 4
+sendall 4 env=MPIR_CVAR_GENQ_SHMEM_POOL_FREE_QUEUE_SENDER_SIDE=false
 anyall 2
 eagerdt 2
 bottom 2


### PR DESCRIPTION
## Pull Request Description

Receiver side free cell allocation does not working due to:
1. MPMC dequeue not exit on success
2. trying to using global rank of receiver at allocation

This PR fixes both of them and adds a test to make sure the functionality is at least tested.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
