### PR TITLE
config: fix typo in help text for --with-wrapper-dl-type

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -586,7 +586,7 @@ AC_ARG_ENABLE(multi-aliases,
 		enable_multi_aliases=yes)
 
 AC_ARG_WITH([wrapper-dl-type],
-            [AS_HELP_STRING([--enable-wrapper-dl-type],
+            [AS_HELP_STRING([--with-wrapper-dl-type],
                             [Dynamic loading model for alternate MPI
                              libraries, used when programs are linked
                              by mpicc compiler wrappers.  This only


### PR DESCRIPTION
## Pull Request Description

It should be --with-wrapper-dl-type instead of --enable-wrapper-dl-type.


Fixes #6889 
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
