### PR TITLE
ROMIO: call MPI_ APIs instead of PMPI_

### DIFF
--- a/src/mpi/romio/adio/common/ad_end.c
+++ b/src/mpi/romio/adio/common/ad_end.c
@@ -14,7 +14,7 @@ void ADIO_End(int *error_code)
 
     /* if a default errhandler was set on MPI_FILE_NULL then we need to ensure
      * that our reference to that errhandler is released */
-    PMPI_File_set_errhandler(MPI_FILE_NULL, MPI_ERRORS_RETURN);
+    MPI_File_set_errhandler(MPI_FILE_NULL, MPI_ERRORS_RETURN);
 
 /* free file and info tables used for Fortran interface */
     if (ADIOI_Ftable)

--- a/src/mpi/romio/mpi-io/close.c
+++ b/src/mpi/romio/mpi-io/close.c
@@ -74,7 +74,7 @@ int MPI_File_close(MPI_File * fh)
      * somehow inform the MPI library that we no longer hold a reference to any
      * user defined error handler.  We do this by setting the errhandler at this
      * point to MPI_ERRORS_RETURN. */
-    error_code = PMPI_File_set_errhandler(*fh, MPI_ERRORS_RETURN);
+    error_code = MPI_File_set_errhandler(*fh, MPI_ERRORS_RETURN);
     if (error_code != MPI_SUCCESS)
         goto fn_fail;
 


### PR DESCRIPTION
If profiling is enabled, `MPI_` calls will directed to `PMPI_` calls.
(See `mpi-io/mpioprof.h`)