### PR TITLE
ch4/coll: Fix memory leak in release_gather collectives

### DIFF
--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.c
@@ -197,7 +197,6 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
      * reduce buffer (divided into multiple cells) per rank. */
 
     if (RELEASE_GATHER_FIELD(comm_ptr, is_initialized) == 0) {
-        RELEASE_GATHER_FIELD(comm_ptr, is_initialized) = 1;
         /* CVARs may get updated. Turn them into per-comm settings */
         RELEASE_GATHER_FIELD(comm_ptr, bcast_tree_type) =
             get_tree_type(MPIR_CVAR_BCAST_INTRANODE_TREE_TYPE);

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.c
@@ -437,8 +437,10 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
 
   fn_exit:
     MPIR_FUNC_EXIT;
-    if (mpi_errno_ret != MPI_SUCCESS)
+    if (mpi_errno_ret != MPI_SUCCESS) {
+        MPIDI_POSIX_mpi_release_gather_comm_free(comm_ptr);
         RELEASE_GATHER_FIELD(comm_ptr, is_initialized) = 0;
+    }
     return mpi_errno_ret;
   fn_fail:
     goto fn_exit;


### PR DESCRIPTION
## Pull Request Description

Initialization for release_gather collectives on a communicator can fail, e.g. due to shm limits. If we need to disable release_gather collectives in such cases, make sure to free any associated resources to avoid leaks.

Fixes #6744 
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
