### PR TITLE
misc: use MPIR_Datatype_is_contig over MPIR_Datatype_iscontig

### DIFF
--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -214,8 +214,8 @@ static int do_localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
         copy_sz = rdata_sz;
 
     /* This case is specific for contig datatypes */
-    MPIR_Datatype_iscontig(sendtype, &sendtype_iscontig);
-    MPIR_Datatype_iscontig(recvtype, &recvtype_iscontig);
+    MPIR_Datatype_is_contig(sendtype, &sendtype_iscontig);
+    MPIR_Datatype_is_contig(recvtype, &recvtype_iscontig);
 
     MPIR_Type_get_true_extent_impl(sendtype, &sendtype_true_lb, &true_extent);
     MPIR_Type_get_true_extent_impl(recvtype, &recvtype_true_lb, &true_extent);


### PR DESCRIPTION
## Pull Request Description

Use `MPIR_Datatype_is_contig` over the former `MPIR_Datatype_iscontig` (which was removed in https://github.com/pmodels/mpich/pull/6390). This should resolve build failures when GPU support is enabled.

Reference https://github.com/pmodels/mpich/pull/6390/commits/04c6f0d0faf0afdf23d2568ba0b6d95a7fe6f388
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
