### PR TITLE
romio: Fix wrong communicator use in ADIOI_GEN_OpenColl

### DIFF
--- a/src/mpi/romio/adio/common/ad_opencoll.c
+++ b/src/mpi/romio/adio/common/ad_opencoll.c
@@ -80,11 +80,11 @@ void ADIOI_GEN_OpenColl(ADIO_File fd, int rank, int access_mode, int *error_code
             tmp_comm = fd->comm;
             fd->comm = MPI_COMM_SELF;
             (*(fd->fns->ADIOI_xxx_Open)) (fd, error_code);
-            fd->comm = tmp_comm;
-            MPI_Bcast(error_code, 1, MPI_INT, fd->hints->ranklist[0], fd->comm);
+            MPI_Bcast(error_code, 1, MPI_INT, fd->hints->ranklist[0], tmp_comm);
             /* if no error, close the file and reopen normally below */
             if (*error_code == MPI_SUCCESS)
                 (*(fd->fns->ADIOI_xxx_Close)) (fd, error_code);
+            fd->comm = tmp_comm;
 
             fd->access_mode = access_mode;      /* back to original */
         } else


### PR DESCRIPTION
## Pull Request Description

When ADIOI_GEN_OpenColl is called in ADIO_CREAT mode,
file creation is done by calling ADIOI_xxx_Open with MPI_COMM_SELF by rank == fd->hints->ranklist[0].
If successful, the file is closed with ADIOI_xxx_Close, and later the file will be opened by all without creation flag.

The problem is that the communicator of ADIOI_GEN_OpenColl is passed to ADIOI_xxx_Close instead of MPI_COMM_SELF.
If a collective call is made using this communicator in ADIOI_xxx_Close, it may hang.

Fixes: #6868

## Contribution Agreement
I have sent the MPICH Individual Contributor License Agreement by e-mail and am awaiting approval.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
