### PR TITLE
mpl/gpu/ze: fix issue when using whole device in ZE_AFFINITY_MASK

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -45,8 +45,8 @@ static int gpu_initialized = 0;
 static uint32_t device_count;   /* Counts all local devices, does not include subdevices */
 static uint32_t local_ze_device_count;  /* Counts all local devices and subdevices */
 static uint32_t global_ze_device_count; /* Counts all global devices and subdevices */
-static uint32_t max_dev_id;     /* Does not include subdevices */
-static uint32_t max_subdev_id;
+static int max_dev_id;  /* Does not include subdevices */
+static int max_subdev_id;
 static char **device_list = NULL;
 static int *engine_conversion = NULL;
 
@@ -204,7 +204,7 @@ static int fd_to_handle(int dev_fd, int fd, int *handle);
 static int handle_to_fd(int dev_fd, int handle, int *fd);
 static int close_handle(int dev_fd, int handle);
 static int parse_affinity_mask();
-static void get_max_dev_id(uint32_t *max_dev_id, uint32_t *max_subdev_id);
+static void get_max_dev_id(int *max_dev_id, int *max_subdev_id);
 static int gpu_mem_hook_init(void);
 static int remove_ipc_handle_entry(MPL_ze_mapped_buffer_entry_t * cache_entry, int dev_id);
 static int MPL_event_pool_add_new_pool(void);
@@ -1177,7 +1177,7 @@ static int parse_affinity_mask()
 }
 
 /* Get the max dev_id and subdev_id based on the environment */
-static void get_max_dev_id(uint32_t *max_dev_id, uint32_t *max_subdev_id)
+static void get_max_dev_id(int *max_dev_id, int *max_subdev_id)
 {
     /* This function assumes that parse_affinity_mask was previously called */
     int mpl_err = MPL_SUCCESS;


### PR DESCRIPTION
## Pull Request Description

`mask_contents` uses signed integers and sets initial values to -1. Since `get_max_dev_id` was modified in #6929 to take unsigned integers, without converting during the comparison, `max_subdev_id` is assigned the incorrect value, causing an assertion failure when using whole device ids in `ZE_AFFINITY_MASK`.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
