### PR TITLE
test: add p2p benchmark code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 [submodule "modules/yaksa"]
 	path = modules/yaksa
 	url = https://github.com/pmodels/yaksa
+[submodule "modules/mydef_boot"]
+	path = modules/mydef_boot
+	url = https://github.com/pmodels/mydef_boot

--- a/autogen.sh
+++ b/autogen.sh
@@ -65,6 +65,7 @@ do_hydra=yes
 do_romio=yes
 do_pmi=yes
 do_doc=no
+do_mydef=yes
 
 yaksa_depth=
 
@@ -536,6 +537,14 @@ fn_json_gen() {
     echo "done"
 }
 
+fn_mydef() {
+    MYDEF_BOOT=$PWD/modules/mydef_boot
+    export PATH=$MYDEF_BOOT/bin:$PATH
+    export PERL5LIB=$MYDEF_BOOT/lib/perl5
+    export MYDEFLIB=$MYDEF_BOOT/lib/MyDef
+    (cd test/mpi/bench && ./autogen.sh)
+}
+
 # internal
 _patch_libtool() {
     _file=$1
@@ -731,9 +740,9 @@ EOF
             echo ">= $ver"
         else
             echo "bad autoconf installation"
-            echo "--- autoreconf diagnositcs ---"
+            echo "--- autoreconf diagnostics ---"
             $(cat autoreconf.err)
-            echo "--- autoreconf diagnositcs ---"
+            echo "--- autoreconf diagnostics ---"
             cat <<EOF
 You either do not have autoconf in your path or it is too old (version
 $ver or higher required). You may be able to use
@@ -1102,3 +1111,5 @@ fn_build_configure
 fn_ch4_api
 
 fn_json_gen
+
+fn_mydef

--- a/test/mpi/bench/.gitignore
+++ b/test/mpi/bench/.gitignore
@@ -1,0 +1,3 @@
+/*.c
+/p2p_bw
+/p2p_latency

--- a/test/mpi/bench/Makefile.am
+++ b/test/mpi/bench/Makefile.am
@@ -1,0 +1,17 @@
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+include $(top_srcdir)/Makefile_single.mtest
+LDADD += -lm
+
+## for all programs that are just built from the single corresponding source
+## file, we don't need per-target _SOURCES rules, automake will infer them
+## correctly
+noinst_PROGRAMS = \
+    p2p_latency \
+    p2p_bw
+
+.def.c:
+	mydef_page $<

--- a/test/mpi/bench/autogen.sh
+++ b/test/mpi/bench/autogen.sh
@@ -1,0 +1,3 @@
+for a in *.def ; do
+    mydef_page $a
+done

--- a/test/mpi/bench/config
+++ b/test/mpi/bench/config
@@ -1,0 +1,3 @@
+module: c
+CC: mpicc
+run: mpirun -n 2

--- a/test/mpi/bench/macros/bench_frame.def
+++ b/test/mpi/bench/macros/bench_frame.def
@@ -9,10 +9,16 @@
 subcode: bench_frame
     $include stdio
     $include stdlib
-    $include mpi
+    $(if:HAS_MTEST)
+        $include mpitest.h
+    $(else)
+        $include mpi
 
     $function main
-        MPI_Init(NULL, NULL);
+        $(if:HAS_MTEST)
+            MTest_Init(NULL, NULL);
+        $(else)
+            MPI_Init(NULL, NULL);
 
         $my grank, gsize: int
         MPI_Comm_rank(MPI_COMM_WORLD, &grank);
@@ -23,7 +29,12 @@ subcode: bench_frame
                 return 1
 
         MPI_Comm comm = MPI_COMM_WORLD;
-        char *buf = malloc(MAX_BUFSIZE)
+
+        $my void *buf
+        $(if:HAS_MTEST)
+            $call mtest_malloc, MAX_BUFSIZE
+        $(else)
+            buf = malloc(MAX_BUFSIZE)
         $if !buf
             printf("! Failed to allocate buffer (size=%d)\n", MAX_BUFSIZE)
             return 1
@@ -35,7 +46,10 @@ subcode: bench_frame
         $if grank == 0
             printf("\n")
 
-        MPI_Finalize();
+        $(if:HAS_MTEST)
+            MTest_Finalize(0);
+        $(else)
+            MPI_Finalize();
 
 macros:
     use_double: 1

--- a/test/mpi/bench/macros/bench_frame.def
+++ b/test/mpi/bench/macros/bench_frame.def
@@ -1,0 +1,93 @@
+/*
+ * bench_frame       : boilerplate for mpi program
+ * measure(iter)     : measures `tf_dur` for $(iter) iterations
+ * run_stat(N, var)  : run N measurements and obtain (avg, std) in sum1, sum2
+ * warm_up(iter, dur): repeat until measurements (iter, dur) stabilize
+ * report_latency(msgsize, MULTIPLICITY) : print a line of latency result
+ */
+
+subcode: bench_frame
+    $include stdio
+    $include stdlib
+    $include mpi
+
+    $function main
+        MPI_Init(NULL, NULL);
+
+        $my grank, gsize: int
+        MPI_Comm_rank(MPI_COMM_WORLD, &grank);
+        MPI_Comm_size(MPI_COMM_WORLD, &gsize);
+        $(if:MIN_PROCS)
+            $if gsize < $(MIN_PROCS)
+                printf("! Test $(_pagename) requires $(MIN_PROCS) processes !\n");
+                return 1
+
+        MPI_Comm comm = MPI_COMM_WORLD;
+        char *buf = malloc(MAX_BUFSIZE)
+        $if !buf
+            printf("! Failed to allocate buffer (size=%d)\n", MAX_BUFSIZE)
+            return 1
+
+        $if grank == 0
+            printf("TEST $(_pagename):\n")
+            $call @report_header
+        $call main
+        $if grank == 0
+            printf("\n")
+
+        MPI_Finalize();
+
+macros:
+    use_double: 1
+
+#----------------------------------------
+subcode: _autoload
+    $register_prefix(comm) MPI_Comm
+
+subcode: foreach_size
+    $for int size = 0; size < $(MAX_MSG); size = (size==0)?1:size*2
+        $(set:MSG_SIZE=size)
+        BLOCK
+
+subcode: measure(iter)
+    tf_start = MPI_Wtime()
+    $for 0:$(iter)
+        BLOCK
+    tf_dur = MPI_Wtime() - tf_start
+
+subcode: run_stat(N, var)
+    $my double sum1=0, double sum2=0
+    $for 0:$(N)
+        BLOCK
+        sum1 += $(var)
+        sum2 += $(var) * $(var)
+    sum1 /= $(N)
+    sum2 /= $(N)
+    sum2 = sqrt(sum2 - sum1 * sum1)
+
+subcode: warm_up(iter, dur)
+    $(set:MIN_ITER=(int) ($(iter) * 0.001 / $(dur)))
+    $(iter) = 2
+    $my double last_dur = 1.0
+    $my int num_best = 0
+    $while num_best < 10
+        BLOCK
+        $if $(iter) < $(MIN_ITER)
+            $(iter) = $(MIN_ITER)
+            num_best = 0
+            continue
+        # check that t_dur is no longer monotonically decreasing
+        $if $(dur) > last_dur
+            num_best++
+        last_dur = $(dur)
+
+subcode: header_latency
+    printf("%12s %10s(us) %6s(us) %12s(MB/s)\n", "msgsize", "latency", "sigma", "bandwidth")
+
+subcode: report_latency(MSGSIZE, MULTIPLICITY)
+    $my tf_latency, tf_sigma, tf_bw
+    tf_latency = sum1 / ($(MULTIPLICITY)) * 1e6
+    tf_sigma = sum2 / ($(MULTIPLICITY)) * 1e6
+    tf_bw = $(MSGSIZE) / tf_latency
+    printf("%12d %10.3f     %6.3f     %12.3f\n", $(MSGSIZE), tf_latency, tf_sigma, tf_bw)
+

--- a/test/mpi/bench/macros/bench_p2p.def
+++ b/test/mpi/bench/macros/bench_p2p.def
@@ -1,0 +1,79 @@
+/*
+ * Defines following functions:
+ *   bench_p2p
+ *       bench_send, bench_warmup
+ *       bench_recv
+ *
+ * For each measurement -
+ *    First sender tells receiver the `iter` parameter. `iter = 0` means to quit.
+ *    For each iteration runs `send_side` and `recv_side` assuming the measurement on sender side represents a latency measurement.
+ * 
+ * Caller page defines -
+ *     subcode: sender_side, recv_side
+ *     macro:
+ *         MULTIPLICITY: divisor for each measurement
+ */
+
+macros:
+    MIN_PROCS: 2
+    MAX_BUFSIZE: 5000000  # 5 MB
+
+subcode: _autoload
+    $register_name(src) int
+    $register_name(dst) int
+    $register_name(buf) void *
+    $register_name(size) int
+    $define TAG 0
+    $define SYNC_TAG 100
+    $define MAX_BUFSIZE 5000000
+    $define NUM_REPEAT 20
+
+subcode: report_header
+        $call header_latency
+
+fncode: bench_p2p(comm, src, dst, buf, size)
+    int rank;
+    MPI_Comm_rank(comm, &rank)
+
+    $(if:!MULTIPLICITY)
+        $(set:MULTIPLICITY=1)
+
+    $if rank == src
+        iter = bench_warmup(comm, dst, buf, size)
+        &call run_stat, NUM_REPEAT, tf_latency
+            tf_latency = bench_send(iter, comm, dst, buf, size)
+            tf_latency /= iter
+        $call report_latency, size, $(MULTIPLICITY)
+        $call send_stop
+    $elif rank == dst
+        bench_recv(comm, src, buf, size)
+
+    subcode: send_stop
+        iter = 0;
+        MPI_Send(&iter, 1, MPI_INT, dst, SYNC_TAG, comm)
+
+#---------------------------------------- 
+fncode: bench_send(int iter, comm, dst, buf, size)
+    # synchronize with receiver
+    MPI_Send(&iter, 1, MPI_INT, dst, SYNC_TAG, comm);
+
+    &call measure, iter
+        $call @send_side
+
+    return tf_dur
+
+fncode: bench_recv(comm, src, buf, size)
+    $while 1
+        int iter;
+        # synchronize with sender */
+        MPI_Recv(&iter, 1, MPI_INT, src, SYNC_TAG, comm, MPI_STATUS_IGNORE);
+        $if iter == 0
+            # time to quit
+            break
+        $for i=0:iter
+            $call @recv_side
+
+fncode: bench_warmup(comm, dst, buf, size): int
+    &call warm_up, iter, tf_dur
+        tf_dur = bench_send(iter, comm, dst, buf, size)
+    return iter

--- a/test/mpi/bench/macros/mtest.def
+++ b/test/mpi/bench/macros/mtest.def
@@ -1,0 +1,14 @@
+macros:
+    HAS_MTEST: 1
+
+subcode: mtest_malloc(size)
+    MTestArgList *head = MTestArgListCreate(argc, argv)
+    int send_rank = 0, recv_rank = 1;
+    $(for:a in send,recv)
+        $if grank == $(a)_rank
+            $my mtest_mem_type_e $(a)_memtype, int $(a)_device
+            $(a)_memtype = MTestArgListGetMemType(head, "$(a)mem")
+            $(a)_device = MTestArgListGetInt_with_default(head, "$(a)dev", 0)
+            MTestMalloc($(size), $(a)_memtype, NULL, &buf, $(a)_device)
+            MTestPrintfMsg(1, "Allocating buffer: memtype=%s, device=%d, size=%d\n", MTest_memtype_name($(a)_memtype), $(a)_device, $(size))
+    MTestArgListDestroy(head)

--- a/test/mpi/bench/p2p_bw.def
+++ b/test/mpi/bench/p2p_bw.def
@@ -1,5 +1,6 @@
 include: macros/bench_frame.def
 include: macros/bench_p2p.def
+include: macros/mtest.def
 
 subcode: _autoload
     $define WINDOW_SIZE 64

--- a/test/mpi/bench/p2p_bw.def
+++ b/test/mpi/bench/p2p_bw.def
@@ -1,0 +1,26 @@
+include: macros/bench_frame.def
+include: macros/bench_p2p.def
+
+subcode: _autoload
+    $define WINDOW_SIZE 64
+
+page: p2p_bw, bench_frame
+    MULTIPLICITY: WINDOW_SIZE
+    data: buf, size, MPI_CHAR
+
+    $for int size = 1; size < MAX_BUFSIZE; size *= 2
+        bench_p2p(comm, 0, 1, buf, size)
+
+    subcode: send_side
+        $my MPI_Request reqs[WINDOW_SIZE]
+        $for j=0:WINDOW_SIZE
+            MPI_Isend($(data), dst, TAG, comm, &reqs[j])
+        MPI_Waitall(WINDOW_SIZE, reqs, MPI_STATUSES_IGNORE)
+        MPI_Recv(NULL, 0, MPI_DATATYPE_NULL, dst, TAG, comm, MPI_STATUS_IGNORE)
+
+    subcode: recv_side
+        $my MPI_Request reqs[WINDOW_SIZE]
+        $for j=0:WINDOW_SIZE
+            MPI_Irecv($(data), src, TAG, comm, &reqs[j])
+        MPI_Waitall(WINDOW_SIZE, reqs, MPI_STATUSES_IGNORE)
+        MPI_Send(NULL, 0, MPI_DATATYPE_NULL, src, TAG, comm)

--- a/test/mpi/bench/p2p_latency.def
+++ b/test/mpi/bench/p2p_latency.def
@@ -1,0 +1,18 @@
+include: macros/bench_frame.def
+include: macros/bench_p2p.def
+
+page: p2p_latency, bench_frame
+    MULTIPLICITY: 2
+    data: buf, size, MPI_CHAR
+
+    bench_p2p(comm, 0, 1, buf, 0)
+    $for int size = 1; size < MAX_BUFSIZE; size *= 2
+        bench_p2p(comm, 0, 1, buf, size)
+
+    subcode: send_side
+        MPI_Send($(data), dst, TAG, comm);
+        MPI_Recv($(data), dst, TAG, comm, MPI_STATUS_IGNORE);
+
+    subcode: recv_side
+        MPI_Recv($(data), src, TAG, comm, MPI_STATUS_IGNORE);
+        MPI_Send($(data), src, TAG, comm);

--- a/test/mpi/bench/p2p_latency.def
+++ b/test/mpi/bench/p2p_latency.def
@@ -1,5 +1,6 @@
 include: macros/bench_frame.def
 include: macros/bench_p2p.def
+include: macros/mtest.def
 
 page: p2p_latency, bench_frame
     MULTIPLICITY: 2

--- a/test/mpi/bench/testlist
+++ b/test/mpi/bench/testlist
@@ -1,0 +1,2 @@
+p2p_latency 2 resultTest=TestBench
+p2p_bw 2 resultTest=TestBench

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -1904,5 +1904,6 @@ AC_OUTPUT(maint/testmerge \
           impls/mpich/ulfm/Makefile \
           impls/mpich/info/Makefile \
           impls/mpich/info/testlist \
+          bench/Makefile \
           )
 

--- a/test/mpi/runtests
+++ b/test/mpi/runtests
@@ -934,6 +934,8 @@ sub get_resultTest {
         return \&TestStatusNoErrors;
     } elsif ($resultTest eq "TestErrFatal") {
         return \&TestErrFatal;
+    } elsif ($resultTest eq "TestBench") {
+        return \&TestBench;
     } else {
         die "resultTest $resultTest not defined!\n";
     }
@@ -1107,6 +1109,22 @@ sub TestErrFatal {
     my $found_error = 0;
     if (!$run_status) {
         expect_status_nonzero($programname);
+        $found_error = 1;
+    }
+    return ($found_error, $inline);
+}
+
+# Only check exit code: 0 means success, non-zero means failure
+sub TestBench {
+    my ($MPIOUT, $programname) = @_;
+    my ($found_error, $inline);
+
+    while (<$MPIOUT>) {
+        print STDOUT $_;
+    }
+    my $rc = close($MPIOUT);
+    if (!$rc) {
+        expect_status_zero($programname, $?);
         $found_error = 1;
     }
     return ($found_error, $inline);


### PR DESCRIPTION
## Pull Request Description
While [OSU micro benchmarks](https://mvapich.cse.ohio-state.edu/benchmarks/) are commonly used, they still require separate builds and its comprehensive inclusions of many options make using and tuning the benchmarks non-trivial. This PR adds simple benchmark code that can be used in CI testing. Each test consists of a single standalone C source code with minimum options, thus allowing quick testing and easy adaptations.

The PR also introduces [MyDef](https://github.com/hzhou/MyDef) template system. MyDef allows the construction of code in layers. However, before getting familiar, developers will likely feel the source code in MyDef to be mysterious. To start, follow the instructions to get the source code in C and read the C code.

* `autogen.sh` (in `topsrc_dir`) will convert `.def` code into `.c`, thus removing the dependency on MyDef.
* If one added MyDef to `PATH`,  one can manually convert the code or use Makefile
```
[test/mpi/bench]$ mydef_page p2p_latency.def
PAGE: p2p_latency
  --> [./p2p_latency.c]
```
Or 
```
$ mydef_run p2p_latency.def
PAGE: p2p_latency
  --> [./p2p_latency.c]
mpicc -o ./p2p_latency ./p2p_latency.c -lm && mpirun -n 2 ./p2p_latency
TEST p2p_latency:
     msgsize    latency(us)  sigma(us)    bandwidth(MB/s)
           0      0.465      0.002            0.000
           1      0.475      0.001            2.105
           2      0.476      0.002            4.205
           4      0.478      0.019            8.360
           8      0.476      0.002           16.800
          16      0.475      0.002           33.694
          32      0.474      0.002           67.451
          64      0.476      0.001          134.424
         128      0.505      0.003          253.422
         256      0.523      0.004          489.442
         512      0.608      0.005          842.436
        1024      0.776      0.003         1318.895
        2048      0.932      0.003         2196.811
        4096      1.273      0.004         3216.882
        8192      1.949      0.006         4202.567
       16384      4.143      0.017         3954.333
       32768      5.674      0.016         5775.437
       65536      8.632      0.018         7592.587
      131072     14.502      0.050         9038.108
      262144     26.104      0.052        10042.183
      524288     50.209      0.104        10442.031
     1048576    106.563      0.234         9839.961
     2097152    219.804      0.385         9541.020
     4194304    476.780      1.431         8797.154

```

* The usual `make` works as well
```
$ make testing
../runtests -srcdir=. -tests=testlist,testlist.gpu,testlist.dtp,testlist.collalgo -testdirs= \
        -mpiexec="/home/hzhou/MPI/bin/mpiexec"  -xmlfile=summary.xml \
        -tapfile=summary.tap -junitfile=summary.junit.xml
Load tests in .
Running tests in . [00:00:00]
TEST p2p_latency:
     msgsize    latency(us)  sigma(us)    bandwidth(MB/s)
           0      0.472      0.007            0.000
           1      0.481      0.001            2.081
           2      0.480      0.001            4.162
           4      0.481      0.002            8.320
           8      0.480      0.001           16.663
          16      0.480      0.001           33.321
          32      0.479      0.001           66.751
          64      0.480      0.001          133.334
         128      0.505      0.001          253.306
         256      0.521      0.002          491.461
         512      0.601      0.003          851.506
        1024      0.775      0.003         1321.005
        2048      0.935      0.004         2190.365
        4096      1.271      0.004         3222.500
        8192      1.942      0.005         4217.288
       16384      4.141      0.018         3956.726
       32768      5.629      0.022         5821.091
       65536      8.561      0.020         7654.838
      131072     14.381      0.030         9114.115
      262144     25.907      0.054        10118.604
      524288     49.848      0.098        10517.631
     1048576    105.883      0.262         9903.189
     2097152    217.566      0.529         9639.174
     4194304    475.046      1.003         8829.267

TEST p2p_bw:
     msgsize    latency(us)  sigma(us)    bandwidth(MB/s)
           1      0.224      0.000            4.458
           2      0.224      0.000            8.918
           4      0.224      0.001           17.854
           8      0.225      0.001           35.634
          16      0.224      0.000           71.417
          32      0.224      0.000          142.606
          64      0.225      0.000          284.557
         128      0.258      0.000          496.326
         256      0.267      0.000          958.630
         512      0.284      0.001         1803.500
        1024      0.346      0.001         2957.940
        2048      0.366      0.001         5602.925
        4096      0.503      0.002         8151.093
        8192      0.783      0.007        10463.363
       16384      1.841      0.031         8897.694
       32768      3.291      0.006         9956.639
       65536      6.063      0.012        10809.210
      131072     11.672      0.325        11229.356
      262144     22.565      0.017        11617.333
      524288     44.575      0.059        11762.012
     1048576     87.345      0.173        12005.058
     2097152    171.658      0.299        12217.021
     4194304    342.196      0.284        12257.009

 All 2 tests passed! (total runtime: 0 min 6 sec)
TAP formatted results in /home/hzhou/work/pull_requests/2311_bench/test/mpi/bench/summary.tap
JUNIT formatted results in /home/hzhou/work/pull_requests/2311_bench/test/mpi/bench/summary.junit.xml

```
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
