### PR TITLE
errhan: zero ErrorRing when adding new code

### DIFF
--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -1268,6 +1268,7 @@ int MPIR_Err_create_code_valist(int lastcode, int fatal, const char fcname[],
             if (error_ring_loc > max_error_ring_loc)
                 max_error_ring_loc = error_ring_loc;
 
+            memset(&ErrorRing[ring_idx], 0, sizeof(MPIR_Err_msg_t));
             ring_msg = ErrorRing[ring_idx].msg;
 
             if (specific_msg != NULL) {


### PR DESCRIPTION
## Pull Request Description
We use a cyclic array with limited capacity (128) to store a history of error codes. When the ring_idx goes around, we end up reuse some of the values from previous error codes. Preset it to zero prevents that.

Fixes #6931 

[skip warnings]



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
