### PR TITLE
attr: Code style, better comments, white space fixes

### DIFF
--- a/src/mpi/attr/attrutil.c
+++ b/src/mpi/attr/attrutil.c
@@ -226,8 +226,6 @@ int MPIR_Attr_delete_list(int handle, MPIR_Attribute ** attr)
         /* --END ERROR HANDLING-- */
         /* For this attribute, find the delete function for the
          * corresponding keyval */
-        /* Still to do: capture any error returns but continue to
-         * process attributes */
         mpi_errno = MPIR_Call_attr_delete(handle, p);
 
         /* We must also remove the keyval reference.  If the keyval


### PR DESCRIPTION
## Pull Request Description

* Normalize check-for-error code style.
* Add MPIR_FUNC_ENTER/EXIT to MPIR_ layer routines.
* Consolidate attribute implementations for comm/datatype/win.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
