### PR TITLE
confdb: fix syntax error in PAC_SET_MPI_TYPE

### DIFF
--- a/confdb/aclocal_datatype.m4
+++ b/confdb/aclocal_datatype.m4
@@ -91,7 +91,7 @@ dnl Multiplier can be used to define double types
 dnl     e.g. PAC_SET_MPI_TYPE(48, MPI_COMPLEX, $pac_cv_f77_sizeof_real, 2)
 dnl
 AC_DEFUN([PAC_SET_MPI_TYPE], [
-    if test -z "$3" -o $3 = 0 ; then
+    if test -z "$3" -o "$3" = 0 ; then
         $2=MPI_DATATYPE_NULL
         F77_$2=MPI_DATATYPE_NULL
         F08_$2=MPI_DATATYPE_NULL%MPI_VAL


### PR DESCRIPTION
## Pull Request Description
It is a syntax error when `$3` is empty:
```
    if test -z "" -o = 0 ;
```
This fixes an error that `MPI_REAL2` was not set to `MPI_DATATYPE_NULL` when it is not available.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
