### PR TITLE
f08: check err after cdesc_create_datatype

### DIFF
--- a/maint/local_python/binding_f08.py
+++ b/maint/local_python/binding_f08.py
@@ -69,6 +69,7 @@ def dump_f08_wrappers_c(func, is_large):
 
         code_list.append("if (%s->rank != 0 && !CFI_is_contiguous(%s)) {" % (buf, buf))
         code_list.append("    err = cdesc_create_datatype(%s, %s, %s, &%s_i);" % (buf, ct, dt, dt))
+        code_list.append("    if (err) return err;")
         code_list.append("    %s_i = 1;" % ct)
         code_list.append("}")
         code_list.append("")


### PR DESCRIPTION
## Pull Request Description
We neglected to check error from cdesc_create_datatype, which resulted in *silent* error for case such as:
```
    call MPI_Isend( A(1:30:3,1:20:2), size(A(1:30:3,1:20:2))-1, MPI_INTEGER, me, 99, MPI_COMM_WORLD, r(1))
```

Fixes #6909 
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
