### PR TITLE
misc: Fix error handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -361,15 +361,6 @@ AC_ARG_ENABLE(error-checking,
         all       - error checking always enabled (default)
 ],,enable_error_checking=runtime)
 
-AC_ARG_ENABLE(error-messages,
-[  --enable-error-messages=level - Control the amount of detail in error messages.
-        all       - Maximum amount of information
-        generic   - Only generic messages (no information about the specific
-                    instance)
-        class     - One message per MPI error class
-        none      - No messages
-],,enable_error_messages=all)
-
 AC_ARG_ENABLE(tag-error-bits,
 [  --enable-tag-error-bits=yes|no - Control whether bits are taken from the user tag for error handling.
         yes       - Two bits are taken from the user tag to support error propagation.
@@ -1014,26 +1005,6 @@ case "$enable_error_checking" in
 esac
 # permit @HAVE_ERROR_CHECKING@ substitution in mpir_ext.h
 AC_SUBST([HAVE_ERROR_CHECKING])
-
-# error-messages
-case "$enable_error_messages" in
-    no|none)
-        error_message_kind="MPICH_ERROR_MSG__NONE"
-    ;;
-    all|yes)
-	error_message_kind="MPICH_ERROR_MSG__ALL"
-    ;;
-    generic)
-	error_message_kind="MPICH_ERROR_MSG__GENERIC"
-    ;;
-    class)
-	error_message_kind="MPICH_ERROR_MSG__CLASS"
-    ;;
-    *)
-    AC_MSG_WARN([Unknown value $enable_error_messages for enable-error-messages])
-    ;;
-esac
-AC_DEFINE_UNQUOTED(MPICH_ERROR_MSG_LEVEL,$error_message_kind,[define to enable error messages])
 
 #error-tags
 if test "$enable_tag_error_bits" = "yes" ; then

--- a/maint/extracterrmsgs
+++ b/maint/extracterrmsgs
@@ -225,12 +225,12 @@ sub CreateErrmsgsHeader {
  * This file automatically created by extracterrmsgs\
  * DO NOT EDIT\
  */\n";
-    print $FD "#if MPICH_ERROR_MSG_LEVEL > MPICH_ERROR_MSG__CLASS
+    print $FD "
 typedef struct msgpair {
         const unsigned int sentinal1;
         const char *short_name, *long_name; 
         const unsigned int sentinal2; } msgpair;
-#endif\n"
+\n"
 }
 #
 # We also need a way to create the records
@@ -247,24 +247,11 @@ typedef struct msgpair {
 sub CreateErrMsgMapping {
     my $OUTFD = $_[0];
 
-    # For the case of classes only, output the strings for the class 
-    # messages
-    print $OUTFD "#if MPICH_ERROR_MSG_LEVEL == MPICH_ERROR_MSG__CLASS\n";
-    print $OUTFD "static const char *classToMsg[] = {\n";
-    for (my $i=0; $i<=$max_err_class; $i++) {
-	my $shortname = $class_msgs[$i];
-        my $msg       = $longnames{$shortname};
-        print $OUTFD "    \"$msg\", /* $i  $class_msgs[$i] */\n";
-    }
-    print $OUTFD "    NULL\n};\n";
-    print $OUTFD "#endif /* MSG_CLASS */\n";
-
     # Now, output each short,long key
     # Do the generic, followed by the specific, messages
     # The long messages must be available for the generic message output.
     # An alternative is to separate the short from the long messages;
     # the long messages are needed for > MSG_NONE, the short for > MSG_CLASS.
-    print $OUTFD "#if MPICH_ERROR_MSG_LEVEL > MPICH_ERROR_MSG__CLASS\n";
     print $OUTFD "/* The names are in sorted order, allowing the use of a simple\
   linear search or bisection algorithm to find the message corresponding to\
   a particular message */\n";
@@ -323,11 +310,9 @@ sub CreateErrMsgMapping {
 	print $OUTFD "\n";
     }
     print $OUTFD "};\n";
-    print $OUTFD "#endif\n\n";
 
     $num = 0;
     # Now output the instance specific messages
-    print $OUTFD "#if MPICH_ERROR_MSG_LEVEL > MPICH_ERROR_MSG__GENERIC\n";
     foreach my $key (sort keys %specific_msgs)
     {
 	my $longvalue = "\"\0\"";
@@ -361,9 +346,7 @@ sub CreateErrMsgMapping {
 	print $OUTFD "\n";
     }
     print $OUTFD "};\n";
-    print $OUTFD "#endif\n\n";
 
-    print $OUTFD "#if MPICH_ERROR_MSG_LEVEL > MPICH_ERROR_MSG__CLASS\n";
     my $maxval = $max_err_class + 1;
     print $OUTFD "static int class_to_index[] = {\n    ";
     for (my $i=0; $i<=$max_err_class; $i++) {
@@ -377,7 +360,6 @@ sub CreateErrMsgMapping {
 	print $OUTFD "\n    " if !(($i + 1) % 10);
     }
     print $OUTFD "\n};\n";
-    print $OUTFD "#endif\n";
 }
 #
 # Add a call to test this message for the error message.

--- a/src/mpi/attr/attrutil.c
+++ b/src/mpi/attr/attrutil.c
@@ -88,20 +88,7 @@ int MPIR_Call_attr_delete(int handle, MPIR_Attribute * attr_p)
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     /* --BEGIN ERROR HANDLING-- */
     if (rc != 0) {
-#if MPICH_ERROR_MSG_LEVEL < MPICH_ERROR_MSG__ALL
-        /* If rc is a valid error class, then return that.
-         * Note that it may be a dynamic error class */
-        /* AMBIGUOUS: This is an ambiguity in the MPI standard: What is the
-         * error value returned from the user-provided routine?  Particularly
-         * with the MPI-2 feature of user-defined error codes, the
-         * user expectation is probably that the user-provided error code
-         * is returned. */
         mpi_errno = rc;
-#else
-        mpi_errno =
-            MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                 MPI_ERR_OTHER, "**user", "**userdel %d", rc);
-#endif
         goto fn_fail;
     }
     /* --END ERROR HANDLING-- */
@@ -146,13 +133,7 @@ int MPIR_Call_attr_copy(int handle, MPIR_Attribute * attr_p, void **value_copy, 
 
     /* --BEGIN ERROR HANDLING-- */
     if (rc != 0) {
-#if MPICH_ERROR_MSG_LEVEL < MPICH_ERROR_MSG__ALL
         mpi_errno = rc;
-#else
-        mpi_errno =
-            MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                 MPI_ERR_OTHER, "**user", "**usercopy %d", rc);
-#endif
         goto fn_fail;
     }
     /* --END ERROR HANDLING-- */

--- a/src/mpi/attr/attrutil.c
+++ b/src/mpi/attr/attrutil.c
@@ -220,8 +220,6 @@ int MPIR_Attr_delete_list(int handle, MPIR_Attribute ** attr)
         /* --END ERROR HANDLING-- */
         /* For this attribute, find the delete function for the
          * corresponding keyval */
-        /* Still to do: capture any error returns but continue to
-         * process attributes */
         mpi_errno = MPIR_Call_attr_delete(handle, p);
 
         /* We must also remove the keyval reference.  If the keyval

--- a/src/mpi/attr/attrutil.c
+++ b/src/mpi/attr/attrutil.c
@@ -69,8 +69,7 @@ void MPID_Attr_free(MPIR_Attribute * attr_ptr)
 */
 int MPIR_Call_attr_delete(int handle, MPIR_Attribute * attr_p)
 {
-    int rc;
-    int mpi_errno = MPI_SUCCESS;
+    int mpi_errno = MPI_SUCCESS, rc;
     MPII_Keyval *kv = attr_p->keyval;
 
     if (kv->delfn.user_function == NULL)
@@ -88,7 +87,7 @@ int MPIR_Call_attr_delete(int handle, MPIR_Attribute * attr_p)
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     /* --BEGIN ERROR HANDLING-- */
     if (rc != 0) {
-        mpi_errno = rc;
+        MPIR_ERR_SET1(mpi_errno, MPI_ERR_OTHER, "**user", "**userdel %d", rc);
         goto fn_fail;
     }
     /* --END ERROR HANDLING-- */
@@ -113,8 +112,7 @@ int MPIR_Call_attr_delete(int handle, MPIR_Attribute * attr_p)
 */
 int MPIR_Call_attr_copy(int handle, MPIR_Attribute * attr_p, void **value_copy, int *flag)
 {
-    int mpi_errno = MPI_SUCCESS;
-    int rc;
+    int mpi_errno = MPI_SUCCESS, rc;
     MPII_Keyval *kv = attr_p->keyval;
 
     if (kv->copyfn.user_function == NULL)
@@ -133,7 +131,7 @@ int MPIR_Call_attr_copy(int handle, MPIR_Attribute * attr_p, void **value_copy, 
 
     /* --BEGIN ERROR HANDLING-- */
     if (rc != 0) {
-        mpi_errno = rc;
+        MPIR_ERR_SET1(mpi_errno, MPI_ERR_OTHER, "**user", "**usercopy %d", rc);
         goto fn_fail;
     }
     /* --END ERROR HANDLING-- */
@@ -168,9 +166,7 @@ int MPIR_Attr_dup_list(int handle, MPIR_Attribute * old_attrs, MPIR_Attribute **
         new_p = MPID_Attr_alloc();
         /* --BEGIN ERROR HANDLING-- */
         if (!new_p) {
-            mpi_errno =
-                MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                     MPI_ERR_OTHER, "**nomem", 0);
+            MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**nomem");
             goto fn_fail;
         }
         /* --END ERROR HANDLING-- */

--- a/test/mpi/attr/attrerr.c
+++ b/test/mpi/attr/attrerr.c
@@ -66,7 +66,7 @@ void abort_msg(const char *str, int code)
 int test_communicators(void)
 {
     MPI_Comm dup_comm_world, d2;
-    int world_rank, world_size, key_1;
+    int world_rank, world_size, key_1, flag = 0;
     int err, errs = 0;
     MPI_Aint value;
 
@@ -99,12 +99,32 @@ int test_communicators(void)
         printf("delete function return code was MPI_SUCCESS in put\n");
     }
 
-    /* Because the attribute delete function should fail, the attribute
-     * should *not be removed* */
     err = MPI_Attr_delete(dup_comm_world, key_1);
     if (err == MPI_SUCCESS) {
         errs++;
         printf("delete function return code was MPI_SUCCESS in delete\n");
+    }
+
+    /* Because the attribute delete function should fail, the attribute
+     * may *not be removed* */
+    err = MPI_Attr_get(dup_comm_world, key_1, &value, &flag);
+    if (err) {
+        errs++;
+        printf("Error with get\n");
+
+    }
+#if !defined(USE_STRICT_MPI) && defined(MPICH)
+    if (!flag) {
+        errs++;
+        printf("delete function failed but the attribute was removed\n");
+    }
+#endif
+    if (!flag) {
+        err = MPI_Attr_put(dup_comm_world, key_1, (void *) (MPI_Aint) (2 * world_rank));
+        if (err) {
+            errs++;
+            printf("Error with second put\n");
+        }
     }
 
     err = MPI_Comm_dup(dup_comm_world, &d2);

--- a/test/mpi/attr/attrerrtype.c
+++ b/test/mpi/attr/attrerrtype.c
@@ -68,7 +68,7 @@ void abort_msg(const char *str, int code)
 int test_attrs(void)
 {
     MPI_Datatype dup_type, d2;
-    int world_rank, world_size, key_1;
+    int world_rank, world_size, key_1, flag = 0;
     int err, errs = 0;
     MPI_Aint value;
 
@@ -101,12 +101,32 @@ int test_attrs(void)
         printf("delete function return code was MPI_SUCCESS in put\n");
     }
 
-    /* Because the attribute delete function should fail, the attribute
-     * should *not be removed* */
     err = MPI_Type_delete_attr(dup_type, key_1);
     if (err == MPI_SUCCESS) {
         errs++;
         printf("delete function return code was MPI_SUCCESS in delete\n");
+    }
+
+    /* Because the attribute delete function should fail, the attribute
+     * may *not be removed* */
+    err = MPI_Type_get_attr(dup_type, key_1, &value, &flag);
+    if (err) {
+        errs++;
+        printf("Error with get\n");
+
+    }
+#if !defined(USE_STRICT_MPI) && defined(MPICH)
+    if (!flag) {
+        errs++;
+        printf("delete function failed but the attribute was removed\n");
+    }
+#endif
+    if (!flag) {
+        err = MPI_Type_set_attr(dup_type, key_1, (void *) (MPI_Aint) (2 * world_rank));
+        if (err) {
+            errs++;
+            printf("Error with second put\n");
+        }
     }
 
     err = MPI_Type_dup(dup_type, &d2);


### PR DESCRIPTION
## Pull Request Description

### attr: Fix cleanup on errors from user delete callbacks

* Prevent memory leaks upon failures in attribute list duplication.

### errhan: Fix user callback error pass-through

Handle consistently the return error code from user callbacks in
copy/delete attributes and query/cancel/free generalized requests.

### errhan: Better handling of user callback errors

* If a user callback returns an non-MPI error code, put it in the error
  string but do not return it back to the caller of the outer MPI routine.
  Otherwise, inspecting a non-MPI error code for error class or string
  is doomed to fail.

* If a user callback returns a predefined error class, still create and
  return error code of that class. This way, the error string will contain
  the stack trace, and the caller can still get the error class out of
  the returned error code.

* Dynamically defined error classes/codes pass through from callbacks to
  the caller of the outer MPI routine. Unfortunately, inspecting the error
  string will not provide the stack trace.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
