### PR TITLE
ROMIO: Enable ROMIO to be built stand alone (try again)

### DIFF
--- a/confdb/aclocal_romio.m4
+++ b/confdb/aclocal_romio.m4
@@ -1,5 +1,5 @@
 dnl
-dnl This files contains additional macros for using autoconf to 
+dnl This files contains additional macros for using autoconf to
 dnl build configure scripts.
 dnl
 dnl Almost all of this file is taken from the aclocal.m4 of MPICH
@@ -19,21 +19,21 @@ AC_DEFUN([PAC_GET_FORTNAMES],[
 EOF
    $F77 $FFLAGS -c confftest.f > /dev/null 2>&1
    if test ! -s confftest.$OBJEXT ; then
-	AC_MSG_WARN([Unable to test Fortran compiler.  Compiling a test 
+	AC_MSG_WARN([Unable to test Fortran compiler.  Compiling a test
 program failed to produce an object file])
 	NOF77=1
    elif test -z "$FORTRANNAMES" ; then
      # MAC OS X (and probably FreeBSD need strings - (not strings -a)
      # Cray doesn't accept -a ...
      allstrings="-a"
-     if test $arch_CRAY ; then 
-	allstrings="" 
+     if test $arch_CRAY ; then
+	allstrings=""
      elif strings - confftest.$OBJEXT < /dev/null >/dev/null 2>&1 ; then
          allstrings="-"
      elif strings -a confftest.$OBJEXT < /dev/null >/dev/null 2>&1 ; then
          allstrings="-a"
      fi
-    
+
      nameform1=`strings $allstrings confftest.$OBJEXT | grep mpir_init_fop_  | head -1`
      nameform2=`strings $allstrings confftest.$OBJEXT | grep MPIR_INIT_FOP   | head -1`
      nameform3=`strings $allstrings confftest.$OBJEXT | grep mpir_init_fop   | head -1`
@@ -47,8 +47,8 @@ program failed to produce an object file])
         echo "Fortran externals have a trailing underscore and are lowercase"
 	FORTRANNAMES="FORTRANUNDERSCORE"
     elif test -n "$nameform2" ; then
-	echo "Fortran externals are uppercase"     
-	FORTRANNAMES="FORTRANCAPS" 
+	echo "Fortran externals are uppercase"
+	FORTRANNAMES="FORTRANCAPS"
     elif test -n "$nameform3" ; then
 	echo "Fortran externals are lower case"
 	FORTRANNAMES="FORTRANNOUNDERSCORE"
@@ -76,7 +76,7 @@ if test -n "$arch_IRIX"; then
    dnl  For example
    dnl  IRIX_5_4400 (IRIX 5.x, using MIPS 4400)
    osversion=`uname -r | sed 's/\..*//'`
-   dnl Note that we need to allow brackets here, so we briefly turn off 
+   dnl Note that we need to allow brackets here, so we briefly turn off
    dnl the macro quotes
    changequote(,)dnl
    dnl Get the second field (looking for 6.1)
@@ -111,7 +111,7 @@ if test -n "$arch_IRIX"; then
    fi
    AC_MSG_RESULT($cputype)
    dnl echo "checking for osversion and cputype"
-   dnl cputype may contain R4400, R2000A/R3000, or something else.  
+   dnl cputype may contain R4400, R2000A/R3000, or something else.
    dnl We may eventually need to look at it.
    if test -z "$osversion" ; then
         AC_MSG_RESULT([Could not determine OS version.  Please send])
@@ -123,9 +123,9 @@ if test -n "$arch_IRIX"; then
         true
    elif test $osversion = 6 ; then
         true
-   else 
+   else
        AC_MSG_RESULT([Could not recognize the version of IRIX (got $osversion).
-ROMIO knows about versions 4, 5 and 6; the version being returned from 
+ROMIO knows about versions 4, 5 and 6; the version being returned from
 uname -r is $osversion.  Please send])
        uname -a 2>&1
        hinv 2>&1
@@ -138,7 +138,7 @@ uname -r is $osversion.  Please send])
    changequote(,)dnl
    cputype=`echo $cputype | sed -e 's%.*/%%' -e 's/R//' | tr -d "[A-Z]"`
    changequote([,])dnl
-   case $cputype in 
+   case $cputype in
         3000) ;;
         4000) ;;
         4400) ;;
@@ -150,7 +150,7 @@ uname -r is $osversion.  Please send])
         *)
 	AC_MSG_WARN([Unexpected IRIX/MIPS chipset $cputype.  Please send the output])
         uname -a 2>&1
-        hinv 2>&1 
+        hinv 2>&1
         AC_MSG_WARN([to romio-maint@mcs.anl.gov
 ROMIO will continue and assume that the cputype is
 compatible with a MIPS 4400 processor.])
@@ -172,7 +172,7 @@ define(PAC_TEST_MPI,[
      main(int argc, char **argv)
      {
          MPI_Init(&argc,&argv);
-         MPI_Finalize(); 
+         MPI_Finalize();
      }
 EOF
   rm -f conftest$EXEEXT
@@ -225,10 +225,10 @@ define(PAC_MPI_LONG_LONG_INT,[
 #include "mpi.h"
      main(int argc, char **argv)
      {
-         long long i;   
+         long long i;
          MPI_Init(&argc,&argv);
          MPI_Send(&i, 1, MPI_LONG_LONG_INT, 0, 0, MPI_COMM_WORLD);
-         MPI_Finalize(); 
+         MPI_Finalize();
      }
 EOF
   rm -f conftest$EXEEXT
@@ -247,7 +247,7 @@ dnl
 define(PAC_LONG_LONG_64,[
 if test -n "$longlongsize" ; then
     if test "$longlongsize" = 8 ; then
-       echo "defining MPI_Offset as long long in C and integer*8 in Fortran" 
+       echo "defining MPI_Offset as long long in C and integer*8 in Fortran"
        AC_DEFINE(HAVE_LONG_LONG_64,,[Define if long long is 64 bits])
        DEFINE_MPI_OFFSET="typedef long long MPI_Offset;"
        FORTRAN_MPI_OFFSET="integer*8"
@@ -260,8 +260,8 @@ if test -n "$longlongsize" ; then
        LL="\%d"
        MPI_OFFSET_KIND1="!"
        MPI_OFFSET_KIND2="!"
-    else 
-       echo "defining MPI_Offset as long in C and integer in Fortran" 
+    else
+       echo "defining MPI_Offset as long in C and integer in Fortran"
        DEFINE_MPI_OFFSET="typedef long MPI_Offset;"
        FORTRAN_MPI_OFFSET="integer"
        LL="\%ld"
@@ -274,14 +274,14 @@ else
       if test "$longlongsize" = 8 ; then
          PAC_TEST_LONG_LONG()
       else
-         echo "defining MPI_Offset as long in C and integer in Fortran" 
+         echo "defining MPI_Offset as long in C and integer in Fortran"
          DEFINE_MPI_OFFSET="typedef long MPI_Offset;"
          FORTRAN_MPI_OFFSET="integer"
          LL="\%ld"
          MPI_OFFSET_KIND1="!"
          MPI_OFFSET_KIND2="!"
       fi
-   else 
+   else
 dnl   check if longlong is not supported or only its size cannot be determined
 dnl   because the program cannot be run.
       rm -f ltest.c
@@ -297,14 +297,14 @@ EOF
       if test -x conftest$EXEEXT ; then
          echo "assuming size of long long is 8bytes; use '-longlongsize' to indicate otherwise"
          rm -f conftest$EXEEXT ltest.c
-         echo "defining MPI_Offset as long long in C and integer*8 in Fortran" 
+         echo "defining MPI_Offset as long long in C and integer*8 in Fortran"
          AC_DEFINE(HAVE_LONG_LONG_64,,[Define if long long is 64 bits])
          DEFINE_MPI_OFFSET="typedef long long MPI_Offset;"
          FORTRAN_MPI_OFFSET="integer*8"
          LL="\%lld"
-      else 
+      else
          echo "assuming long long is not available; use '-longlongsize' to indicate otherwise"
-         echo "defining MPI_Offset as long in C and integer in Fortran" 
+         echo "defining MPI_Offset as long in C and integer in Fortran"
          DEFINE_MPI_OFFSET="typedef long MPI_Offset;"
          FORTRAN_MPI_OFFSET="integer"
          LL="\%ld"
@@ -326,7 +326,7 @@ define(PAC_MPI_INFO,[
          MPI_Info info;
          MPI_Init(&argc,&argv);
          MPI_Info_create(&info);
-         MPI_Finalize(); 
+         MPI_Finalize();
      }
 EOF
   rm -f conftest$EXEEXT
@@ -363,7 +363,7 @@ define(PAC_MPI_DARRAY_SUBARRAY,[
          MPI_Init(&argc,&argv);
          MPI_Type_create_darray(i, i, i, &i, &i, &i, &i, i, MPI_INT, &t);
          MPI_Type_create_subarray(i, &i, &i, &i, i, MPI_INT, &t);
-         MPI_Finalize(); 
+         MPI_Finalize();
      }
 EOF
   rm -f conftest$EXEEXT
@@ -480,7 +480,7 @@ define(PAC_TEST_MPI_SGI_type_is_contig,[
 
          MPI_Init(&argc,&argv);
          i = MPI_SGI_type_is_contig(type);
-         MPI_Finalize(); 
+         MPI_Finalize();
      }
 EOF
   rm -f conftest$EXEEXT
@@ -507,7 +507,7 @@ define(PAC_TEST_MPI_COMBINERS,[
 
          MPI_Init(&argc,&argv);
          i = MPI_COMBINER_STRUCT;
-         MPI_Finalize(); 
+         MPI_Finalize();
      }
 EOF
   rm -f conftest$EXEEXT
@@ -581,7 +581,7 @@ fi
 KINDVAL=""
 if $FC -o conftest$EXEEXT conftest.$ac_f90ext $FCFLAGS >/dev/null 2>&1 ; then
     ./conftest$EXEEXT >/dev/null 2>&1
-    if test -s conftest.out ; then 
+    if test -s conftest.out ; then
         KINDVAL=`cat conftest.out`
     fi
 fi
@@ -624,7 +624,7 @@ EOF
 dnl
 dnl
 dnl PAC_GET_XFS_MEMALIGN
-dnl 
+dnl
 dnl
 define(PAC_GET_XFS_MEMALIGN,
 [AC_MSG_CHECKING([for memory alignment needed for direct I/O])
@@ -634,7 +634,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <stdio.h>
-main() { 
+main() {
   struct dioattr st;
   int fd = open("/tmp/romio_tmp.bin", O_RDWR | O_CREAT, 0644);
   FILE *f=fopen("memalignval","w");
@@ -704,7 +704,7 @@ fi
 KINDVAL=""
 if $FC -o kind$EXEEXT kind.f $FCFLAGS >/dev/null 2>&1 ; then
     ./kind >/dev/null 2>&1
-    if test -s k.out ; then 
+    if test -s k.out ; then
         KINDVAL=`cat k.out`
     fi
 fi
@@ -773,7 +773,7 @@ define(PAC_TEST_MPIR_STATUS_SET_BYTES,[
 
          MPI_Init(&argc,&argv);
          MPIR_Status_set_bytes(status,type,err);
-         MPI_Finalize(); 
+         MPI_Finalize();
      }
 EOF
   rm -f conftest$EXEEXT

--- a/src/mpi/romio/Makefile.am
+++ b/src/mpi/romio/Makefile.am
@@ -3,6 +3,24 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
+if ROMIO_INSIDE_OMPI
+AM_CPPFLAGS = \
+        -I@main_top_srcdir@ \
+        -I@main_top_srcdir@/opal/include \
+        -I@main_top_builddir@/opal/include \
+        -I@main_top_builddir@/ompi/include \
+        -I$(top_srcdir)/include \
+        -I$(top_srcdir)/adio/include
+else
+if ROMIO_INSIDE_MPICH
+# when building under MPICH we must be able to find mpi.h
+AM_CPPFLAGS = -I@main_top_builddir@/src/include -I@main_top_srcdir@/src/include
+else
+AM_CPPFLAGS =
+endif
+endif
+
+
 ## TODO: need to write an automakefile that handles two primary cases:
 ## 1) that ROMIO is being embedded within the MPI library, as in MPICH or Open
 ##    MPI
@@ -17,7 +35,6 @@ include_HEADERS =
 nodist_include_HEADERS =
 noinst_HEADERS = 
 AM_CFLAGS = @VISIBILITY_CFLAGS@
-AM_CPPFLAGS =
 EXTRA_DIST =
 SUFFIXES = 
 doc1_src_txt =
@@ -45,14 +62,12 @@ romio_other_sources =
 glue_sources = 
 
 # ------------------------------------------------------------------------
-# when building under MPICH we must be able to find mpi.h
-AM_CPPFLAGS += $(MPI_H_INCLUDE)
-
-# ------------------------------------------------------------------------
 # handle the "include" directory here
 AM_CPPFLAGS += -I$(top_builddir)/include -I$(top_srcdir)/include $(external_includes)
+AM_CPPFLAGS += -I$(top_srcdir)/adio/include
 # nodist_ b/c these are created by config.status and should not be distributed
-nodist_include_HEADERS += include/mpio.h include/mpiof.h
+nodist_include_HEADERS += include/mpio.h
+noinst_HEADERS += include/ompi_grequestx.h include/io_romio_conv.h
 
 # ------------------------------------------------------------------------
 
@@ -69,8 +84,13 @@ EXTRA_DIST += autogen.sh
 if BUILD_ROMIO_EMBEDDED
 # Build a libtool convenience library that the enclosing MPI implementation can
 # use by adding it to the right _LIBADD variable.
+if ROMIO_INSIDE_OMPI
+noinst_LTLIBRARIES = libromio_dist.la
+libromio_dist_la_SOURCES = $(romio_mpi_sources) $(romio_other_sources) $(glue_sources)
+else
 noinst_LTLIBRARIES = libromio.la
 libromio_la_SOURCES = $(romio_mpi_sources) $(romio_other_sources) $(glue_sources)
+endif
 
 ## NOTE: ROMIO's old build system builds a bunch of _foo.o objects that contain
 ## PMPI_ implementations as well as calls to only other PMPI routines.  In
@@ -83,17 +103,25 @@ libromio_la_SOURCES = $(romio_mpi_sources) $(romio_other_sources) $(glue_sources
 ## Annoying, right?
 if BUILD_PROFILING_LIB
 # The current best strategy for now is to build the PMPI symbols as a separate
-# convenience lib to permit adding the special "-D..." argument for all objects.
-# MPICH will then link in both convenience library into libmpi, since it
-# won't work very well the other way around.
+# convenience lib, libpromio.la, to permit adding the special "-D..." argument
+# for all objects. MPICH will then link in both convenience libraries,
+# libromio.la and libpromio.la, into libmpi, since it won't work very well the
+# other way around.
+# $(romio_mpi_sources) are the ones needed to be built twice. Once in
+# libromio.la without -DMPIO_BUILD_PROFILING and the other in libpromio.la.
 noinst_LTLIBRARIES += libpromio.la
 libpromio_la_SOURCES = $(romio_mpi_sources)
-libpromio_la_CPPFLAGS = $(AM_CPPFLAGS) -DMPIO_BUILD_PROFILING 
+libpromio_la_CPPFLAGS = $(AM_CPPFLAGS) -DMPIO_BUILD_PROFILING
 libpromio_la_LDFLAGS = $(external_ldflags)
 libpromio_la_LIBADD = $(external_libs)
 else !BUILD_PROFILING_LIB
+if ROMIO_INSIDE_OMPI
+libromio_dist_la_LDFLAGS = $(external_ldflags)
+libromio_dist_la_LIBADD = $(external_libs)
+else !ROMIO_INSIDE_OMPI
 libromio_la_LDFLAGS = $(external_ldflags)
 libromio_la_LIBADD = $(external_libs)
+endif !ROMIO_INSIDE_OMPI
 endif !BUILD_PROFILING_LIB
 
 if BUILD_ABI_LIB
@@ -115,12 +143,18 @@ endif BUILD_ABI_LIB
 # ---------------------------
 else !BUILD_ROMIO_EMBEDDED
 lib_LTLIBRARIES = libromio.la
-libromio_la_SOURCES = $(romio_mpi_sources) $(romio_other_sources) $(glue_sources)
+libromio_la_SOURCES = $(romio_other_sources) $(glue_sources)
 if BUILD_PROFILING_LIB
+# $(romio_mpi_sources) are the ones needed to be built twice.
+noinst_LTLIBRARIES = libpromio.la
 libpromio_la_SOURCES = $(romio_mpi_sources)
 libpromio_la_CPPFLAGS = $(AM_CPPFLAGS) -DMPIO_BUILD_PROFILING
-endif BUILD_PROFILING_LIB
-
+libpromio_la_LDFLAGS = $(external_ldflags)
+libpromio_la_LIBADD = $(external_libs)
+libromio_la_LIBADD = libpromio.la
+else !BUILD_PROFILING_LIB
+libromio_la_SOURCES += $(romio_mpi_sources)
+endif !BUILD_PROFILING_LIB
 endif
 
 # --------------------------------------------------------------------------

--- a/src/mpi/romio/adio/Makefile.mk
+++ b/src/mpi/romio/adio/Makefile.mk
@@ -20,7 +20,8 @@ noinst_HEADERS +=                      \
     adio/include/mpiu_greq.h           \
     adio/include/nopackage.h           \
     adio/include/mpiu_external32.h     \
-    adio/include/hint_fns.h
+    adio/include/hint_fns.h            \
+    adio/include/ad_tuning.h
 
 include $(top_srcdir)/adio/ad_daos/Makefile.mk
 include $(top_srcdir)/adio/ad_gpfs/Makefile.mk

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_hints.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_hints.c
@@ -83,7 +83,7 @@ void ADIOI_GPFS_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
      */
     if (!fd->hints->initialized) {
 
-        ad_get_env_vars();
+        ad_get_env_vars(fd);
         ad_gpfs_get_env_vars();
         did_anything = 1;
 

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -171,14 +171,14 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
          * because the difference in starting and ending offsets for 1 byte is
          * 0 the same as 0 bytes so it cannot be distinguished.
          */
-        if ((romio_read_aggmethod == 1) || (romio_read_aggmethod == 2)) {
+        if ((fd->romio_read_aggmethod == 1) || (fd->romio_read_aggmethod == 2)) {
             count_sizes = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
             MPI_Count buftype_size;
             MPI_Type_size_x(datatype, &buftype_size);
             my_count_size = (ADIO_Offset) count *(ADIO_Offset) buftype_size;
         }
-        if (romio_tunegather) {
-            if ((romio_read_aggmethod == 1) || (romio_read_aggmethod == 2)) {
+        if (fd->romio_tunegather) {
+            if ((fd->romio_read_aggmethod == 1) || (fd->romio_read_aggmethod == 2)) {
                 gpfs_offsets0 = (ADIO_Offset *) ADIOI_Malloc(6 * nprocs * sizeof(ADIO_Offset));
                 gpfs_offsets = gpfs_offsets0 + 3 * nprocs;
                 for (ii = 0; ii < nprocs; ii++) {
@@ -218,7 +218,7 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
         } else {
             MPI_Allgather(&start_offset, 1, ADIO_OFFSET, st_offsets, 1, ADIO_OFFSET, fd->comm);
             MPI_Allgather(&end_offset, 1, ADIO_OFFSET, end_offsets, 1, ADIO_OFFSET, fd->comm);
-            if ((romio_read_aggmethod == 1) || (romio_read_aggmethod == 2)) {
+            if ((fd->romio_read_aggmethod == 1) || (fd->romio_read_aggmethod == 2)) {
                 MPI_Allgather(&count_sizes, 1, ADIO_OFFSET, count_sizes, 1, ADIO_OFFSET, fd->comm);
             }
         }
@@ -278,7 +278,7 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
      *
      */
     int currentNonZeroDataIndex = 0;
-    if ((romio_read_aggmethod == 1) || (romio_read_aggmethod == 2)) {
+    if ((fd->romio_read_aggmethod == 1) || (fd->romio_read_aggmethod == 2)) {
         /* Take out the 0-data offsets by shifting the indexes with data to the
          * front and keeping track of the non-zero data index for use as the
          * length.  By doing this we will optimally use all available aggs
@@ -295,7 +295,7 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
         }
     }
     if (gpfsmpio_tuneblocking) {
-        if ((romio_read_aggmethod == 1) || (romio_read_aggmethod == 2)) {
+        if ((fd->romio_read_aggmethod == 1) || (fd->romio_read_aggmethod == 2)) {
             ADIOI_GPFS_Calc_file_domains(fd, st_offsets, end_offsets, currentNonZeroDataIndex,
                                          nprocs_for_coll, &min_st_offset,
                                          &fd_start, &fd_end, &fd_size, fd->fs_ptr);
@@ -305,7 +305,7 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
                                          &fd_start, &fd_end, &fd_size, fd->fs_ptr);
         }
     } else {
-        if ((romio_read_aggmethod == 1) || (romio_read_aggmethod == 2)) {
+        if ((fd->romio_read_aggmethod == 1) || (fd->romio_read_aggmethod == 2)) {
             ADIOI_Calc_file_domains(st_offsets, end_offsets, currentNonZeroDataIndex,
                                     nprocs_for_coll, &min_st_offset,
                                     &fd_start, &fd_end,
@@ -321,7 +321,7 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
     }
 
     GPFSMPIO_T_CIO_SET_GET(r, 1, 1, GPFSMPIO_CIO_T_MYREQ, GPFSMPIO_CIO_T_FD_PART);
-    if ((romio_read_aggmethod == 1) || (romio_read_aggmethod == 2)) {
+    if ((fd->romio_read_aggmethod == 1) || (fd->romio_read_aggmethod == 2)) {
         /* If the user has specified to use a one-sided aggregation method then
          * do that at this point instead of the two-phase I/O.
          */

--- a/src/mpi/romio/adio/common/ad_close.c
+++ b/src/mpi/romio/adio/common/ad_close.c
@@ -55,7 +55,7 @@ void ADIO_Close(ADIO_File fd, int *error_code)
     }
 
     if (fd->fortran_handle != -1) {
-        ADIOI_Ftable[fd->fortran_handle] = MPI_FILE_NULL;
+        ADIOI_Ftable[fd->fortran_handle] = ADIO_FILE_NULL;
     }
 
     if (fd->hints)

--- a/src/mpi/romio/adio/common/ad_darray.c
+++ b/src/mpi/romio/adio/common/ad_darray.c
@@ -6,17 +6,17 @@
 #include "adio.h"
 #include "adio_extern.h"
 
-static int MPIOI_Type_block(int *array_of_gsizes, int dim, int ndims, int nprocs,
+static int MPIOI_Type_block(const int *array_of_gsizes, int dim, int ndims, int nprocs,
                             int rank, int darg, int order, MPI_Aint orig_extent,
                             MPI_Datatype type_old, MPI_Datatype * type_new, MPI_Aint * st_offset);
-static int MPIOI_Type_cyclic(int *array_of_gsizes, int dim, int ndims, int nprocs,
+static int MPIOI_Type_cyclic(const int *array_of_gsizes, int dim, int ndims, int nprocs,
                              int rank, int darg, int order, MPI_Aint orig_extent,
                              MPI_Datatype type_old, MPI_Datatype * type_new, MPI_Aint * st_offset);
 
 
 int ADIO_Type_create_darray(int size, int rank, int ndims,
-                            int *array_of_gsizes, int *array_of_distribs,
-                            int *array_of_dargs, int *array_of_psizes,
+                            const int *array_of_gsizes, const int *array_of_distribs,
+                            const int *array_of_dargs, const int *array_of_psizes,
                             int order, MPI_Datatype oldtype, MPI_Datatype * newtype)
 {
     MPI_Datatype type_old, type_new = MPI_DATATYPE_NULL, types[1];
@@ -139,7 +139,7 @@ int ADIO_Type_create_darray(int size, int rank, int ndims,
 /* Returns MPI_SUCCESS on success, an MPI error code on failure.  Code above
  * needs to call MPIO_Err_return_xxx.
  */
-static int MPIOI_Type_block(int *array_of_gsizes, int dim, int ndims, int nprocs,
+static int MPIOI_Type_block(const int *array_of_gsizes, int dim, int ndims, int nprocs,
                             int rank, int darg, int order, MPI_Aint orig_extent,
                             MPI_Datatype type_old, MPI_Datatype * type_new, MPI_Aint * st_offset)
 {
@@ -210,7 +210,7 @@ static int MPIOI_Type_block(int *array_of_gsizes, int dim, int ndims, int nprocs
 /* Returns MPI_SUCCESS on success, an MPI error code on failure.  Code above
  * needs to call MPIO_Err_return_xxx.
  */
-static int MPIOI_Type_cyclic(int *array_of_gsizes, int dim, int ndims, int nprocs,
+static int MPIOI_Type_cyclic(const int *array_of_gsizes, int dim, int ndims, int nprocs,
                              int rank, int darg, int order, MPI_Aint orig_extent,
                              MPI_Datatype type_old, MPI_Datatype * type_new, MPI_Aint * st_offset)
 {

--- a/src/mpi/romio/adio/common/ad_hints.c
+++ b/src/mpi/romio/adio/common/ad_hints.c
@@ -30,7 +30,7 @@ void ADIOI_GEN_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
         *error_code = MPI_SUCCESS;
         return;
     }
-    ad_get_env_vars();
+    ad_get_env_vars(fd);
 
     /* Interpreting MPI-4.0 to mean ROMIO should only return hints it knows
      * about when user calls MPI_File_get_info */

--- a/src/mpi/romio/adio/common/ad_iread.c
+++ b/src/mpi/romio/adio/common/ad_iread.c
@@ -24,6 +24,19 @@
 #include "mpiu_greq.h"
 
 #ifdef ROMIO_HAVE_WORKING_AIO
+
+#if !defined(MPI_IMPL_IS_MPICH) && !defined(HAVE_MPIX_GREQUEST_CLASS)
+void ADIOI_GEN_IreadContig(ADIO_File fd, void *buf, int count,
+                           MPI_Datatype datatype, int file_ptr_type,
+                           ADIO_Offset offset, MPI_Request * request, int *error_code)
+{
+    static char myname[] = "ADIOI_GEN_IREADCONTIG";
+    *error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                       myname, __LINE__,
+                                       MPI_ERR_UNSUPPORTED_OPERATION, "**fileopunsupported", 0);
+}
+#else
+
 /* ADIOI_GEN_IreadContig
  *
  * This code handles two distinct cases.  If ROMIO_HAVE_WORKING_AIO is not
@@ -61,6 +74,7 @@ void ADIOI_GEN_IreadContig(ADIO_File fd, void *buf, MPI_Aint count,
 
     *error_code = MPI_SUCCESS;
 }
+#endif
 #endif
 
 /* Generic implementation of IreadStrided calls the blocking ReadStrided

--- a/src/mpi/romio/adio/common/ad_iread_coll.c
+++ b/src/mpi/romio/adio/common/ad_iread_coll.c
@@ -8,6 +8,19 @@
 #include "mpiu_greq.h"
 #include "mpioimpl.h"
 
+#if !defined(MPI_IMPL_IS_MPICH) && !defined(HAVE_MPIX_GREQUEST_CLASS) && !defined(HAVE_MPI_GREQUEST_EXTENSIONS)
+void ADIOI_GEN_IreadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
+                                MPI_Datatype datatype, int file_ptr_type,
+                                ADIO_Offset offset, MPI_Request * request, int *error_code)
+{
+    static char myname[] = "ADIOI_GEN_IreadStridedColl";
+
+    *error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                       myname, __LINE__,
+                                       MPI_ERR_UNSUPPORTED_OPERATION, "**fileopunsupported", 0);
+}
+#else
+
 #ifdef MPL_USE_DBG_LOGGING
 #define RDCOLL_DEBUG 1
 #endif
@@ -1290,3 +1303,4 @@ static int ADIOI_GEN_irc_wait_fn(int count, void **array_of_states,
   fn_exit:
     return errcode;
 }
+#endif

--- a/src/mpi/romio/adio/common/ad_iwrite.c
+++ b/src/mpi/romio/adio/common/ad_iwrite.c
@@ -35,6 +35,24 @@
 
 #ifdef ROMIO_HAVE_WORKING_AIO
 
+#if !defined(MPI_IMPL_IS_MPICH) && !defined(HAVE_MPIX_GREQUEST_CLASS) && !defined(HAVE_MPI_GREQUEST_EXTENSIONS)
+void ADIOI_GEN_IwriteContig(ADIO_File fd, const void *buf, int count,
+                            MPI_Datatype datatype, int file_ptr_type,
+                            ADIO_Offset offset, ADIO_Request * request, int *error_code)
+{
+    static char myname[] = "ADIOI_GEN_IWRITECONTIG";
+    *error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                       myname, __LINE__,
+                                       MPI_ERR_UNSUPPORTED_OPERATION, "**fileopunsupported", 0);
+}
+
+int ADIOI_GEN_aio(ADIO_File fd, void *buf, int count, MPI_Datatype type,
+                  ADIO_Offset offset, int wr, MPI_Request * request)
+{
+    return -1;
+}
+#else
+
 static MPIX_Grequest_class ADIOI_GEN_greq_class = 0;
 
 /* ADIOI_GEN_IwriteContig
@@ -189,6 +207,7 @@ int ADIOI_GEN_aio(ADIO_File fd, void *buf, MPI_Aint count, MPI_Datatype type,
     memcpy(&(aio_req->req), request, sizeof(MPI_Request));
     return 0;
 }
+#endif
 #endif
 
 

--- a/src/mpi/romio/adio/common/ad_iwrite_coll.c
+++ b/src/mpi/romio/adio/common/ad_iwrite_coll.c
@@ -12,6 +12,23 @@
 #include "mpe.h"
 #endif
 
+#if !defined(MPI_IMPL_IS_MPICH) && !defined(HAVE_MPIX_GREQUEST_CLASS) && !defined(HAVE_MPI_GREQUEST_EXTENSIONS)
+void ADIOI_GEN_IwriteStridedColl(ADIO_File fd, const void *buf, MPI_Aint count,
+                                 MPI_Datatype datatype, int file_ptr_type,
+                                 ADIO_Offset offset, MPI_Request * request, int *error_code)
+{
+    static char myname[] = "ADIOI_GEN_IwriteStridedColl";
+
+    *error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                       myname, __LINE__,
+                                       MPI_ERR_UNSUPPORTED_OPERATION, "**fileopunsupported", 0);
+}
+#else
+
+#ifdef MPIO_BUILD_PROFILING
+#include "../../mpi-io/mpioprof.h"
+#endif
+
 /* ADIOI_GEN_IwriteStridedColl */
 struct ADIOI_GEN_IwriteStridedColl_vars {
     /* requests */
@@ -1494,3 +1511,4 @@ static int ADIOI_GEN_iwc_wait_fn(int count, void **array_of_states,
   fn_exit:
     return errcode;
 }
+#endif

--- a/src/mpi/romio/adio/common/ad_open.c
+++ b/src/mpi/romio/adio/common/ad_open.c
@@ -15,11 +15,11 @@ static int build_cb_config_list(ADIO_File fd,
                                 MPI_Comm orig_comm, MPI_Comm comm,
                                 int rank, int procs, int *error_code);
 
-MPI_File ADIO_Open(MPI_Comm orig_comm,
-                   MPI_Comm comm, const char *filename, int file_system,
-                   ADIOI_Fns * ops,
-                   int access_mode, ADIO_Offset disp, MPI_Datatype etype,
-                   MPI_Datatype filetype, MPI_Info info, int perm, int *error_code)
+ADIO_File ADIO_Open(MPI_Comm orig_comm,
+                    MPI_Comm comm, const char *filename, int file_system,
+                    ADIOI_Fns * ops,
+                    int access_mode, ADIO_Offset disp, MPI_Datatype etype,
+                    MPI_Datatype filetype, MPI_Info info, int perm, int *error_code)
 {
     MPI_File mpi_fh;
     ADIO_File fd;
@@ -35,12 +35,11 @@ MPI_File ADIO_Open(MPI_Comm orig_comm,
     /* obtain MPI_File handle */
     mpi_fh = MPIO_File_create(sizeof(struct ADIOI_FileD));
     if (mpi_fh == MPI_FILE_NULL) {
-        fd = MPI_FILE_NULL;
+        fd = ADIO_FILE_NULL;
         *error_code = MPIO_Err_create_code(*error_code,
                                            MPIR_ERR_RECOVERABLE,
                                            myname, __LINE__, MPI_ERR_OTHER, "**nomem2", 0);
         goto fn_exit;
-
     }
     fd = MPIO_File_resolve(mpi_fh);
 

--- a/src/mpi/romio/adio/common/ad_opencoll.c
+++ b/src/mpi/romio/adio/common/ad_opencoll.c
@@ -19,15 +19,6 @@
  * on MPI-IO scalability").
  */
 
-enum {
-    BLOCKSIZE = 0,
-    STRIPE_SIZE,
-    STRIPE_FACTOR,
-    START_IODEVICE,
-    STAT_ITEMS
-} file_stats;
-
-
 /* generate an MPI datatype describing the members of the ADIO_File struct that
  * we want to ensure all processes have.  In deferred open, aggregators will
  * open the file and possibly read layout and other information.
@@ -36,6 +27,14 @@ enum {
 
 static MPI_Datatype make_stats_type(ADIO_File fd)
 {
+    enum file_stats {
+        BLOCKSIZE = 0,
+        STRIPE_SIZE,
+        STRIPE_FACTOR,
+        START_IODEVICE,
+        STAT_ITEMS
+    };
+
     int lens[STAT_ITEMS];
     MPI_Aint offsets[STAT_ITEMS];
     MPI_Datatype types[STAT_ITEMS];

--- a/src/mpi/romio/adio/common/ad_read_coll.c
+++ b/src/mpi/romio/adio/common/ad_read_coll.c
@@ -614,8 +614,8 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
          * minus what was satisfied in previous iteration
          * req_size = size corresponding to req_off */
 
+        int flag = 0;
         size = MPL_MIN(coll_bufsize, end_loc - st_loc + 1 - done);
-        bool flag = false;
         for (i = 0; i < nprocs; i++) {
             if (others_req[i].count) {
                 for (j = curr_offlen_ptr[i]; j < others_req[i].count; j++) {
@@ -626,7 +626,7 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
                         req_off = others_req[i].offsets[j];
                     }
                     if (req_off < off + size) {
-                        flag = true;
+                        flag = 1;
                     }
                 }
             }

--- a/src/mpi/romio/adio/common/ad_subarray.c
+++ b/src/mpi/romio/adio/common/ad_subarray.c
@@ -7,9 +7,9 @@
 #include "adio_extern.h"
 
 int ADIO_Type_create_subarray(int ndims,
-                              int *array_of_sizes,
-                              int *array_of_subsizes,
-                              int *array_of_starts,
+                              const int *array_of_sizes,
+                              const int *array_of_subsizes,
+                              const int *array_of_starts,
                               int order, MPI_Datatype oldtype, MPI_Datatype * newtype)
 {
     MPI_Aint lb, ub, extent, disps[1], size;

--- a/src/mpi/romio/adio/common/ad_tuning.c
+++ b/src/mpi/romio/adio/common/ad_tuning.c
@@ -17,13 +17,6 @@
 
 #include "ad_tuning.h"
 
-int romio_write_aggmethod;
-int romio_read_aggmethod;
-int romio_onesided_no_rmw;
-int romio_onesided_always_rmw;
-int romio_onesided_inform_rmw;
-int romio_tunegather;
-
 /* set internal variables for tuning environment variables */
 /** \page mpiio_vars MPIIO Configuration
   \section env_sec Environment Variables
@@ -76,39 +69,39 @@ int romio_tunegather;
  *
  */
 
-void ad_get_env_vars(void)
+void ad_get_env_vars(ADIO_File fd)
 {
     char *x;
 
-    romio_write_aggmethod = 0;
+    fd->romio_write_aggmethod = 0;
     x = getenv("ROMIO_WRITE_AGGMETHOD");
     if (x)
-        romio_write_aggmethod = atoi(x);
+        fd->romio_write_aggmethod = atoi(x);
 
-    romio_read_aggmethod = 0;
+    fd->romio_read_aggmethod = 0;
     x = getenv("ROMIO_READ_AGGMETHOD");
     if (x)
-        romio_read_aggmethod = atoi(x);
+        fd->romio_read_aggmethod = atoi(x);
 
-    romio_onesided_no_rmw = 0;
+    fd->romio_onesided_no_rmw = 0;
     x = getenv("ROMIO_ONESIDED_NO_RMW");
     if (x)
-        romio_onesided_no_rmw = atoi(x);
+        fd->romio_onesided_no_rmw = atoi(x);
 
-    romio_onesided_always_rmw = 0;
+    fd->romio_onesided_always_rmw = 0;
     x = getenv("ROMIO_ONESIDED_ALWAYS_RMW");
     if (x)
-        romio_onesided_always_rmw = atoi(x);
-    if (romio_onesided_always_rmw)
-        romio_onesided_no_rmw = 1;
+        fd->romio_onesided_always_rmw = atoi(x);
+    if (fd->romio_onesided_always_rmw)
+        fd->romio_onesided_no_rmw = 1;
 
-    romio_onesided_inform_rmw = 0;
+    fd->romio_onesided_inform_rmw = 0;
     x = getenv("ROMIO_ONESIDED_INFORM_RMW");
     if (x)
-        romio_onesided_inform_rmw = atoi(x);
+        fd->romio_onesided_inform_rmw = atoi(x);
 
-    romio_tunegather = 1;
+    fd->romio_tunegather = 1;
     x = getenv("ROMIO_TUNEGATHER");
     if (x)
-        romio_tunegather = atoi(x);
+        fd->romio_tunegather = atoi(x);
 }

--- a/src/mpi/romio/adio/common/cb_config_list.c
+++ b/src/mpi/romio/adio/common/cb_config_list.c
@@ -31,7 +31,6 @@
 
 #undef CB_CONFIG_LIST_DEBUG
 
-/* a couple of globals keep things simple */
 int ADIOI_cb_config_list_keyval = MPI_KEYVAL_INVALID;
 
 /* internal stuff */
@@ -260,8 +259,7 @@ int ADIOI_cb_config_list_parse(char *config_list,
     int token, max_procs, cur_rank = 0, nr_procnames;
     char *cur_procname, *cur_procname_p, **procnames;
     char *used_procnames;
-    char *yylval;
-    char *token_ptr;
+    char *yylval, *token_ptr;
 
     nr_procnames = array->namect;
     procnames = array->names;
@@ -696,18 +694,18 @@ static int cb_config_list_lex(char *yylval, char **token_ptr)
     slen = (int) strcspn(token, DELIMS);
 
     if (*token == COLON) {
-        *token_ptr = token + 1;
+        (*token_ptr)++;
         return AGG_COLON;
     }
     if (*token == COMMA) {
-        *token_ptr = token + 1;
+        (*token_ptr)++;
         return AGG_COMMA;
     }
 
     if (*token == '*') {
         /* make sure that we don't have characters after the '*' */
         if (slen == 1) {
-            *token_ptr = token + 1;
+            (*token_ptr)++;
             return AGG_WILDCARD;
         } else
             return AGG_ERROR;
@@ -722,6 +720,6 @@ static int cb_config_list_lex(char *yylval, char **token_ptr)
      */
     ADIOI_Strncpy(yylval, token, slen);
     yylval[slen] = '\0';
-    *token_ptr = token + slen;
+    (*token_ptr) += slen;
     return AGG_STRING;
 }

--- a/src/mpi/romio/adio/common/flatten.c
+++ b/src/mpi/romio/adio/common/flatten.c
@@ -182,6 +182,9 @@ static void flatlist_node_grow(ADIOI_Flatlist_node * flat, int idx)
     }
 }
 
+static MPI_Count ADIOI_Count_contiguous_blocks(MPI_Datatype datatype, MPI_Count * curr_index);
+static void ADIOI_Flatten(MPI_Datatype datatype, ADIOI_Flatlist_node * flat,
+                          ADIO_Offset st_offset, MPI_Count * curr_index);
 static void ADIOI_Optimize_flattened(ADIOI_Flatlist_node * flat_type);
 /* flatten datatype and add it to Flatlist */
 static ADIOI_Flatlist_node *ADIOI_Flatten_datatype(MPI_Datatype datatype)

--- a/src/mpi/romio/adio/common/greq_fns.c
+++ b/src/mpi/romio/adio/common/greq_fns.c
@@ -9,7 +9,7 @@
 /* In cases where nonblocking operation will carry out blocking version,
  * instantiate and complete a generalized request  */
 
-void MPIO_Completed_request_create(MPI_File * fh, MPI_Offset bytes,
+void MPIO_Completed_request_create(ADIO_File * fh, MPI_Offset bytes,
                                    int *error_code, MPI_Request * request)
 {
     MPI_Status *status;

--- a/src/mpi/romio/adio/common/iscontig.c
+++ b/src/mpi/romio/adio/common/iscontig.c
@@ -5,7 +5,10 @@
 
 #include "adio.h"
 
-#if defined(MPICH)
+#if defined(ROMIO_INSIDE_MPICH) || defined(HAVE_MPIR_EXT_DATATYPE_ISCONTIG)
+
+/* MPICH also provides this routine */
+int MPIR_Ext_datatype_iscontig(MPI_Datatype datatype, int *flag);
 
 void ADIOI_Datatype_iscontig(MPI_Datatype datatype, int *flag)
 {
@@ -49,7 +52,7 @@ void ADIOI_Datatype_iscontig(MPI_Datatype datatype, int *flag)
     *flag = MPI_SGI_type_is_contig(datatype) && (displacement == 0);
 }
 
-#elif defined(OMPI_BUILDING) && OMPI_BUILDING
+#elif defined(ROMIO_INSIDE_OMPI)
 
 /* void ADIOI_Datatype_iscontig(MPI_Datatype datatype, int *flag) is defined
  * and implemented in OpenMPI itself */
@@ -97,6 +100,7 @@ void ADIOI_Datatype_iscontig(MPI_Datatype datatype, int *flag)
                 ADIOI_Type_dispose(types);
                 ADIOI_Free(ints);
                 ADIOI_Free(adds);
+                ADIOI_Free(cnts);
                 ADIOI_Free(types);
             }
             break;

--- a/src/mpi/romio/adio/common/onesided_aggregation.c
+++ b/src/mpi/romio/adio/common/onesided_aggregation.c
@@ -15,6 +15,16 @@
 
 //  #define onesidedtrace 1
 
+/* This data structure holds the number of extents, the index into the flattened buffer and the remnant length
+ * beyond the flattened buffer index corresponding to the base buffer offset for non-contiguous source data
+ * for the range to be written corresponding to the round and target agg.
+ */
+typedef struct NonContigSourceBufOffset {
+    int dataTypeExtent;
+    int flatBufIndice;
+    ADIO_Offset indiceOffset;
+} NonContigSourceBufOffset;
+
 /* This data structure holds the access state of the source buffer for target
  * file domains within aggregators corresponding to the target data blocks.  It
  * is designed to be initialized with a starting point for a given file domain
@@ -890,7 +900,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
     char *write_buf = write_buf0;
     MPI_Win write_buf_window = fd->io_buf_window;
 
-    if (!romio_onesided_no_rmw) {
+    if (!fd->romio_onesided_no_rmw) {
         *hole_found = 0;
     }
 
@@ -981,7 +991,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
         }       // if ((stripeSize>0) && (segmentIter==0))
 
 
-        if (romio_onesided_always_rmw && ((stripeSize == 0) || (segmentIter == 0))) {   // read in the first buffer
+        if (fd->romio_onesided_always_rmw && ((stripeSize == 0) || (segmentIter == 0))) {   // read in the first buffer
             ADIO_Offset tmpCurrentRoundFDEnd = 0;
             if ((fd_end[myAggRank] - currentRoundFDStart) < coll_bufsize) {
                 if (myAggRank == greatestFileDomainAggRank) {
@@ -995,7 +1005,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
                 tmpCurrentRoundFDEnd = currentRoundFDStart + coll_bufsize - (ADIO_Offset) 1;
 #ifdef onesidedtrace
             printf
-                ("romio_onesided_always_rmw - first buffer pre-read for file offsets %ld to %ld total is %d\n",
+                ("fd->romio_onesided_always_rmw - first buffer pre-read for file offsets %ld to %ld total is %d\n",
                  currentRoundFDStart, tmpCurrentRoundFDEnd,
                  (int) (tmpCurrentRoundFDEnd - currentRoundFDStart) + 1);
 #endif
@@ -1019,7 +1029,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
             }
         }
     }   // if iAmUsedAgg
-    if (romio_onesided_always_rmw && ((stripeSize == 0) || (segmentIter == 0))) // wait until the first buffer is read
+    if (fd->romio_onesided_always_rmw && ((stripeSize == 0) || (segmentIter == 0))) // wait until the first buffer is read
         MPI_Barrier(fd->comm);
 
 #ifdef ROMIO_GPFS
@@ -1138,7 +1148,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
                         printf("bufferAmountToSend is %d\n", bufferAmountToSend);
 #endif
                         if (bufferAmountToSend > 0) {   /* we have data to send this round */
-                            if (romio_write_aggmethod == 2) {
+                            if (fd->romio_write_aggmethod == 2) {
                                 /* Only allocate these arrays if we are using method 2 and only do it once for this round/target agg.
                                  */
                                 if (!allocatedDerivedTypeArrays) {
@@ -1193,7 +1203,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
                              * chunk in the target, of source data is non-contiguous then pack the data first.
                              */
 
-                            if (romio_write_aggmethod == 1) {
+                            if (fd->romio_write_aggmethod == 1) {
                                 MPI_Win_lock(MPI_LOCK_SHARED, targetAggsForMyData[aggIter], 0,
                                              write_buf_window);
                                 char *putSourceData = NULL;
@@ -1228,7 +1238,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
                              * to be used subsequently when building the derived type for 1 mpi_put for all the data for this
                              * round/agg.
                              */
-                            else if (romio_write_aggmethod == 2) {
+                            else if (fd->romio_write_aggmethod == 2) {
 
                                 if (bufTypeIsContig) {
                                     targetAggBlockLengths[targetAggContigAccessCount] =
@@ -1275,7 +1285,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
 
                     /* For romio_write_aggmethod of 2 now build the derived type using the data from this round/agg and do 1 single mpi_put.
                      */
-                    if (romio_write_aggmethod == 2) {
+                    if (fd->romio_write_aggmethod == 2) {
 
                         MPI_Datatype sourceBufferDerivedDataType, targetBufferDerivedDataType;
                         MPI_Type_create_struct(targetAggContigAccessCount, targetAggBlockLengths,
@@ -1323,7 +1333,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
                             MPI_Type_free(&targetBufferDerivedDataType);
                         }
                     }
-                    if (!romio_onesided_no_rmw) {
+                    if (!fd->romio_onesided_no_rmw) {
                         MPI_Win_lock(MPI_LOCK_SHARED, targetAggsForMyData[aggIter], 0,
                                      fd->io_buf_put_amounts_window);
                         MPI_Accumulate(&numBytesPutThisAggRound, 1, MPI_INT,
@@ -1391,7 +1401,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
             }
 #endif
             int doWriteContig = 1;
-            if (!romio_onesided_no_rmw) {
+            if (!fd->romio_onesided_no_rmw) {
                 if (stripeSize == 0) {
                     if (fd->io_buf_put_amounts !=
                         ((int) (currentRoundFDEnd - currentRoundFDStart) + 1)) {
@@ -1505,7 +1515,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
         if (iAmUsedAgg && stripeSize == 0) {
             currentRoundFDStart += coll_bufsize;
 
-            if (romio_onesided_always_rmw && (roundIter < (numberOfRounds - 1))) {      // read in the buffer for the next round unless this is the last round
+            if (fd->romio_onesided_always_rmw && (roundIter < (numberOfRounds - 1))) {  // read in the buffer for the next round unless this is the last round
                 ADIO_Offset tmpCurrentRoundFDEnd = 0;
                 if ((fd_end[myAggRank] - currentRoundFDStart) < coll_bufsize) {
                     if (myAggRank == greatestFileDomainAggRank) {
@@ -1519,7 +1529,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
                     tmpCurrentRoundFDEnd = currentRoundFDStart + coll_bufsize - (ADIO_Offset) 1;
 #ifdef onesidedtrace
                 printf
-                    ("romio_onesided_always_rmw - round %d buffer pre-read for file offsets %ld to %ld total is %d\n",
+                    ("fd->romio_onesided_always_rmw - round %d buffer pre-read for file offsets %ld to %ld total is %d\n",
                      roundIter, currentRoundFDStart, tmpCurrentRoundFDEnd,
                      (int) (tmpCurrentRoundFDEnd - currentRoundFDStart) + 1);
 #endif
@@ -2469,7 +2479,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
                         }
 
                         if (bufferAmountToRecv > 0) {   /* we have data to recv this round */
-                            if (romio_read_aggmethod == 2) {
+                            if (fd->romio_read_aggmethod == 2) {
                                 /* Only allocate these arrays if we are using method 2 and only do it once for this round/source agg.
                                  */
                                 if (!allocatedDerivedTypeArrays) {
@@ -2523,7 +2533,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
                              * contiguous chunk from the target, if the source is non-contiguous then unpack the data after
                              * the MPI_Win_unlock is done to make sure the data has arrived first.
                              */
-                            if (romio_read_aggmethod == 1) {
+                            if (fd->romio_read_aggmethod == 1) {
                                 MPI_Win_lock(MPI_LOCK_SHARED, sourceAggsForMyData[aggIter], 0,
                                              read_buf_window);
                                 char *getSourceData = NULL;
@@ -2560,7 +2570,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
                              * to be used subsequently when building the derived type for 1 mpi_put for all the data for this
                              * round/agg.
                              */
-                            else if (romio_read_aggmethod == 2) {
+                            else if (fd->romio_read_aggmethod == 2) {
                                 if (bufTypeIsContig) {
                                     sourceAggBlockLengths[sourceAggContigAccessCount] =
                                         bufferAmountToRecv;
@@ -2590,7 +2600,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
 
                     /* For romio_read_aggmethod of 2 now build the derived type using the data from this round/agg and do 1 single mpi_put.
                      */
-                    if (romio_read_aggmethod == 2) {
+                    if (fd->romio_read_aggmethod == 2) {
                         MPI_Datatype recvBufferDerivedDataType, sourceBufferDerivedDataType;
 
                         MPI_Type_create_struct(sourceAggContigAccessCount, sourceAggBlockLengths,

--- a/src/mpi/romio/adio/include/ad_tuning.h
+++ b/src/mpi/romio/adio/include/ad_tuning.h
@@ -33,6 +33,6 @@ extern int romio_onesided_inform_rmw;
 extern int romio_tunegather;
 
 /* set internal variables for tuning environment variables */
-void ad_get_env_vars(void);
+void ad_get_env_vars(ADIO_File fd);
 
 #endif /* AD_TUNING_H_INCLUDED */

--- a/src/mpi/romio/adio/include/adio.h
+++ b/src/mpi/romio/adio/include/adio.h
@@ -80,6 +80,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <stdint.h>     /* uintptr_t */
 #ifdef SPPUX
 #include <sys/cnx_fcntl.h>
 #endif
@@ -364,10 +365,10 @@ typedef struct {
 
 void ADIO_Init(int *argc, char ***argv, int *error_code);
 void ADIO_End(int *error_code);
-MPI_File ADIO_Open(MPI_Comm orig_comm, MPI_Comm comm, const char *filename,
-                   int file_system, ADIOI_Fns * ops,
-                   int access_mode, ADIO_Offset disp, MPI_Datatype etype,
-                   MPI_Datatype filetype, MPI_Info info, int perm, int *error_code);
+ADIO_File ADIO_Open(MPI_Comm orig_comm, MPI_Comm comm, const char *filename,
+                    int file_system, ADIOI_Fns * ops,
+                    int access_mode, ADIO_Offset disp, MPI_Datatype etype,
+                    MPI_Datatype filetype, MPI_Info info, int perm, int *error_code);
 void ADIOI_OpenColl(ADIO_File fd, int rank, int acces_mode, int *error_code);
 void ADIO_ImmediateOpen(ADIO_File fd, int *error_code);
 void ADIO_Close(ADIO_File fd, int *error_code);
@@ -440,29 +441,29 @@ int ADIO_Feature(ADIO_File fd, int flag);
 
 /* functions to help deal with the array datatypes */
 int ADIO_Type_create_subarray(int ndims,
-                              int *array_of_sizes,
-                              int *array_of_subsizes,
-                              int *array_of_starts,
+                              const int *array_of_sizes,
+                              const int *array_of_subsizes,
+                              const int *array_of_starts,
                               int order, MPI_Datatype oldtype, MPI_Datatype * newtype);
 int ADIO_Type_create_darray(int size, int rank, int ndims,
-                            int *array_of_gsizes, int *array_of_distribs,
-                            int *array_of_dargs, int *array_of_psizes,
+                            const int *array_of_gsizes, const int *array_of_distribs,
+                            const int *array_of_dargs, const int *array_of_psizes,
                             int order, MPI_Datatype oldtype, MPI_Datatype * newtype);
 
 /* MPI_File management functions (in mpio_file.c) */
 MPI_File MPIO_File_create(int size);
 ADIO_File MPIO_File_resolve(MPI_File mpi_fh);
-void MPIO_File_free(MPI_File * mpi_fh);
+void MPIO_File_free(ADIO_File * fd);
 MPI_File MPIO_File_f2c(MPI_Fint fh);
 MPI_Fint MPIO_File_c2f(MPI_File fh);
 int MPIO_Err_create_code(int lastcode, int fatal, const char fcname[],
                          int line, int error_class, const char generic_msg[],
                          const char specific_msg[], ...);
-int MPIO_Err_return_file(MPI_File mpi_fh, int error_code);
+int MPIO_Err_return_file(ADIO_File adio_fh, int error_code);
 int MPIO_Err_return_comm(MPI_Comm mpi_comm, int error_code);
 
 /* request management helper functions */
-void MPIO_Completed_request_create(MPI_File * fh, MPI_Offset nbytes,
+void MPIO_Completed_request_create(ADIO_File * fd, MPI_Offset nbytes,
                                    int *error_code, MPI_Request * request);
 
 #include "adioi.h"

--- a/src/mpi/romio/adio/include/adio.h
+++ b/src/mpi/romio/adio/include/adio.h
@@ -57,10 +57,7 @@
 
 /* Include romioconf.h if we haven't already (some include files may
    need to include romioconf before some system includes) */
-#ifndef ROMIOCONF_H_INCLUDED
 #include "romioconf.h"
-#define ROMIOCONF_H_INCLUDED
-#endif
 
 #ifdef BUILD_MPI_ABI
 #include "romio_abi_internal.h"
@@ -246,6 +243,14 @@ typedef struct ADIOI_FileD {
     struct quobyte_fh *file_handle;     /* file handle for quobytefs */
 #endif
     int dirty_write;            /* this client has written data */
+
+    /* see file adio/common/onesided_aggregation.c for descriptions of the next 6 members */
+    int romio_write_aggmethod;
+    int romio_read_aggmethod;
+    int romio_onesided_no_rmw;
+    int romio_onesided_always_rmw;
+    int romio_onesided_inform_rmw;
+    int romio_tunegather;
 } ADIOI_FileD;
 
 typedef struct ADIOI_FileD *ADIO_File;

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -94,6 +94,18 @@ struct ADIOI_Hints_struct {
     } fs_hints;
 };
 
+#ifndef HAVE_MPI_DATAREP_CONVERSION_FUNCTION
+typedef int (MPI_Datarep_conversion_function) (void *, MPI_Datatype, int,
+                                               void *, MPI_Offset, void *);
+#endif
+#ifndef HAVE_MPI_DATAREP_EXTENT_FUNCTION
+typedef int (MPI_Datarep_extent_function) (MPI_Datatype datatype, MPI_Aint *, void *);
+#endif
+#ifndef HAVE_MPI_DATAREP_CONVERSION_FUNCTION_C
+typedef int (MPI_Datarep_conversion_function_c) (void *, MPI_Datatype, MPI_Count,
+                                                 void *, MPI_Offset, void *);
+#endif
+
 typedef struct ADIOI_Datarep {
     char *name;
     void *state;

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -803,7 +803,7 @@ int MPIOI_File_write_all_begin(MPI_File fh, MPI_Offset offset, int file_ptr_type
                                MPI_Aint count, MPI_Datatype datatype, char *myname);
 int MPIOI_File_read_all_end(MPI_File fh, void *buf, char *myname, MPI_Status * status);
 int MPIOI_File_write_all_end(MPI_File fh, const void *buf, char *myname, MPI_Status * status);
-int MPIOI_File_iwrite(MPI_File fh,
+int MPIOI_File_iwrite(ADIO_File adio_fh,
                       MPI_Offset offset,
                       int file_ptr_type,
                       const void *buf,
@@ -813,7 +813,7 @@ int MPIOI_File_iread(MPI_File fh,
                      int file_ptr_type,
                      void *buf,
                      MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Request * request);
-int MPIOI_File_iwrite_all(MPI_File fh,
+int MPIOI_File_iwrite_all(ADIO_File adio_fh,
                           MPI_Offset offset,
                           int file_ptr_type,
                           const void *buf,

--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -1061,6 +1061,26 @@ ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset);
 
 #endif
 
+#ifdef ROMIO_INSIDE_MPICH
+/* only built within MPI requires MPL */
 #include "mpl.h"
+#else
+#define MPL_UNREFERENCED_ARG(a)
+#define MPL_MAX(a,b) (((a) > (b)) ? (a) : (b))
+#define MPL_MIN(a,b) (((a) < (b)) ? (a) : (b))
+#define MPL_malloc(a,b) malloc((size_t)(a))
+#define MPL_calloc(a,b,c) calloc((size_t)(a),(size_t)(b))
+#define MPL_free(a) free((void *)(a))
+#define MPL_direct_free(a) free((void *)(a))
+#define MPL_external_free(a) free((void *)(a))
+#define MPL_realloc(a,b,c) realloc((void *)(a),(size_t)(b))
+#define MPL_VG_MEM_INIT(addr_,len_)  do {} while (0)
+extern void MPL_create_pathname(char *dest_filename, const char *dirname,
+                                const char *prefix, const int is_dir);
+extern int MPL_strnapp(char *dest, const char *src, size_t n);
+#define MPL_MEM_IO 0
+typedef int MPL_memory_class;
+extern void *MPL_aligned_alloc(size_t alignment, size_t size, MPL_memory_class class);
+#endif
 
 #endif /* ADIOI_H_INCLUDED */

--- a/src/mpi/romio/adio/include/adioi_error.h
+++ b/src/mpi/romio/adio/include/adioi_error.h
@@ -19,7 +19,7 @@
                                           myname, __LINE__,             \
                                           MPI_ERR_FILE,                 \
                                           "**iobadfh", 0);              \
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);   \
+        error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);  \
         goto fn_exit;                                                   \
     }
 
@@ -33,7 +33,7 @@
                                               (myname_), __LINE__,      \
                                               MPI_ERR_COMM,             \
                                               "**commnull", 0);         \
-            error_code_ = MPIO_Err_return_file(MPI_FILE_NULL, (error_code_)); \
+            error_code_ = MPIO_Err_return_file(ADIO_FILE_NULL, (error_code_)); \
             goto fn_exit;                                               \
         }                                                               \
     } while (0)

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -1599,6 +1599,9 @@ AC_CHECK_DECLS([MPI_ERRORS_ABORT], [], [], [[#include <mpi.h>]])
 if test "$FROM_MPICH" = no ; then
    AC_CHECK_FUNCS([MPIR_Get_node_id], [],
                   [AC_SEARCH_LIBS([MPIR_Get_node_id], [mpi])])
+
+   AC_CHECK_FUNCS([MPIR_Ext_datatype_iscontig], [],
+                  [AC_SEARCH_LIBS([MPIR_Ext_datatype_iscontig], [mpi])])
 fi
 
 AC_SUBST(ARCH)

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -1593,6 +1593,8 @@ AC_MSG_NOTICE([setting CFLAGS to $CFLAGS])
 AC_MSG_NOTICE([setting USER_CFLAGS to $USER_CFLAGS])
 AC_MSG_NOTICE([setting USER_FFLAGS to $USER_FFLAGS])
 
+AC_CHECK_DECLS([MPI_ERRORS_ABORT], [], [], [[#include <mpi.h>]])
+
 # check subroutines when ROMIO is built outside MPICH
 if test "$FROM_MPICH" = no ; then
    AC_CHECK_FUNCS([MPIR_Get_node_id], [],

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -1612,6 +1612,15 @@ if test "$FROM_MPICH" = no ; then
 
    AC_CHECK_FUNCS([MPIR_Ext_datatype_iscontig], [],
                   [AC_SEARCH_LIBS([MPIR_Ext_datatype_iscontig], [mpi])])
+
+   AC_CHECK_FUNCS([MPL_create_pathname], [],
+                  [AC_SEARCH_LIBS([MPL_create_pathname], [mpi mpl])])
+
+   AC_CHECK_FUNCS([MPL_strnapp], [],
+                  [AC_SEARCH_LIBS([MPL_strnapp], [mpi mpl])])
+
+   AC_CHECK_FUNCS([MPL_aligned_alloc], [],
+                  [AC_SEARCH_LIBS([MPL_aligned_alloc], [mpi mpl])])
 fi
 CPPFLAGS=$saved_CPPFLAGS
 

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -1601,7 +1601,8 @@ AC_CHECK_DECLS([MPI_ERRORS_ABORT], [], [], [[#include <mpi.h>]])
 
 AC_CHECK_TYPES([MPI_Datarep_conversion_function,
                 MPI_Datarep_extent_function,
-                MPI_Datarep_conversion_function_c],
+                MPI_Datarep_conversion_function_c,
+                MPIX_Grequest_class],
                [], [], [#include <mpi.h>])
 
 # check subroutines when ROMIO is built outside MPICH

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -1593,7 +1593,16 @@ AC_MSG_NOTICE([setting CFLAGS to $CFLAGS])
 AC_MSG_NOTICE([setting USER_CFLAGS to $USER_CFLAGS])
 AC_MSG_NOTICE([setting USER_FFLAGS to $USER_FFLAGS])
 
+# check whether some constants and subroutines are defined in mpi.h
+saved_CPPFLAGS=$CPPFLAGS
+CPPFLAGS="$MPI_H_INCLUDE -I${top_build_dir}/include $CPPFLAGS"
+
 AC_CHECK_DECLS([MPI_ERRORS_ABORT], [], [], [[#include <mpi.h>]])
+
+AC_CHECK_TYPES([MPI_Datarep_conversion_function,
+                MPI_Datarep_extent_function,
+                MPI_Datarep_conversion_function_c],
+               [], [], [#include <mpi.h>])
 
 # check subroutines when ROMIO is built outside MPICH
 if test "$FROM_MPICH" = no ; then
@@ -1603,6 +1612,7 @@ if test "$FROM_MPICH" = no ; then
    AC_CHECK_FUNCS([MPIR_Ext_datatype_iscontig], [],
                   [AC_SEARCH_LIBS([MPIR_Ext_datatype_iscontig], [mpi])])
 fi
+CPPFLAGS=$saved_CPPFLAGS
 
 AC_SUBST(ARCH)
 AC_SUBST(FILE_SYSTEM)

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -1593,6 +1593,12 @@ AC_MSG_NOTICE([setting CFLAGS to $CFLAGS])
 AC_MSG_NOTICE([setting USER_CFLAGS to $USER_CFLAGS])
 AC_MSG_NOTICE([setting USER_FFLAGS to $USER_FFLAGS])
 
+# check subroutines when ROMIO is built outside MPICH
+if test "$FROM_MPICH" = no ; then
+   AC_CHECK_FUNCS([MPIR_Get_node_id], [],
+                  [AC_SEARCH_LIBS([MPIR_Get_node_id], [mpi])])
+fi
+
 AC_SUBST(ARCH)
 AC_SUBST(FILE_SYSTEM)
 AC_SUBST(CC)

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -18,23 +18,48 @@ AC_INIT([ROMIO],
         [http://www.mpich.org/])
 
 dnl AC_CONFIG_AUX_DIR(../../../confdb)
-dnl Set the directory that contains the required install-sh, config.sub,
-dnl and config.guess .  Make sure that these are updated (in MPICH, use
-dnl the top-level confdb files).  This separate directory is used for
-dnl the moment to allow ROMIO to be separatedly distributed.
-dnl scripts.
+dnl Set the directory that contains the required install-sh, config.sub, and
+dnl config.guess scripts. Make sure that these are updated (in MPICH, use the
+dnl top-level confdb files).  This separate directory is used for the moment
+dnl to allow ROMIO to be separately distributed.
 AC_CONFIG_AUX_DIR([confdb])
 AC_CONFIG_MACRO_DIR([confdb])
 
 AM_INIT_AUTOMAKE([-Wall -Werror -Wno-portability-recursive foreign 1.12.3 silent-rules subdir-objects])
 AM_MAINTAINER_MODE([enable])
 
+# Need to figure out what CC we are going to use before calling AC_PROG_CC
+# if CC is not set and --with-mpi is set, use MPI C compiler under --with-mpi
+AC_ARG_WITH(mpi,
+   [AS_HELP_STRING([--with-mpi=path],
+                   [Path to installation of MPI (headers, libs, etc)])])
+if test "x$with_mpi" != x ; then
+   if test "x$with_mpi" = xno ; then
+      AC_MSG_ERROR([--with-mpi cannot be no, as ROMIO requires MPI compilers])
+   fi
+   if test "x$with_mpi" != xyes ; then
+      if test "x$CC" = x ; then
+         CC="${with_mpi}/bin/mpicc"
+      else
+         cc_dir=`AS_DIRNAME(["$CC"])`
+         if test "x$cc_dir" = "x." ; then
+            # CC does not contain the full path name
+            AC_PATH_PROG([ac_mpicc], [$CC], [], [${with_mpi}/bin])
+            if test "x$ac_mpicc" = x ; then
+               AC_MSG_WARN([file '$CC' cannot be found under $with_mpi/bin])
+            else
+               CC=$ac_mpicc
+            fi
+         fi
+      fi
+   fi
+   # ignore if --with-mpi or --with-mpi=yes is used
+fi
+
 dnl must come before LT_INIT, which AC_REQUIREs AC_PROG_CC
 AC_PROG_CC
 AC_PROG_CC_C99
 AM_PROG_CC_C_O
-PAC_CHECK_VISIBILITY
-AC_SUBST(VISIBILITY_CFLAGS)
 
 AC_USE_SYSTEM_EXTENSIONS
 PAC_C_NO_COMMON
@@ -59,58 +84,127 @@ AH_TOP([/*
  */
 #ifndef ROMIOCONF_H_INCLUDED
 #define ROMIOCONF_H_INCLUDED
+#include "nopackage.h"
+#ifdef BUILD_ROMIO_EMBEDDED
 #include <mplconfig.h>
+#endif
 ])
 AH_BOTTOM([
+#ifdef BUILD_ROMIO_EMBEDDED
 /* quash PACKAGE and PACKAGE_* vars, see MPICH top-level configure.ac for
  * more info */
 #include "nopackage.h"
-
+#endif
 #endif /* !defined(ROMIOCONF_H_INCLUDED) */
 ])
 
-dnl
 NOF77=0
 NOF90=0
 ARCH=""
-arch_IRIX=""
 MPI_IMPL=""
 MPI_INCLUDE_DIR=""
-ROMIO_INCLUDE=""
-
-# Used by the new build system, should contain zero or more "-Iblah" args for
-# inclusion in AM_CPPFLAGS.  Should not contain relative paths.  This probably
-# overlaps with ROMIO_INCLUDE some, but adding a new var is easier than teasing
-# apart all of the current usages of that variable and re-testing all of the
-# non-MPICH and exotic platform cases.
-MPI_H_INCLUDE=""
-AC_SUBST([MPI_H_INCLUDE])
-
 TEST_LIBNAME=""
 FILE_SYSTEM=""
 
-# Do not set variables to empty that may be communicated from the
-# outside environment (e.g., MPI_LIB, MPI_BIN_DIR, LIBNAME)
-DEBUG=no
-MIPS=0
-BITS=0
-
+# if ROMIO is being built embedded in MPICH, FROM_MPICH has been set to yes by MPICH configure
 AC_ARG_VAR([FROM_MPICH],[set to "yes" if building ROMIO inside of MPICH])
 FROM_MPICH=${FROM_MPICH:-no}
 
+# if ROMIO is being built embedded in LAM MPI, FROM_LAM has been set to yes by LAM/MPI configure
+# Note LAM/MPI has officially retired in 2015.
 AC_ARG_VAR([FROM_LAM],[set to "yes" if building ROMIO inside of LAM])
 FROM_LAM=${FROM_LAM:-no}
 if test "$FROM_LAM" = 1 ; then FROM_LAM=yes ; fi
 
+# if ROMIO is being built embedded in OpenMPI, FROM_OMPI has been set to yes by OpenMPI configure
 AC_ARG_VAR([FROM_OMPI],[set to "yes" if building ROMIO inside of Open MPI])
 FROM_OMPI=${FROM_OMPI:-no}
 if test "$FROM_OMPI" = 1 ; then FROM_OMPI=yes ; fi
 
+# Check if we are building within a known or unknown MPI, by checking whether
+# CC is an MPI compiler. If building within a known MPI implementation or
+# within MPI, we must avoid the tests about an existing implementation
+# Currently only recognized MPI implementations are MPICH, OpenMPI, and LAM/MPI
+#   build_ROMIO_EMBEDDED - whether we are building within an MPI
+#   WITHIN_KNOWN_MPI_IMPL - whether ROMIO is built within a known MPI
+#   MPI_IMPL - the base of MPI C compiler vendor (either MPICH or OpenMPI)
+
+if test "x$FROM_MPICH" = xyes ; then
+   MPI_IMPL=mpich
+   WITHIN_KNOWN_MPI_IMPL=yes
+   build_ROMIO_EMBEDDED=yes
+   mpio_glue=mpich
+   AC_DEFINE(ROMIO_INSIDE_MPICH,1,[Define if compiling within MPICH])
+elif test "x$FROM_OMPI" = xyes ; then
+   MPI_IMPL=open_mpi
+   WITHIN_KNOWN_MPI_IMPL=yes
+   build_ROMIO_EMBEDDED=yes
+   mpio_glue=openmpi
+   AC_DEFINE([ROMIO_INSIDE_OMPI], [1], [Define if compiling within OpenMPI])
+else
+   WITHIN_KNOWN_MPI_IMPL=no
+   # check if C compiler is already an MPI C compiler
+   # If we are building ROMIO stand alone, CC is an MPI compiler.
+   AC_MSG_CHECKING([whether C compiler is an MPI compiler])
+   AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <mpi.h>]],[[
+      int err, rank;
+      err = MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+   ]])], [build_ROMIO_EMBEDDED=no])
+   if test "x$build_ROMIO_EMBEDDED" = xno ; then
+      AC_MSG_RESULT([yes])
+   else
+      AC_MSG_RESULT([no])
+   fi
+   mpio_glue=default
+fi
+AM_CONDITIONAL([BUILD_ROMIO_EMBEDDED],[test "$build_ROMIO_EMBEDDED" = "yes" ])
+AM_CONDITIONAL([ROMIO_INSIDE_MPICH], [test "x$FROM_MPICH" = xyes])
+AM_CONDITIONAL([ROMIO_INSIDE_OMPI], [test "x$FROM_OMPI" = xyes])
+
+if test "x$build_ROMIO_EMBEDDED" = xyes ; then
+   AC_DEFINE([BUILD_ROMIO_EMBEDDED], [1], [Define if ROMIO is built embedded])
+else
+   dnl Check if MPI C compiler is MPICH based, e.g. Cray MPI
+   saved_CFLAGS=$CFLAGS
+   saved_CPPFLAGS=$CPPFLAGS
+   AC_MSG_CHECKING([whether MPI C compiler is MPICH based])
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+      #include <mpi.h>
+      #ifndef MPICH_NAME
+      #error MPICH_NAME is not defined
+      #endif
+   ]])], [MPI_IMPL=mpich])
+   if test "x$MPI_IMPL" = xmpich ; then
+      AC_MSG_RESULT([yes])
+   else
+      AC_MSG_RESULT([no])
+   fi
+   AC_MSG_CHECKING([whether MPI C compiler is OpenMPI based])
+   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+      #include <mpi.h>
+      #ifndef OMPI_MAJOR_VERSION
+      #error OMPI_MAJOR_VERSION is not defined
+      #endif
+   ]])], [MPI_IMPL=open_mpi])
+   if test "x$MPI_IMPL" = xopen_mpi ; then
+      AC_MSG_RESULT([yes])
+   else
+      AC_MSG_RESULT([no])
+   fi
+   CFLAGS=$saved_CFLAGS
+   CPPFLAGS=$saved_CPPFLAGS
+fi
+
+if test "x$MPI_IMPL" = xmpich ; then
+   AC_DEFINE([MPI_IMPL_IS_MPICH], [1], [Define if MPI implementation is MPICH])
+elif test "x$MPI_IMPL" = xopen_mpi ; then
+   AC_DEFINE([MPI_IMPL_IS_OMPI], [1], [Define if MPI implementation is OpenMPI])
+fi
+
 # MPL
 AC_ARG_VAR([MPLLIBNAME],[can be used to override the name of the MPL library (default: "mpl")])
 MPLLIBNAME=${MPLLIBNAME:-"mpl"}
-export MPLLIBNAME
-AC_SUBST(MPLLIBNAME)
+
 AC_ARG_WITH([mpl-prefix],
             [AS_HELP_STRING([[--with-mpl-prefix[=DIR]]],
                             [use the MPL library installed in DIR. Pass
@@ -118,46 +212,47 @@ AC_ARG_WITH([mpl-prefix],
                              distributed with Hydra.])],
             [],dnl action-if-given
             [with_mpl_prefix=embedded]) dnl action-if-not-given
-mpl_srcdir=""
-AC_SUBST([mpl_srcdir])
-# Controls whether we recurse into the MPL dir when running "dist" rules like
-# "make distclean".  Technically we are cheating whenever DIST_SUBDIRS is not a
-# superset of SUBDIRS, but we don't want to double-distclean and similar.
-mpl_dist_srcdir=""
-AC_SUBST(mpl_dist_srcdir)
-mpl_includedir=""
-AC_SUBST([mpl_includedir])
-mpl_libdir=""
-AC_SUBST([mpl_libdir])
-mpl_lib=""
-AC_SUBST([mpl_lib])
-if test "$FROM_MPICH" = "no" ; then
-    if test "$with_mpl_prefix" = "embedded" ; then
-        mpl_srcdir="mpl"
-        mpl_dist_srcdir="mpl"
-        mpl_subdir_args="--disable-versioning --enable-embedded"
-        PAC_CONFIG_SUBDIR_ARGS([mpl],[$mpl_subdir_args],[],[AC_MSG_ERROR(MPL configure failed)])
-        mpl_includedir='-I$(top_builddir)/mpl/include -I$(top_srcdir)/mpl/include'
-        mpl_lib="mpl/lib${MPLLIBNAME}.la"
-    else
-        # The user specified an already-installed MPL; just sanity check, don't
-        # subconfigure it
-        AS_IF([test -s "${with_mpl_prefix}/include/mplconfig.h"],
-            [:],[AC_MSG_ERROR([the MPL installation in "${with_mpl_prefix}" appears broken])])
-        mpl_includedir="-I${with_mpl_prefix}/include"
-        mpl_libdir="-L${with_mpl_prefix}/lib"
-        mpl_lib="-l${MPLLIBNAME}"
-    fi
-else
-    # we are configuring romio inside mpich. MPICH should configured MPL already,
-    # just set mpl_includedir and source mpl/localdefs if any.
-    pac_skip_mpl_lib=yes
-    PAC_CONFIG_MPL
+
+# When building ROMIO stand alone, we do not need to build MPL
+if test "x$build_ROMIO_EMBEDDED" = xyes; then
+   # Controls whether we go recursively into the MPL dir when running "dist"
+   # rules like "make distclean".  Technically we are cheating whenever
+   # DIST_SUBDIRS is not a superset of SUBDIRS, but we don't want to
+   # double-distclean and similar.
+   if test "$FROM_MPICH" = "no" && test "$FROM_OMPI" = "no"; then
+      if test "$with_mpl_prefix" = "embedded" ; then
+         mpl_srcdir='mpl'
+         mpl_builddir='$(top_builddir)/mpl'
+         mpl_dist_srcdir='$(mpl_srcdir)'
+         mpl_subdir_args="--disable-versioning --enable-embedded"
+         PAC_CONFIG_SUBDIR_ARGS([mpl],[$mpl_subdir_args],[],[AC_MSG_ERROR(MPL configure failed)])
+         mpl_includedir='-I$(top_builddir)/mpl/include -I$(top_srcdir)/mpl/include'
+         mpl_libdir='-L$(top_builddir)/mpl'
+         mpl_lib='$(top_builddir)'"/mpl/lib${MPLLIBNAME}.la"
+      else
+         # The user specified an already-installed MPL; just sanity check, don't
+         # subconfigure it
+         AS_IF([test -s "${with_mpl_prefix}/include/mplconfig.h"],
+               [:],[AC_MSG_ERROR([the MPL installation in "${with_mpl_prefix}" appears broken])])
+         mpl_includedir="-I${with_mpl_prefix}/include"
+         mpl_libdir="-L${with_mpl_prefix}/lib"
+         mpl_lib="-l${MPLLIBNAME}"
+      fi
+   elif test "$FROM_MPICH" = "yes" ; then
+      # we are configuring romio inside mpich. MPICH should configured MPL already,
+      # just set mpl_includedir and source mpl/localdefs if any.
+      pac_skip_mpl_lib=yes
+      PAC_CONFIG_MPL
+   fi
+   AC_SUBST([mpl_srcdir])
+   AC_SUBST([mpl_builddir])
+   AC_SUBST([mpl_dist_srcdir])
+   AC_SUBST([mpl_includedir])
+   AC_SUBST([mpl_libdir])
+   AC_SUBST([mpl_lib])
 fi
 
-CFLAGS=${CFLAGS:-""}
 LL="lld"
-AR_LOCAL=""
 DEFINE_HAVE_MPI_GREQUEST="#undef HAVE_MPI_GREQUEST"
 HAVE_MPI_INFO=""
 BUILD_MPI_INFO=""
@@ -172,25 +267,14 @@ MPI_FARRAY4=""
 MPI_FARRAY5=""
 MPI_FARRAY6=""
 MPI_FARRAY7=""
-DEFS=""
-ROMIO_LFLAGS=""
-ROMIO_TCFLAGS=""
-ROMIO_TCPPFLAGS=""
-ROMIO_TFFLAGS=""
-NOPROFILE=0
-MPIRUN=""
-FORTRAN_TEST=""
 MAKE=${MAKE:-"make"}
-# foll. needed for f77 test programs
+# following are needed for f77 test programs
 F77GETARG="call getarg(i,str)"
 F77IARGC="iargc()"
 FORTRAN_MPI_OFFSET=""
-MPI_OFFSET_KIND1="!"
-MPI_OFFSET_KIND2="!"
 TEST_CC=""
 TEST_F77=""
 #
-known_mpi_impls="mpich_mpi mpich_mpi sgi_mpi hp_mpi cray_mpi lam_mpi open_mpi_mpi"
 
 dnl An m4 macro for use with m4_foreach_w and friends.  You should modify this
 dnl list if you want to add a known file system.  The list is just whitespace
@@ -215,52 +299,65 @@ AC_ARG_ENABLE(mpi-abi,
         enable_mpi_abi=no)
 AM_CONDITIONAL([BUILD_ABI_LIB], [test "$enable_mpi_abi" = "yes"])
 
-AC_ARG_ENABLE(aio,[
---enable-aio - Request use of asynchronous I/O routines (default)],
-[
-  if test "x$enableval" = "xno" ; then
-    disable_aio=yes
-  else
-    disable_aio=no
-  fi
-], disable_aio=no)
+AC_ARG_ENABLE(aio,
+   [AS_HELP_STRING([--disable-aio],
+                   [Turn off support for asynchronous I/O routines. @<:@default: enabled@:>@])],
+   [enable_aio=${enableval}], [enable_aio=yes])
 AC_ARG_ENABLE(echo,
-[--enable-echo  - Turn on strong echoing. The default is enable=no.] ,set -x)
+   [AS_HELP_STRING([--enable-echo],
+                   [Turn on strong echoing. @<:@default: disabled@:>@])],
+   [set -x])
+AC_ARG_ENABLE(fortran,
+   [AS_HELP_STRING([--disable-fortran],
+                   [Turn off support for Fortran. @<:@default: enabled@:>@])],
+   [enable_fortran=${enableval}], [enable_fortran=yes])
 AC_ARG_ENABLE(f77,
-[--enable-f77 - Turn on support for Fortran 77 (default)],,enable_f77=yes)
+   [AS_HELP_STRING([--disable-f77],
+                   [Turn off support for Fortran 77. @<:@default: enabled@:>@])],
+   [enable_f77=${enableval}], [enable_f77=yes])
 AC_ARG_ENABLE(f90,
-[--enable-f90 - Turn on support for Fortran 90 (default)],,enable_f90=yes)
+   [AS_HELP_STRING([--disable-f90],
+                   [Turn off support for Fortran 90. @<:@default: enabled@:>@])],
+   [enable_f90=${enableval}], [enable_f90=yes])
 AC_ARG_ENABLE(weak-symbols,
-[--enable-weak-symbols - Turn on support for weak symbols],,enable_weak_symbols=yes)
+   [AS_HELP_STRING([--disable-weak-symbols],
+                   [Turn off support for weak symbols. @<:@default: enabled@:>@])],
+   [enable_weak_symbols=${enableval}], [enable_weak_symbols=yes])
 AC_ARG_ENABLE(debug,
-[--enable-debug - Build a debugging version],,)
-AC_ARG_WITH(file-system,[
---with-file-system=name - Build with support for the named file systems],,)
-AC_ARG_WITH(pvfs2,[
---with-pvfs2=path - Path to installation of PVFS (version 2)],,)
-AC_ARG_WITH(mpi-impl,[
---with-mpi-impl=name - Specify MPI implementation to build ROMIO for],,)
-dnl
-AC_ARG_WITH(mpi, [
---with-mpi=path   - Path to installation of MPI (headers, libs, etc)],,)
-dnl
-if test "$enable_f77" != "yes" ; then
-   NOF77=1
+   [AS_HELP_STRING([--enable-debug],
+                   [Build a debugging version. @<:@default: disabled@:>@])],
+   [enable_debug=${enableval}], [enable_debug=no])
+AC_ARG_WITH(file-system,
+   [AS_HELP_STRING([--with-file-system=name],
+                   [Build with support for the named file systems])])
+AC_ARG_WITH(pvfs2,
+   [AS_HELP_STRING([--with-pvfs2=path],
+                   [Path to installation of PVFS (version 2)])])
+AC_ARG_WITH(mpi-impl,
+   [AS_HELP_STRING([--with-mpi-impl=name],
+                   [Specify MPI implementation to build ROMIO for])])
+
+if test "x$enable_fortran" = xno ; then
+   if test "x$enable_f77" = yes ; then
+      AC_MSG_WARN([disabling F77 due to the use of --disable-fortran])
+   fi
+   enable_f77=no
+   if test "x$enable_f90" = yes ; then
+      AC_MSG_WARN([disabling F90 due to the use of --disable-fortran])
+   fi
+   enable_f90=no
 fi
-if test "$enable_f90" != "yes" ; then
-   NOF90=1
-fi
-if test "$enable_debug" = "yes" ; then
-    DEBUG=yes
-fi
-MPI=$with_mpi
-if test -n "$with_mpi"; then
-       CC=$MPI/bin/mpicc
+
+if test "x$MPI_IMPL" = xopen_mpi ; then
+   # OpenMPI implements its own aio
+   enable_aio=no
 fi
 
 # start with the set of file systems that the user asked for
-# FILE_SYSTEM=$with_file_system
-FILE_SYSTEM=`echo $with_file_system | sed -e 's/:.*$//'`
+if test "x$with_file_system" != x ; then
+   # FILE_SYSTEM=$with_file_system
+   FILE_SYSTEM=`echo $with_file_system | sed -e 's/:.*$//'`
+fi
 
 # Check if Make is working
 PAC_PROG_MAKE
@@ -331,21 +428,8 @@ AC_SUBST(docdir)
 if test -z "$htmldir" ; then htmldir='${prefix}/www' ; fi
 AC_SUBST(htmldir)
 
-
-# If we are building within a known MPI implementation, we must avoid the
-# tests about an existing implementation
-if test "$FROM_MPICH" != no -o "$FROM_LAM" != no -o "$FROM_OMPI" != no ; then
-    WITHIN_KNOWN_MPI_IMPL=yes
-else
-    WITHIN_KNOWN_MPI_IMPL=no
-fi
-
-# Open MPI: Set the MPI implementation
-if test "$FROM_OMPI" = "yes" ; then
-    MPI_IMPL=open_mpi
-fi
-
 # check for valid MPI implementation
+known_mpi_impls="mpich_mpi mpich_mpi sgi_mpi hp_mpi cray_mpi lam_mpi open_mpi_mpi"
 if test -n "$MPI_IMPL" ; then
    found=no
    for mpi in $known_mpi_impls ; do
@@ -355,111 +439,125 @@ if test -n "$MPI_IMPL" ; then
       fi
    done
    if test $found = no ; then
-      AC_MSG_WARN([Unknown MPI implementation $MPI... proceeding anyway])
+      AC_MSG_WARN([Unknown MPI implementation $with_mpi... proceeding anyway])
    fi
 fi
 #
 
-if test -n "${with_mpi}" ; then
-	MPI_INCLUDE_DIR="${with_mpi}"/include
-	MPI_LIB_DIR="${with_mpi}"/lib
+if test "x$build_ROMIO_EMBEDDED" = xyes && test "x$with_mpi" != x ; then
+   MPI_INCLUDE_DIR="${with_mpi}/include"
+   if test ! -f "$MPI_INCLUDE_DIR/mpi.h" ; then
+      AC_MSG_ERROR([MPI header file $MPI_INCLUDE_DIR/mpi.h not found])
+   fi
+   MPI_CPPFLAGS="-I$MPI_INCLUDE_DIR"
+   MPI_LIB_DIR="${with_mpi}/lib"
+   if test ! -d "$MPI_LIB_DIR" ; then
+      AC_MSG_ERROR([MPI library directory $MPI_LIB_DIR not found])
+   fi
+   MPI_LDFLAGS="-L$MPI_LIB_DIR"
+   MPI_LIB="-lmpi"
 fi
 
-# check for valid MPI include directory if specified
-if test $WITHIN_KNOWN_MPI_IMPL = no ; then
-   if test -n "$MPI_INCLUDE_DIR"; then
-      if test ! -f "$MPI_INCLUDE_DIR/mpi.h" ; then
-         AC_MSG_ERROR([Include file $MPI_INCLUDE_DIR/mpi.h not found])
-      fi
-   else
-#     assume that mpi.h is in the default path
-#     set MPI_INCLUDE_DIR to ".", so that it translates to -I. in the
-#     compile command. Some compilers complain if it's only -I
-      MPI_INCLUDE_DIR=.
-   fi
-else
+if test "x$MPI_INCLUDE_DIR" = x ; then
+   # assume that mpi.h is in the default path
+   # set MPI_INCLUDE_DIR to ".", so that it translates to -I. in the
+   # compile command. Some compilers complain if it's only -I
    MPI_INCLUDE_DIR=.
-fi
-#
-# check for valid MPI library if specified
-if test $WITHIN_KNOWN_MPI_IMPL = no ; then
-   if test -n "$MPI_LIB" ; then
-      if test ! -f "$MPI_LIB" ; then
-         AC_MSG_ERROR([MPI library $MPI_LIB not found])
-      fi
-   fi
+   MPI_CPPFLAGS="-I$MPI_INCLUDE_DIR"
 fi
 
-# USER_CFLAGS and USER_FFLAGS are used only in test/Makefile.in
-if test $DEBUG = "yes"; then
-    USER_CFLAGS="$CFLAGS -g"
-    USER_FFLAGS="$FFLAGS -g"
-else
-    USER_CFLAGS="$CFLAGS -O"
-    USER_FFLAGS="$FFLAGS -O"
-fi
-#
 # Here begin the architecture-specific tests.
 # --------------------------------------------------------------------------
-# We must first select the C and Fortran compilers.  Because of the
-# way that the PROG_CC autoconf macro works (and all of the macros that
-# require it, including CHECK_HEADERS), that macro must occur exactly
-# once in the configure.ac file, at least as of autoconf 2.57 .
-# Unfortunately, this requirement is not enforced.  To handle this,
-# we first case on the architecture; then use PROG_CC, then case on the
-# architecture again for any arch-specific features.  We also set the
-# C_DEBUG_FLAG and F77_DEBUG_FLAG in case debugging is selected.
+# We must first select the C and Fortran compilers.  Because of the way that
+# the AC_PROG_CC, AC_PROG_CPP, AC_PROG_F77, AC_PROG_FC, autoconf macro works
+# (and all of the macros that require it, including CHECK_HEADERS), that macro
+# must occur exactly once in the configure.ac file, at least as of autoconf
+# 2.57. Unfortunately, this requirement is not enforced. To handle this, we
+# first case on the architecture; then use AC_PROG_CC, then case on the
+# architecture again for any arch-specific features.  We also add debug flags
+# to CFLAGS and FFLAGS in case debugging is selected.
 #
-# For the MPICH and MPICH configures, the compilers will already be
-# selected, so most of the compiler-selection code will be bypassed.
+# For the MPICH and OpenMPI configures, the compilers will already be selected,
+# so most of the compiler-selection code will be bypassed.
 # --------------------------------------------------------------------------
-# For historical reasons
-if test -z "$FC" ; then
-    FC=$F77
+
+if test "x$build_ROMIO_EMBEDDED" = xno && test $enable_debug = "yes"; then
+   CFLAGS="$CFLAGS -g -O0"
+   if test "x$GCC" = xyes ; then
+      CFLAGS="$CFLAGS -Wall -Wstrict-prototypes -Wmissing-prototypes"
+   fi
+   FFLAGS="$FFLAGS -g -O0"
 fi
-#
-C_DEBUG_FLAG="-g"
-F77_DEBUG_FLAG="-g"
 
 dnl AC_PROG_{CXX,F77,FC} must come early in configure.ac in order to control
 dnl compiler search order and avoid some esoteric autoconf macro expansion
 dnl errors
 if test "$enable_f77" = "yes" ; then
-    # suppress default "-g -O2" from AC_PROG_F77
-    : ${FFLAGS=""}
-    AC_PROG_F77([PAC_F77_SEARCH_LIST])
+   if test "x$with_mpi" != x ; then
+      if test "x$with_mpi" = xno ; then
+         AC_MSG_ERROR([--with-mpi cannot be no, as ROMIO requires MPI compilers])
+      fi
+      if test "x$with_mpi" != xyes ; then
+         if test "x$F77" = x ; then
+            F77="${with_mpi}/bin/mpif77"
+            if test -f $with_mpi/bin/mpifort ; then
+               F77="${with_mpi}/bin/mpifort"
+            fi
+         else
+            f77_dir=`AS_DIRNAME(["$F77"])`
+            if test "x$f77_dir" = "x." ; then
+               # F77 does not contain the full path name
+               if test ! -e $with_mpi/bin/$F77 ; then
+                  AC_MSG_WARN([file '$F77' cannot be found under $with_mpi/bin])
+               else
+                  F77=$with_mpi/bin/$F77
+               fi
+            fi
+         fi
+      fi
+      # ignore if --with-mpi or --with-mpi=yes is used
+   fi
+   AC_PROG_F77([$F77 PAC_F77_SEARCH_LIST])
+else
+   NOF77=1
 fi
 if test "$enable_f90" = "yes" ; then
-    # suppress default "-g -O2" from AC_PROG_FC
-    : ${FCFLAGS=""}
-    AC_PROG_FC([PAC_FC_SEARCH_LIST])
+   if test "x$with_mpi" != x ; then
+      if test "x$with_mpi" = xno ; then
+         AC_MSG_ERROR([--with-mpi cannot be no, as ROMIO requires MPI compilers])
+      fi
+      if test "x$with_mpi" != xyes ; then
+         if test "x$FC" = x ; then
+            FC="${with_mpi}/bin/mpif90"
+            if test -f $with_mpi/bin/mpifort ; then
+               FC="${with_mpi}/bin/mpifort"
+            fi
+         else
+            fc_dir=`AS_DIRNAME(["$FC"])`
+            if test "x$fc_dir" = "x." ; then
+               # FC does not contain the full path name
+               if test ! -e $with_mpi/bin/$FC ; then
+                  AC_MSG_WARN([file '$FC' cannot be found under $with_mpi/bin])
+               else
+                  FC=$with_mpi/bin/$FC
+               fi
+            fi
+         fi
+      fi
+      # ignore if --with-mpi or --with-mpi=yes is used
+   fi
+   if test "x$FC" = x ; then
+      FC=$F77
+   fi
+   AC_PROG_FC([$FC PAC_FC_SEARCH_LIST])
+else
+   NOF90=1
 fi
 
-if test "$CC" = "gcc" -a -z "$C_DEBUG_FLAG" ; then
-     C_DEBUG_FLAG="-g -O -Wall -Wstrict-prototypes -Wmissing-prototypes"
-fi
-if test $DEBUG = "yes" ; then
-    CFLAGS="$CFLAGS $C_DEBUG_FLAG"
-else
-    CFLAGS="$CFLAGS $C_OPT_FLAG"
-fi
 # ---------------------------------------------------------------------------
 # Here go the rest of the tests
 # ---------------------------------------------------------------------------
 
-AC_CHECK_TYPE(long long)
-AC_CHECK_SIZEOF(long long)
-if test -z "$MPI_IMPL" ; then
-	MPI_IMPL=mpich
-	mpi_mpich=1
-fi
-if test $MPI_IMPL = "mpich" ; then
-	TEST_CC=mpicc
-	TEST_F77=mpifort
-else
-	TEST_CC="$CC"
-	TEST_F77="$F77"
-fi
 # there used to be a ton of arch-specific stuff in here.  If some random
 # platform really truly needs it, restore it, but that defeats the whole
 
@@ -479,11 +577,6 @@ if test $NOF77 = 0 ; then
     fi
     dnl PAC_PROG_F77_NAME_MANGLE
     dnl (need to set the new name format)
-    rm -f test/mpif.h
-    if test "$MPI_INCLUDE_DIR" != "." && test $WITHIN_KNOWN_MPI_IMPL = no ; then
-        if test ! -d test ; then mkdir test ; fi
-        ln -s $MPI_INCLUDE_DIR/mpif.h test
-    fi
 else
     F77=":"
 fi
@@ -498,7 +591,7 @@ AC_TYPE_OFF_T
 # Find the CPP before the header check
 AC_PROG_CPP
 AC_CHECK_HEADERS([unistd.h fcntl.h malloc.h stddef.h sys/types.h limits.h time.h dirent.h])
-AC_CHECK_HEADERS(mpix.h,,,[#include <mpi.h>])
+AC_CHECK_HEADERS(mpix.h,,,[[#include <mpi.h>]])
 #
 
 # When compiling ROMIO on Darwin with _POSIX_C_SOURCE defined (such as when
@@ -540,6 +633,7 @@ fi
 
 # LL is the printf-style format name for output of a MPI_Offset.
 # We have to match this to the type that we use for MPI_Offset.
+AC_CHECK_TYPE(long long)
 AC_CHECK_SIZEOF(long long)
 if test "$ac_cv_sizeof_long_long" != 0 ; then
     if test "$ac_cv_sizeof_long_long" = "8" ; then
@@ -554,16 +648,12 @@ if test "$ac_cv_sizeof_long_long" != 0 ; then
        FORTRAN_MPI_OFFSET="integer"
        AC_DEFINE(MPI_OFFSET_IS_INT,1,[Define if MPI_Offset is int])
        LL="d"
-       MPI_OFFSET_KIND1="!"
-       MPI_OFFSET_KIND2="!"
     else
        AC_MSG_NOTICE([defining MPI_Offset as long in C and integer in Fortran])
        MPI_OFFSET_TYPE="long"
        DEFINE_MPI_OFFSET="typedef long MPI_Offset;"
        FORTRAN_MPI_OFFSET="integer"
        LL="ld"
-       MPI_OFFSET_KIND1="!"
-       MPI_OFFSET_KIND2="!"
     fi
 else
     AC_MSG_NOTICE([defining MPI_Offset as long in C and integer in Fortran])
@@ -571,8 +661,6 @@ else
     DEFINE_MPI_OFFSET="typedef long MPI_Offset;"
     FORTRAN_MPI_OFFSET="integer"
     LL="ld"
-    MPI_OFFSET_KIND1="!"
-    MPI_OFFSET_KIND2="!"
 fi
 
 
@@ -585,58 +673,55 @@ if test -n "$ac_cv_sizeof_long_long"; then
    fi
 fi
 #
-if test -n "$OFFSET_KIND" -a "A$MPI_OFFSET_KIND1" = "A!" ; then
-  MPI_OFFSET_KIND1="        INTEGER MPI_OFFSET_KIND"
-  MPI_OFFSET_KIND2="        PARAMETER (MPI_OFFSET_KIND=$OFFSET_KIND)"
-  MPI_OFFSET_KIND_VAL=$OFFSET_KIND
-else
- if test "$FORTRAN_MPI_OFFSET" = "integer*8" && test "A$MPI_OFFSET_KIND2" = "A!" && test $NOF77 = 0 && test $NOF90 = 0 ; then
-   PAC_MPI_OFFSET_KIND
- fi
- #
-  if test "$FORTRAN_MPI_OFFSET" = "integer" && test "A$MPI_OFFSET_KIND2" = "A!" && test $NOF77 = 0 && test $NOF90 = 0 ; then
-   PAC_MPI_OFFSET_KIND_4BYTE
-  fi
-fi
 #
 # Test that we can use the FORTRAN_MPI_OFFSET type.  If the environment
 # is a strict Fortran 90/95 or later compiler, the "integer*8" format
 # may not work.
 if test "$NOF77" = 0 ; then
-    rm -f conftest*
-    ac_cv_f77_offset_type_works=no
-    AC_MSG_CHECKING([that we can use $FORTRAN_MPI_OFFSET to declare MPI_DISPLACMENT_CURRENT])
-    cat >conftest.f <<EOF
-        program main
-        $FORTRAN_MPI_OFFSET j
-        end
-EOF
-    if $F77 -o conftest$EXEEXT conftest.f >>config.log 2>&1 && test -x conftest$EXEEXT ; then
-        ac_cv_f77_offset_type_works=yes
-    fi
-    rm -f conftest*
-    AC_MSG_RESULT($ac_cv_f77_offset_type_works)
+   if test -n "$OFFSET_KIND" ; then
+      MPI_OFFSET_KIND1="        INTEGER MPI_OFFSET_KIND"
+      MPI_OFFSET_KIND2="        PARAMETER (MPI_OFFSET_KIND=$OFFSET_KIND)"
+      MPI_OFFSET_KIND_VAL=$OFFSET_KIND
+   else
+      if test "$FORTRAN_MPI_OFFSET" = "integer*8" ; then
+         PAC_MPI_OFFSET_KIND
+      fi
+      if test "$FORTRAN_MPI_OFFSET" = "integer" ; then
+         PAC_MPI_OFFSET_KIND_4BYTE
+      fi
+   fi
 
-    if test "$ac_cv_f77_offset_type_works" != "yes" -a -n "$MPI_OFFSET_KIND_VAL"; then
-        AC_MSG_CHECKING([whether we can use KIND with the selected F77 compiler $F77])
-        ac_cv_f77_allows_offset_kind=no
-        rm -f conftest*
-        cat >conftest.f <<EOF
-        program main
-        integer (kind=$MPI_OFFSET_KIND_VAL) j
-        end
-EOF
-        if $F77 -o conftest$EXEEXT conftest.f >>config.log 2>&1 && test -x conftest$EXEEXT ; then
-            ac_cv_f77_allows_offset_kind=yes
-        fi
-        rm -f conftest*
-        AC_MSG_RESULT($ac_cv_f77_allows_offset_kind)
-        if test "$ac_cv_f77_allows_offset_kind" ; then
-             FORTRAN_MPI_OFFSET="integer (kind=$MPI_OFFSET_KIND_VAL)"
-        else
-             AC_MSG_WARN([Could not find a way to declare an integer type corresponding to MPI_Offset in Fortran.])
-        fi
-    fi
+   AC_MSG_CHECKING([that we can use $FORTRAN_MPI_OFFSET to declare MPI_DISPLACMENT_CURRENT])
+   AC_LANG_PUSH([Fortran 77])
+   AC_COMPILE_IFELSE(
+      [AC_LANG_SOURCE([
+       program main
+       $FORTRAN_MPI_OFFSET j
+       end
+      ])],
+      [ac_cv_f77_offset_type_works=yes], [ac_cv_f77_offset_type_works=no])
+   AC_MSG_RESULT($ac_cv_f77_offset_type_works)
+   AC_LANG_POP([Fortran 77])
+
+   if test "x$ac_cv_f77_offset_type_works" = xno && test -n "$MPI_OFFSET_KIND_VAL"; then
+      AC_MSG_CHECKING([whether we can use KIND with the selected F77 compiler $F77])
+      AC_LANG_PUSH([Fortran 77])
+      AC_COMPILE_IFELSE(
+         [AC_LANG_SOURCE([
+          program main
+          integer (kind=$MPI_OFFSET_KIND_VAL) j
+          end
+         ])],
+         [ac_cv_f77_allows_offset_kind=yes], [ac_cv_f77_allows_offset_kind=no])
+      AC_MSG_RESULT($ac_cv_f77_allows_offset_kind)
+      AC_LANG_POP([Fortran 77])
+
+      if test "x$ac_cv_f77_allows_offset_kind" = xyes ; then
+         FORTRAN_MPI_OFFSET="integer (kind=$MPI_OFFSET_KIND_VAL)"
+      else
+         AC_MSG_WARN([Could not find a way to declare an integer type corresponding to MPI_Offset in Fortran.])
+      fi
+   fi
 fi
 
 #
@@ -703,26 +788,38 @@ else
 fi
 AC_SUBST(HAVE_WEAK_SYMBOLS)
 
-AM_CONDITIONAL([BUILD_ROMIO_EMBEDDED],[test "$WITHIN_KNOWN_MPI_IMPL" = "yes" ])
 # FIXME need to get this right for non-MPICH builds
 AM_CONDITIONAL([BUILD_MPIO_REQUEST],[false])
-# FIXME need to get this right for non-MPICH builds
-AM_CONDITIONAL([BUILD_MPIO_ERRHAN],[false])
+
+# Use ROMIO's error handlers if not built from MPICH
+AM_CONDITIONAL([BUILD_MPIO_ERRHAN],[test "x$FROM_MPICH" = xno])
 
 # if we don't have weak symbol support, we must build a separate convenience
 # library in order to provide the "PMPI_" symbols
-AM_CONDITIONAL([BUILD_PROFILING_LIB],[test "x$HAVE_WEAK_SYMBOLS" = "x0"])
-# disable visibility if building profiling library
-if test "x$HAVE_WEAK_SYMBOLS" = "x0" ; then
-    VISIBILITY_CFLAGS=""
+# AM_CONDITIONAL([BUILD_PROFILING_LIB],[test "x$HAVE_WEAK_SYMBOLS" = "x0"])
+# Only consider this when ROMIO is built within MPICH
+# Open MPI requires the profile library disabled
+NOPROFILE=1
+if test "x$HAVE_WEAK_SYMBOLS" = x0 && test "x$FROM_MPICH" = xyes ; then
+   NOPROFILE=0
+   # define MPIO_BUILD_PROFILING only for libpromio.la, not libromio.la
+   # AC_DEFINE(MPIO_BUILD_PROFILING, 1, [if build with profiling])
 fi
+AM_CONDITIONAL([BUILD_PROFILING_LIB], [test "x$NOPROFILE" = x0])
 
+# set visibility if not building profiling library and not stand alone
+if test "x$HAVE_WEAK_SYMBOLS" = x1 && test "x$build_ROMIO_EMBEDDED" = xyes ; then
+   PAC_CHECK_VISIBILITY
+fi
+AC_SUBST(VISIBILITY_CFLAGS)
 
 # weird: we have conflated "build ROMIO's versions of the fortran bindings" and
-# "build ROMIO"s fortran I/O tests". Of course the common situaiton is that we
+# "build ROMIO"s fortran I/O tests". Of course the common situation is that we
 # are building as part of MPICH, which builds its own fortran bindings, but we
 # still want tests built
-AM_CONDITIONAL([BUILD_F77_BINDINGS],[test "x$NOF77" != "x1" && test "x$FROM_MPICH" != "xyes"])
+# Building Fortran binding is only necessary when ROMIO is built in stand alone,
+# as both MPICH and OpenMPI have their own fortran bindings.
+AM_CONDITIONAL([BUILD_F77_BINDINGS], [test "x$NOF77" != x1 && test "x$build_ROMIO_EMBEDDED" = xno])
 
 AM_CONDITIONAL([BUILD_F77_TESTS],[test "x$NOF77" != "x1"])
 
@@ -907,7 +1004,7 @@ if test "$file_system_args" = "BGQ" -a -n "$file_system_gpfs"; then
     AC_DEFINE(BGQPLATFORM,1,BGQ platform)
     AM_CONDITIONAL([BUILD_AD_BG],[true])
     dnl what if anything can make Blue Gene support aio?
-    disable_aio=yes
+    enable_aio=no
 fi
 if test "$file_system_args" = "PE" -a -n "$file_system_gpfs"; then
     AC_DEFINE(PEPLATFORM,1,PE platform)
@@ -942,8 +1039,8 @@ if test -n "$file_system_lustre"; then
             ioctl(fd, LL_IOC_LADVISE, &ladvise_hdr);
             return 0; }
         ])],
-        lustre_lockahead="yes"
-	AC_DEFINE(HAVE_LUSTRE_LOCKAHEAD, 1, [Define if LUSTRE_LOCKAHEAD is enabled.]) )
+        [lustre_lockahead="yes"
+	 AC_DEFINE(HAVE_LUSTRE_LOCKAHEAD, 1, [Define if LUSTRE_LOCKAHEAD is enabled.])])
 fi
 
 # Add conditional compilation of Lustre lockahead sources
@@ -1021,9 +1118,9 @@ if test -n "$file_system_pvfs2"; then
 	      PVFS_sys_attr attr;
 	      PVFS_sys_create(NULL, ref, attr, NULL, NULL, NULL, NULL);
 	  return 0; }
-       ])],
-       , AC_DEFINE(HAVE_PVFS2_CREATE_WITHOUT_LAYOUT, 1,
-       		[Define if PVFS_sys_create does not have layout parameter])
+       ])], [],
+       [AC_DEFINE(HAVE_PVFS2_CREATE_WITHOUT_LAYOUT, 1,
+                  [Define if PVFS_sys_create does not have layout parameter])]
        )
 fi
 
@@ -1047,7 +1144,7 @@ AS_IF([test -n "$file_system_gpfs"],
 # was *linked* with pthreads, but would succeed if the application was
 # *not linked* with pthreads.
 #
-if test "x$disable_aio" = "xno" ; then
+if test "x$enable_aio" = "xyes" ; then
     AC_SEARCH_LIBS(aio_write,aio rt,aio_write_found=yes,aio_write_found=no)
     if test "$aio_write_found" = no ; then
         # If not found, try finding pthread_create first, and if
@@ -1059,14 +1156,14 @@ if test "x$disable_aio" = "xno" ; then
     fi
 fi
 
-if test "x$disable_aio" = "xno" -a -n "$aio_write_found" ; then
+if test "x$enable_aio" = "xyes" -a -n "$aio_write_found" ; then
     AC_CHECK_HEADERS([signal.h aio.h sys/aio.h] )
     if test "$ac_cv_header_aio_h" = "no" -a "$ac_cv_header_sys_aio_h" = "no" ; then
-    	disable_aio=yes
+       enable_aio=no
     fi
 fi
 
-if test "$ac_cv_header_aio_h" = "yes" -o "$ac_cv_header_sys_aio_h" = "yes" -o "x$disable_aio" = "xno"; then
+if test "$ac_cv_header_aio_h" = "yes" -o "$ac_cv_header_sys_aio_h" = "yes" -o "x$enable_aio" = "xyes"; then
 
     # Check that aio is available (many systems appear to have aio
     # either installed improperly or turned off).
@@ -1301,7 +1398,7 @@ AC_CHECK_DECLS([pwrite])
 # because we may set CC to something that does not yet exist!
 ####################################################################
 
-if test -n "$mpi_mpich"; then
+if test "x$MPI_IMPL" = xmpich ; then
    if test "$FROM_MPICH" = no; then
       AC_DEFINE(NEEDS_MPI_TEST,1,[Define if mpi_test needed])
       AC_DEFINE(MPICH,1,[Define if using MPICH])
@@ -1327,20 +1424,41 @@ AC_SUBST(srcdir)
 AC_ARG_VAR([main_top_srcdir],[set by the MPICH configure to indicate the MPICH source root])
 AC_ARG_VAR([main_top_builddir],[set by the MPICH configure to indicate the MPICH build root])
 
-# The master_top_srcdir is the location of the source for the building
-# package.  This is used only as part of the MPICH build, including
+# For OpenMPI, the roots have different names from MPICH
+if test "x$FROM_OMPI" = xyes ; then
+   if test "x$OMPI_TOP_BUILDDIR" = x ; then
+      mjain_top_srcdir=`readlink -f $srcdir/../../../../..`
+   else
+      mjain_top_srcdir=$OMPI_TOP_SRCDIR
+   fi
+   if test "x$OMPI_TOP_BUILDDIR" = x ; then
+      mjain_top_builddir=`readlink -f ../../../../..`
+   else
+      mjain_top_builddir=$OMPI_TOP_BUILDDIR
+   fi
+fi
+
+# The main_top_srcdir is the location of the source for the building
+# package. This is used only as part of the MPICH or OpenMPI build, including
 # the documentation targets mandoc, htmldoc, and latexdoc
 if test -z "$main_top_srcdir" ; then
     if test "$FROM_MPICH" = yes ; then
         AC_MSG_WARN([Could not determine main_top_srcdir])
+    elif test "$FROM_OMPI" = yes ; then
+        AC_MSG_WARN([Could not determine main_top_srcdir])
+    else
+        main_top_srcdir=`readlink -f $ROMIO_HOME`
     fi
 fi
+AC_SUBST(main_top_srcdir)
 #
 # Get the main builddir (which may be imported from above)
 if test -z "$main_top_builddir" ; then
     if test "$FROM_MPICH" = yes ; then
         # this variable is essential to proper build operation
-        AC_MSG_ERROR([Could not determine main_top_srcdir])
+        AC_MSG_ERROR([Could not determine main_top_builddir])
+    elif test "$FROM_OMPI" = yes ; then
+        AC_MSG_ERROR([Could not determine main_top_builddir])
     fi
     main_top_builddir=`pwd`
 fi
@@ -1354,13 +1472,13 @@ if test "$FROM_MPICH" = yes ; then
    AC_DEFINE(ROMIO_INSIDE_MPICH,1,[Define if compiling within MPICH])
 fi
 
-if test "$FROM_MPICH" = no ; then
+if test "x$FROM_OMPI" = xyes ; then
     if test -z "$LIBNAME"; then
-        LIBNAME="$top_build_dir/lib/libmpio.a"
+        LIBNAME="$top_build_dir/libromio_dist.la"
     fi
-    #
-    if test ! -d $top_build_dir/lib ; then
-        mkdir $top_build_dir/lib
+elif test "$FROM_MPICH" = no ; then
+    if test -z "$LIBNAME"; then
+        LIBNAME="$top_build_dir/libromio.la"
     fi
 else
     MPILIBNAME=${MPILIBNAME:-mpich}
@@ -1388,12 +1506,6 @@ AC_SUBST(MPIO_EXTRA_REAL_POBJECTS)
 AC_CHECK_PROGS(DOCTEXT,doctext,true)
 AC_SUBST(DOCTEXT)
 #
-if test $NOF77 = 1 ; then
-   F77=":"
-else
-   FORTRAN_TEST="fperf fcoll_test fmisc pfcoll_test"
-fi
-#
 if test $WITHIN_KNOWN_MPI_IMPL = no ; then
    PAC_TEST_MPI
    PAC_NEEDS_FINT
@@ -1401,36 +1513,34 @@ else
    NEEDS_MPI_FINT=""
 fi
 #
-if test "$MPI_INCLUDE_DIR" = "." ; then
-   ROMIO_INCLUDE="-I../include"
-else
-   ROMIO_INCLUDE="-I../include -I$MPI_INCLUDE_DIR"
-fi
-#
 TEST_LIBNAME=$LIBNAME
-MPIRUN=mpirun
 if test $FROM_OMPI = yes ; then
    # Open MPI does have the status set bytes functionality
 
    AC_DEFINE(HAVE_STATUS_SET_BYTES,1,[Define if have MPIR_Status_set_bytes])
    AC_DEFINE(HAVE_MPI_STATUS_SET_ELEMENTS_X, 1, [Define if MPI library provides MPI_STATUS_SET_ELEMENTS_X])
 
-   # Used in the tests/ subdirectory for after ROMIO is built
-
-   TEST_CC=mpicc
-   TEST_F77=mpifort
-   MPIRUN=mpirun
-   MPI_LIB=
-   NOPROFILE=1
-   ROMIO_INCLUDE=
-   USER_CFLAGS=
-   USER_FFLAGS=
-   TEST_LIBNAME=
+   TEST_CC='$(bindir)/mpicc'
+   TEST_F77='$(bindir)/mpifort'
+   MPI_INCLUDE_DIR="${main_topbuild_dir}/ompi/include"
+   MPI_CPPFLAGS="-I$MPI_INCLUDE_DIR"
+   MPI_LIB_DIR="${main_topbuild_dir}/ompi/lib"
+   MPI_LDFLAGS="-L$MPI_LIB_DIR"
+   MPI_LIB="-lmpi"
+   MPIRUN='${bindir}/mpirun -mca io romio321'
+   AC_DEFINE([HAVE_MPI_OFFSET], [1], [Will always be 1 - OMPI has MPI_Offset])
    AC_DEFINE(HAVE_MPI_DARRAY_SUBARRAY,1,[Define if Darray is available])
    HAVE_MPI_DARRAY_SUBARRAY="#define HAVE_MPI_DARRAY_SUBARRAY"
    # Open MPI: see comments in mpi-io/mpioprof.h
-   AC_DEFINE(MPIO_BUILD_PROFILING, 1, [hack to make ROMIO build without profiling])
-   DEFINE_HAVE_MPI_GREQUEST="#define HAVE_MPI_GREQUEST"
+   DEFINE_HAVE_MPI_GREQUEST="#define HAVE_MPI_GREQUEST 1"
+
+   AC_ARG_ENABLE([grequest-extensions],
+       [AS_HELP_STRING([--enable-grequest-extensions],
+                       [Enable support for Grequest extensions (default: disabled)])])
+   AS_IF([test "x$enable_grequest_extensions" = "xyes"],
+         [DEFINE_HAVE_MPI_GREQUEST_EXTENSIONS="#include \"ompi_grequestx.h\""],
+         [DEFINE_HAVE_MPI_GREQUEST_EXTENSIONS="#undef HAVE_MPI_GREQUEST_EXTENSIONS"])
+
    AC_DEFINE(HAVE_DECL_MPI_COMBINER_HINDEXED_BLOCK, 1, [Define if MPI library provides HINDEXED_BLOCK datatype])
 elif test $FROM_MPICH = yes ; then
    # For now, separate the mpich from mpich cases
@@ -1456,6 +1566,11 @@ elif test $FROM_MPICH = yes ; then
    ROMIO_INCLUDE=""
    USER_CFLAGS=""
    USER_FFLAGS=""
+   MPI_INCLUDE_DIR="${main_topbuild_dir}/src/include"
+   MPI_CPPFLAGS="-I$MPI_INCLUDE_DIR -I${main_top_srcdir}/src/include"
+   MPI_LIB_DIR="${main_topbuild_dir}/src/lib"
+   MPI_LDFLAGS="-L$MPI_LIB_DIR"
+   MPI_LIB="-lmpi"
    TEST_LIBNAME=""
    MPIRUN='${bindir}/mpiexec'
    #
@@ -1465,13 +1580,22 @@ elif test $FROM_MPICH = yes ; then
    DEFINE_HAVE_MPI_GREQUEST="#define HAVE_MPI_GREQUEST 1"
    DEFINE_HAVE_MPI_GREQUEST_EXTENSIONS="#define HAVE_MPI_GREQUEST_EXTENSIONS 1"
    AC_DEFINE(HAVE_MPIX_H, 1, [])
-   AC_DEFINE(HAVE_MPIIO_CONST, const, Set if MPI-IO prototypes use const qualifier)
+   # HAVE_MPIIO_CONST is now determined by whether MPI_VERSION >= 3
+   # AC_DEFINE(HAVE_MPIIO_CONST, const, Set if MPI-IO prototypes use const qualifier)
    AC_DEFINE(HAVE_MPI_TYPE_SIZE_X, 1, [Define if MPI library provides MPI_TYPE_SIZE_X])
    AC_DEFINE(HAVE_MPI_STATUS_SET_ELEMENTS_X, 1, [Define if MPI library provides MPI_STATUS_SET_ELEMENTS_X])
    AC_DEFINE(HAVE_DECL_MPI_COMBINER_HINDEXED_BLOCK, 1, [Define if MPI library provides HINDEXED_BLOCK datatype])
    AC_DEFINE(HAVE_MPIX_TYPE_IOV, 1, [Define if MPI library provides MPIX_Type_iov and MPIX_Type_iov_len])
 fi
-#
+
+if test "x$MPIRUN" = x ; then
+   if test "$with_mpi" != x ; then
+      MPIRUN=$with_mpi/bin/mpiexec
+   else
+      MPIRUN=mpiexec
+   fi
+fi
+
 #
 # feature tests:  we can't test features if building as part of MPICH because
 # we don't yet have an implementation against which we can test
@@ -1484,14 +1608,29 @@ if test $WITHIN_KNOWN_MPI_IMPL = no ; then
                  [AC_DEFINE_UNQUOTED([MPI_Count],[MPI_Aint],
                  [Define to "MPI_Aint" if MPI does not provide MPI_Count])],
                  [[#include <mpi.h>]])
+   # HAVE_MPIIO_CONST is now determined by whether MPI_VERSION >= 3
+   # PAC_TEST_NEEDS_CONST
    AC_CHECK_DECLS([MPI_COMBINER_HINDEXED_BLOCK], [], [], [[#include <mpi.h>]])
    AC_CHECK_FUNCS(MPI_Type_size_x MPI_Status_set_elements_x)
+
+   if test "x$build_ROMIO_EMBEDDED" = xno && test "x$ac_cv_func_MPI_Status_set_elements_x" = xyes ; then
+      # define HAVE_STATUS_SET_BYTES if it has not been defined in the above
+      # call to PAC_TEST_MPIR_STATUS_SET_BYTES, as MPIR_Status_set_bytes is
+      # implemented using MPI_Status_set_elements_x in status_setb.c
+      AC_CHECK_DECL([HAVE_STATUS_SET_BYTES], [],
+         [AC_DEFINE([HAVE_STATUS_SET_BYTES], [1], [Define if have MPIR_Status_set_bytes])])
+   fi
 fi
 #
-if test -z "$TEST_CC" ; then
+# when build stand alone, CC and F77 are expected to be MPI compilers
+if test "x$build_ROMIO_EMBEDDED" = xno ; then
+   TEST_CC="$CC"
+   TEST_F77="$F77"
+fi
+if test "x$TEST_CC" = x ; then
    TEST_CC="$CC"
 fi
-if test -z "$TEST_F77" ; then
+if test "x$TEST_F77" = x ; then
    TEST_F77="$F77"
 fi
 #
@@ -1541,40 +1680,27 @@ done
 # FIXME eliminate FILE_SYS_DIRS and EXTRA_SRC_DIRS
 EXTRA_SRC_DIRS=""
 
-mpio_glue=""
-if test "$FROM_MPICH" = yes -o "${MPI_IMPL}_mpi" = "mpich_mpi"; then
-    mpio_glue=mpich
-elif test "$FROM_OMPI" = yes -o "${MPI_IMPL}_mpi" = "open_mpi_mpi" ; then
-    mpio_glue=openmpi
-else
-    mpio_glue=default
-fi
-
 AM_CONDITIONAL([MPIO_GLUE_MPICH],[test "X$mpio_glue" = "Xmpich"])
 AM_CONDITIONAL([MPIO_GLUE_OPENMPI],[test "X$mpio_glue" = "Xopenmpi"])
 AM_CONDITIONAL([MPIO_GLUE_DEFAULT],[test "X$mpio_glue" = "Xdefault"])
 
 if test "$BUILD_MPI_INFO" = 1 ; then
     EXTRA_SRC_DIRS="$EXTRA_SRC_DIRS mpi2-other/info"
-    if test "$NOF77" = 0 -a "$FROM_MPICH" != yes ; then
+    if test "$NOF77" = 0 && test "$FROM_MPICH" != yes ; then
         EXTRA_SRC_DIRS="$EXTRA_SRC_DIRS mpi2-other/info/fortran"
     fi
 fi
 if test "$BUILD_MPI_ARRAY" = 1 ; then
     EXTRA_SRC_DIRS="$EXTRA_SRC_DIRS mpi2-other/array"
-    if test "$NOF77" = 0 -a "$FROM_MPICH" != yes ; then
+    if test "$NOF77" = 0 && test "$FROM_MPICH" != yes ; then
         EXTRA_SRC_DIRS="$EXTRA_SRC_DIRS mpi2-other/array/fortran"
     fi
 fi
-if test "$NOF77" = 0 -a "$FROM_MPICH" != yes ; then
+if test "$NOF77" = 0 && test "$FROM_MPICH" != yes ; then
    EXTRA_SRC_DIRS="$EXTRA_SRC_DIRS mpi-io/fortran"
 fi
 AC_SUBST(EXTRA_SRC_DIRS)
 AC_SUBST(FILE_SYS_DIRS)
-
-#
-CFLAGS="$CFLAGS -DHAVE_ROMIOCONF_H"
-#
 
 AC_MSG_NOTICE([setting SYSDEP_INC to $SYSDEP_INC])
 AC_SUBST(SYSDEP_INC)
@@ -1585,13 +1711,66 @@ PAC_C_GNU_ATTRIBUTE
 # support gcov test coverage information
 PAC_ENABLE_COVERAGE
 
-AC_MSG_NOTICE([setting CC to $CC])
-AC_MSG_NOTICE([setting F77 to $F77])
-AC_MSG_NOTICE([setting TEST_CC to $TEST_CC])
-AC_MSG_NOTICE([setting TEST_F77 to $TEST_F77])
-AC_MSG_NOTICE([setting CFLAGS to $CFLAGS])
-AC_MSG_NOTICE([setting USER_CFLAGS to $USER_CFLAGS])
-AC_MSG_NOTICE([setting USER_FFLAGS to $USER_FFLAGS])
+# check some MPI constants and data types
+if test "x$build_ROMIO_EMBEDDED" = xno; then
+   AC_CHECK_DECL([MPI_FILE_DEFINED], [], [], [[#include <mpi.h>]])
+   if test "x${ac_cv_have_decl_MPI_FILE_DEFINED}" = xno ; then
+      AC_CHECK_TYPE([MPI_File],
+                    [AC_DEFINE([MPI_FILE_DEFINED],[1],
+                               [whether type MPI_File is defined])],
+                    [], [[#include <mpi.h>]])
+   fi
+
+   AC_CHECK_DECL([HAVE_MPI_OFFSET], [], [], [[#include <mpi.h>]])
+   if test "x${ac_cv_have_decl_HAVE_MPI_OFFSET}" = xno ; then
+      AC_CHECK_TYPE([MPI_Offset],
+                    [AC_DEFINE([HAVE_MPI_OFFSET],[1],
+                               [whether type MPI_Offset is defined])],
+                    [], [[#include <mpi.h>]])
+   fi
+
+   AC_CHECK_DECLS([MPI_FILE_NULL], [], [], [[#include <mpi.h>]])
+
+   AC_CHECK_DECL([MPIIMPL_HAVE_MPI_COMBINER_DUP], [], [], [[#include <mpi.h>]])
+   if test "x${ac_cv_have_decl_MPIIMPL_HAVE_MPI_COMBINER_DUP}" = xno ; then
+      AC_CHECK_DECL([MPI_COMBINER_DUP],
+                    [AC_DEFINE([MPIIMPL_HAVE_MPI_COMBINER_DUP], [1],
+                               [whether MPI_COMBINER_DUP is defined])],
+                    [], [[#include <mpi.h>]])
+   fi
+
+   AC_CHECK_DECL([MPIIMPL_HAVE_MPI_COMBINER_SUBARRAY], [], [], [[#include <mpi.h>]])
+   if test "x${ac_cv_have_decl_MPIIMPL_HAVE_MPI_COMBINER_SUBARRAY}" = xno ; then
+      AC_CHECK_DECL([MPI_COMBINER_SUBARRAY],
+                    [AC_DEFINE([MPIIMPL_HAVE_MPI_COMBINER_SUBARRAY], [1],
+                               [whether MPI_COMBINER_SUBARRAY is defined])],
+                    [], [[#include <mpi.h>]])
+   fi
+
+   AC_CHECK_DECL([MPIIMPL_HAVE_MPI_COMBINER_DARRAY], [], [], [[#include <mpi.h>]])
+   if test "x${ac_cv_have_decl_MPIIMPL_HAVE_MPI_COMBINER_DARRAY}" = xno ; then
+      AC_CHECK_DECL([MPI_COMBINER_DARRAY],
+                    [AC_DEFINE([MPIIMPL_HAVE_MPI_COMBINER_DARRAY], [1],
+                               [whether MPI_COMBINER_DARRAY is defined])],
+                    [], [[#include <mpi.h>]])
+   fi
+
+   AC_CHECK_DECL([MPIO_Request_c2f], [], [], [[#include <mpi.h>]])
+   if test "x${ac_cv_have_decl_MPIO_Request_c2f}" = xno ; then
+      AC_DEFINE([MPIO_Request_c2f], [MPI_Request_c2f],
+                [whether MPIO_Request_c2f is defined])
+   fi
+
+   AC_CHECK_DECL([MPIO_Request_f2c], [], [], [[#include <mpi.h>]])
+   if test "x${ac_cv_have_decl_MPIO_Request_f2c}" = xno ; then
+      AC_DEFINE([MPIO_Request_f2c], [MPI_Request_f2c],
+                [whether MPIO_Request_f2c is defined])
+   fi
+
+   AC_CHECK_FUNCS(strncat)
+
+   AC_TYPE_UINTPTR_T
+fi
 
 # check whether some constants and subroutines are defined in mpi.h
 saved_CPPFLAGS=$CPPFLAGS
@@ -1626,22 +1805,11 @@ CPPFLAGS=$saved_CPPFLAGS
 
 AC_SUBST(ARCH)
 AC_SUBST(FILE_SYSTEM)
-AC_SUBST(CC)
-AC_SUBST(CPPFLAGS)
-AC_SUBST(CFLAGS)
-AC_SUBST(USER_CFLAGS)
-AC_SUBST(USER_FFLAGS)
-AC_SUBST(MIPS)
-AC_SUBST(BITS)
-AC_SUBST(AR)
-AC_SUBST(AR_FLAGS)
 AC_SUBST(MPI_INCLUDE_DIR)
 AC_SUBST(MPI_LIB)
-AC_SUBST(F77)
 AC_SUBST(NOF77)
 AC_SUBST(NOPROFILE)
 AC_SUBST(MAKE)
-AC_SUBST(arch_IRIX)
 AC_SUBST(ROMIO_HOME)
 AC_SUBST(LIBNAME)
 AC_SUBST(TEST_LIBNAME)
@@ -1649,16 +1817,12 @@ AC_SUBST(LL)
 AC_SUBST(F77GETARG)
 AC_SUBST(F77IARGC)
 AC_SUBST(FORTRAN_MPI_OFFSET)
-AC_SUBST(FROM_MPICH)
-AC_SUBST(FROM_LAM)
-AC_SUBST(WITHIN_KNOWN_MPI_IMPL)
 AC_SUBST(NEEDS_MPI_FINT)
 AC_SUBST(HAVE_MPI_INFO)
-AC_SUBST(BUILD_MPI_INFO)
 AC_SUBST(HAVE_MPI_DARRAY_SUBARRAY)
-AC_SUBST(BUILD_MPI_ARRAY)
 AC_SUBST(DEFINE_MPI_OFFSET)
 AC_SUBST(DEFINE_HAVE_MPI_GREQUEST)
+AC_SUBST(DEFINE_HAVE_MPI_GREQUEST_EXTENSIONS)
 AC_SUBST(MPI_OFFSET_TYPE)
 AC_SUBST(MPI_FINFO1)
 AC_SUBST(MPI_FINFO2)
@@ -1675,13 +1839,7 @@ AC_SUBST(MPI_OFFSET_KIND1)
 AC_SUBST(MPI_OFFSET_KIND2)
 AC_SUBST(TEST_CC)
 AC_SUBST(TEST_F77)
-AC_SUBST(ROMIO_INCLUDE)
-AC_SUBST(ROMIO_LFLAGS)
-AC_SUBST(ROMIO_TCFLAGS)
-AC_SUBST(ROMIO_TCPPFLAGS)
-AC_SUBST(ROMIO_TFFLAGS)
 AC_SUBST(MPIRUN)
-AC_SUBST(FORTRAN_TEST)
 dnl
 dnl Support shared libraries
 if test -z "$ENABLE_SHLIB" ; then
@@ -1694,12 +1852,6 @@ AC_SUBST(LIBTOOL)
 # other appropriate suffix)
 SHLIBNAME=`echo $LIBNAME | sed 's/\.a$//'`
 AC_SUBST(SHLIBNAME)
-dnl
-if test ! -d adio ; then mkdir adio ; fi
-if test ! -d adio/include ; then mkdir adio/include ; fi
-if test ! -d mpi2-other ; then mkdir mpi2-other ; fi
-if test ! -d mpi-io ; then mkdir mpi-io ; fi
-if test ! -d mpi-io/glue ; then mkdir mpi-io/glue ; fi
 
 # Create makefiles for all of the adio devices.  Only the ones that
 # are active will be called by the top level ROMIO make
@@ -1713,7 +1865,6 @@ AC_CONFIG_FILES([
     test/large_file.c
     test-internal/Makefile
     include/mpio.h
-    include/mpiof.h
     mpi2-other/info/fortran/Makefile
     mpi2-other/array/fortran/Makefile
     test/fmisc.f
@@ -1726,6 +1877,36 @@ AC_CONFIG_FILES([test/runtests], [chmod +x test/runtests])
 AC_CONFIG_FILES([test/parallel_run.sh], [chmod +x test/parallel_run.sh])
 
 AC_OUTPUT
+if test "x$build_ROMIO_EMBEDDED" = xno; then
+echo "------------------------------------------------------------------------------"
+echo \
+"
+   ${PACKAGE_NAME} Version ${PACKAGE_VERSION}
+
+   Features:  Build static libraries     - $enable_static
+              Build shared libraries     - $enable_shared
+              Build Fortran 77 support   - $enable_f77
+              Build Fortran 90 support   - $enable_f90
+              Enable weak symbols        - $enable_weak_symbols
+              Enable Asynchronous I/O    - $enable_aio
+              File systems               - $FILE_SYSTEM"
+
+echo "\
+
+   Compilers: CC           = ${CC}
+              CFLAGS       = ${CFLAGS}
+              TEST_CC      = ${TEST_CC}"
+if test "x${enable_f77}" = xyes; then
+   echo "\
+
+              F77          = ${F77}
+              FC           = ${FC}
+              FFLAGS       = ${FFLAGS}
+              TEST_F77     = ${TEST_F77}"
+fi
+echo "\
+
+------------------------------------------------------------------------------"
+fi
 
 dnl PAC_SUBDIR_CACHE_CLEANUP
-exit 0

--- a/src/mpi/romio/include/io_romio_conv.h
+++ b/src/mpi/romio/include/io_romio_conv.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef MCA_IO_ROMIO_CONV_H
+#define MCA_IO_ROMIO_CONV_H
+
+/* Prefix that we add to all ROMIO symbols */
+#ifdef ROMIO_PREFIX
+#undef ROMIO_PREFIX
+#endif
+#define ROMIO_PREFIX(foo) mca_io_romio_dist_##foo
+
+/* Section 9.2 */
+/* Begin Prototypes */
+#define MPI_File_open ROMIO_PREFIX(MPI_File_open)
+#define MPI_File_close ROMIO_PREFIX(MPI_File_close)
+#define MPI_File_delete ROMIO_PREFIX(MPI_File_delete)
+#define MPI_File_set_size ROMIO_PREFIX(MPI_File_set_size)
+#define MPI_File_preallocate ROMIO_PREFIX(MPI_File_preallocate)
+#define MPI_File_get_size ROMIO_PREFIX(MPI_File_get_size)
+#define MPI_File_get_group ROMIO_PREFIX(MPI_File_get_group)
+#define MPI_File_get_amode ROMIO_PREFIX(MPI_File_get_amode)
+#define MPI_File_set_info ROMIO_PREFIX(MPI_File_set_info)
+#define MPI_File_get_info ROMIO_PREFIX(MPI_File_get_info)
+
+/* Section 9.3 */
+#define MPI_File_set_view ROMIO_PREFIX(MPI_File_set_view)
+#define MPI_File_get_view ROMIO_PREFIX(MPI_File_get_view)
+
+/* Section 9.4.2 */
+#define MPI_File_read_at ROMIO_PREFIX(MPI_File_read_at)
+#define MPI_File_read_at_all ROMIO_PREFIX(MPI_File_read_at_all)
+#define MPI_File_write_at ROMIO_PREFIX(MPI_File_write_at)
+#define MPI_File_write_at_all ROMIO_PREFIX(MPI_File_write_at_all)
+#define MPI_File_iread_at ROMIO_PREFIX(MPI_File_iread_at)
+#define MPI_File_iwrite_at ROMIO_PREFIX(MPI_File_iwrite_at)
+
+/* Section 9.4.3 */
+#define MPI_File_read ROMIO_PREFIX(MPI_File_read)
+#define MPI_File_read_all ROMIO_PREFIX(MPI_File_read_all)
+#define MPI_File_write ROMIO_PREFIX(MPI_File_write)
+#define MPI_File_write_all ROMIO_PREFIX(MPI_File_write_all)
+
+#define MPI_File_iread ROMIO_PREFIX(MPI_File_iread)
+#define MPI_File_iread_all ROMIO_PREFIX(MPI_File_iread_all)
+#define MPI_File_iwrite ROMIO_PREFIX(MPI_File_iwrite)
+#define MPI_File_iwrite_all ROMIO_PREFIX(MPI_File_iwrite_all)
+#define MPI_File_iread_at_all ROMIO_PREFIX(MPI_File_iread_at_all)
+#define MPI_File_iwrite_at_all ROMIO_PREFIX(MPI_File_iwrite_at_all)
+
+
+#define MPI_File_seek ROMIO_PREFIX(MPI_File_seek)
+#define MPI_File_get_position ROMIO_PREFIX(MPI_File_get_position)
+#define MPI_File_get_byte_offset ROMIO_PREFIX(MPI_File_get_byte_offset)
+
+/* Section 9.4.4 */
+#define MPI_File_read_shared ROMIO_PREFIX(MPI_File_read_shared)
+#define MPI_File_write_shared ROMIO_PREFIX(MPI_File_write_shared)
+#define MPI_File_iread_shared ROMIO_PREFIX(MPI_File_iread_shared)
+#define MPI_File_iwrite_shared ROMIO_PREFIX(MPI_File_iwrite_shared)
+#define MPI_File_read_ordered ROMIO_PREFIX(MPI_File_read_ordered)
+#define MPI_File_write_ordered ROMIO_PREFIX(MPI_File_write_ordered)
+#define MPI_File_seek_shared ROMIO_PREFIX(MPI_File_seek_shared)
+#define MPI_File_get_position_shared ROMIO_PREFIX(MPI_File_get_position_shared)
+
+/* Section 9.4.5 */
+#define MPI_File_read_at_all_begin ROMIO_PREFIX(MPI_File_read_at_all_begin)
+#define MPI_File_read_at_all_end ROMIO_PREFIX(MPI_File_read_at_all_end)
+#define MPI_File_write_at_all_begin ROMIO_PREFIX(MPI_File_write_at_all_begin)
+#define MPI_File_write_at_all_end ROMIO_PREFIX(MPI_File_write_at_all_end)
+#define MPI_File_read_all_begin ROMIO_PREFIX(MPI_File_read_all_begin)
+#define MPI_File_read_all_end ROMIO_PREFIX(MPI_File_read_all_end)
+#define MPI_File_write_all_begin ROMIO_PREFIX(MPI_File_write_all_begin)
+#define MPI_File_write_all_end ROMIO_PREFIX(MPI_File_write_all_end)
+#define MPI_File_read_ordered_begin ROMIO_PREFIX(MPI_File_read_ordered_begin)
+#define MPI_File_read_ordered_end ROMIO_PREFIX(MPI_File_read_ordered_end)
+#define MPI_File_write_ordered_begin ROMIO_PREFIX(MPI_File_write_ordered_begin)
+#define MPI_File_write_ordered_end ROMIO_PREFIX(MPI_File_write_ordered_end)
+
+/* Section 9.5.1 */
+#define MPI_File_get_type_extent ROMIO_PREFIX(MPI_File_get_type_extent)
+
+/* Section 9.6.1 */
+#define MPI_File_set_atomicity ROMIO_PREFIX(MPI_File_set_atomicity)
+#define MPI_File_get_atomicity ROMIO_PREFIX(MPI_File_get_atomicity)
+#define MPI_File_sync ROMIO_PREFIX(MPI_File_sync)
+
+/* Section 4.13.3 */
+#define MPI_File_set_errhandler ROMIO_PREFIX(MPI_File_set_errhandler)
+#define MPI_File_get_errhandler ROMIO_PREFIX(MPI_File_get_errhandler)
+/* End Prototypes */
+
+#define MPI_Register_datarep ROMIO_PREFIX(MPI_Register_datarep)
+
+/* JMS these don't seem to work... */
+#define MPI_File_f2c ROMIO_PREFIX(MPI_File_f2c)
+#define MPI_File_c2f ROMIO_PREFIX(MPI_File_c2f)
+
+#define MPIO_Request_c2f ROMIO_PREFIX(MPIO_Request_c2f)
+#define MPIO_Request_f2c ROMIO_PREFIX(MPIO_Request_f2c)
+
+/* Conversion of MPI_File and MPIO_Request */
+#define MPI_File ROMIO_PREFIX(MPI_File)
+
+/* Open MPI's mpi.h #define's MPI_FILE_NULL, so we need to undef it
+   here and allow it to be re-assigned to whatever ROMIO wants */
+#undef MPI_FILE_NULL
+
+/* Let's not use MPIR_Status_set_bytes */
+#ifndef MPIR_Status_set_bytes
+#define MPIR_Status_set_bytes ROMIO_PREFIX(MPIR_Status_set_bytes)
+#endif
+
+#endif /* MCA_IO_ROMIO_CONV_H */

--- a/src/mpi/romio/include/mpio.h.in
+++ b/src/mpi/romio/include/mpio.h.in
@@ -10,6 +10,20 @@
 
 #include "mpi.h"
 
+#ifdef ROMIO_INSIDE_OMPI
+/* Open MPI: We need to rename almost all of MPI-IO functions, as well
+ * the types to be names that conform to the prefix rule.
+ */
+#include "io_romio_conv.h"
+
+/* These datatypes and combiners have been defined in OpenMPI */
+#define MPIIMPL_HAVE_MPI_COMBINER_DARRAY 1
+#define MPIIMPL_HAVE_MPI_TYPE_CREATE_DARRAY 1
+#define MPIIMPL_HAVE_MPI_COMBINER_SUBARRAY 1
+#define MPIIMPL_HAVE_MPI_TYPE_CREATE_DARRAY 1
+#define MPIIMPL_HAVE_MPI_COMBINER_DUP 1
+#endif
+
 #if defined(HAVE_VISIBILITY)
 #define ROMIO_API_PUBLIC __attribute__((visibility ("default")))
 #else
@@ -35,6 +49,12 @@ typedef struct ADIOI_FileD *MPI_File;
 typedef struct ADIOI_RequestD *MPIO_Request;  
 #else
 #define MPIO_Request MPI_Request
+#ifndef MPIO_Request_c2f
+#define MPIO_Request_c2f MPI_Request_c2f
+#endif
+#ifndef MPIO_Request_f2c
+#define MPIO_Request_f2c MPI_Request_f2c
+#endif
 #define MPIO_USES_MPI_REQUEST
 /* Also rename the MPIO routines to get the MPI versions */
 #define MPIO_Wait MPI_Wait
@@ -43,6 +63,8 @@ typedef struct ADIOI_RequestD *MPIO_Request;
 #define PMPIO_Test PMPI_Test
 #endif
 #define MPIO_REQUEST_DEFINED
+
+@DEFINE_HAVE_MPI_GREQUEST_EXTENSIONS@
 
 #ifndef HAVE_MPI_OFFSET
 /* *INDENT-OFF* */
@@ -94,7 +116,7 @@ typedef int MPI_Fint;
 
 #define MPI_DISPLACEMENT_CURRENT   -54278278
 
-#ifndef MPICH
+#if !defined(MPI_FILE_NULL) && (!defined(HAVE_DECL_MPI_FILE_NULL) || HAVE_DECL_MPI_FILE_NULL == 0)
 /* FIXME: Make sure that we get a consistent definition of MPI_FILE_NULL
 	in MPICH */
 /* MPICH defines null object handles differently */
@@ -126,6 +148,9 @@ typedef int MPI_Fint;
 #  define MPI_DISTRIBUTE_DFLT_DARG -49767
 #endif
 
+#if !defined(ROMIO_INSIDE_MPICH) && !defined(MPICH_ATTR_POINTER_WITH_TYPE_TAG)
+#  define MPICH_ATTR_POINTER_WITH_TYPE_TAG(buffer_idx, type_idx)
+#endif
 
 /* MPI-IO function prototypes */
 
@@ -247,7 +272,7 @@ int MPI_File_set_atomicity(MPI_File fh, int flag) ROMIO_API_PUBLIC;
 int MPI_File_get_atomicity(MPI_File fh, int *flag) ROMIO_API_PUBLIC;
 int MPI_File_sync(MPI_File fh) ROMIO_API_PUBLIC;
 
-/* Section 4.13.3 */
+/* MPI 3.1 Section 8.3.3 */
 #ifndef MPICH
 /* MPICH provides these definitions */
 int MPI_File_set_errhandler(MPI_File file, MPI_Errhandler errhandler) ROMIO_API_PUBLIC;
@@ -369,8 +394,11 @@ int MPI_Type_create_darray(int size, int rank, int ndims, const int array_of_gsi
 #endif
 #endif
 /* above needed for some versions of mpi.h in MPICH!! */
+
+#ifndef ROMIO_INSIDE_OMPI
 MPI_File MPI_File_f2c(MPI_Fint file) ROMIO_API_PUBLIC;
 MPI_Fint MPI_File_c2f(MPI_File file) ROMIO_API_PUBLIC;
+#endif
 
 
 #ifndef HAVE_MPI_GREQUEST
@@ -425,6 +453,8 @@ MPI_Info MPI_Info_f2c(MPI_Fint info) ROMIO_API_PUBLIC;
 
 #endif   /* HAVE_PRAGMA_HP_SEC_DEF */
 
+
+#ifndef ROMIO_INSIDE_OMPI
 
 /**************** BINDINGS FOR THE PROFILING INTERFACE ***************/
 
@@ -689,6 +719,8 @@ int PMPI_Info_free(MPI_Info *) ROMIO_API_PUBLIC;
 
 MPI_Fint PMPI_Info_c2f(MPI_Info) ROMIO_API_PUBLIC;
 MPI_Info PMPI_Info_f2c(MPI_Fint) ROMIO_API_PUBLIC;
+#endif
+
 #endif
 
 #if defined(__cplusplus)

--- a/src/mpi/romio/include/mpio.h.in
+++ b/src/mpi/romio/include/mpio.h.in
@@ -47,18 +47,18 @@ typedef struct ADIOI_RequestD *MPIO_Request;
 #ifndef HAVE_MPI_OFFSET
 /* *INDENT-OFF* */
 @DEFINE_MPI_OFFSET@
-/* *INDENT-ON* */
-/* If we needed to define MPI_Offset, then we also need to make
-   this definition. */
-#ifndef HAVE_MPI_DATAREP_FUNCTIONS
-#define HAVE_MPI_DATAREP_FUNCTIONS
+#endif
+#ifndef HAVE_MPI_DATAREP_CONVERSION_FUNCTION
 typedef int (MPI_Datarep_conversion_function)(void *, MPI_Datatype, int, 
              void *, MPI_Offset, void *);
+#endif
+#ifndef HAVE_MPI_DATAREP_CONVERSION_FUNCTION_C
 typedef int (MPI_Datarep_conversion_function_c)(void *, MPI_Datatype, MPI_Count,
                                                 void *, MPI_Offset, void *);
+#endif
+#ifndef HAVE_MPI_DATAREP_EXTENT_FUNCTION
 typedef int (MPI_Datarep_extent_function)(MPI_Datatype datatype, MPI_Aint *,
 					  void *);
-#endif
 #endif
 
 #ifndef NEEDS_MPI_FINT

--- a/src/mpi/romio/include/ompi_grequestx.h
+++ b/src/mpi/romio/include/ompi_grequestx.h
@@ -1,0 +1,28 @@
+#define HAVE_MPI_GREQUEST_EXTENSIONS 1
+
+extern void opal_progress(void);
+
+typedef int (MPIX_Grequest_poll_function) (void *, MPI_Status *);
+typedef int (MPIX_Grequest_wait_function) (int, void **, double, MPI_Status *);
+typedef int MPIX_Grequest_class;
+
+extern int ompi_grequestx_start(MPI_Grequest_query_function * gquery,
+                                MPI_Grequest_free_function * gfree,
+                                MPI_Grequest_cancel_function * gcancel,
+                                MPIX_Grequest_poll_function * gpoll,
+                                void *gstate, MPI_Request * request);
+
+extern int ompi_grequestx_class_create(MPI_Grequest_query_function * gquery,
+                                       MPI_Grequest_free_function * gfree,
+                                       MPI_Grequest_cancel_function * gcancel,
+                                       MPIX_Grequest_poll_function * gpoll,
+                                       MPIX_Grequest_wait_function * gwait,
+                                       MPIX_Grequest_class * greq_class);
+
+extern int ompi_grequestx_class_allocate(MPIX_Grequest_class greq_class,
+                                         void *extra_state, MPI_Request * request);
+
+#define MPIR_Ext_cs_yield opal_progress
+#define PMPIX_Grequest_class_allocate(greq_class,extra_state,request) ompi_grequestx_class_allocate(greq_class,extra_state,request)
+#define PMPIX_Grequest_class_create(query_fn,free_fn,cancel_fn,poll_fn,wait_fn,greq_class) ompi_grequestx_class_create(query_fn,free_fn,cancel_fn,poll_fn,wait_fn,greq_class)
+#define PMPIX_Grequest_start(query_fn,free_fn,cancel_fn,poll_fn,extra_state,request) ompi_grequestx_start(query_fn,free_fn,cancel_fn,poll_fn,extra_state,request)

--- a/src/mpi/romio/mpi-io/Makefile.mk
+++ b/src/mpi/romio/mpi-io/Makefile.mk
@@ -75,11 +75,11 @@ romio_mpi_sources +=          \
 
 
 # non-MPI/PMPI sources that will be included in libromio
-romio_other_sources +=       \
-    mpi-io/mpich_fileutil.c \
-    mpi-io/mpir-mpioinit.c   \
-    mpi-io/mpiu_greq.c \
-    mpi-io/mpiu_external32.c \
+romio_other_sources +=        \
+    mpi-io/mpich_fileutil.c   \
+    mpi-io/mpir-mpioinit.c    \
+    mpi-io/mpiu_greq.c        \
+    mpi-io/mpiu_external32.c  \
     mpi-io/mpir_cst_filesys.c \
     mpi-io/mpl_str.c
 

--- a/src/mpi/romio/mpi-io/Makefile.mk
+++ b/src/mpi/romio/mpi-io/Makefile.mk
@@ -9,11 +9,15 @@ include $(top_srcdir)/mpi-io/fortran/Makefile.mk
 AM_CPPFLAGS += -I$(top_builddir)/mpi-io -I$(top_srcdir)/mpi-io
 noinst_HEADERS += mpi-io/mpioimpl.h mpi-io/mpioprof.h
 
+if !ROMIO_INSIDE_OMPI
+romio_mpi_sources +=          \
+    mpi-io/file_c2f.c         \
+    mpi-io/file_f2c.c
+endif
+
 romio_mpi_sources +=          \
     mpi-io/close.c            \
     mpi-io/delete.c           \
-    mpi-io/file_c2f.c         \
-    mpi-io/file_f2c.c         \
     mpi-io/fsync.c            \
     mpi-io/get_amode.c        \
     mpi-io/get_atom.c         \
@@ -103,5 +107,5 @@ endif BUILD_MPIO_REQUEST
 
 # not used in MPICH
 if BUILD_MPIO_ERRHAN
-romio_other_sources += $(mpio_request_sources)
+romio_other_sources += $(mpio_extra_sources)
 endif BUILD_MPIO_ERRHAN

--- a/src/mpi/romio/mpi-io/Makefile.mk
+++ b/src/mpi/romio/mpi-io/Makefile.mk
@@ -76,7 +76,8 @@ romio_other_sources +=       \
     mpi-io/mpir-mpioinit.c   \
     mpi-io/mpiu_greq.c \
     mpi-io/mpiu_external32.c \
-    mpi-io/mpir_cst_filesys.c
+    mpi-io/mpir_cst_filesys.c \
+    mpi-io/mpl_str.c
 
 # helper variables for conditionally compiled sources
 mpio_request_sources=   \

--- a/src/mpi/romio/mpi-io/close.c
+++ b/src/mpi/romio/mpi-io/close.c
@@ -59,7 +59,7 @@ int MPI_File_close(MPI_File * fh)
          * but a race condition in GPFS necessated this.  See ticket #2214 */
         MPI_Barrier((adio_fh)->comm);
         if ((adio_fh)->shared_fp_fd != ADIO_FILE_NULL) {
-            MPI_File *fh_shared = &(adio_fh->shared_fp_fd);
+            ADIO_File *fh_shared = &(adio_fh->shared_fp_fd);
             ADIO_Close((adio_fh)->shared_fp_fd, &error_code);
             MPIO_File_free(fh_shared);
             /* --BEGIN ERROR HANDLING-- */
@@ -74,12 +74,16 @@ int MPI_File_close(MPI_File * fh)
      * somehow inform the MPI library that we no longer hold a reference to any
      * user defined error handler.  We do this by setting the errhandler at this
      * point to MPI_ERRORS_RETURN. */
+#ifdef MPIO_BUILD_PROFILING
     error_code = PMPI_File_set_errhandler(*fh, MPI_ERRORS_RETURN);
+#else
+    error_code = MPI_File_set_errhandler(*fh, MPI_ERRORS_RETURN);
+#endif
     if (error_code != MPI_SUCCESS)
         goto fn_fail;
 
     ADIO_Close(adio_fh, &error_code);
-    MPIO_File_free(fh);
+    MPIO_File_free(&adio_fh);
     /* --BEGIN ERROR HANDLING-- */
     if (error_code != MPI_SUCCESS)
         goto fn_fail;

--- a/src/mpi/romio/mpi-io/delete.c
+++ b/src/mpi/romio/mpi-io/delete.c
@@ -62,7 +62,7 @@ int MPI_File_delete(ROMIO_CONST char *filename, MPI_Info info)
          * the error up.  In the PRINT_ERR_MSG case MPI_Abort has already
          * been called as well, so we probably didn't even make it this far.
          */
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+        error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
         goto fn_exit;
     }
     /* --END ERROR HANDLING-- */
@@ -82,7 +82,7 @@ int MPI_File_delete(ROMIO_CONST char *filename, MPI_Info info)
     (fsops->ADIOI_xxx_Delete) (filename, &error_code);
     /* --BEGIN ERROR HANDLING-- */
     if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+        error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
     /* --END ERROR HANDLING-- */
 
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/fortran/closef.c
+++ b/src/mpi/romio/mpi-io/fortran/closef.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_close_(MPI_File *, MPI_Fint *);
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/deletef.c
+++ b/src/mpi/romio/mpi-io/fortran/deletef.c
@@ -10,7 +10,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -56,8 +56,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_delete_(char *FORT_MIXED_LEN_DECL, MP
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/fsyncf.c
+++ b/src/mpi/romio/mpi-io/fortran/fsyncf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_sync_(MPI_Fint *, MPI_Fint *);
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_amodef.c
+++ b/src/mpi/romio/mpi-io/fortran/get_amodef.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_amode_(MPI_Fint *, MPI_Fint *, MP
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_atomf.c
+++ b/src/mpi/romio/mpi-io/fortran/get_atomf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_atomicity_(MPI_Fint *, MPI_Fint *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_bytofff.c
+++ b/src/mpi/romio/mpi-io/fortran/get_bytofff.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_byte_offset_(MPI_Fint *, MPI_Offs
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_errhf.c
+++ b/src/mpi/romio/mpi-io/fortran/get_errhf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_errhandler_(MPI_Fint *, MPI_Fint 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_extentf.c
+++ b/src/mpi/romio/mpi-io/fortran/get_extentf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_type_extent_(MPI_Fint *, MPI_Fint
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,14 @@ void mpi_file_get_type_extent_(MPI_Fint * fh, MPI_Fint * datatype,
 
 void mpi_file_get_type_extent_(MPI_Fint * fh, MPI_Fint * datatype,
                                MPI_Fint * extent, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_get_type_extent_(MPI_Fint * fh, MPI_Fint * datatype,
+                                                     MPI_Fint * extent, MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_get_type_extent_(MPI_Fint * fh, MPI_Fint * datatype,
+                                                     MPI_Fint * extent, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Datatype datatype_c;
@@ -109,20 +115,3 @@ void mpi_file_get_type_extent_(MPI_Fint * fh, MPI_Fint * datatype,
     *ierr = MPI_File_get_type_extent(fh_c, datatype_c, &extent_c);
     *(MPI_Aint *) extent = extent_c;    /* Have to assume it's really an MPI_Aint? */
 }
-
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_get_type_extent_(MPI_Fint * fh, MPI_Datatype * datatype,
-                                                     MPI_Fint * extent, MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_get_type_extent_(MPI_Fint * fh, MPI_Datatype * datatype,
-                                                     MPI_Fint * extent, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Aint extent_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_get_type_extent(fh_c, *datatype, &extent_c);
-    *(MPI_Aint *) extent = extent_c;    /* Have to assume it's really an MPI_Aint? */
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/get_groupf.c
+++ b/src/mpi/romio/mpi-io/fortran/get_groupf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_group_(MPI_Fint *, MPI_Group *, M
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -92,6 +90,12 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_group_(MPI_Fint *, MPI_Group *, M
 void mpi_file_get_group_(MPI_Fint * fh, MPI_Fint * group, MPI_Fint * ierr);
 
 void mpi_file_get_group_(MPI_Fint * fh, MPI_Fint * group, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_get_group_(MPI_Fint * fh, MPI_Fint * group, MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_get_group_(MPI_Fint * fh, MPI_Fint * group, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Group group_c;
@@ -100,15 +104,3 @@ void mpi_file_get_group_(MPI_Fint * fh, MPI_Fint * group, MPI_Fint * ierr)
     *ierr = MPI_File_get_group(fh_c, &group_c);
     *group = MPI_Group_c2f(group_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_get_group_(MPI_Fint * fh, MPI_Group * group, MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_get_group_(MPI_Fint * fh, MPI_Group * group, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_get_group(fh_c, group);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/get_infof.c
+++ b/src/mpi/romio/mpi-io/fortran/get_infof.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_info_(MPI_Fint *, MPI_Fint *, MPI
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_posn_shf.c
+++ b/src/mpi/romio/mpi-io/fortran/get_posn_shf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_position_shared_(MPI_Fint *, MPI_
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_posnf.c
+++ b/src/mpi/romio/mpi-io/fortran/get_posnf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_position_(MPI_Fint *, MPI_Offset 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/get_sizef.c
+++ b/src/mpi/romio/mpi-io/fortran/get_sizef.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_get_size_(MPI_Fint *, MPI_Offset *, M
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/iotestf.c
+++ b/src/mpi/romio/mpi-io/fortran/iotestf.c
@@ -6,7 +6,7 @@
 #include "adio.h"
 #include "mpio.h"
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -52,8 +52,6 @@ FORTRAN_API void FORT_CALL mpio_test_(MPI_Fint * request, MPI_Fint * flag, MPI_S
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/iowaitf.c
+++ b/src/mpi/romio/mpi-io/fortran/iowaitf.c
@@ -6,7 +6,7 @@
 #include "adio.h"
 #include "mpio.h"
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -48,8 +48,6 @@ FORTRAN_API void FORT_CALL mpio_wait_(MPI_Fint * request, MPI_Status * status, M
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/iread_atf.c
+++ b/src/mpi/romio/mpi-io/fortran/iread_atf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_iread_at_(MPI_Fint *, MPI_Offset *, v
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,16 @@ void mpi_file_iread_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 
 void mpi_file_iread_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                         MPI_Fint * count, MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_iread_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
+                                              MPI_Fint * count, MPI_Fint * datatype,
+                                              MPI_Fint * request, MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_iread_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
+                                              MPI_Fint * count, MPI_Fint * datatype,
+                                              MPI_Fint * request, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPIO_Request req_c;
@@ -110,21 +118,3 @@ void mpi_file_iread_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 
     *request = MPIO_Request_c2f(req_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_iread_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
-                                              MPI_Fint * count, MPI_Datatype * datatype,
-                                              MPI_Fint * request, MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_iread_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
-                                              MPI_Fint * count, MPI_Datatype * datatype,
-                                              MPI_Fint * request, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPIO_Request req_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_iread_at(fh_c, *offset, buf, *count, *datatype, &req_c);
-    *request = MPIO_Request_c2f(req_c);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/iread_shf.c
+++ b/src/mpi/romio/mpi-io/fortran/iread_shf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_iread_shared_(MPI_Fint *, void *, MPI
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,16 @@ void mpi_file_iread_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_iread_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                             MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_iread_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                  MPI_Fint * datatype, MPI_Fint * request,
+                                                  MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_iread_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                  MPI_Fint * datatype, MPI_Fint * request,
+                                                  MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPIO_Request req_c;
@@ -108,21 +116,3 @@ void mpi_file_iread_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
     *ierr = MPI_File_iread_shared(fh_c, buf, *count, datatype_c, &req_c);
     *request = MPIO_Request_c2f(req_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_iread_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                  MPI_Datatype * datatype, MPI_Fint * request,
-                                                  MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_iread_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                  MPI_Datatype * datatype, MPI_Fint * request,
-                                                  MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPIO_Request req_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_iread_shared(fh_c, buf, *count, *datatype, &req_c);
-    *request = MPIO_Request_c2f(req_c);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/ireadf.c
+++ b/src/mpi/romio/mpi-io/fortran/ireadf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_iread_(MPI_Fint *, void *, MPI_Fint *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,15 @@ void mpi_file_iread_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_iread_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                      MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_iread_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                           MPI_Fint * datatype, MPI_Fint * request,
+                                           MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_iread_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                           MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPIO_Request req_c;
@@ -108,21 +115,3 @@ void mpi_file_iread_(MPI_Fint * fh, void *buf, MPI_Fint * count,
     *ierr = MPI_File_iread(fh_c, buf, *count, datatype_c, &req_c);
     *request = MPIO_Request_c2f(req_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_iread_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                           MPI_Datatype * datatype, MPI_Fint * request,
-                                           MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_iread_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                           MPI_Datatype * datatype, MPI_Fint * request,
-                                           MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPIO_Request req_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_iread(fh_c, buf, *count, *datatype, &req_c);
-    *request = MPIO_Request_c2f(req_c);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/iwrite_atf.c
+++ b/src/mpi/romio/mpi-io/fortran/iwrite_atf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_iwrite_at_(MPI_Fint *, MPI_Offset *, 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -99,6 +97,16 @@ void mpi_file_iwrite_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 
 void mpi_file_iwrite_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                          MPI_Fint * count, MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_iwrite_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
+                                               MPI_Fint * count, MPI_Fint * datatype,
+                                               MPI_Fint * request, MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_iwrite_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
+                                               MPI_Fint * count, MPI_Fint * datatype,
+                                               MPI_Fint * request, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPIO_Request req_c;
@@ -110,21 +118,3 @@ void mpi_file_iwrite_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
     *ierr = MPI_File_iwrite_at(fh_c, *offset, buf, *count, datatype_c, &req_c);
     *request = MPIO_Request_c2f(req_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_iwrite_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
-                                               MPI_Fint * count, MPI_Datatype * datatype,
-                                               MPI_Fint * request, MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_iwrite_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
-                                               MPI_Fint * count, MPI_Datatype * datatype,
-                                               MPI_Fint * request, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPIO_Request req_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_iwrite_at(fh_c, *offset, buf, *count, *datatype, &req_c);
-    *request = MPIO_Request_c2f(req_c);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/iwrite_shf.c
+++ b/src/mpi/romio/mpi-io/fortran/iwrite_shf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_iwrite_shared_(MPI_Fint *, void *, MP
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -97,6 +95,16 @@ void mpi_file_iwrite_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                              MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr);
 void mpi_file_iwrite_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                              MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_iwrite_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                   MPI_Fint * datatype, MPI_Fint * request,
+                                                   MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_iwrite_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                   MPI_Fint * datatype, MPI_Fint * request,
+                                                   MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPIO_Request req_c;
@@ -108,21 +116,3 @@ void mpi_file_iwrite_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
     *ierr = MPI_File_iwrite_shared(fh_c, buf, *count, datatype_c, &req_c);
     *request = MPIO_Request_c2f(req_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_iwrite_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                   MPI_Datatype * datatype, MPI_Fint * request,
-                                                   MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_iwrite_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                   MPI_Datatype * datatype, MPI_Fint * request,
-                                                   MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPIO_Request req_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_iwrite_shared(fh_c, buf, *count, *datatype, &req_c);
-    *request = MPIO_Request_c2f(req_c);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/iwritef.c
+++ b/src/mpi/romio/mpi-io/fortran/iwritef.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_iwrite_(MPI_Fint *, void *, MPI_Fint 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,16 @@ void mpi_file_iwrite_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_iwrite_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                       MPI_Fint * datatype, MPI_Fint * request, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_iwrite_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                            MPI_Fint * datatype, MPI_Fint * request,
+                                            MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_iwrite_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                            MPI_Fint * datatype, MPI_Fint * request,
+                                            MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPIO_Request req_c;
@@ -109,21 +117,3 @@ void mpi_file_iwrite_(MPI_Fint * fh, void *buf, MPI_Fint * count,
     *ierr = MPI_File_iwrite(fh_c, buf, *count, datatype_c, &req_c);
     *request = MPIO_Request_c2f(req_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_iwrite_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                            MPI_Datatype * datatype, MPI_Fint * request,
-                                            MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_iwrite_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                            MPI_Datatype * datatype, MPI_Fint * request,
-                                            MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPIO_Request req_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_iwrite(fh_c, buf, *count, *datatype, &req_c);
-    *request = MPIO_Request_c2f(req_c);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/preallocf.c
+++ b/src/mpi/romio/mpi-io/fortran/preallocf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_preallocate_(MPI_Fint *, MPI_Offset *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/rd_atallbf.c
+++ b/src/mpi/romio/mpi-io/fortran/rd_atallbf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_at_all_begin_(MPI_Fint *, MPI_Of
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_read_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 
 void mpi_file_read_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                                  MPI_Fint * count, MPI_Fint * datatype, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_read_at_all_begin(fh_c, *offset, buf, *count, datatype_c);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_read_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_read_at_all_begin_(MPI_Fint * fh, MPI_Offset
 FORTRAN_API void FORT_CALL mpi_file_read_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset,
                                                        void *buf, MPI_Fint * count,
                                                        MPI_Fint * datatype, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_at_all_begin(fh_c, *offset, buf, *count, (MPI_Datatype) * datatype);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_read_at_all_begin(fh_c, *offset, buf, *count, datatype_c);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/rd_atallef.c
+++ b/src/mpi/romio/mpi-io/fortran/rd_atallef.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_at_all_end_(MPI_Fint *, void *, 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/read_allbf.c
+++ b/src/mpi/romio/mpi-io/fortran/read_allbf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_all_begin_(MPI_Fint *, void *, M
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,14 @@ void mpi_file_read_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_read_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                               MPI_Fint * datatype, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_read_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                    MPI_Fint * datatype, MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_read_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                    MPI_Fint * datatype, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Datatype datatype_c;
@@ -107,17 +113,3 @@ void mpi_file_read_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
     *ierr = MPI_File_read_all_begin(fh_c, buf, *count, datatype_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_read_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                    MPI_Fint * datatype, MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_read_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                    MPI_Fint * datatype, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_all_begin(fh_c, buf, *count, (MPI_Datatype) * datatype);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/read_allef.c
+++ b/src/mpi/romio/mpi-io/fortran/read_allef.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_all_end_(MPI_Fint *, void *, MPI
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/read_allf.c
+++ b/src/mpi/romio/mpi-io/fortran/read_allf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_all_(MPI_Fint *, void *, MPI_Fin
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_read_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_read_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                         MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_read_all(fh_c, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_read_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_read_all_(MPI_Fint * fh, void *buf, MPI_Fint
 FORTRAN_API void FORT_CALL mpi_file_read_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                               MPI_Fint * datatype, MPI_Status * status,
                                               MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_all(fh_c, buf, *count, (MPI_Datatype) * datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_read_all(fh_c, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/read_atallf.c
+++ b/src/mpi/romio/mpi-io/fortran/read_atallf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -55,8 +55,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_at_all_(MPI_Fint *, MPI_Offset *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -102,15 +100,6 @@ void mpi_file_read_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 void mpi_file_read_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                            MPI_Fint * count, MPI_Fint * datatype,
                            MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_read_at_all(fh_c, *offset, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_read_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
@@ -120,10 +109,13 @@ FORTRAN_API void FORT_CALL mpi_file_read_at_all_(MPI_Fint * fh, MPI_Offset * off
 FORTRAN_API void FORT_CALL mpi_file_read_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                                                  MPI_Fint * count, MPI_Fint * datatype,
                                                  MPI_Status * status, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_at_all(fh_c, *offset, buf, *count, (MPI_Datatype) * datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_read_at_all(fh_c, *offset, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/read_atf.c
+++ b/src/mpi/romio/mpi-io/fortran/read_atf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_at_(MPI_Fint *, MPI_Offset *, vo
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_read_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 
 void mpi_file_read_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                        MPI_Fint * count, MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_read_at(fh_c, *offset, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_read_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_read_at_(MPI_Fint * fh, MPI_Offset * offset,
 FORTRAN_API void FORT_CALL mpi_file_read_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                                              MPI_Fint * count, MPI_Fint * datatype,
                                              MPI_Status * status, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_at(fh_c, *offset, buf, *count, (MPI_Datatype) * datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_read_at(fh_c, *offset, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/read_ordbf.c
+++ b/src/mpi/romio/mpi-io/fortran/read_ordbf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_ordered_begin_(MPI_Fint *, void 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,14 @@ void mpi_file_read_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_read_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                   MPI_Fint * datatype, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_read_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                        MPI_Fint * datatype, MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_read_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                        MPI_Fint * datatype, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Datatype datatype_c;
@@ -107,17 +113,3 @@ void mpi_file_read_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
     *ierr = MPI_File_read_ordered_begin(fh_c, buf, *count, datatype_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_read_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                        MPI_Fint * datatype, MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_read_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                        MPI_Fint * datatype, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_ordered_begin(fh_c, buf, *count, (MPI_Datatype) * datatype);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/read_ordef.c
+++ b/src/mpi/romio/mpi-io/fortran/read_ordef.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_ordered_end_(MPI_Fint *, void *,
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/read_ordf.c
+++ b/src/mpi/romio/mpi-io/fortran/read_ordf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_ordered_(MPI_Fint *, void *, MPI
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_read_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_read_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                             MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_read_ordered(fh_c, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_read_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_read_ordered_(MPI_Fint * fh, void *buf, MPI_
 FORTRAN_API void FORT_CALL mpi_file_read_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                                   MPI_Fint * datatype, MPI_Status * status,
                                                   MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_ordered(fh_c, buf, *count, (MPI_Datatype) * datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_read_ordered(fh_c, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/read_shf.c
+++ b/src/mpi/romio/mpi-io/fortran/read_shf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_shared_(MPI_Fint *, void *, MPI_
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -97,6 +95,15 @@ void mpi_file_read_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                            MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr);
 void mpi_file_read_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                            MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_read_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                 MPI_Fint * datatype, MPI_Status * status,
+                                                 MPI_Fint * ierr);
+FORTRAN_API void FORT_CALL mpi_file_read_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                 MPI_Fint * datatype, MPI_Status * status,
+                                                 MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Datatype datatype_c;
@@ -106,18 +113,3 @@ void mpi_file_read_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
     *ierr = MPI_File_read_shared(fh_c, buf, *count, datatype_c, status);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_read_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                 MPI_Fint * datatype, MPI_Status * status,
-                                                 MPI_Fint * ierr);
-FORTRAN_API void FORT_CALL mpi_file_read_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                 MPI_Fint * datatype, MPI_Status * status,
-                                                 MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read_shared(fh_c, buf, *count, (MPI_Datatype) * datatype, status);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/readf.c
+++ b/src/mpi/romio/mpi-io/fortran/readf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_read_(MPI_Fint *, void *, MPI_Fint *,
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,15 @@ void mpi_file_read_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_read_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                     MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_read_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                          MPI_Fint * datatype, MPI_Status * status,
+                                          MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_read_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                          MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Datatype datatype_c;
@@ -107,18 +114,3 @@ void mpi_file_read_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
     *ierr = MPI_File_read(fh_c, buf, *count, datatype_c, status);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_read_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                          MPI_Fint * datatype, MPI_Status * status,
-                                          MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_read_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                          MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_read(fh_c, buf, *count, (MPI_Datatype) * datatype, status);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/seek_shf.c
+++ b/src/mpi/romio/mpi-io/fortran/seek_shf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_seek_shared_(MPI_Fint *, MPI_Offset *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/seekf.c
+++ b/src/mpi/romio/mpi-io/fortran/seekf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_seek_(MPI_Fint *, MPI_Offset *, MPI_F
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/set_atomf.c
+++ b/src/mpi/romio/mpi-io/fortran/set_atomf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_set_atomicity_(MPI_Fint *, MPI_Fint *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/set_errhf.c
+++ b/src/mpi/romio/mpi-io/fortran/set_errhf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_set_errhandler_(MPI_Fint *, MPI_Fint 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/set_infof.c
+++ b/src/mpi/romio/mpi-io/fortran/set_infof.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_set_info_(MPI_Fint *, MPI_Fint *, MPI
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/set_sizef.c
+++ b/src/mpi/romio/mpi-io/fortran/set_sizef.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -49,8 +49,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_set_size_(MPI_Fint *, MPI_Offset *, M
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/wr_atallbf.c
+++ b/src/mpi/romio/mpi-io/fortran/wr_atallbf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_at_all_begin_(MPI_Fint *, MPI_O
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -99,15 +97,6 @@ void mpi_file_write_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 
 void mpi_file_write_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                                   MPI_Fint * count, MPI_Fint * datatype, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_write_at_all_begin(fh_c, *offset, buf, *count, datatype_c);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_write_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset,
@@ -117,10 +106,13 @@ FORTRAN_API void FORT_CALL mpi_file_write_at_all_begin_(MPI_Fint * fh, MPI_Offse
 FORTRAN_API void FORT_CALL mpi_file_write_at_all_begin_(MPI_Fint * fh, MPI_Offset * offset,
                                                         void *buf, MPI_Fint * count,
                                                         MPI_Fint * datatype, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_at_all_begin(fh_c, *offset, buf, *count, (MPI_Datatype) * datatype);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_write_at_all_begin(fh_c, *offset, buf, *count, datatype_c);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/wr_atallef.c
+++ b/src/mpi/romio/mpi-io/fortran/wr_atallef.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_at_all_end_(MPI_Fint *, void *,
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/write_allbf.c
+++ b/src/mpi/romio/mpi-io/fortran/write_allbf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_all_begin_(MPI_Fint *, void *, 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -97,6 +95,13 @@ void mpi_file_write_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                MPI_Fint * datatype, MPI_Fint * ierr);
 void mpi_file_write_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                MPI_Fint * datatype, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_write_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                     MPI_Fint * datatype, MPI_Fint * ierr);
+FORTRAN_API void FORT_CALL mpi_file_write_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                     MPI_Fint * datatype, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Datatype datatype_c;
@@ -106,16 +111,3 @@ void mpi_file_write_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
     *ierr = MPI_File_write_all_begin(fh_c, buf, *count, datatype_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_write_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                     MPI_Fint * datatype, MPI_Fint * ierr);
-FORTRAN_API void FORT_CALL mpi_file_write_all_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                     MPI_Fint * datatype, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_all_begin(fh_c, buf, *count, (MPI_Datatype) * datatype);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/write_allef.c
+++ b/src/mpi/romio/mpi-io/fortran/write_allef.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_all_end_(MPI_Fint *, void *, MP
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/write_allf.c
+++ b/src/mpi/romio/mpi-io/fortran/write_allf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_all_(MPI_Fint *, void *, MPI_Fi
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_write_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_write_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                          MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_write_all(fh_c, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_write_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_write_all_(MPI_Fint * fh, void *buf, MPI_Fin
 FORTRAN_API void FORT_CALL mpi_file_write_all_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                                MPI_Fint * datatype, MPI_Status * status,
                                                MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_all(fh_c, buf, *count, *datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_write_all(fh_c, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/write_atallf.c
+++ b/src/mpi/romio/mpi-io/fortran/write_atallf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -57,8 +57,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_at_all_(MPI_Fint *, MPI_Offset 
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -104,15 +102,6 @@ void mpi_file_write_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 void mpi_file_write_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                             MPI_Fint * count, MPI_Fint * datatype,
                             MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_write_at_all(fh_c, *offset, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_write_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
@@ -122,10 +111,13 @@ FORTRAN_API void FORT_CALL mpi_file_write_at_all_(MPI_Fint * fh, MPI_Offset * of
 FORTRAN_API void FORT_CALL mpi_file_write_at_all_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                                                   MPI_Fint * count, MPI_Fint * datatype,
                                                   MPI_Status * status, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_at_all(fh_c, *offset, buf, *count, *datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_write_at_all(fh_c, *offset, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/write_atf.c
+++ b/src/mpi/romio/mpi-io/fortran/write_atf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_at_(MPI_Fint *, MPI_Offset *, v
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -99,15 +97,6 @@ void mpi_file_write_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
 
 void mpi_file_write_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                         MPI_Fint * count, MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_write_at(fh_c, *offset, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_write_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
@@ -117,10 +106,13 @@ FORTRAN_API void FORT_CALL mpi_file_write_at_(MPI_Fint * fh, MPI_Offset * offset
 FORTRAN_API void FORT_CALL mpi_file_write_at_(MPI_Fint * fh, MPI_Offset * offset, void *buf,
                                               MPI_Fint * count, MPI_Fint * datatype,
                                               MPI_Status * status, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_at(fh_c, *offset, buf, *count, *datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_write_at(fh_c, *offset, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/write_ordbf.c
+++ b/src/mpi/romio/mpi-io/fortran/write_ordbf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_ordered_begin_(MPI_Fint *, void
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,6 +96,14 @@ void mpi_file_write_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_write_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                    MPI_Fint * datatype, MPI_Fint * ierr)
+#else
+/* Prototype to keep compiler happy */
+FORTRAN_API void FORT_CALL mpi_file_write_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                         MPI_Fint * datatype, MPI_Fint * ierr);
+
+FORTRAN_API void FORT_CALL mpi_file_write_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
+                                                         MPI_Fint * datatype, MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
     MPI_Datatype datatype_c;
@@ -107,17 +113,3 @@ void mpi_file_write_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
     *ierr = MPI_File_write_ordered_begin(fh_c, buf, *count, datatype_c);
 }
-#else
-/* Prototype to keep compiler happy */
-FORTRAN_API void FORT_CALL mpi_file_write_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                         MPI_Fint * datatype, MPI_Fint * ierr);
-
-FORTRAN_API void FORT_CALL mpi_file_write_ordered_begin_(MPI_Fint * fh, void *buf, MPI_Fint * count,
-                                                         MPI_Fint * datatype, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_ordered_begin(fh_c, buf, *count, *datatype);
-}
-#endif

--- a/src/mpi/romio/mpi-io/fortran/write_ordef.c
+++ b/src/mpi/romio/mpi-io/fortran/write_ordef.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_ordered_end_(MPI_Fint *, void *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS

--- a/src/mpi/romio/mpi-io/fortran/write_ordf.c
+++ b/src/mpi/romio/mpi-io/fortran/write_ordf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_ordered_(MPI_Fint *, void *, MP
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_write_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_write_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                              MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_write_ordered(fh_c, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_write_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_write_ordered_(MPI_Fint * fh, void *buf, MPI
 FORTRAN_API void FORT_CALL mpi_file_write_ordered_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                                    MPI_Fint * datatype, MPI_Status * status,
                                                    MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_ordered(fh_c, buf, *count, *datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_write_ordered(fh_c, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/write_shf.c
+++ b/src/mpi/romio/mpi-io/fortran/write_shf.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_shared_(MPI_Fint *, void *, MPI
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_write_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_write_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                             MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_write_shared(fh_c, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_write_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_write_shared_(MPI_Fint * fh, void *buf, MPI_
 FORTRAN_API void FORT_CALL mpi_file_write_shared_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                                   MPI_Fint * datatype, MPI_Status * status,
                                                   MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write_shared(fh_c, buf, *count, *datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_write_shared(fh_c, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fortran/writef.c
+++ b/src/mpi/romio/mpi-io/fortran/writef.c
@@ -7,7 +7,7 @@
 #include "mpio.h"
 
 
-#if defined(MPIO_BUILD_PROFILING) || defined(HAVE_WEAK_SYMBOLS)
+#if defined(MPIO_BUILD_PROFILING) && defined(HAVE_WEAK_SYMBOLS)
 
 #if defined(HAVE_WEAK_SYMBOLS)
 #if defined(HAVE_PRAGMA_WEAK)
@@ -53,8 +53,6 @@ extern FORTRAN_API void FORT_CALL mpi_file_write_(MPI_Fint *, void *, MPI_Fint *
 
 /* end of weak pragmas */
 #endif
-/* Include mapping from MPI->PMPI */
-#include "mpioprof.h"
 #endif
 
 #ifdef FORTRANCAPS
@@ -98,15 +96,6 @@ void mpi_file_write_(MPI_Fint * fh, void *buf, MPI_Fint * count,
 
 void mpi_file_write_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                      MPI_Fint * datatype, MPI_Status * status, MPI_Fint * ierr)
-{
-    MPI_File fh_c;
-    MPI_Datatype datatype_c;
-
-    fh_c = MPI_File_f2c(*fh);
-    datatype_c = MPI_Type_f2c(*datatype);
-
-    *ierr = MPI_File_write(fh_c, buf, *count, datatype_c, status);
-}
 #else
 /* Prototype to keep compiler happy */
 FORTRAN_API void FORT_CALL mpi_file_write_(MPI_Fint * fh, void *buf, MPI_Fint * count,
@@ -116,10 +105,13 @@ FORTRAN_API void FORT_CALL mpi_file_write_(MPI_Fint * fh, void *buf, MPI_Fint * 
 FORTRAN_API void FORT_CALL mpi_file_write_(MPI_Fint * fh, void *buf, MPI_Fint * count,
                                            MPI_Fint * datatype, MPI_Status * status,
                                            MPI_Fint * ierr)
+#endif
 {
     MPI_File fh_c;
+    MPI_Datatype datatype_c;
 
     fh_c = MPI_File_f2c(*fh);
-    *ierr = MPI_File_write(fh_c, buf, *count, *datatype, status);
+    datatype_c = MPI_Type_f2c(*datatype);
+
+    *ierr = MPI_File_write(fh_c, buf, *count, datatype_c, status);
 }
-#endif

--- a/src/mpi/romio/mpi-io/fsync.c
+++ b/src/mpi/romio/mpi-io/fsync.c
@@ -49,10 +49,10 @@ int MPI_File_sync(MPI_File fh)
     if ((adio_fh == NULL) || ((adio_fh)->cookie != ADIOI_FILE_COOKIE)) {
         error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
                                           myname, __LINE__, MPI_ERR_ARG, "**iobadfh", 0);
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+        error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
         goto fn_exit;
     }
-    MPIO_CHECK_WRITABLE(fh, myname, error_code);
+    MPIO_CHECK_WRITABLE(adio_fh, myname, error_code);
     /* --END ERROR HANDLING-- */
 
     ADIO_Flush(adio_fh, &error_code);

--- a/src/mpi/romio/mpi-io/get_errh.c
+++ b/src/mpi/romio/mpi-io/get_errh.c
@@ -49,10 +49,10 @@ int MPI_File_get_errhandler(MPI_File mpi_fh, MPI_Errhandler * errhandler)
     } else {
         fh = MPIO_File_resolve(mpi_fh);
         /* --BEGIN ERROR HANDLING-- */
-        if ((fh <= (MPI_File) 0) || ((fh)->cookie != ADIOI_FILE_COOKIE)) {
+        if ((fh <= (ADIO_File) 0) || ((fh)->cookie != ADIOI_FILE_COOKIE)) {
             error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
                                               myname, __LINE__, MPI_ERR_ARG, "**iobadfh", 0);
-            error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+            error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
             goto fn_exit;
         }
         /* --END ERROR HANDLING-- */

--- a/src/mpi/romio/mpi-io/get_size.c
+++ b/src/mpi/romio/mpi-io/get_size.c
@@ -78,7 +78,7 @@ int MPI_File_get_size(MPI_File fh, MPI_Offset * size)
     return error_code;
   fn_fail:
     /* --BEGIN ERROR HANDLING-- */
-    error_code = MPIO_Err_return_file(fh, error_code);
+    error_code = MPIO_Err_return_file(adio_fh, error_code);
     goto fn_exit;
     /* --END ERROR HANDLING-- */
 }

--- a/src/mpi/romio/mpi-io/glue/Makefile.mk
+++ b/src/mpi/romio/mpi-io/glue/Makefile.mk
@@ -5,6 +5,7 @@
 
 include $(top_srcdir)/mpi-io/glue/default/Makefile.mk
 include $(top_srcdir)/mpi-io/glue/mpich/Makefile.mk
+include $(top_srcdir)/mpi-io/glue/openmpi/Makefile.mk
 
 if !BUILD_ROMIO_EMBEDDED
 romio_other_sources += \

--- a/src/mpi/romio/mpi-io/glue/default/mpio_err.c
+++ b/src/mpi/romio/mpi-io/glue/default/mpio_err.c
@@ -40,25 +40,21 @@ int MPIO_Err_create_code(int lastcode, int fatal, const char fcname[],
     return error_class;
 }
 
-int MPIO_Err_return_file(MPI_File mpi_fh, int error_code)
+int MPIO_Err_return_file(ADIO_File adio_fh, int error_code)
 {
-    ADIO_File adio_fh;
-
-    if (mpi_fh == MPI_FILE_NULL) {
-        if (ADIOI_DFLT_ERR_HANDLER != MPI_ERRORS_RETURN) {
+    if (adio_fh == ADIO_FILE_NULL) {
+        if (ADIOI_DFLT_ERR_HANDLER == MPI_ERRORS_ARE_FATAL ||
+            ADIOI_DFLT_ERR_HANDLER != MPI_ERRORS_RETURN) {
             MPI_Abort(MPI_COMM_WORLD, 1);
         } else {
             return error_code;
         }
     }
 
-    adio_fh = MPIO_File_resolve(mpi_fh);
-
-    if (adio_fh->err_handler != MPI_ERRORS_RETURN) {
+    if (adio_fh->err_handler == MPI_ERRORS_ARE_FATAL || adio_fh->err_handler != MPI_ERRORS_RETURN)
         MPI_Abort(MPI_COMM_WORLD, 1);
-    } else {
-        return error_code;
-    }
+
+    return error_code;
 }
 
 int MPIO_Err_return_comm(MPI_Comm mpi_comm, int error_code)

--- a/src/mpi/romio/mpi-io/glue/default/mpio_file.c
+++ b/src/mpi/romio/mpi-io/glue/default/mpio_file.c
@@ -11,7 +11,7 @@
  * of MPI_File structures:
  * - MPIO_File_create(size)
  * - MPIO_File_resolve(mpi_fh)
- * - MPIO_File_free(mpi_fh)
+ * - MPIO_File_free(adio_fh)
  *
  */
 
@@ -25,13 +25,13 @@ MPI_File MPIO_File_create(int size)
 
 ADIO_File MPIO_File_resolve(MPI_File mpi_fh)
 {
-    return mpi_fh;
+    return (ADIO_File) mpi_fh;
 }
 
-void MPIO_File_free(MPI_File * mpi_fh)
+void MPIO_File_free(ADIO_File * adio_fh)
 {
-    ADIOI_Free(*mpi_fh);
-    *mpi_fh = MPI_FILE_NULL;
+    ADIOI_Free(*adio_fh);
+    *adio_fh = ADIO_FILE_NULL;
 }
 
 extern ADIO_File *ADIOI_Ftable;
@@ -54,7 +54,7 @@ MPI_File MPIO_File_f2c(MPI_Fint fh)
         /* there is no way to return an error from MPI_File_f2c */
         return MPI_FILE_NULL;
     }
-    return ADIOI_Ftable[fh];
+    return (MPI_File) ADIOI_Ftable[fh];
 #endif
 }
 
@@ -64,27 +64,28 @@ MPI_Fint MPIO_File_c2f(MPI_File fh)
     return (MPI_Fint) fh;
 #else
     int i;
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
 
-    if ((fh == MPI_FILE_NULL) || (fh->cookie != ADIOI_FILE_COOKIE))
+    if ((fh == MPI_FILE_NULL) || (adio_fh->cookie != ADIOI_FILE_COOKIE))
         return (MPI_Fint) 0;
     if (!ADIOI_Ftable) {
         ADIOI_Ftable_max = 1024;
-        ADIOI_Ftable = (MPI_File *)
-            ADIOI_Malloc(ADIOI_Ftable_max * sizeof(MPI_File));
+        ADIOI_Ftable = (ADIO_File *)
+            ADIOI_Malloc(ADIOI_Ftable_max * sizeof(ADIO_File));
         ADIOI_Ftable_ptr = 0;   /* 0 can't be used though, because
-                                 * MPI_FILE_NULL=0 */
+                                 * ADIO_FILE_NULL=0 */
         for (i = 0; i < ADIOI_Ftable_max; i++)
-            ADIOI_Ftable[i] = MPI_FILE_NULL;
+            ADIOI_Ftable[i] = ADIO_FILE_NULL;
     }
     if (ADIOI_Ftable_ptr == ADIOI_Ftable_max - 1) {
-        ADIOI_Ftable = (MPI_File *) ADIOI_Realloc(ADIOI_Ftable,
-                                                  (ADIOI_Ftable_max + 1024) * sizeof(MPI_File));
+        ADIOI_Ftable = (ADIO_File *) ADIOI_Realloc(ADIOI_Ftable,
+                                                   (ADIOI_Ftable_max + 1024) * sizeof(ADIO_File));
         for (i = ADIOI_Ftable_max; i < ADIOI_Ftable_max + 1024; i++)
-            ADIOI_Ftable[i] = MPI_FILE_NULL;
+            ADIOI_Ftable[i] = ADIO_FILE_NULL;
         ADIOI_Ftable_max += 1024;
     }
     ADIOI_Ftable_ptr++;
-    ADIOI_Ftable[ADIOI_Ftable_ptr] = fh;
+    ADIOI_Ftable[ADIOI_Ftable_ptr] = adio_fh;
     return (MPI_Fint) ADIOI_Ftable_ptr;
 #endif
 }

--- a/src/mpi/romio/mpi-io/glue/mpich/mpio_err.c
+++ b/src/mpi/romio/mpi-io/glue/mpich/mpio_err.c
@@ -28,7 +28,7 @@ int MPIO_Err_create_code(int lastcode, int fatal, const char fcname[],
     return error_code;
 }
 
-int MPIO_Err_return_file(MPI_File mpi_fh, int error_code)
+int MPIO_Err_return_file(ADIO_File adio_fh, int error_code)
 {
     MPI_Errhandler e;
     void (*c_errhandler) (MPI_File *, int *, ...);
@@ -43,14 +43,10 @@ int MPIO_Err_return_file(MPI_File mpi_fh, int error_code)
      */
 
     /* First, get the handler and the corresponding function */
-    if (mpi_fh == MPI_FILE_NULL) {
+    if (adio_fh == ADIO_FILE_NULL)
         e = ADIOI_DFLT_ERR_HANDLER;
-    } else {
-        ADIO_File fh;
-
-        fh = MPIO_File_resolve(mpi_fh);
-        e = fh->err_handler;
-    }
+    else
+        e = adio_fh->err_handler;
 
     /* Actually, e is just the value provide by the MPICH routines
      * file_set_errhandler.  This is actually a *pointer* to the
@@ -70,7 +66,7 @@ int MPIO_Err_return_file(MPI_File mpi_fh, int error_code)
 
     /* --BEGIN ERROR HANDLING-- */
     if (MPIR_Err_is_fatal(error_code) || kind == 0) {
-        ADIO_File fh = MPIO_File_resolve(mpi_fh);
+        ADIO_File fh = MPIO_File_resolve(adio_fh);
 
         snprintf(error_msg, 4096, "I/O error: ");
         len = (int) strlen(error_msg);
@@ -79,9 +75,9 @@ int MPIO_Err_return_file(MPI_File mpi_fh, int error_code)
     }
     /* --END ERROR HANDLING-- */
     else if (kind == 2) {
-        (*c_errhandler) (&mpi_fh, &error_code, 0);
+        (*c_errhandler) (&adio_fh, &error_code, 0);
     } else if (kind == 3) {
-        MPIR_File_call_cxx_errhandler(&mpi_fh, &error_code, c_errhandler);
+        MPIR_File_call_cxx_errhandler(&adio_fh, &error_code, c_errhandler);
     }
 
     /* kind == 1 just returns */

--- a/src/mpi/romio/mpi-io/glue/mpich/mpio_file.c
+++ b/src/mpi/romio/mpi-io/glue/mpich/mpio_file.c
@@ -13,7 +13,7 @@
  * of MPI_File structures:
  * - MPIO_File_create(size)
  * - MPIO_File_resolve(mpi_fh)
- * - MPIO_File_free(mpi_fh)
+ * - MPIO_File_free(adio_fh)
  *
  */
 
@@ -27,13 +27,13 @@ MPI_File MPIO_File_create(int size)
 
 ADIO_File MPIO_File_resolve(MPI_File mpi_fh)
 {
-    return mpi_fh;
+    return (ADIO_File) mpi_fh;
 }
 
-void MPIO_File_free(MPI_File * mpi_fh)
+void MPIO_File_free(ADIO_File * adio_fh)
 {
-    ADIOI_Free(*mpi_fh);
-    *mpi_fh = MPI_FILE_NULL;
+    ADIOI_Free(*adio_fh);
+    *adio_fh = ADIO_FILE_NULL;
 }
 
 MPI_File MPIO_File_f2c(MPI_Fint fh)

--- a/src/mpi/romio/mpi-io/glue/openmpi/mpio_err.c
+++ b/src/mpi/romio/mpi-io/glue/openmpi/mpio_err.c
@@ -39,7 +39,7 @@ int MPIO_Err_create_code(int lastcode, int fatal, const char fcname[],
     return error_class;
 }
 
-int MPIO_Err_return_file(MPI_File mpi_fh, int error_code)
+int MPIO_Err_return_file(ADIO_File adio_fh, int error_code)
 {
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/glue/openmpi/mpio_file.c
+++ b/src/mpi/romio/mpi-io/glue/openmpi/mpio_file.c
@@ -13,7 +13,7 @@
  * of MPI_File structures:
  * - MPIO_File_create(size)
  * - MPIO_File_resolve(mpi_fh)
- * - MPIO_File_free(mpi_fh)
+ * - MPIO_File_free(adio_fh)
  *
  */
 
@@ -27,18 +27,21 @@ MPI_File MPIO_File_create(int size)
 
 ADIO_File MPIO_File_resolve(MPI_File mpi_fh)
 {
-    return mpi_fh;
+    return (ADIO_File) mpi_fh;
 }
 
-void MPIO_File_free(MPI_File * mpi_fh)
+void MPIO_File_free(ADIO_File * adio_fh)
 {
-    ADIOI_Free(*mpi_fh);
-    *mpi_fh = MPI_FILE_NULL;
+    ADIOI_Free(*adio_fh);
+    *adio_fh = ADIO_FILE_NULL;
 }
 
 /* these functions aren't needed with the way Open MPI uses ROMIO */
 #if 0
 
+extern ADIO_File *ADIOI_Ftable;
+extern int ADIOI_Ftable_ptr;
+extern int ADIOI_Ftable_max;
 
 MPI_File MPIO_File_f2c(MPI_Fint fh)
 {
@@ -53,9 +56,11 @@ MPI_File MPIO_File_f2c(MPI_Fint fh)
         return MPI_FILE_NULL;
     if ((fh < 0) || (fh > ADIOI_Ftable_ptr)) {
         FPRINTF(stderr, "MPI_File_f2c: Invalid file handle\n");
-        MPI_Abort(MPI_COMM_WORLD, 1);
+        /* MPI_Abort(MPI_COMM_WORLD, 1); */
+        /* there is no way to return an error from MPI_File_f2c */
+        return MPI_FILE_NULL;
     }
-    return ADIOI_Ftable[fh];
+    return (MPI_File) ADIOI_Ftable[fh];
 #endif
 }
 
@@ -65,27 +70,28 @@ MPI_Fint MPIO_File_c2f(MPI_File fh)
     return (MPI_Fint) fh;
 #else
     int i;
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
 
-    if ((fh == MPI_FILE_NULL) || (fh->cookie != ADIOI_FILE_COOKIE))
+    if ((fh == MPI_FILE_NULL) || (adio_fh->cookie != ADIOI_FILE_COOKIE))
         return (MPI_Fint) 0;
     if (!ADIOI_Ftable) {
         ADIOI_Ftable_max = 1024;
-        ADIOI_Ftable = (MPI_File *)
-            ADIOI_Malloc(ADIOI_Ftable_max * sizeof(MPI_File));
+        ADIOI_Ftable = (ADIO_File *)
+            ADIOI_Malloc(ADIOI_Ftable_max * sizeof(ADIO_File));
         ADIOI_Ftable_ptr = 0;   /* 0 can't be used though, because
-                                 * MPI_FILE_NULL=0 */
+                                 * ADIO_FILE_NULL=0 */
         for (i = 0; i < ADIOI_Ftable_max; i++)
-            ADIOI_Ftable[i] = MPI_FILE_NULL;
+            ADIOI_Ftable[i] = ADIO_FILE_NULL;
     }
     if (ADIOI_Ftable_ptr == ADIOI_Ftable_max - 1) {
-        ADIOI_Ftable = (MPI_File *) ADIOI_Realloc(ADIOI_Ftable,
-                                                  (ADIOI_Ftable_max + 1024) * sizeof(MPI_File));
+        ADIOI_Ftable = (ADIO_File *) ADIOI_Realloc(ADIOI_Ftable,
+                                                   (ADIOI_Ftable_max + 1024) * sizeof(ADIO_File));
         for (i = ADIOI_Ftable_max; i < ADIOI_Ftable_max + 1024; i++)
-            ADIOI_Ftable[i] = MPI_FILE_NULL;
+            ADIOI_Ftable[i] = ADIO_FILE_NULL;
         ADIOI_Ftable_max += 1024;
     }
     ADIOI_Ftable_ptr++;
-    ADIOI_Ftable[ADIOI_Ftable_ptr] = fh;
+    ADIOI_Ftable[ADIOI_Ftable_ptr] = adio_fh;
     return (MPI_Fint) ADIOI_Ftable_ptr;
 #endif
 }

--- a/src/mpi/romio/mpi-io/iread.c
+++ b/src/mpi/romio/mpi-io/iread.c
@@ -72,8 +72,10 @@ int MPI_File_iread(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI
                                   buf, count, datatype, myname, request);
 
     /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
+    if (error_code != MPI_SUCCESS) {
+        ADIO_File adio_fh = MPIO_File_resolve(fh);
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
+    }
     /* --END ERROR HANDLING-- */
 
 #ifdef MPI_hpux
@@ -120,8 +122,10 @@ int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datat
                                   buf, count, datatype, myname, request);
 
     /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
+    if (error_code != MPI_SUCCESS) {
+        ADIO_File adio_fh = MPIO_File_resolve(fh);
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
+    }
     /* --END ERROR HANDLING-- */
 
 #ifdef MPI_hpux
@@ -132,7 +136,6 @@ int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datat
 }
 
 /* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_iread(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *buf, MPI_Aint count,
                      MPI_Datatype datatype, char *myname, MPI_Request * request)
 {
@@ -214,4 +217,3 @@ int MPIOI_File_iread(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *bu
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/iread_all.c
+++ b/src/mpi/romio/mpi-io/iread_all.c
@@ -74,7 +74,8 @@ int MPI_File_iread_all(MPI_File fh, void *buf, int count,
 
     /* --BEGIN ERROR HANDLING-- */
     if (error_code != MPI_SUCCESS) {
-        error_code = MPIO_Err_return_file(fh, error_code);
+        ADIO_File adio_fh = MPIO_File_resolve(fh);
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
     }
     /* --END ERROR HANDLING-- */
 
@@ -122,7 +123,8 @@ int MPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count,
 
     /* --BEGIN ERROR HANDLING-- */
     if (error_code != MPI_SUCCESS) {
-        error_code = MPIO_Err_return_file(fh, error_code);
+        ADIO_File adio_fh = MPIO_File_resolve(fh);
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
     }
     /* --END ERROR HANDLING-- */
 
@@ -134,8 +136,6 @@ int MPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count,
 }
 
 /* Note: MPIOI_File_iread_all also used by MPI_File_iread_at_all */
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_iread_all(MPI_File fh,
                          MPI_Offset offset,
                          int file_ptr_type,
@@ -202,4 +202,3 @@ int MPIOI_File_iread_all(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/iread_at.c
+++ b/src/mpi/romio/mpi-io/iread_at.c
@@ -75,8 +75,10 @@ int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_
                                   count, datatype, myname, request);
 
     /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
+    if (error_code != MPI_SUCCESS) {
+        ADIO_File adio_fh = MPIO_File_resolve(fh);
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
+    }
     /* --END ERROR HANDLING-- */
 
 #ifdef MPI_hpux
@@ -125,8 +127,10 @@ int MPI_File_iread_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count cou
                                   count, datatype, myname, request);
 
     /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
+    if (error_code != MPI_SUCCESS) {
+        ADIO_File adio_fh = MPIO_File_resolve(fh);
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
+    }
     /* --END ERROR HANDLING-- */
 
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/iread_atall.c
+++ b/src/mpi/romio/mpi-io/iread_atall.c
@@ -74,8 +74,10 @@ int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf,
                                       count, datatype, myname, request);
 
     /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
+    if (error_code != MPI_SUCCESS) {
+        ADIO_File adio_fh = MPIO_File_resolve(fh);
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
+    }
     /* --END ERROR HANDLING-- */
 
 #ifdef MPI_hpux
@@ -122,8 +124,10 @@ int MPI_File_iread_at_all_c(MPI_File fh, MPI_Offset offset, void *buf,
                                       count, datatype, myname, request);
 
     /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
+    if (error_code != MPI_SUCCESS) {
+        ADIO_File adio_fh = MPIO_File_resolve(fh);
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
+    }
     /* --END ERROR HANDLING-- */
 
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/iwrite.c
+++ b/src/mpi/romio/mpi-io/iwrite.c
@@ -60,6 +60,7 @@ int MPI_File_iwrite(MPI_File fh, ROMIO_CONST void *buf, int count,
                     MPI_Datatype datatype, MPI_Request * request)
 {
     int error_code = MPI_SUCCESS;
+    ADIO_File adio_fh;
     static char myname[] = "MPI_FILE_IWRITE";
 #ifdef MPI_hpux
     int fl_xmpi;
@@ -68,12 +69,13 @@ int MPI_File_iwrite(MPI_File fh, ROMIO_CONST void *buf, int count,
 #endif /* MPI_hpux */
 
 
-    error_code = MPIOI_File_iwrite(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
+    adio_fh = MPIO_File_resolve(fh);
+    error_code = MPIOI_File_iwrite(adio_fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
                                    buf, count, datatype, myname, request);
 
     /* --BEGIN ERROR HANDLING-- */
     if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
     /* --END ERROR HANDLING-- */
 
 #ifdef MPI_hpux
@@ -108,6 +110,7 @@ int MPI_File_iwrite_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                       MPI_Datatype datatype, MPI_Request * request)
 {
     int error_code = MPI_SUCCESS;
+    ADIO_File adio_fh;
     static char myname[] = "MPI_FILE_IWRITE";
 #ifdef MPI_hpux
     int fl_xmpi;
@@ -116,12 +119,13 @@ int MPI_File_iwrite_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
 #endif /* MPI_hpux */
 
 
-    error_code = MPIOI_File_iwrite(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
+    adio_fh = MPIO_File_resolve(fh);
+    error_code = MPIOI_File_iwrite(adio_fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
                                    buf, count, datatype, myname, request);
 
     /* --BEGIN ERROR HANDLING-- */
     if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
+        error_code = MPIO_Err_return_file(adio_fh, error_code);
     /* --END ERROR HANDLING-- */
 
 #ifdef MPI_hpux
@@ -131,9 +135,7 @@ int MPI_File_iwrite_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
     return error_code;
 }
 
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_iwrite(MPI_File fh,
+int MPIOI_File_iwrite(ADIO_File adio_fh,
                       MPI_Offset offset,
                       int file_ptr_type,
                       const void *buf,
@@ -143,11 +145,9 @@ int MPIOI_File_iwrite(MPI_File fh,
     MPI_Count datatype_size;
     ADIO_Status status;
     ADIO_Offset off, bufsize;
-    ADIO_File adio_fh;
     MPI_Offset nbytes = 0;
 
     ROMIO_THREAD_CS_ENTER();
-    adio_fh = MPIO_File_resolve(fh);
 
     /* --BEGIN ERROR HANDLING-- */
     MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
@@ -215,4 +215,3 @@ int MPIOI_File_iwrite(MPI_File fh,
     ROMIO_THREAD_CS_EXIT();
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/iwrite_all.c
+++ b/src/mpi/romio/mpi-io/iwrite_all.c
@@ -62,6 +62,7 @@ int MPI_File_iwrite_all(MPI_File fh, ROMIO_CONST void *buf, int count,
                         MPI_Datatype datatype, MPI_Request * request)
 {
     int error_code;
+    ADIO_File adio_fh;
     static char myname[] = "MPI_FILE_IWRITE_ALL";
 #ifdef MPI_hpux
     int fl_xmpi;
@@ -69,7 +70,9 @@ int MPI_File_iwrite_all(MPI_File fh, ROMIO_CONST void *buf, int count,
     HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITEALL, TRDTBLOCK, fh, datatype, count);
 #endif /* MPI_hpux */
 
-    error_code = MPIOI_File_iwrite_all(fh, (MPI_Offset) 0,
+    adio_fh = MPIO_File_resolve(fh);
+
+    error_code = MPIOI_File_iwrite_all(adio_fh, (MPI_Offset) 0,
                                        ADIO_INDIVIDUAL, buf, count, datatype, myname, request);
 
 #ifdef MPI_hpux
@@ -111,7 +114,9 @@ int MPI_File_iwrite_all_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
     HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITEALL, TRDTBLOCK, fh, datatype, count);
 #endif /* MPI_hpux */
 
-    error_code = MPIOI_File_iwrite_all(fh, (MPI_Offset) 0,
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+
+    error_code = MPIOI_File_iwrite_all(adio_fh, (MPI_Offset) 0,
                                        ADIO_INDIVIDUAL, buf, count, datatype, myname, request);
 
 #ifdef MPI_hpux
@@ -122,9 +127,7 @@ int MPI_File_iwrite_all_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
 }
 
 /* Note: MPIOI_File_iwrite_all also used by MPI_File_iwrite_at_all */
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_iwrite_all(MPI_File fh,
+int MPIOI_File_iwrite_all(ADIO_File adio_fh,
                           MPI_Offset offset,
                           int file_ptr_type,
                           const void *buf,
@@ -133,13 +136,10 @@ int MPIOI_File_iwrite_all(MPI_File fh,
 {
     int error_code;
     MPI_Count datatype_size;
-    ADIO_File adio_fh;
     void *e32buf = NULL;
     const void *xbuf = NULL;
 
     ROMIO_THREAD_CS_ENTER();
-
-    adio_fh = MPIO_File_resolve(fh);
 
     /* --BEGIN ERROR HANDLING-- */
     MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
@@ -187,4 +187,3 @@ int MPIOI_File_iwrite_all(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/iwrite_atall.c
+++ b/src/mpi/romio/mpi-io/iwrite_atall.c
@@ -63,6 +63,7 @@ int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf
                            int count, MPI_Datatype datatype, MPI_Request * request)
 {
     int error_code;
+    ADIO_File adio_fh;
     static char myname[] = "MPI_FILE_IWRITE_AT_ALL";
 #ifdef MPI_hpux
     int fl_xmpi;
@@ -70,7 +71,9 @@ int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf
     HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITEATALL, TRDTBLOCK, fh, datatype, count);
 #endif /* MPI_hpux */
 
-    error_code = MPIOI_File_iwrite_all(fh, offset, ADIO_EXPLICIT_OFFSET,
+    adio_fh = MPIO_File_resolve(fh);
+
+    error_code = MPIOI_File_iwrite_all(adio_fh, offset, ADIO_EXPLICIT_OFFSET,
                                        buf, count, datatype, myname, request);
 
 #ifdef MPI_hpux
@@ -112,7 +115,9 @@ int MPI_File_iwrite_at_all_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *b
     HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITEATALL, TRDTBLOCK, fh, datatype, count);
 #endif /* MPI_hpux */
 
-    error_code = MPIOI_File_iwrite_all(fh, offset, ADIO_EXPLICIT_OFFSET,
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+
+    error_code = MPIOI_File_iwrite_all(adio_fh, offset, ADIO_EXPLICIT_OFFSET,
                                        buf, count, datatype, myname, request);
 
 #ifdef MPI_hpux

--- a/src/mpi/romio/mpi-io/mpir-mpioinit.c
+++ b/src/mpi/romio/mpi-io/mpir-mpioinit.c
@@ -32,12 +32,13 @@ void MPIR_MPIOInit(int *error_code)
             *error_code = MPIO_Err_create_code(MPI_SUCCESS,
                                                MPIR_ERR_RECOVERABLE, myname, __LINE__,
                                                MPI_ERR_OTHER, "**initialized", 0);
-            *error_code = MPIO_Err_return_file(MPI_FILE_NULL, *error_code);
+            *error_code = MPIO_Err_return_file(ADIO_FILE_NULL, *error_code);
             return;
         }
         /* --END ERROR HANDLING-- */
 
-        MPI_Keyval_create(MPI_NULL_COPY_FN, ADIOI_End_call, &ADIO_Init_keyval, (void *) 0);
+        MPI_Comm_create_keyval(MPI_COMM_NULL_COPY_FN, ADIOI_End_call, &ADIO_Init_keyval,
+                               (void *) 0);
 
         /* put a dummy attribute on MPI_COMM_SELF, because we want the delete
          * function to be called when MPI_COMM_SELF is freed. Clarified

--- a/src/mpi/romio/mpi-io/mpir_cst_filesys.c
+++ b/src/mpi/romio/mpi-io/mpir_cst_filesys.c
@@ -13,6 +13,9 @@
 #include <dirent.h>
 #endif
 
+#if defined(ROMIO_INSIDE_MPICH) || defined(HAVE_MPIR_GET_NODE_ID)
+extern int MPIR_Get_node_id(MPI_Comm comm, int rank, int *id);
+
 static int comm_split_filesystem_exhaustive(MPI_Comm comm, int key,
                                             const char *dirname, MPI_Comm * newcomm)
 {
@@ -252,3 +255,4 @@ int MPIR_Comm_split_filesystem(MPI_Comm comm, int key, const char *dirname, MPI_
     }
     return mpi_errno;
 }
+#endif

--- a/src/mpi/romio/mpi-io/mpl_str.c
+++ b/src/mpi/romio/mpi-io/mpl_str.c
@@ -1,0 +1,136 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil ; -*- */
+/*
+ *  (C) 2001 by Argonne National Laboratory.
+ *      See COPYRIGHT in top-level directory.
+ */
+
+#include "romioconf.h"
+#ifndef ROMIO_INSIDE_MPICH
+
+#include <stdio.h>
+#include <stdlib.h>     /* posix_memalign() */
+
+#include <stdarg.h>     /* va_start() va_end() */
+#include <string.h>     /* strchr() */
+#include <ctype.h>      /* isdigit() */
+#include <assert.h>
+
+#include <sys/types.h>  /* getpid() */
+#include <unistd.h>     /* getpid() */
+#include <time.h>       /* time() */
+
+#include <adio.h>       /* PATH_MAX */
+
+#ifndef HAVE_MPL_CREATE_PATHNAME
+
+static unsigned int xorshift_rand(void)
+{
+    /* time returns long; keep the lower and most significant 32 bits */
+    unsigned int val = time(NULL) & 0xffffffff;
+
+    /* Marsaglia's xorshift random number generator */
+    val ^= val << 13;
+    val ^= val >> 17;
+    val ^= val << 5;
+
+    return val;
+}
+
+/*@ MPL_create_pathname - Generate a random pathname
+
+Input Parameters:
++   dirname - String containing the path of the parent dir (current dir if NULL)
++   prefix - String containing the prefix of the generated name
+-   is_dir - Boolean to tell if the path should be treated as a directory
+
+Output Parameters:
+.   dest_filename - String to copy the generated path name
+
+    Notes:
+    dest_filename should point to a preallocated buffer of PATH_MAX size.
+
+  Module:
+  Utility
+  @*/
+void MPL_create_pathname(char *dest_filename, const char *dirname,
+                         const char *prefix, const int is_dir)
+{
+    /* Generate a random number which doesn't interfere with user application */
+    const unsigned int rdm = xorshift_rand();
+    const unsigned int pid = (unsigned int) getpid();
+
+    if (dirname) {
+        snprintf(dest_filename, PATH_MAX, "%s/%s.%u.%u%c", dirname, prefix,
+                     rdm, pid, is_dir ? '/' : '\0');
+    } else {
+        snprintf(dest_filename, PATH_MAX, "%s.%u.%u%c", prefix, rdm, pid, is_dir ? '/' : '\0');
+    }
+}
+#endif
+
+#ifndef HAVE_MPL_STRNAPP
+/*@ MPL_strnapp - Append to a string with a maximum length
+
+Input Parameters:
++   instr - String to copy
+-   maxlen - Maximum total length of 'outstr'
+
+Output Parameters:
+.   outstr - String to copy into
+
+    Notes:
+    This routine is similar to 'strncat' except that the 'maxlen' argument
+    is the maximum total length of 'outstr', rather than the maximum
+    number of characters to move from 'instr'.  Thus, this routine is
+    easier to use when the declared size of 'instr' is known.
+
+  Module:
+  Utility
+  @*/
+int MPL_strnapp(char *dest, const char *src, size_t n)
+{
+    char *restrict d_ptr = dest;
+    const char *restrict s_ptr = src;
+    register int i;
+
+    /* Get to the end of dest */
+    i = (int) n;
+    while (i-- > 0 && *d_ptr)
+        d_ptr++;
+    if (i <= 0)
+        return 1;
+
+    /* Append.  d_ptr points at first null and i is remaining space. */
+    while (*s_ptr && i-- > 0) {
+        *d_ptr++ = *s_ptr++;
+    }
+
+    /* We allow i >= (not just >) here because the first while decrements
+     * i by one more than there are characters, leaving room for the null */
+    if (i >= 0) {
+        *d_ptr = 0;
+        return 0;
+    } else {
+        /* Force the null at the end */
+        *--d_ptr = 0;
+
+        /* We may want to force an error message here, at least in the
+         * debugging version */
+        return 1;
+    }
+}
+#endif
+
+#ifndef HAVE_MPL_ALIGNED_ALLOC
+void *MPL_aligned_alloc(size_t alignment, size_t size, MPL_memory_class class)
+{
+    void *ptr;
+    int ret;
+
+    ret = posix_memalign(&ptr, alignment, size);
+    if (ret != 0)
+        return NULL;
+    return ptr;
+}
+#endif
+#endif

--- a/src/mpi/romio/mpi-io/open.c
+++ b/src/mpi/romio/mpi-io/open.c
@@ -58,6 +58,7 @@ int MPI_File_open(MPI_Comm comm, ROMIO_CONST char *filename, int amode,
     int known_fstype;
     char *tmp;
     MPI_Comm dupcomm = MPI_COMM_NULL;
+    ADIO_File adio_fh;
     ADIOI_Fns *fsops;
     static char myname[] = "MPI_FILE_OPEN";
 #ifdef MPI_hpux
@@ -149,8 +150,8 @@ int MPI_File_open(MPI_Comm comm, ROMIO_CONST char *filename, int amode,
     }
 /* use default values for disp, etype, filetype */
 
-    *fh = ADIO_Open(comm, dupcomm, filename, file_system, fsops, amode, 0,
-                    MPI_BYTE, MPI_BYTE, info, ADIO_PERM_NULL, &error_code);
+    adio_fh = ADIO_Open(comm, dupcomm, filename, file_system, fsops, amode, 0,
+                        MPI_BYTE, MPI_BYTE, info, ADIO_PERM_NULL, &error_code);
 
     /* --BEGIN ERROR HANDLING-- */
     if (error_code != MPI_SUCCESS) {
@@ -158,32 +159,34 @@ int MPI_File_open(MPI_Comm comm, ROMIO_CONST char *filename, int amode,
     }
     /* --END ERROR HANDLING-- */
 
+    *fh = (MPI_File) adio_fh;
+
     /* if MPI_MODE_SEQUENTIAL requested, file systems cannot do explicit offset
      * or independent file pointer accesses, leaving not much else aside from
      * shared file pointer accesses. */
-    if (!ADIO_Feature((*fh), ADIO_SHARED_FP) && (amode & MPI_MODE_SEQUENTIAL)) {
+    if (!ADIO_Feature((adio_fh), ADIO_SHARED_FP) && (amode & MPI_MODE_SEQUENTIAL)) {
         error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
                                           myname, __LINE__,
                                           MPI_ERR_UNSUPPORTED_OPERATION, "**iosequnsupported", 0);
-        ADIO_Close(*fh, &error_code);
+        ADIO_Close(adio_fh, &error_code);
         goto fn_fail;
     }
 
     /* determine name of file that will hold the shared file pointer */
     /* can't support shared file pointers on a file system that doesn't
      * support file locking. */
-    if ((error_code == MPI_SUCCESS) && ADIO_Feature((*fh), ADIO_SHARED_FP)) {
+    if ((error_code == MPI_SUCCESS) && ADIO_Feature(adio_fh, ADIO_SHARED_FP)) {
         MPI_Comm_rank(dupcomm, &rank);
-        ADIOI_Shfp_fname(*fh, rank, &error_code);
+        ADIOI_Shfp_fname(adio_fh, rank, &error_code);
         if (error_code != MPI_SUCCESS)
             goto fn_fail;
 
         /* if MPI_MODE_APPEND, set the shared file pointer to end of file.
          * indiv. file pointer already set to end of file in ADIO_Open.
          * Here file view is just bytes. */
-        if ((*fh)->access_mode & MPI_MODE_APPEND) {
-            if (rank == (*fh)->hints->ranklist[0])      /* only one person need set the sharedfp */
-                ADIO_Set_shared_fp(*fh, (*fh)->fp_ind, &error_code);
+        if (adio_fh->access_mode & MPI_MODE_APPEND) {
+            if (rank == adio_fh->hints->ranklist[0])    /* only one person need set the sharedfp */
+                ADIO_Set_shared_fp(adio_fh, adio_fh->fp_ind, &error_code);
             MPI_Barrier(dupcomm);
         }
     }
@@ -198,7 +201,7 @@ int MPI_File_open(MPI_Comm comm, ROMIO_CONST char *filename, int amode,
     /* --BEGIN ERROR HANDLING-- */
     if (dupcomm != MPI_COMM_NULL)
         MPI_Comm_free(&dupcomm);
-    error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+    error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
     goto fn_exit;
     /* --END ERROR HANDLING-- */
 }

--- a/src/mpi/romio/mpi-io/read.c
+++ b/src/mpi/romio/mpi-io/read.c
@@ -115,8 +115,6 @@ int MPI_File_read_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype dataty
     return error_code;
 }
 
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_read(MPI_File fh,
                     MPI_Offset offset,
                     int file_ptr_type,
@@ -225,4 +223,3 @@ int MPIOI_File_read(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/read_all.c
+++ b/src/mpi/romio/mpi-io/read_all.c
@@ -116,8 +116,6 @@ int MPI_File_read_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype da
 }
 
 /* Note: MPIOI_File_read_all also used by MPI_File_read_at_all */
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_read_all(MPI_File fh,
                         MPI_Offset offset,
                         int file_ptr_type,
@@ -184,4 +182,3 @@ int MPIOI_File_read_all(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/read_allb.c
+++ b/src/mpi/romio/mpi-io/read_allb.c
@@ -89,8 +89,6 @@ int MPI_File_read_all_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datat
     return error_code;
 }
 
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_read_all_begin(MPI_File fh,
                               MPI_Offset offset,
                               int file_ptr_type,
@@ -165,4 +163,3 @@ int MPIOI_File_read_all_begin(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/read_alle.c
+++ b/src/mpi/romio/mpi-io/read_alle.c
@@ -47,8 +47,6 @@ int MPI_File_read_all_end(MPI_File fh, void *buf, MPI_Status * status)
     return error_code;
 }
 
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_read_all_end(MPI_File fh, void *buf, char *myname, MPI_Status * status)
 {
     int error_code = MPI_SUCCESS;
@@ -82,4 +80,3 @@ int MPIOI_File_read_all_end(MPI_File fh, void *buf, char *myname, MPI_Status * s
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/register_datarep.c
+++ b/src/mpi/romio/mpi-io/register_datarep.c
@@ -139,7 +139,7 @@ int MPIOI_Register_datarep(const char *datarep,
         error_code = MPIO_Err_create_code(MPI_SUCCESS,
                                           MPIR_ERR_RECOVERABLE,
                                           myname, __LINE__, MPI_ERR_ARG, "**datarepname", 0);
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+        error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
         goto fn_exit;
     }
     /* --END ERROR HANDLING-- */
@@ -157,7 +157,7 @@ int MPIOI_Register_datarep(const char *datarep,
                                               myname, __LINE__,
                                               MPI_ERR_DUP_DATAREP,
                                               "**datarepused", "**datarepused %s", datarep);
-            error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+            error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
             goto fn_exit;
         }
     }
@@ -169,7 +169,7 @@ int MPIOI_Register_datarep(const char *datarep,
                                           myname, __LINE__,
                                           MPI_ERR_CONVERSION, "**drconvnotsupported", 0);
 
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+        error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
         goto fn_exit;
     }
 
@@ -178,7 +178,7 @@ int MPIOI_Register_datarep(const char *datarep,
         error_code = MPIO_Err_create_code(MPI_SUCCESS,
                                           MPIR_ERR_RECOVERABLE,
                                           myname, __LINE__, MPI_ERR_ARG, "**datarepextent", 0);
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+        error_code = MPIO_Err_return_file(ADIO_FILE_NULL, error_code);
         goto fn_exit;
     }
     /* --END ERROR HANDLING-- */

--- a/src/mpi/romio/mpi-io/register_datarep.c
+++ b/src/mpi/romio/mpi-io/register_datarep.c
@@ -73,7 +73,7 @@ int MPI_Register_datarep(ROMIO_CONST char *datarep,
                          MPI_Datarep_conversion_function * write_conversion_fn,
                          MPI_Datarep_extent_function * dtype_file_extent_fn, void *extra_state)
 {
-    int is_large = false;
+    int is_large = 0;
     return MPIOI_Register_datarep(datarep, (MPIOI_VOID_FN *) read_conversion_fn,
                                   (MPIOI_VOID_FN *) write_conversion_fn,
                                   dtype_file_extent_fn, extra_state, is_large);
@@ -113,7 +113,7 @@ int MPI_Register_datarep_c(ROMIO_CONST char *datarep,
                            MPI_Datarep_conversion_function_c * write_conversion_fn,
                            MPI_Datarep_extent_function * dtype_file_extent_fn, void *extra_state)
 {
-    int is_large = true;
+    int is_large = 1;
     return MPIOI_Register_datarep(datarep, (MPIOI_VOID_FN *) read_conversion_fn,
                                   (MPIOI_VOID_FN *) write_conversion_fn,
                                   dtype_file_extent_fn, extra_state, is_large);

--- a/src/mpi/romio/mpi-io/set_errh.c
+++ b/src/mpi/romio/mpi-io/set_errh.c
@@ -51,8 +51,11 @@ int MPI_File_set_errhandler(MPI_File mpi_fh, MPI_Errhandler errhandler)
         MPIO_CHECK_FILE_HANDLE(fh, myname, error_code);
         /* --END ERROR HANDLING-- */
 
-        if ((errhandler != MPI_ERRORS_RETURN) && (errhandler != MPI_ERRORS_ARE_FATAL) &&
-            (errhandler != MPI_ERRORS_ABORT)) {
+        if ((errhandler != MPI_ERRORS_RETURN) && (errhandler != MPI_ERRORS_ARE_FATAL)
+#ifdef HAVE_MPI_ERRORS_ABORT
+            && (errhandler != MPI_ERRORS_ABORT)
+#endif
+           ) {
             error_code = MPIO_Err_create_code(MPI_SUCCESS,
                                               MPIR_ERR_RECOVERABLE,
                                               myname, __LINE__,

--- a/src/mpi/romio/mpi-io/set_info.c
+++ b/src/mpi/romio/mpi-io/set_info.c
@@ -45,7 +45,7 @@ int MPI_File_set_info(MPI_File fh, MPI_Info info)
 
     /* --BEGIN ERROR HANDLING-- */
     MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_INFO_ALL(info, error_code, fh->comm);
+    MPIO_CHECK_INFO_ALL(info, error_code, adio_fh->comm);
     /* --END ERROR HANDLING-- */
 
     /* set new info */

--- a/src/mpi/romio/mpi-io/set_size.c
+++ b/src/mpi/romio/mpi-io/set_size.c
@@ -60,7 +60,7 @@ int MPI_File_set_size(MPI_File fh, MPI_Offset size)
         error_code = MPIO_Err_return_file(adio_fh, error_code);
         goto fn_exit;
     }
-    MPIO_CHECK_WRITABLE(fh, myname, error_code);
+    MPIO_CHECK_WRITABLE(adio_fh, myname, error_code);
     /* --END ERROR HANDLING-- */
 
     tmp_sz = size;

--- a/src/mpi/romio/mpi-io/set_view.c
+++ b/src/mpi/romio/mpi-io/set_view.c
@@ -179,7 +179,7 @@ int MPI_File_set_view(MPI_File fh, MPI_Offset disp, MPI_Datatype etype,
     return error_code;
   fn_fail:
     /* --BEGIN ERROR HANDLING-- */
-    error_code = MPIO_Err_return_file(fh, error_code);
+    error_code = MPIO_Err_return_file(adio_fh, error_code);
     goto fn_exit;
     /* --END ERROR HANDLING-- */
 }

--- a/src/mpi/romio/mpi-io/write.c
+++ b/src/mpi/romio/mpi-io/write.c
@@ -114,8 +114,6 @@ int MPI_File_write_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
     return error_code;
 }
 
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_write(MPI_File fh,
                      MPI_Offset offset,
                      int file_ptr_type,
@@ -224,4 +222,3 @@ int MPIOI_File_write(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/write_all.c
+++ b/src/mpi/romio/mpi-io/write_all.c
@@ -115,8 +115,6 @@ int MPI_File_write_all_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
     return error_code;
 }
 
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_write_all(MPI_File fh,
                          MPI_Offset offset,
                          int file_ptr_type,
@@ -178,4 +176,3 @@ int MPIOI_File_write_all(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/write_allb.c
+++ b/src/mpi/romio/mpi-io/write_allb.c
@@ -88,8 +88,6 @@ int MPI_File_write_all_begin_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count cou
     return error_code;
 }
 
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_write_all_begin(MPI_File fh,
                                MPI_Offset offset,
                                int file_ptr_type,
@@ -160,4 +158,3 @@ int MPIOI_File_write_all_begin(MPI_File fh,
 
     return error_code;
 }
-#endif

--- a/src/mpi/romio/mpi-io/write_alle.c
+++ b/src/mpi/romio/mpi-io/write_alle.c
@@ -46,8 +46,6 @@ int MPI_File_write_all_end(MPI_File fh, ROMIO_CONST void *buf, MPI_Status * stat
     return error_code;
 }
 
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
 int MPIOI_File_write_all_end(MPI_File fh, const void *buf, char *myname, MPI_Status * status)
 {
     int error_code;
@@ -86,4 +84,3 @@ int MPIOI_File_write_all_end(MPI_File fh, const void *buf, char *myname, MPI_Sta
 
     return error_code;
 }
-#endif


### PR DESCRIPTION
This PR is the 2nd try to enable ROMIO to be built outside/inside of MPICH.
(The first try is #4008.)

This PR has been tested using below.
1. build inside of MPICH (main branch 9f2c4c98f4c233c7775495bd77c535393c125597)
2. built outside MPICH, using MPICH version 4.0.2
3. built outside MPICH, using Open-MPI version 5.0.2
