### PR TITLE
mpi/misc: Add support for GPU memory allocation kinds

### DIFF
--- a/src/binding/c/misc_api.txt
+++ b/src/binding/c/misc_api.txt
@@ -139,33 +139,6 @@ MPIX_GPU_query_support:
     is_supported: LOGICAL, direction=out, [true if gpu of given type is supported, false otherwise.]
     .desc: Returns whether the specific type of GPU is supported
     .skip: global_cs, validate-GPU_TYPE
-{
-    *is_supported = 0;
-    if (MPIR_CVAR_ENABLE_GPU) {
-        MPL_gpu_type_t type;
-        MPL_gpu_query_support(&type);
-
-        switch (gpu_type) {
-            case MPIX_GPU_SUPPORT_CUDA:
-                if (type == MPL_GPU_TYPE_CUDA)
-                    *is_supported = 1;
-                break;
-
-            case MPIX_GPU_SUPPORT_ZE:
-                if (type == MPL_GPU_TYPE_ZE)
-                    *is_supported = 1;
-                break;
-
-            case MPIX_GPU_SUPPORT_HIP:
-                if (type == MPL_GPU_TYPE_HIP)
-                    *is_supported = 1;
-                break;
-
-            default:
-                MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_ARG, "**badgputype");
-        }
-    }
-}
 
 MPIX_Query_cuda_support:
     .desc: Returns whether CUDA is supported

--- a/src/mpi/misc/Makefile.mk
+++ b/src/mpi/misc/Makefile.mk
@@ -6,4 +6,5 @@
 mpi_core_sources += \
     src/mpi/misc/utils.c \
     src/mpi/misc/f2c_impl.c \
-    src/mpi/misc/memory_alloc_kinds.c
+    src/mpi/misc/memory_alloc_kinds.c \
+    src/mpi/misc/gpu_query.c

--- a/src/mpi/misc/gpu_query.c
+++ b/src/mpi/misc/gpu_query.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpiimpl.h"
+
+int MPIR_GPU_query_support_impl(int gpu_type, int *is_supported)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    *is_supported = 0;
+    if (MPIR_CVAR_ENABLE_GPU) {
+        MPL_gpu_type_t type;
+        MPL_gpu_query_support(&type);
+
+        switch (gpu_type) {
+        case MPIX_GPU_SUPPORT_CUDA:
+            if (type == MPL_GPU_TYPE_CUDA)
+                *is_supported = 1;
+            break;
+
+        case MPIX_GPU_SUPPORT_ZE:
+            if (type == MPL_GPU_TYPE_ZE)
+                *is_supported = 1;
+            break;
+
+        case MPIX_GPU_SUPPORT_HIP:
+            if (type == MPL_GPU_TYPE_HIP)
+                *is_supported = 1;
+            break;
+
+        default:
+            MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_ARG, "**badgputype");
+        }
+    }
+
+fn_fail:
+    return mpi_errno;
+}

--- a/src/mpi/misc/memory_alloc_kinds.c
+++ b/src/mpi/misc/memory_alloc_kinds.c
@@ -5,34 +5,57 @@
 
 #include "mpiimpl.h"
 
-static const char *memory_alloc_kinds[3][5] = {
-    /* mpi 4.1 kinds */
-    {"mpi", "alloc_mem", "win_allocate", "win_allocate_shared", NULL},
-    {"system", NULL},
-    {NULL}
-};
+/* mpi 4.1 kinds */
+static const char *mpi_kinds[5] =
+    { "mpi", "alloc_mem", "win_allocate", "win_allocate_shared", NULL };
+static const char *system_kinds[2] = { "system", NULL };
+
+/* memory allocation kinds side doc 1.0 */
+static const char *cuda_kinds[5] = { "cuda", "host", "device", "managed", NULL };
+static const char *rocm_kinds[5] = { "rocm", "host", "device", "managed", NULL };
+static const char *ze_kinds[5] = { "level_zero", "host", "device", "shared", NULL };
+
+/* we support a maximum of 3 kinds at a time: mpi,system,gpu */
+static const char **memory_alloc_kinds[4] = { mpi_kinds, system_kinds, NULL, NULL };
 
 static bool is_supported(const char *kind);
+static void init_gpu_kinds(void);
 
 int MPIR_get_supported_memory_kinds(char *requested_kinds, char **out_kinds)
 {
+    static bool gpu_init_done = 0;
     char *tmp_strs[1024];
-    int num = 2;
-    /* mpi and system kinds are always supported */
-    tmp_strs[0] = MPL_strdup("mpi");
-    tmp_strs[1] = MPL_strdup("system");
+    int num = 0;
 
-    /* match user kinds with supported kinds */
+    if (!gpu_init_done) {
+        init_gpu_kinds();
+    }
+
+    /* add kinds without restrictors */
+    for (int i = 0; memory_alloc_kinds[i]; i++) {
+        tmp_strs[i] = MPL_strdup(memory_alloc_kinds[i][0]);
+        num++;
+    }
+
+    /* match user requested kinds with supported kinds */
     if (requested_kinds != NULL) {
         char *tmp = MPL_strdup(requested_kinds);
         char *save_tmp = tmp;
         for (char *kind = MPL_strsep(&tmp, ","); kind; kind = MPL_strsep(&tmp, ",")) {
-            if (!MPL_stricmp(kind, "mpi") || !MPL_stricmp(kind, "system")) {
-                continue;
-            } else if (is_supported(kind)) {
-                tmp_strs[num++] = MPL_strdup(kind);
-                /* FIXME: use dynamic storage */
-                MPIR_Assert(num < 1024);
+            if (is_supported(kind)) {
+                /* check if kind is already in supported list */
+                bool found = false;
+                for (int i = 0; i < num; i++) {
+                    if (MPL_stricmp(kind, tmp_strs[i]) == 0) {
+                        found = true;
+                    }
+                }
+
+                if (!found) {
+                    tmp_strs[num++] = MPL_strdup(kind);
+                    /* FIXME: use dynamic storage */
+                    MPIR_Assert(num < 1024);
+                }
             }
         }
         MPL_free(save_tmp);
@@ -50,6 +73,20 @@ int MPIR_get_supported_memory_kinds(char *requested_kinds, char **out_kinds)
 
 /*** static functions ***/
 
+/* Requested kinds are of the form <kind>[:restrictor1][:restrictor2][...]
+ * MPICH does not differentiate any of the defined restrictors. Thus, if the
+ * user asks for a memory kind with one or more restrictors, we only check to
+ * see if those restrictors are valid. For example:
+ *
+ * supported:     cuda
+ * supported:     cuda:device
+ * supported:     cuda:device:managed
+ * supported:     mpi:alloc_mem
+ * supported:     rocm
+ * not supported: cuda:dev
+ * not supported: mpi:host
+ * not supported: system:foo
+ */
 static bool is_supported(const char *kind)
 {
     bool ret = false;
@@ -57,7 +94,8 @@ static bool is_supported(const char *kind)
     char *save_tmp = tmp;
 
     char *k = MPL_strsep(&tmp, ":");
-    for (int i = 0; memory_alloc_kinds[i][0]; i++) {
+
+    for (int i = 0; memory_alloc_kinds[i]; i++) {
         if (!MPL_stricmp(k, memory_alloc_kinds[i][0])) {
             ret = true;
 
@@ -79,4 +117,20 @@ static bool is_supported(const char *kind)
 
     MPL_free(save_tmp);
     return ret;
+}
+
+void init_gpu_kinds(void)
+{
+    if (MPIR_CVAR_ENABLE_GPU) {
+        MPL_gpu_type_t type;
+        MPL_gpu_query_support(&type);
+
+        if (type == MPL_GPU_TYPE_CUDA) {
+            memory_alloc_kinds[2] = cuda_kinds;
+        } else if (type == MPL_GPU_TYPE_HIP) {
+            memory_alloc_kinds[2] = rocm_kinds;
+        } else if (type == MPL_GPU_TYPE_ZE) {
+            memory_alloc_kinds[2] = ze_kinds;
+        }
+    }
 }

--- a/src/mpi/session/session_impl.c
+++ b/src/mpi/session/session_impl.c
@@ -34,10 +34,6 @@ int MPIR_Session_init_impl(MPIR_Info * info_ptr, MPIR_Errhandler * errhandler_pt
         MPIR_Session_get_strict_finalize_from_info(info_ptr, &strict_finalize);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* Get memory allocation kinds requested by the user (if any) */
-    mpi_errno = MPIR_Session_get_memory_kinds_from_info(info_ptr, &memory_alloc_kinds);
-    MPIR_ERR_CHECK(mpi_errno);
-
     /* Remark on MPI_THREAD_SINGLE: Multiple sessions may run in threads
      * concurrently, so significant work is needed to support per-session MPI_THREAD_SINGLE.
      * For now, it probably still works with MPI_THREAD_SINGLE since we use MPL_Initlock_lock
@@ -60,6 +56,10 @@ int MPIR_Session_init_impl(MPIR_Info * info_ptr, MPIR_Errhandler * errhandler_pt
     session_ptr->requested_thread_level = thread_level;
     session_ptr->strict_finalize = strict_finalize;
 
+    /* Get memory allocation kinds requested by the user (if any). This depends on CVAR
+     * infrastructure, so it must run after MPII_Init_thread. */
+    mpi_errno = MPIR_Session_get_memory_kinds_from_info(info_ptr, &memory_alloc_kinds);
+    MPIR_ERR_CHECK(mpi_errno);
     if (memory_alloc_kinds) {
         session_ptr->memory_alloc_kinds = memory_alloc_kinds;
     } else {

--- a/test/mpi/impls/mpich/cuda/Makefile.am
+++ b/test/mpi/impls/mpich/cuda/Makefile.am
@@ -10,4 +10,5 @@ LDADD += -lm
 noinst_PROGRAMS = \
     saxpy \
     stream \
-    stream_allred
+    stream_allred \
+    mem_alloc

--- a/test/mpi/impls/mpich/cuda/mem_alloc.cu
+++ b/test/mpi/impls/mpich/cuda/mem_alloc.cu
@@ -1,0 +1,161 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <mpi.h>
+#include <cuda_runtime.h>
+
+#define CUDA_CHECK(mpi_comm, call)                                  \
+    {                                                               \
+        const cudaError_t error = call;                             \
+        if (error != cudaSuccess)                                   \
+        {                                                           \
+            fprintf(stderr, "An error occurred: \"%s\" at %s:%d\n", \
+                    cudaGetErrorString(error), __FILE__, __LINE__); \
+            MPI_Abort(mpi_comm, error);                             \
+        }                                                           \
+    }
+
+int main(int argc, char *argv[])
+{
+    int cuda_device_aware = 0;
+    int cuda_managed_aware = 0;
+    int len = 0, flag = 0;
+    int *managed_buf = NULL;
+    int *device_buf = NULL, *system_buf = NULL;
+    int nranks = 0;
+    int rank;
+    MPI_Info info;
+    MPI_Session session;
+    MPI_Group wgroup;
+    MPI_Comm system_comm;
+    MPI_Comm cuda_managed_comm = MPI_COMM_NULL;
+    MPI_Comm cuda_device_comm = MPI_COMM_NULL;
+
+    // Usage mode: REQUESTED
+    MPI_Info_create(&info);
+    MPI_Info_set(info, "mpi_memory_alloc_kinds", "system,cuda:device,cuda:managed");
+    MPI_Session_init(info, MPI_ERRORS_ARE_FATAL, &session);
+    MPI_Info_free(&info);
+
+    // Usage mode: PROVIDED
+    MPI_Session_get_info(session, &info);
+    MPI_Info_get_string(info, "mpi_memory_alloc_kinds", &len, NULL, &flag);
+
+    if (flag) {
+        char *val, *valptr, *kind;
+
+        val = valptr = (char *) malloc(len);
+        if (NULL == val)
+            return 1;
+
+        MPI_Info_get_string(info, "mpi_memory_alloc_kinds", &len, val, &flag);
+
+        while ((kind = strsep(&val, ",")) != NULL) {
+            if (strcasecmp(kind, "cuda:managed") == 0) {
+                cuda_managed_aware = 1;
+            } else if (strcasecmp(kind, "cuda:device") == 0) {
+                cuda_device_aware = 1;
+            }
+        }
+        free(valptr);
+    }
+
+    MPI_Info_free(&info);
+
+    MPI_Group_from_session_pset(session, "mpi://WORLD", &wgroup);
+
+    // Create a communicator for operations on system memory
+    // Usage mode: ASSERTED
+    MPI_Info_create(&info);
+    MPI_Info_set(info, "mpi_assert_memory_alloc_kinds", "system");
+    MPI_Comm_create_from_group(wgroup,
+                               "org.mpi-forum.side-doc.mem-alloc-kind.cuda-example.system",
+                               info, MPI_ERRORS_ABORT, &system_comm);
+    MPI_Info_free(&info);
+
+    MPI_Comm_size(system_comm, &nranks);
+    MPI_Comm_rank(system_comm, &rank);
+
+    /*** Check for CUDA awareness ***/
+
+    // Note: MPI does not require homogeneous support
+    // across all processes for memory allocation kinds.
+    // This example chooses to use
+    // CUDA managed allocations (or device allocations)
+    // only when all processes report it is supported.
+
+    // Check if all processes have CUDA managed support
+    MPI_Allreduce(MPI_IN_PLACE, &cuda_managed_aware, 1, MPI_INT, MPI_LAND, system_comm);
+    assert(cuda_managed_aware);
+
+    // Create a communicator for operations that use
+    // CUDA managed buffers.
+    // Usage mode: ASSERTED
+    MPI_Info_create(&info);
+    MPI_Info_set(info, "mpi_assert_memory_alloc_kinds", "cuda:managed");
+    MPI_Comm_create_from_group(wgroup,
+                               "org.mpi-forum.side-doc.mem-alloc-kind.cuda-example.managed",
+                               info, MPI_ERRORS_ABORT, &cuda_managed_comm);
+    MPI_Info_free(&info);
+
+    // Check if all processes have CUDA device support
+    MPI_Allreduce(MPI_IN_PLACE, &cuda_device_aware, 1, MPI_INT, MPI_LAND, system_comm);
+    assert(cuda_device_aware);
+    // Create a communicator for operations that use
+    // CUDA device buffers.
+    // Usage mode: ASSERTED
+    MPI_Info_create(&info);
+    MPI_Info_set(info, "mpi_assert_memory_alloc_kinds", "cuda:device");
+    MPI_Comm_create_from_group(wgroup,
+                               "org.mpi-forum.side-doc.mem-alloc-kind.cuda-example.device",
+                               info, MPI_ERRORS_ABORT, &cuda_device_comm);
+    MPI_Info_free(&info);
+
+    MPI_Group_free(&wgroup);
+
+    /*** Execute using both types of memory ***/
+    // Allocate managed buffer and initialize it
+    CUDA_CHECK(system_comm,
+               cudaMallocManaged((void **) &managed_buf, sizeof(int), cudaMemAttachGlobal));
+    *managed_buf = 1;
+
+    // Perform communication using cuda_managed_comm
+    // if it's available.
+    MPI_Allreduce(MPI_IN_PLACE, managed_buf, 1, MPI_INT, MPI_SUM, cuda_managed_comm);
+    assert((*managed_buf) == nranks);
+
+    CUDA_CHECK(system_comm, cudaFree(managed_buf));
+
+    // Allocate system buffer and initialize it
+    // (using cudaMallocHost for better performance of cudaMemcpy)
+    CUDA_CHECK(system_comm, cudaMallocHost((void **) &system_buf, sizeof(int)));
+    *system_buf = 1;
+
+    // Allocate CUDA device buffer and initialize it
+    CUDA_CHECK(system_comm, cudaMalloc((void **) &device_buf, sizeof(int)));
+    CUDA_CHECK(system_comm,
+               cudaMemcpyAsync(device_buf, system_buf, sizeof(int), cudaMemcpyHostToDevice, 0));
+    CUDA_CHECK(system_comm, cudaStreamSynchronize(0));
+
+    // Perform communication using cuda_device_comm
+    // if it's available.
+    MPI_Allreduce(MPI_IN_PLACE, device_buf, 1, MPI_INT, MPI_SUM, cuda_device_comm);
+    CUDA_CHECK(system_comm,
+               cudaMemcpyAsync(system_buf, device_buf, sizeof(int), cudaMemcpyDeviceToHost, 0));
+    CUDA_CHECK(system_comm, cudaStreamSynchronize(0));
+    assert((*system_buf) == nranks);
+
+    if (cuda_managed_comm != MPI_COMM_NULL)
+        MPI_Comm_disconnect(&cuda_managed_comm);
+    if (cuda_device_comm != MPI_COMM_NULL)
+        MPI_Comm_disconnect(&cuda_device_comm);
+    MPI_Comm_disconnect(&system_comm);
+
+    MPI_Session_finalize(&session);
+    if (rank == 0) {
+        printf("No Errors\n");
+    }
+
+    return 0;
+}

--- a/test/mpi/impls/mpich/cuda/testlist
+++ b/test/mpi/impls/mpich/cuda/testlist
@@ -2,3 +2,4 @@ saxpy 2
 stream 2 env=MPIR_CVAR_CH4_RESERVE_VCIS=1
 stream 2 env=MPIR_CVAR_CH4_RESERVE_VCIS=1 env=MPIR_CVAR_CH4_ENABLE_STREAM_WORKQ=1 env=MPIR_CVAR_GPU_HAS_WAIT_KERNEL=1 arg=-progress-thread
 stream_allred 4 env=MPIR_CVAR_CH4_RESERVE_VCIS=1
+mem_alloc 4

--- a/test/mpi/impls/mpich/info/memory_alloc_kinds.c
+++ b/test/mpi/impls/mpich/info/memory_alloc_kinds.c
@@ -80,7 +80,8 @@ int main(int argc, char *argv[])
 
 static int check_value(const char *value, const char *expected)
 {
-    if (strcmp(value, expected)) {
+    /* MPICH may add GPU kinds after the mpi,system related kinds, which we ignore here */
+    if (strncmp(value, expected, strlen(expected))) {
         printf("mpi_memory_alloc_kinds value is \"%s\", expected \"%s\"\n", value, expected);
         return 1;
     }


### PR DESCRIPTION
## Pull Request Description

Implementation of device memory query functionality as specified in https://github.com/mpi-forum/mem-alloc. Users can check whether CUDA, HIP, or ZE memory types (with or without restrictors) are supported by MPICH at runtime. Memory allocation kind info assertions are not implemented in this PR.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
