### PR TITLE
mpl/cuda: Fix potential crash in memory hooks

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -508,6 +508,11 @@ __attribute__ ((visibility("default")))
 CUresult CUDAAPI cuMemFree(CUdeviceptr dptr)
 {
     CUresult result;
+    if (!gpu_initialized) {
+        int ret = MPL_gpu_init(0);
+        assert(ret == 0);
+    }
+
     gpu_free_hooks_cb((void *) dptr);
     result = sys_cuMemFree(dptr);
     return (result);
@@ -519,6 +524,11 @@ __attribute__ ((visibility("default")))
 cudaError_t CUDARTAPI cudaFree(void *dptr)
 {
     cudaError_t result;
+    if (!gpu_initialized) {
+        int ret = MPL_gpu_init(0);
+        assert(ret == 0);
+    }
+
     gpu_free_hooks_cb(dptr);
     result = sys_cudaFree(dptr);
     return result;


### PR DESCRIPTION
## Pull Request Description

MPL intercepts calls to free CUDA device memory so it can execute its own hooks before calling cudaFree. If the application calls cudaFree before the hooks are initialized, the internal function pointer for cudaFree is NULL and will cause the application to segfault. Check and initialize the memory hooks, if needed, before executing them.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
