### PR TITLE
ROMIO: use int instead of bool as bool is for C++

### DIFF
--- a/src/mpi/romio/adio/common/ad_read_coll.c
+++ b/src/mpi/romio/adio/common/ad_read_coll.c
@@ -614,8 +614,8 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
          * minus what was satisfied in previous iteration
          * req_size = size corresponding to req_off */
 
+        int flag = 0;
         size = MPL_MIN(coll_bufsize, end_loc - st_loc + 1 - done);
-        bool flag = false;
         for (i = 0; i < nprocs; i++) {
             if (others_req[i].count) {
                 for (j = curr_offlen_ptr[i]; j < others_req[i].count; j++) {
@@ -626,7 +626,7 @@ static void ADIOI_Read_and_exch(ADIO_File fd, void *buf, MPI_Datatype
                         req_off = others_req[i].offsets[j];
                     }
                     if (req_off < off + size) {
-                        flag = true;
+                        flag = 1;
                     }
                 }
             }

--- a/src/mpi/romio/mpi-io/register_datarep.c
+++ b/src/mpi/romio/mpi-io/register_datarep.c
@@ -73,7 +73,7 @@ int MPI_Register_datarep(ROMIO_CONST char *datarep,
                          MPI_Datarep_conversion_function * write_conversion_fn,
                          MPI_Datarep_extent_function * dtype_file_extent_fn, void *extra_state)
 {
-    int is_large = false;
+    int is_large = 0;
     return MPIOI_Register_datarep(datarep, (MPIOI_VOID_FN *) read_conversion_fn,
                                   (MPIOI_VOID_FN *) write_conversion_fn,
                                   dtype_file_extent_fn, extra_state, is_large);
@@ -113,7 +113,7 @@ int MPI_Register_datarep_c(ROMIO_CONST char *datarep,
                            MPI_Datarep_conversion_function_c * write_conversion_fn,
                            MPI_Datarep_extent_function * dtype_file_extent_fn, void *extra_state)
 {
-    int is_large = true;
+    int is_large = 1;
     return MPIOI_Register_datarep(datarep, (MPIOI_VOID_FN *) read_conversion_fn,
                                   (MPIOI_VOID_FN *) write_conversion_fn,
                                   dtype_file_extent_fn, extra_state, is_large);


### PR DESCRIPTION
Use `int` or `bool`?
Below shows other places also use bool in ROMIO.
This PR changes one of the file. More can be added if `int` should be used.
```
% cd src/mpi/romio/
% git grep bool
  Makefile.am:## source files is different and inverted (in the boolean sense) compared with
  adio/ad_daos/ad_daos.h:extern bool adio_daos_bypass_duns;
  adio/ad_daos/ad_daos.h:                                bool create, struct adio_daos_hdl **hdl);
  adio/ad_daos/ad_daos_common.c:bool adio_daos_bypass_duns;
  adio/ad_daos/ad_daos_common.c:    d_getenv_bool("DAOS_BYPASS_DUNS", &adio_daos_bypass_duns);
  adio/ad_daos/ad_daos_hhash.c:static bool
  adio/ad_daos/ad_daos_hhash.c:static bool rec_decref(struct d_hash_table *htable, d_list_t * rlink)
  adio/ad_daos/ad_daos_hhash.c:                            bool create, struct adio_daos_hdl **hdl)
  adio/ad_daos/ad_daos_io.c:    bool flag;
  adio/ad_daos/ad_daos_io.c:            bool flag;
  adio/ad_gpfs/bg/ad_bg_pset.c:#include <stdbool.h>
  adio/ad_gpfs/bg/ad_bg_pset.c:bool dimTorus[BGQ_TORUS_MAX_DIMS];
  adio/ad_gpfs/bg/ad_bg_pset.c:        dimTorus[0] = (bool) (ND_ENABLE_TORUS_DIM_A & net->NetFlags);
  adio/ad_gpfs/bg/ad_bg_pset.c:        dimTorus[1] = (bool) (ND_ENABLE_TORUS_DIM_B & net->NetFlags);
  adio/ad_gpfs/bg/ad_bg_pset.c:        dimTorus[2] = (bool) (ND_ENABLE_TORUS_DIM_C & net->NetFlags);
  adio/ad_gpfs/bg/ad_bg_pset.c:        dimTorus[3] = (bool) (ND_ENABLE_TORUS_DIM_D & net->NetFlags);
  adio/ad_gpfs/bg/ad_bg_pset.c:        dimTorus[4] = (bool) (ND_ENABLE_TORUS_DIM_E & net->NetFlags);
  adio/include/adio.h:    int is_agg;                 /* bool: if I am an aggregator */
  adio/include/adio.h:    int is_external32;          /* bool:  0 means native view */
  mpi2-other/info/info_get.c:. flag - true if key defined, false if not (boolean)
  mpi2-other/info/info_getvln.c:. flag - true if key defined, false if not (boolean)
```
