### PR TITLE
pm/hydra: Support binding to Cray Cassini devices

### DIFF
--- a/src/pm/hydra/lib/tools/topo/hwloc/topo_hwloc.c
+++ b/src/pm/hydra/lib/tools/topo/hwloc/topo_hwloc.c
@@ -306,6 +306,7 @@ static HYD_status get_hw_obj_list(const char *resource, hwloc_obj_t ** resource_
         *resource_list_length = count;
     } else if (!strncmp(resource, "ib", strlen("ib"))
                || !strncmp(resource, "hfi", strlen("hfi"))
+               || !strncmp(resource, "hsn", strlen("hsn"))
                || !strncmp(resource, "eth", strlen("eth"))
                || !strncmp(resource, "en", strlen("en"))) {
         hwloc_obj_t io_device = NULL;
@@ -315,11 +316,15 @@ static HYD_status get_hw_obj_list(const char *resource, hwloc_obj_t ** resource_
             obj_type_prefix = MPL_strdup("ib");
         else if (!strncmp(resource, "hfi", strlen("hfi")))
             obj_type_prefix = MPL_strdup("hfi");
+        else if (!strncmp(resource, "hsn", strlen("hsn")))
+            obj_type_prefix = MPL_strdup("hsn");
         else if (!strncmp(resource, "eth", strlen("eth")) || !strncmp(resource, "en", strlen("en")))
             obj_type_prefix = MPL_strdup("en");
 
         while ((io_device = hwloc_get_next_osdev(topology, io_device))) {
             if (!io_device_found(resource_str, "hfi", io_device, HWLOC_OBJ_OSDEV_OPENFABRICS))
+                continue;
+            if (!io_device_found(resource_str, "hsn", io_device, HWLOC_OBJ_OSDEV_NETWORK))
                 continue;
             if (!io_device_found(resource_str, "ib", io_device, HWLOC_OBJ_OSDEV_NETWORK))
                 continue;

--- a/src/pm/hydra/mpiexec/options.c
+++ b/src/pm/hydra/mpiexec/options.c
@@ -993,6 +993,7 @@ static void bind_to_help_fn(void)
     printf("            ib{<id>|:<n>}    -- bind to non-io ancestor of IB device(s)\n");
     printf("            en|eth{<id>|:<n>} -- bind to non-io ancestor of Ethernet device(s)\n");
     printf("            hfi{<id>|:<n>}   -- bind to non-io ancestor of OPA device(s)\n");
+    printf("            hsn{<id>|:<n>}   -- bind to non-io ancestor of Cray Cassini device(s)\n");
 
 
     printf("\n\n");


### PR DESCRIPTION
## Pull Request Description

Users can use `-bind-to hsn{<id>|:<n>}` to bind/map processes to Cray Cassini network devices.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
