### PR TITLE
configure: use flat_namespace to build libmpifort.dylib

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -202,7 +202,7 @@ lib_lib@MPIFCLIBNAME@_la_SOURCES =
 if BUILD_FC_BINDING
 modinc_HEADERS = $(mpi_fc_modules)
 endif BUILD_FC_BINDING
-lib_lib@MPIFCLIBNAME@_la_LDFLAGS = $(ABIVERSIONFLAGS)
+lib_lib@MPIFCLIBNAME@_la_LDFLAGS = $(ABIVERSIONFLAGS) @FCLIB_LDFLAGS@
 lib_lib@MPIFCLIBNAME@_la_LIBADD = lib/lib@MPILIBNAME@.la $(mpifort_convenience_libs)
 endif BUILD_F77_BINDING
 

--- a/configure.ac
+++ b/configure.ac
@@ -569,17 +569,6 @@ else
 fi
 AC_SUBST(ENABLE_QMPI)
 
-AC_ARG_ENABLE([two-level-namespace],
-              [AS_HELP_STRING([--disable-two-level-namespace],
-                              [(Darwin only) Add `-Wl,-flat_namespace` to
-                               mpicc/mpifort/etc. compiler wrappers.
-                               This may fix some issues due to not resolving
-                               MPI constants, such as MPI_IN_PLACE.
-                               Try disable this option if you encounter these issues
-                               on Mac OS.])],
-              [],
-              [enable_two_level_namespace=yes])
-
 AC_ARG_ENABLE(multi-aliases,
 	AS_HELP_STRING([--enable-multi-aliases],
 		[Multiple aliasing to support multiple fortran compilers (default)]),,
@@ -4087,6 +4076,19 @@ AC_DEFINE(HAVE_MPICHCONF,1,[Define so that we can test whether the mpichconf.h f
 # linking issue on Darwin
 LT_OUTPUT
 
+AC_ARG_ENABLE([two-level-namespace],
+              [AS_HELP_STRING([--enable-two-level-namespace],
+                              [(Darwin only) Do not use `-Wl,-flat_namespace` to
+                               link libmpifort.dylib. MacOS uses two-level namespace
+                               to compile dylibs by default. This may cause issues
+                               not resolving MPI constants, such as MPI_IN_PLACE.
+                               Thus, we use flat_namespace by default. Enable this
+                               option to use two-level-namespace instead. ])],
+              [],
+              [enable_two_level_namespace=no])
+FCLIB_LDFLAGS=
+AC_SUBST([FCLIB_LDFLAGS])
+
 if test "X$enable_shared" = "Xyes" ; then
     # see ticket #1590 for some more background on these Darwin linking issues
     AS_CASE([$host],
@@ -4147,8 +4149,7 @@ if test "X$enable_shared" = "Xyes" ; then
             # necessary for Darwin for now, so this unconditional, single-var
             # approximation will work for now.
             if test "X$pac_cv_wl_flat_namespace_works" = "Xyes" ; then
-                PAC_APPEND_FLAG([-Wl,-flat_namespace], [LDFLAGS])
-                PAC_APPEND_FLAG([-Wl,-flat_namespace], [WRAPPER_LDFLAGS])
+                FCLIB_LDFLAGS="-Wl,-flat_namespace"
             fi
         fi
 


### PR DESCRIPTION
## Pull Request Description
On the latest mac, it requires to build dylibs with -Wl,-flat_namespace in order for common block variables, such as MPI_IN_PLACE, to be recognized.

reference: 
* https://github.com/pmodels/mpich/pull/6903#issuecomment-1958683326
* https://community.intel.com/t5/Intel-Fortran-Compiler/Common-blocks-in-dynamic-shared-libraries-still-not-linked/td-p/757056
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
