### PR TITLE
mpl/cuda: Add thread safety to memory hooks

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -32,6 +32,7 @@ static CUresult CUDAAPI(*sys_cuMemFree) (CUdeviceptr dptr);
 static cudaError_t CUDARTAPI(*sys_cudaFree) (void *dptr);
 
 static int gpu_mem_hook_init();
+static MPL_initlock_t free_hook_mutex = MPL_INITLOCK_INITIALIZER;
 
 int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id, int *subdevice_id)
 {
@@ -359,7 +360,9 @@ int MPL_gpu_init(int debug_summary)
      * in cuda, such as cudaFree and cuMemFree, to track user behaviors on
      * the memory buffer and invalidate cached handle/buffer respectively
      * for result correctness. */
+    MPL_initlock_lock(&free_hook_mutex);
     gpu_mem_hook_init();
+    MPL_initlock_unlock(&free_hook_mutex);
     gpu_initialized = 1;
 
     if (MPL_gpu_info.debug_summary) {
@@ -388,11 +391,13 @@ int MPL_gpu_finalize(void)
     MPL_free(global_to_local_map);
 
     gpu_free_hook_s *prev;
+    MPL_initlock_lock(&free_hook_mutex);
     while (free_hook_chain) {
         prev = free_hook_chain;
         free_hook_chain = free_hook_chain->next;
         MPL_free(prev);
     }
+    MPL_initlock_unlock(&free_hook_mutex);
 
     /* Reset initialization state */
     gpu_initialized = 0;
@@ -483,6 +488,7 @@ static int gpu_mem_hook_init()
     assert(sys_cuMemFree);
     sys_cudaFree = (void *) dlsym(libcudart_handle, "cudaFree");
     assert(sys_cudaFree);
+
     return MPL_SUCCESS;
 }
 
@@ -492,12 +498,15 @@ int MPL_gpu_free_hook_register(void (*free_hook) (void *dptr))
     assert(hook_obj);
     hook_obj->free_hook = free_hook;
     hook_obj->next = NULL;
+
+    MPL_initlock_lock(&free_hook_mutex);
     if (!free_hook_chain)
         free_hook_chain = hook_obj;
     else {
         hook_obj->next = free_hook_chain;
         free_hook_chain = hook_obj;
     }
+    MPL_initlock_unlock(&free_hook_mutex);
 
     return MPL_SUCCESS;
 }
@@ -508,12 +517,15 @@ __attribute__ ((visibility("default")))
 CUresult CUDAAPI cuMemFree(CUdeviceptr dptr)
 {
     CUresult result;
+    MPL_initlock_lock(&free_hook_mutex);
     if (!sys_cuMemFree) {
         gpu_mem_hook_init();
     }
 
     gpu_free_hooks_cb((void *) dptr);
     result = sys_cuMemFree(dptr);
+
+    MPL_initlock_unlock(&free_hook_mutex);
     return (result);
 }
 
@@ -523,12 +535,15 @@ __attribute__ ((visibility("default")))
 cudaError_t CUDARTAPI cudaFree(void *dptr)
 {
     cudaError_t result;
+    MPL_initlock_lock(&free_hook_mutex);
     if (!sys_cudaFree) {
         gpu_mem_hook_init();
     }
 
     gpu_free_hooks_cb(dptr);
     result = sys_cudaFree(dptr);
+
+    MPL_initlock_unlock(&free_hook_mutex);
     return result;
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -508,9 +508,8 @@ __attribute__ ((visibility("default")))
 CUresult CUDAAPI cuMemFree(CUdeviceptr dptr)
 {
     CUresult result;
-    if (!gpu_initialized) {
-        int ret = MPL_gpu_init(0);
-        assert(ret == 0);
+    if (!sys_cuMemFree) {
+        gpu_mem_hook_init();
     }
 
     gpu_free_hooks_cb((void *) dptr);
@@ -524,9 +523,8 @@ __attribute__ ((visibility("default")))
 cudaError_t CUDARTAPI cudaFree(void *dptr)
 {
     cudaError_t result;
-    if (!gpu_initialized) {
-        int ret = MPL_gpu_init(0);
-        assert(ret == 0);
+    if (!sys_cudaFree) {
+        gpu_mem_hook_init();
     }
 
     gpu_free_hooks_cb(dptr);


### PR DESCRIPTION
## Pull Request Description

CUDA memory allocation functions are thread-safe, so our hooks need to
be, as well. Use a static MPL "initlock" to avoid the need for
initialization, since the hooks are installed at link-time.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
