### PR TITLE
nameserv: add infohints to MPI_Lookup_name

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,11 @@
   of 256. One can work around by use an info hint "port_name_size" and use a
   larger port name buffer.
 
+# PMI-1 defines PMI_MAX_PORT_NAME, which may be different from MPI_MAX_PORT_NAME.
+  This is used by "PMI_Lookup_name". Consequently, MPI_Lookup_name accepts info
+  hint "port_name_size" that may be larger than MPI_MAX_PORT_NAME. If the port
+  name does not fit in "port_name_size", it will return a trunction error.
+
 ===============================================================================
                                Changes in 4.2
 ===============================================================================

--- a/src/include/mpir_info.h
+++ b/src/include/mpir_info.h
@@ -101,7 +101,7 @@ extern MPIR_Info MPIR_Info_direct[];
 int MPIR_Info_alloc(MPIR_Info ** info_p_p);
 void MPIR_Info_setup_env(MPIR_Info * info_ptr, int argc, char **argv);
 int MPIR_Info_push(MPIR_Info * info_ptr, const char *key, const char *val);
-const char *MPIR_Info_lookup(MPIR_Info * info_ptr, const char *key);
+const char *MPIR_Info_lookup(const MPIR_Info * info_ptr, const char *key);
 
 /* utility to decode hex info value */
 int MPIR_Info_decode_hex(const char *str, void *buf, int len);

--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -90,7 +90,7 @@ int MPIR_pmi_bcast_local(char *val, int val_size);
 
 /* name service functions */
 int MPIR_pmi_publish(const char name[], const char port[]);
-int MPIR_pmi_lookup(const char name[], char port[]);
+int MPIR_pmi_lookup(const char name[], char port[], int portlen);
 int MPIR_pmi_unpublish(const char name[]);
 
 /* Other misc functions */

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -167,6 +167,8 @@ be in the range 0 to %d
 **namepubnotfound %s:Lookup failed for service name %s
 **namepubnotunpub:Failed to unpublish service name
 **namepubnotunpub %s:Failed to unpublish service name %s
+**namepubtrunc:Lookup returned port_name is truncated
+**namepubtrunc %s:Lookup for service name %s is truncated
 **sendbuf_inplace:sendbuf cannot be MPI_IN_PLACE
 **recvbuf_inplace:recvbuf cannot be MPI_IN_PLACE
 **buf_inplace:buffer cannot be MPI_IN_PLACE

--- a/src/mpi/info/info_impl.c
+++ b/src/mpi/info/info_impl.c
@@ -15,7 +15,7 @@ static int info_find_key(MPIR_Info * info_ptr, const char *key)
     return -1;
 }
 
-const char *MPIR_Info_lookup(MPIR_Info * info_ptr, const char *key)
+const char *MPIR_Info_lookup(const MPIR_Info * info_ptr, const char *key)
 {
     if (!info_ptr) {
         return NULL;

--- a/src/nameserv/file/file_nameserv.c
+++ b/src/nameserv/file/file_nameserv.c
@@ -207,7 +207,14 @@ int MPID_NS_Lookup(MPID_NS_Handle handle, const MPIR_Info * info_ptr,
     } else {
         /* The first line is the name, the second is the
          * process that published. We just read the name */
-        if (!fgets(port, MPI_MAX_PORT_NAME, fp)) {
+        int port_name_size = MPI_MAX_PORT_NAME;
+        if (info_ptr) {
+            const char *val = MPIR_Info_lookup(info_ptr, "port_name_size");
+            if (val) {
+                port_name_size = atoi(val);
+            }
+        }
+        if (!fgets(port, port_name_size, fp)) {
             /* --BEGIN ERROR HANDLING-- */
             port[0] = 0;
             MPIR_ERR_SET1(mpi_errno, MPI_ERR_NAME,

--- a/src/nameserv/pmi/pmi_nameserv.c
+++ b/src/nameserv/pmi/pmi_nameserv.c
@@ -41,10 +41,16 @@ int MPID_NS_Publish(MPID_NS_Handle handle, const MPIR_Info * info_ptr,
 int MPID_NS_Lookup(MPID_NS_Handle handle, const MPIR_Info * info_ptr,
                    const char service_name[], char port[])
 {
-    MPL_UNREFERENCED_ARG(info_ptr);
     MPL_UNREFERENCED_ARG(handle);
 
-    return MPIR_pmi_lookup(service_name, port);
+    int port_name_size = MPI_MAX_PORT_NAME;
+    if (info_ptr) {
+        const char *val = MPIR_Info_lookup(info_ptr, "port_name_size");
+        if (val) {
+            port_name_size = atoi(val);
+        }
+    }
+    return MPIR_pmi_lookup(service_name, port, port_name_size);
 }
 
 int MPID_NS_Unpublish(MPID_NS_Handle handle, const MPIR_Info * info_ptr, const char service_name[])

--- a/src/pmi/configure.ac
+++ b/src/pmi/configure.ac
@@ -99,15 +99,6 @@ if test "$enable_embedded" = "yes" ; then
 fi
 PAC_CONFIG_MPL
 
-# check "mpi.h" for MPI_MAX_PORT_NAME
-if test "$FROM_MPICH" = "yes" ; then
-    PAC_APPEND_FLAG([-I${main_top_srcdir}/src/include], [CPPFLAGS])
-    PAC_APPEND_FLAG([-I${main_top_builddir}/src/include], [CPPFLAGS])
-    AC_DEFINE([HAVE_MPI_H], 1, [define if we have mpi.h])
-else
-    AC_CHECK_HEADER([mpi.h])
-fi
-
 if test "$enable_error_checking" != "no" ; then
     AC_DEFINE([HAVE_ERROR_CHECKING], 1, [Define to enable error checking])
 fi

--- a/src/pmi/include/pmi.h
+++ b/src/pmi/include/pmi.h
@@ -9,6 +9,8 @@
 #define PMI_VERSION    1
 #define PMI_SUBVERSION 1
 
+#define PMI_MAX_PORT_NAME 1024
+
 /* prototypes for the PMI interface in MPICH */
 
 #if defined(__cplusplus)

--- a/src/pmi/src/pmi_v1.c
+++ b/src/pmi/src/pmi_v1.c
@@ -27,12 +27,6 @@
 #include "pmi_msg.h"
 #include "pmi_common.h"
 
-#ifdef HAVE_MPI_H
-#include "mpi.h"        /* to get MPI_MAX_PORT_NAME */
-#else
-#define MPI_MAX_PORT_NAME 256
-#endif
-
 #include <sys/socket.h>
 
 #define USE_WIRE_VER  PMIU_WIRE_V1
@@ -551,7 +545,7 @@ PMI_API_PUBLIC int PMI_Lookup_name(const char service_name[], char port[])
         const char *tmp_port;
         PMIU_msg_get_response_lookup(&pmicmd, &tmp_port);
 
-        MPL_strncpy(port, tmp_port, MPI_MAX_PORT_NAME);
+        MPL_strncpy(port, tmp_port, PMI_MAX_PORT_NAME);
 
     } else {
         PMIU_ERR_SETANDJUMP(pmi_errno, PMI_FAIL, "PMI_Lookup_name called before init\n");

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -740,11 +740,12 @@ int MPIR_pmi_publish(const char name[], const char port[])
     return mpi_errno;
 }
 
-int MPIR_pmi_lookup(const char name[], char port[])
+int MPIR_pmi_lookup(const char name[], char port[], int port_len)
 {
     int mpi_errno = MPI_SUCCESS;
-    SWITCH_PMI(mpi_errno = pmi1_lookup(name, port),
-               mpi_errno = pmi2_lookup(name, port), mpi_errno = pmix_lookup(name, port));
+    SWITCH_PMI(mpi_errno = pmi1_lookup(name, port, port_len),
+               mpi_errno = pmi2_lookup(name, port, port_len),
+               mpi_errno = pmix_lookup(name, port, port_len));
     return mpi_errno;
 }
 

--- a/src/util/mpir_pmi1.inc
+++ b/src/util/mpir_pmi1.inc
@@ -213,15 +213,36 @@ static int pmi1_publish(const char name[], const char port[])
     goto fn_exit;
 }
 
-static int pmi1_lookup(const char name[], char port[])
+static int pmi1_lookup(const char name[], char port[], int port_len)
 {
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
-    pmi_errno = PMI_Lookup_name(name, port);
+#ifdef PMI_MAX_PORT_NAME
+    int maxlen = PMI_MAX_PORT_NAME;
+#else
+    int maxlen = MPI_MAX_PORT_NAME;
+#endif
+    char *tmpbuf = NULL;
+
+    if (port_len >= maxlen) {
+        pmi_errno = PMI_Lookup_name(name, port);
+    } else {
+        /* allocate a temporary buffer for safety */
+        tmpbuf = MPL_malloc(maxlen, MPL_MEM_OTHER);
+        pmi_errno = PMI_Lookup_name(name, tmpbuf);
+        if (pmi_errno == PMI_SUCCESS) {
+            int mpl_err = MPL_strncpy(port, tmpbuf, port_len);
+            MPIR_ERR_CHKANDJUMP1(mpl_err, mpi_errno, MPI_ERR_NAME, "**namepubtrunc",
+                                 "**namepubtrunc %s", name);
+        }
+    }
     MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_NAME, "**namepubnotfound",
                          "**namepubnotfound %s", name);
 
   fn_exit:
+    if (tmpbuf) {
+        MPL_free(tmpbuf);
+    }
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -320,7 +341,7 @@ static int pmi1_publish(const char name[], const char port[])
     return MPI_ERR_INTERN;
 }
 
-static int pmi1_lookup(const char name[], char port[])
+static int pmi1_lookup(const char name[], char port[], int port_len)
 {
     return MPI_ERR_INTERN;
 }

--- a/src/util/mpir_pmi2.inc
+++ b/src/util/mpir_pmi2.inc
@@ -261,13 +261,13 @@ static int pmi2_publish(const char name[], const char port[])
     goto fn_exit;
 }
 
-static int pmi2_lookup(const char name[], char port[])
+static int pmi2_lookup(const char name[], char port[], int port_len)
 {
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
     /* release the global CS for PMI calls */
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-    pmi_errno = PMI2_Nameserv_lookup(name, NULL, port, MPI_MAX_PORT_NAME);
+    pmi_errno = PMI2_Nameserv_lookup(name, NULL, port, port_len);
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_NAME, "**namepubnotfound",
                          "**namepubnotfound %s", name);
@@ -374,7 +374,7 @@ static int pmi2_publish(const char name[], const char port[])
     return MPI_ERR_INTERN;
 }
 
-static int pmi2_lookup(const char name[], char port[])
+static int pmi2_lookup(const char name[], char port[], int port_len)
 {
     return MPI_ERR_INTERN;
 }

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -481,7 +481,7 @@ static int pmix_publish(const char name[], const char port[])
     goto fn_exit;
 }
 
-static int pmix_lookup(const char name[], char port[])
+static int pmix_lookup(const char name[], char port[], int port_len)
 {
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
@@ -490,7 +490,7 @@ static int pmix_lookup(const char name[], char port[])
     MPL_strncpy(pdata[0].key, name, PMIX_MAX_KEYLEN);
     pmi_errno = PMIx_Lookup(pdata, 1, NULL, 0);
     if (pmi_errno == PMIX_SUCCESS) {
-        MPL_strncpy(port, pdata[0].value.data.string, MPI_MAX_PORT_NAME);
+        MPL_strncpy(port, pdata[0].value.data.string, port_len);
     }
     PMIX_PDATA_FREE(pdata, 1);
     MPIR_ERR_CHKANDJUMP1(pmi_errno, mpi_errno, MPI_ERR_NAME, "**namepubnotfound",
@@ -970,7 +970,7 @@ static int pmix_publish(const char name[], const char port[])
     return MPI_ERR_INTERN;
 }
 
-static int pmix_lookup(const char name[], char port[])
+static int pmix_lookup(const char name[], char port[], int port_len)
 {
     return MPI_ERR_INTERN;
 }

--- a/test/mpi/spawn/Makefile.am
+++ b/test/mpi/spawn/Makefile.am
@@ -12,6 +12,7 @@ EXTRA_DIST = testlist
 ## correctly
 noinst_PROGRAMS =         \
     namepub               \
+    namepub_conn          \
     spawn1                \
     spawninfo1            \
     spawnminfo1           \

--- a/test/mpi/spawn/namepub_conn.c
+++ b/test/mpi/spawn/namepub_conn.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpitest.h"
+#include <stdio.h>
+#include <string.h>
+
+#define MTEST_LARGE_PORT_NAME
+#ifdef MTEST_LARGE_PORT_NAME
+#define PORT_SIZE 4096
+
+#define INIT_PORT_INFO(info) \
+    do { \
+        MPI_Info_create(&(info)); \
+        MPI_Info_set(info, "port_name_size", "4096"); \
+    } while (0)
+
+#define FREE_PORT_INFO(info) MPI_Info_free(&(info))
+
+#else
+#define PORT_SIZE MPI_MAX_PORT_NAME
+#define INIT_PORT_INFO(info) do {info = MPI_INFO_NULL;} while (0)
+#define FREE_PORT_INFO(info) do { } while (0)
+
+#endif /* MTEST_LARGE_PORT_NAME */
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+    char serv_name[256] = "MyTest";
+    char port_name[PORT_SIZE];
+    MPI_Info port_info;
+    int rank;
+    MPI_Comm inter_comm;
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    INIT_PORT_INFO(port_info);
+
+    if (rank == 0) {
+        MPI_Open_port(port_info, port_name);
+        MPI_Publish_name(serv_name, port_info, port_name);
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        MPI_Comm_accept(port_name, MPI_INFO_NULL, 0, MPI_COMM_SELF, &inter_comm);
+
+        MPI_Unpublish_name(serv_name, MPI_INFO_NULL, port_name);
+    } else {
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        MPI_Lookup_name(serv_name, port_info, port_name);
+        MPI_Comm_connect(port_name, MPI_INFO_NULL, 0, MPI_COMM_SELF, &inter_comm);
+    }
+
+    MPI_Comm_disconnect(&inter_comm);
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/spawn/testlist.in
+++ b/test/mpi/spawn/testlist.in
@@ -1,4 +1,5 @@
 @namepub_tests@namepub 2
+@namepub_tests@namepub_conn 2
 spawn1 1
 spawn2 1
 spawninfo1 1


### PR DESCRIPTION
## Pull Request Description
Similar to `MPID_Open_port` (https://github.com/pmodels/mpich/pull/5467/commits/ab2be7740cad6c6b482bc41f28553db089059c3c), add info hint "port_name_size" to `MPI_Lookup_name` so user can supply a port_name buffer larger than `MPI_MAX_PORT_NAME` to circumvent larger business cards, e.g. on UCX.

Fixes #6831
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
