### PR TITLE
ch4/ofi: fix NIC selection under striping

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_huge.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_huge.c
@@ -98,8 +98,8 @@ static int get_huge_issue_read(MPIR_Request * rreq)
     int issued_chunks = 0;
 
     int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, nic);
     while (bytesLeft > 0) {
+        int ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, nic);
         fi_addr_t addr = MPIDI_OFI_comm_to_phys(comm, info->origin_rank, nic, vci_remote);
         uint64_t remote_key = info->rma_keys[nic];
 


### PR DESCRIPTION
When striping in enabled, different available NICs should be used for huge message chunks.

NIC IDs were correctly calculated for the different chunks but ctx_id was never re-calculated based on the updated NIC IDs.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
