### PR TITLE
cxx: use do-while in macros

### DIFF
--- a/src/binding/cxx/buildiface
+++ b/src/binding/cxx/buildiface
@@ -1153,11 +1153,11 @@ print $OUTFD "namespace MPI {\n";
 # Provide a way to invoke the error handler on the object
 print $OUTFD "#if \@HAVE_CXX_EXCEPTIONS\@
 #define MPIX_CALLREF( _objptr, fnc ) \\
-    { int err = fnc; if (err) { (_objptr)->Call_errhandler( err ); }}
+    do { int err = fnc; if (err) { (_objptr)->Call_errhandler( err ); }} while(0)
 #define MPIX_CALLOBJ( _obj, fnc ) \\
-    { int err = fnc; if (err) { (_obj).Call_errhandler( err ); }}
+    do { int err = fnc; if (err) { (_obj).Call_errhandler( err ); }} while(0)
 #define MPIX_CALLWORLD( fnc ) \\
-    { int err = fnc ; if (err) MPIR_Call_world_errhand( err ); }
+    do { int err = fnc ; if (err) MPIR_Call_world_errhand( err ); } while(0)
 extern void MPIR_Call_world_errhand( int );
 #else
 #define MPIX_CALLREF( _objptr, fnc ) (void)fnc
@@ -4987,7 +4987,7 @@ sub printCoverageInitialize {
 # ----------------------------------------------------------------------------
 # Read a specification file for a binding.  This helps provide information on
 # exceptions and enhancements to the binding automatically derived from the
-# prototype file (the C header file).  The format of this specificaiton
+# prototype file (the C header file).  The format of this specification
 # file is:
 # class-name: [static] return (args) [const]
 #


### PR DESCRIPTION
## Pull Request Description
Use do-while in macros to prevent compiler complaints of extra semicolons.

This replaces https://github.com/pmodels/mpich/pull/6923. Thanks, @prj, for the contribution.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
