### PR TITLE
util: generic progress hook for all async things

### DIFF
--- a/src/Makefile.mk
+++ b/src/Makefile.mk
@@ -3,7 +3,7 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
-AM_CPPFLAGS += -I$(top_srcdir)/src/include
+AM_CPPFLAGS += -I$(top_srcdir)/src/include -I$(top_srcdir)/src/util
 
 include $(top_srcdir)/src/mpi/Makefile.mk
 include $(top_srcdir)/src/util/Makefile.mk

--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -49,6 +49,9 @@ extern MPL_initlock_t MPIR_init_lock;
 
 #include "typerep_pre.h"        /* needed for MPIR_Typerep_req */
 
+/* FIXME: bad names. Not gpu-specific, confusing with MPIR_Request.
+ *        It's a general async handle.
+ */
 typedef enum {
     MPIR_NULL_REQUEST = 0,
     MPIR_TYPEREP_REQUEST,

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c
@@ -456,8 +456,10 @@ int MPIR_Typerep_test(MPIR_Typerep_req typerep_req, int *completed)
     int mpi_errno = MPI_SUCCESS;
     int rc;
 
-    if (typerep_req.req == MPIR_TYPEREP_REQ_NULL)
+    if (typerep_req.req == MPIR_TYPEREP_REQ_NULL) {
+        MPIR_Assert(0);
         goto fn_exit;
+    }
 
     rc = yaksa_request_test((yaksa_request_t) typerep_req.req, completed);
     MPIR_ERR_CHKANDJUMP(rc, mpi_errno, MPI_ERR_INTERN, "**yaksa");

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -7,6 +7,7 @@
 #include "mpir_info.h"
 #include "mpi_init.h"
 #include <strings.h>
+#include "mpir_async_things.h"
 
 /*
 === BEGIN_MPI_T_CVAR_INFO_BLOCK ===
@@ -210,6 +211,9 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIR_Datatype_init_predefined();
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = MPIR_Async_things_init();
     MPIR_ERR_CHECK(mpi_errno);
 
     if (MPIR_CVAR_DEBUG_HOLD) {
@@ -424,6 +428,9 @@ int MPII_Finalize(MPIR_Session * session_ptr)
 #endif
 
     mpi_errno = MPII_Coll_finalize();
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = MPIR_Async_things_finalize();
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Call the low-priority (post Finalize) callbacks */

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -102,6 +102,10 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
          * Use blocking version for nonblocking kind, since it is less worth of
          * optimization.
          */
+        if (localcopy_kind == LOCALCOPY_NONBLOCKING && extra_param) {
+            MPIR_Typerep_req *typerep_req = extra_param;
+            typerep_req->req = MPIR_TYPEREP_REQ_NULL;
+        }
 
         /* non-contig to non-contig stream enqueue is not supported. */
         MPIR_Assert(localcopy_kind != LOCALCOPY_STREAM);
@@ -301,7 +305,11 @@ static int do_localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
             do_localcopy(sendbuf, sendcount, sendtype, sendoffset, recvbuf, recvcount, recvtype,
                          recvoffset, LOCALCOPY_NONBLOCKING, &gpu_req->u.y_req);
         MPIR_ERR_CHECK(mpi_errno);
-        gpu_req->type = MPIR_TYPEREP_REQUEST;
+        if (gpu_req->u.y_req.req == MPIR_TYPEREP_REQ_NULL) {
+            gpu_req->type = MPIR_NULL_REQUEST;
+        } else {
+            gpu_req->type = MPIR_TYPEREP_REQUEST;
+        }
     } else {
         mpi_errno =
             do_localcopy(sendbuf, sendcount, sendtype, sendoffset, recvbuf, recvcount, recvtype,

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
@@ -25,7 +25,7 @@ typedef struct {
     int max_subdev_id;
 } MPIDI_GPU_device_info_t;
 
-int MPIDI_GPU_ipc_async_start(MPIR_Request * rreq,
+int MPIDI_GPU_ipc_async_start(MPIR_Request * rreq, MPIR_gpu_req * req_p,
                               void *src_buf, MPIDI_GPU_ipc_handle_t gpu_handle);
 
 #endif /* GPU_POST_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.h
@@ -25,4 +25,7 @@ typedef struct {
     int max_subdev_id;
 } MPIDI_GPU_device_info_t;
 
+int MPIDI_GPU_ipc_async_start(MPIR_Request * rreq,
+                              void *src_buf, MPIDI_GPU_ipc_handle_t gpu_handle);
+
 #endif /* GPU_POST_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -246,18 +246,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPC_hdr * ipc_hdr,
             src_count = ipc_hdr->count;
             src_dt = src_dt_ptr->handle;
         }
+        MPIR_gpu_req yreq;
         MPL_gpu_engine_type_t engine =
             MPIDI_IPCI_choose_engine(ipc_hdr->ipc_handle.gpu.global_dev_id, dev_id);
-        mpi_errno = MPIR_Localcopy_gpu(src_buf, src_count, src_dt, 0, NULL,
-                                       MPIDIG_REQUEST(rreq, buffer), MPIDIG_REQUEST(rreq, count),
-                                       MPIDIG_REQUEST(rreq, datatype), 0, &attr,
-                                       MPL_GPU_COPY_DIRECTION_NONE, engine, true);
+        mpi_errno = MPIR_Ilocalcopy_gpu(src_buf, src_count, src_dt, 0, NULL,
+                                        MPIDIG_REQUEST(rreq, buffer), MPIDIG_REQUEST(rreq, count),
+                                        MPIDIG_REQUEST(rreq, datatype), 0, &attr,
+                                        MPL_GPU_COPY_DIRECTION_NONE, engine, true, &yreq);
         MPIR_ERR_CHECK(mpi_errno);
         if (src_dt_ptr) {
             MPIR_Datatype_free(src_dt_ptr);
         }
 
-        mpi_errno = MPIDI_GPU_ipc_async_start(rreq, NULL, src_buf, ipc_hdr->ipc_handle.gpu);
+        mpi_errno = MPIDI_GPU_ipc_async_start(rreq, &yreq, src_buf, ipc_hdr->ipc_handle.gpu);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
     } else if (ipc_hdr->ipc_type == MPIDI_IPCI_TYPE__NONE) {

--- a/src/util/Makefile.mk
+++ b/src/util/Makefile.mk
@@ -14,4 +14,5 @@ mpi_core_sources +=   \
     src/util/mpir_netloc.c     \
     src/util/mpir_hwtopo.c     \
     src/util/mpir_nettopo.c    \
+    src/util/mpir_async_things.c \
     src/util/mpir_progress_hook.c

--- a/src/util/mpir_async_things.c
+++ b/src/util/mpir_async_things.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpidimpl.h"
+#include "mpir_async_things.h"
+
+static MPIR_Async_thing *async_things_list;
+static MPID_Thread_mutex_t async_things_mutex;
+static int async_things_progress_hook_id;
+
+int MPIR_Async_things_init(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    int err;
+    MPID_Thread_mutex_create(&async_things_mutex, &err);
+    MPIR_Assert(err == 0);
+
+    mpi_errno = MPIR_Progress_hook_register(MPIR_Async_things_progress,
+                                            &async_things_progress_hook_id);
+    return mpi_errno;
+}
+
+int MPIR_Async_things_finalize(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    int err;
+    MPID_Thread_mutex_destroy(&async_things_mutex, &err);
+    MPIR_Assert(err == 0);
+
+    mpi_errno = MPIR_Progress_hook_deregister(async_things_progress_hook_id);
+    return mpi_errno;
+}
+
+int MPIR_Async_things_add(int (*poll_fn) (MPIR_Async_thing * entry), void *state)
+{
+    MPIR_Async_thing *entry = MPL_malloc(sizeof(MPIR_Async_thing), MPL_MEM_OTHER);
+    entry->poll_fn = poll_fn;
+    entry->state = state;
+    entry->new_entries = NULL;
+
+    MPID_THREAD_CS_ENTER(VCI, async_things_mutex);
+    bool was_empty = (async_things_list == NULL);
+    DL_APPEND(async_things_list, entry);
+    MPID_THREAD_CS_EXIT(VCI, async_things_mutex);
+
+    if (was_empty) {
+        MPIR_Progress_hook_activate(async_things_progress_hook_id);
+    }
+
+    return MPI_SUCCESS;
+}
+
+int MPIR_Async_things_progress(int *made_progress)
+{
+    MPIR_Async_thing *entry, *tmp;
+    MPID_THREAD_CS_ENTER(VCI, async_things_mutex);
+    DL_FOREACH_SAFE(async_things_list, entry, tmp) {
+        int ret = entry->poll_fn(entry);
+        if (ret != MPIR_ASYNC_THING_NOPROGRESS) {
+            *made_progress = 1;
+            if (entry->new_entries) {
+                DL_CONCAT(async_things_list, entry->new_entries);
+                entry->new_entries = NULL;
+            }
+            if (ret == MPIR_ASYNC_THING_DONE) {
+                DL_DELETE(async_things_list, entry);
+                MPL_free(entry);
+                if (async_things_list == NULL) {
+                    MPIR_Progress_hook_deactivate(async_things_progress_hook_id);
+                }
+            }
+        }
+    }
+    MPID_THREAD_CS_EXIT(VCI, async_things_mutex);
+    return MPI_SUCCESS;
+}

--- a/src/util/mpir_async_things.h
+++ b/src/util/mpir_async_things.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef MPIR_ASYNC_THINGS_H_INCLUDED
+#define MPIR_ASYNC_THINGS_H_INCLUDED
+
+/* Async_things is the most general interface for managing asynchronous progress.
+ * The async things are a collection items that needs progress. Each
+ * "thing" is opaque with all the logic hidden inside the "poll_fn"
+ * callback. The callback is passed with the entry pointer itself, thus
+ * it can -
+ *     * update the entry as a state machine.
+ *     * cleanup the entry states as it progresses.
+ *     * return a new list of new entries to be progressed.
+ *     * return a done state for the entry to be removed.
+ *
+ * Each async things are independent items may be progressed in any order.
+ * A single MPI_Test may progress all or just a few of the items. We only promise
+ * to progress all items eventually after repeated MPI_Test calls.
+ */
+
+/* poll_fn return following states. */
+enum {
+    MPIR_ASYNC_THING_NOPROGRESS = 0,
+    MPIR_ASYNC_THING_UPDATED = 1,
+    MPIR_ASYNC_THING_DONE = 2,
+};
+
+typedef struct MPIR_Async_thing {
+    int (*poll_fn) (struct MPIR_Async_thing * entry);
+    void *state;
+    /* doubly-linked list */
+    struct MPIR_Async_thing *next, *prev;
+    /* poll_fn may add new async thing entries */
+    struct MPIR_Async_thing *new_entries;
+} MPIR_Async_thing;
+
+typedef int (*MPIR_Async_thing_poll_fn) (MPIR_Async_thing *);
+
+/* two access functions to make MPIR_Async_thing opaque */
+static inline void *MPIR_Async_thing_get_state(MPIR_Async_thing * thing)
+{
+    return thing->state;
+}
+
+static inline void MPIR_Async_thing_spawn(MPIR_Async_thing * thing,
+                                          MPIR_Async_thing_poll_fn poll_fn, void *state)
+{
+    MPIR_Async_thing *entry = MPL_malloc(sizeof(MPIR_Async_thing), MPL_MEM_OTHER);
+    entry->poll_fn = poll_fn;
+    entry->state = state;
+    entry->new_entries = NULL;
+
+    DL_APPEND(thing->new_entries, entry);
+}
+
+int MPIR_Async_things_init(void);
+int MPIR_Async_things_finalize(void);
+int MPIR_Async_things_add(MPIR_Async_thing_poll_fn poll_fn, void *state);
+int MPIR_Async_things_progress(int *made_progress);
+
+#endif /* MPIR_ASYNC_THINGS_H_INCLUDED */

--- a/src/util/mpir_progress_hook.c
+++ b/src/util/mpir_progress_hook.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 #include "mpl.h"
 
-#define MAX_PROGRESS_HOOKS 4
+#define MAX_PROGRESS_HOOKS 100
 
 typedef int (*progress_func_ptr_t) (int *made_progress);
 typedef struct progress_hook_slot {


### PR DESCRIPTION
## Pull Request Description
```
/* Async_things is the most general interface for managing asynchrounous progress.
 * The async things are a collection items that needs progress. Each
 * "thing" is opaque with all the logic hidden inside the "poll_fn"
 * callback. The callback is passed with the entry pointer itself, thus
 * it can -
 *     * update the entry as a state machine.
 *     * cleanup entry states as it progresses.
 *     * return a new list of new entries to be progressed.
 *     * return a done state for the entry to be removed.
 *
 * Each async things are independent items may be progressed in any order.
 * A single MPI_Test may progress all or just a few of the items. We only promise
 * to progress all items eventually after sufficent MPI_Test calls.
 */
```
## Design
Separate the task logic and progress.

![image](https://github.com/pmodels/mpich/assets/1496702/d54d8ef2-0b50-49a8-be1d-73ce6ba155b0)

## Related / Discussion
* Generalized request appears to be a close fit --
```
/* current grequest extension: */
int MPIX_Grequest_start(query_fn, free_fn, cancel_fn, poll_fn, void *state, MPI_Request *new_greq);

typedef int (*MPIX_Grequest_poll_fn) (void *state, MPI_Status *status);
/* Potential changes: */
typedef int (*MPIX_Grequest_poll_fn) (MPIX_Async_thing *thing);
void *MPIX_Grequest_get_state(MPI_Request greq);
void *MPIX_Grequest_spawn(MPI_Request greq, MPIX_Grequest_poll_fn poll_fn, void *state, MPI_Request *new_greq);
```
However, it maybe unnecessary for user to get the greq handle back since all user want to do is poking progress
rather than managing the asynchronous objects. MPI progress engine is managing the async things for users.
Users control the logic via the custom `state` already, thus it doesn't need additional handles, nor status queries.
All users needed is general progress -- `MPIX_Stream_progress`. So if we abandon generalized requests, we may
propose -
```
int MPIX_Async_thing_start(MPIX_Async_thing_poll_fn poll_fn, void *state);
typedef (*MPIX_Async_thing_fn) (MPIX_Async_thing *thing);
void *MPIX_Async_thing_get_state(MPIX_Async_thing *thing);
void *MPIX_Async_thing_spawn(MPIX_Async_thing *thing, MPIX_Async_thing_poll_fn poll_fn, void *state);
```

A general MPI progress function e.g. `MPIX_Stream_progress` can be used to progress all the async things without the need of request objects. Users can manage and query async progress states via their own data structures, which, to MPI, are opaque `state` objects. Users can achieve persistence or auto garbage collection inside the callback `poll_fn`. `MPIX_Async_thing_spawn` let users to create arbitrary graph of tasks that are potentially synchronized via shared state objects.

Generalized request can be employed so that the user can use `MPI_Wait` to complete a set of async things. One or more of the async `poll_fn` can simply call `MPI_Grequest_complete` to complete the corresponding generalized request for `MPI_Wait` to complete.

#### Design layers:
* Poking Progress - MPI library, this PR
* Making Progress - offloading devices / separate threads / `poll_fn`
* Query completion - `poll_fn`
* Scheduling / Dispatch / Graph - `poll_fn` via `_spawn`
* Aggregate status / synchronization - `poll_fn` via user `state`s
* Persistence - user, simply store states in a persistent storage
* MPI Request - can be unnecessary, because user `state` already fulfill the role of async handle
* MPI_Wait - MPI generalized request (vanilla, or simpler since `extra_state` and various callbacks are unnecessary)

#### Optimizations:
Poking progress for *many* async objects can perform badly.  Optimization options:
* round-robin polling -- `MPI_Test` won't block, but it does not solve the latency issue
* Associate vci/stream to async things -- user can selectively progress a class of async things
* Associate generalized request to async things -- `MPI_Wait`/`MPI_Test` can focus/prioritize on which aysnc things to progress

#### Related:
* async io
* nonblocking typerep (#6836)
* completion counters (https://github.com/pmodels/mpich/pull/6640)

#### Other references:
* Schafer, Derek, Sheikh Ghafoor, Daniel Holmes, Martin Ruefenacht, and Anthony Skjellum. "User-level scheduled communications for mpi." In 2019 IEEE 26th International Conference on High Performance Computing, Data, and Analytics (HiPC), pp. 290-300. IEEE, 2019
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
