### PR TITLE
errhan: remove error message level

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -361,15 +361,6 @@ AC_ARG_ENABLE(error-checking,
         all       - error checking always enabled (default)
 ],,enable_error_checking=runtime)
 
-AC_ARG_ENABLE(error-messages,
-[  --enable-error-messages=level - Control the amount of detail in error messages.
-        all       - Maximum amount of information
-        generic   - Only generic messages (no information about the specific
-                    instance)
-        class     - One message per MPI error class
-        none      - No messages
-],,enable_error_messages=all)
-
 AC_ARG_ENABLE(tag-error-bits,
 [  --enable-tag-error-bits=yes|no - Control whether bits are taken from the user tag for error handling.
         yes       - Two bits are taken from the user tag to support error propagation.
@@ -1014,26 +1005,6 @@ case "$enable_error_checking" in
 esac
 # permit @HAVE_ERROR_CHECKING@ substitution in mpir_ext.h
 AC_SUBST([HAVE_ERROR_CHECKING])
-
-# error-messages
-case "$enable_error_messages" in
-    no|none)
-        error_message_kind="MPICH_ERROR_MSG__NONE"
-    ;;
-    all|yes)
-	error_message_kind="MPICH_ERROR_MSG__ALL"
-    ;;
-    generic)
-	error_message_kind="MPICH_ERROR_MSG__GENERIC"
-    ;;
-    class)
-	error_message_kind="MPICH_ERROR_MSG__CLASS"
-    ;;
-    *)
-    AC_MSG_WARN([Unknown value $enable_error_messages for enable-error-messages])
-    ;;
-esac
-AC_DEFINE_UNQUOTED(MPICH_ERROR_MSG_LEVEL,$error_message_kind,[define to enable error messages])
 
 #error-tags
 if test "$enable_tag_error_bits" = "yes" ; then

--- a/maint/extracterrmsgs
+++ b/maint/extracterrmsgs
@@ -225,12 +225,12 @@ sub CreateErrmsgsHeader {
  * This file automatically created by extracterrmsgs\
  * DO NOT EDIT\
  */\n";
-    print $FD "#if MPICH_ERROR_MSG_LEVEL > MPICH_ERROR_MSG__CLASS
+    print $FD "
 typedef struct msgpair {
         const unsigned int sentinal1;
         const char *short_name, *long_name; 
         const unsigned int sentinal2; } msgpair;
-#endif\n"
+\n"
 }
 #
 # We also need a way to create the records
@@ -247,24 +247,11 @@ typedef struct msgpair {
 sub CreateErrMsgMapping {
     my $OUTFD = $_[0];
 
-    # For the case of classes only, output the strings for the class 
-    # messages
-    print $OUTFD "#if MPICH_ERROR_MSG_LEVEL == MPICH_ERROR_MSG__CLASS\n";
-    print $OUTFD "static const char *classToMsg[] = {\n";
-    for (my $i=0; $i<=$max_err_class; $i++) {
-	my $shortname = $class_msgs[$i];
-        my $msg       = $longnames{$shortname};
-        print $OUTFD "    \"$msg\", /* $i  $class_msgs[$i] */\n";
-    }
-    print $OUTFD "    NULL\n};\n";
-    print $OUTFD "#endif /* MSG_CLASS */\n";
-
     # Now, output each short,long key
     # Do the generic, followed by the specific, messages
     # The long messages must be available for the generic message output.
     # An alternative is to separate the short from the long messages;
     # the long messages are needed for > MSG_NONE, the short for > MSG_CLASS.
-    print $OUTFD "#if MPICH_ERROR_MSG_LEVEL > MPICH_ERROR_MSG__CLASS\n";
     print $OUTFD "/* The names are in sorted order, allowing the use of a simple\
   linear search or bisection algorithm to find the message corresponding to\
   a particular message */\n";
@@ -323,11 +310,9 @@ sub CreateErrMsgMapping {
 	print $OUTFD "\n";
     }
     print $OUTFD "};\n";
-    print $OUTFD "#endif\n\n";
 
     $num = 0;
     # Now output the instance specific messages
-    print $OUTFD "#if MPICH_ERROR_MSG_LEVEL > MPICH_ERROR_MSG__GENERIC\n";
     foreach my $key (sort keys %specific_msgs)
     {
 	my $longvalue = "\"\0\"";
@@ -361,9 +346,7 @@ sub CreateErrMsgMapping {
 	print $OUTFD "\n";
     }
     print $OUTFD "};\n";
-    print $OUTFD "#endif\n\n";
 
-    print $OUTFD "#if MPICH_ERROR_MSG_LEVEL > MPICH_ERROR_MSG__CLASS\n";
     my $maxval = $max_err_class + 1;
     print $OUTFD "static int class_to_index[] = {\n    ";
     for (my $i=0; $i<=$max_err_class; $i++) {
@@ -377,7 +360,6 @@ sub CreateErrMsgMapping {
 	print $OUTFD "\n    " if !(($i + 1) % 10);
     }
     print $OUTFD "\n};\n";
-    print $OUTFD "#endif\n";
 }
 #
 # Add a call to test this message for the error message.

--- a/src/mpi/attr/attrutil.c
+++ b/src/mpi/attr/attrutil.c
@@ -88,20 +88,8 @@ int MPIR_Call_attr_delete(int handle, MPIR_Attribute * attr_p)
     MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
     /* --BEGIN ERROR HANDLING-- */
     if (rc != 0) {
-#if MPICH_ERROR_MSG_LEVEL < MPICH_ERROR_MSG__ALL
-        /* If rc is a valid error class, then return that.
-         * Note that it may be a dynamic error class */
-        /* AMBIGUOUS: This is an ambiguity in the MPI standard: What is the
-         * error value returned from the user-provided routine?  Particularly
-         * with the MPI-2 feature of user-defined error codes, the
-         * user expectation is probably that the user-provided error code
-         * is returned. */
-        mpi_errno = rc;
-#else
-        mpi_errno =
-            MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                 MPI_ERR_OTHER, "**user", "**userdel %d", rc);
-#endif
+        mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
+                                         MPI_ERR_OTHER, "**user", "**userdel %d", rc);
         goto fn_fail;
     }
     /* --END ERROR HANDLING-- */
@@ -146,13 +134,8 @@ int MPIR_Call_attr_copy(int handle, MPIR_Attribute * attr_p, void **value_copy, 
 
     /* --BEGIN ERROR HANDLING-- */
     if (rc != 0) {
-#if MPICH_ERROR_MSG_LEVEL < MPICH_ERROR_MSG__ALL
-        mpi_errno = rc;
-#else
-        mpi_errno =
-            MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                 MPI_ERR_OTHER, "**user", "**usercopy %d", rc);
-#endif
+        mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
+                                         MPI_ERR_OTHER, "**user", "**userdel %d", rc);
         goto fn_fail;
     }
     /* --END ERROR HANDLING-- */


### PR DESCRIPTION
## Pull Request Description
Remove the configure option
--enable-error-messages={all,generic,class,none}. Support "all" by default.

Return from attribute callback function are supplied by user and potentially are meaningful to users. Direct return the code rather than creating new code.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
