### PR TITLE
mpl/shm: Add error checking for failed segment creation

### DIFF
--- a/src/mpl/src/shm/mpl_shm_mmap.c
+++ b/src/mpl/src/shm/mpl_shm_mmap.c
@@ -85,6 +85,10 @@ static inline int MPL_shm_seg_create_attach_templ(MPL_shm_hnd_t hnd, intptr_t se
         do {
             rc = (int) write(lhnd, "", 1);
         } while ((rc == -1) && (errno == EINTR));
+        if (rc == -1) {
+            rc = MPL_ERR_SHM_INTERN;
+            goto fn_fail;
+        }
 
         rc = MPLI_shm_ghnd_alloc(hnd, MPL_MEM_SHM);
         if (rc != MPL_SUCCESS) {


### PR DESCRIPTION
## Pull Request Description

In case the creation of the shared memory segment fails, check for and return an error immediately. Otherwise the code would continue and crash on a write to unallocated address. This was discovered when our test machines ran out of space in /dev/shm, causing the lseek/write to fail with ENOSPC.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
