### PR TITLE
ROMIO: MPI_Keyval_create and MPI_Keyval_free are deprecated

### DIFF
--- a/src/mpi/romio/adio/ad_daos/ad_daos_common.c
+++ b/src/mpi/romio/adio/ad_daos/ad_daos_common.c
@@ -24,7 +24,7 @@ static int ad_daos_end(MPI_Comm comm, int keyval, void *attribute_val, void *ext
         return error_code;
     }
 
-    MPI_Keyval_free(&keyval);
+    MPI_Comm_free_keyval(&keyval);
     return error_code;
 }
 
@@ -57,7 +57,7 @@ void ADIOI_DAOS_Init(int *error_code)
     adio_daos_path_prefix = getenv("DAOS_UNS_PREFIX");
 
     /** attach to comm_self destroy to finalize DAOS */
-    MPI_Keyval_create(MPI_NULL_COPY_FN, ad_daos_end, &ADIOI_DAOS_Initialized, (void *) 0);
+    MPI_Comm_create_keyval(MPI_NULL_COPY_FN, ad_daos_end, &ADIOI_DAOS_Initialized, (void *) 0);
     MPI_Comm_set_attr(MPI_COMM_SELF, ADIOI_DAOS_Initialized, (void *) 0);
 }
 

--- a/src/mpi/romio/adio/ad_ime/ad_ime_common.c
+++ b/src/mpi/romio/adio/ad_ime/ad_ime_common.c
@@ -36,7 +36,7 @@ int ADIOI_IME_End_call(MPI_Comm comm, int keyval, void *attribute_val, void *ext
 {
     int error_code;
     ADIOI_IME_End(&error_code);
-    MPI_Keyval_free(&keyval);
+    MPI_Comm_free_keyval(&keyval);
     return error_code;
 }
 
@@ -52,7 +52,7 @@ void ADIOI_IME_Init(int rank, int *error_code)
 
     *error_code = MPI_SUCCESS;
 
-    MPI_Keyval_create(MPI_NULL_COPY_FN, ADIOI_IME_End_call, &ADIOI_IME_Initialized, (void *) 0);
+    MPI_Comm_create_keyval(MPI_NULL_COPY_FN, ADIOI_IME_End_call, &ADIOI_IME_Initialized, (void *) 0);
     /* just like romio does, we make a dummy attribute so we
      * get cleaned up */
     MPI_Comm_set_attr(MPI_COMM_SELF, ADIOI_IME_Initialized, (void *) 0);

--- a/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_common.c
+++ b/src/mpi/romio/adio/ad_pvfs2/ad_pvfs2_common.c
@@ -40,7 +40,7 @@ int ADIOI_PVFS2_End_call(MPI_Comm comm, int keyval, void *attribute_val, void *e
 {
     int error_code;
     ADIOI_PVFS2_End(&error_code);
-    MPI_Keyval_free(&keyval);
+    MPI_Comm_free_keyval(&keyval);
     return error_code;
 }
 
@@ -75,7 +75,7 @@ void ADIOI_PVFS2_Init(int *error_code)
         return;
     }
 
-    MPI_Keyval_create(MPI_NULL_COPY_FN, ADIOI_PVFS2_End_call, &ADIOI_PVFS2_Initialized, (void *) 0);
+    MPI_Comm_create_keyval(MPI_NULL_COPY_FN, ADIOI_PVFS2_End_call, &ADIOI_PVFS2_Initialized, (void *) 0);
     /* just like romio does, we make a dummy attribute so we
      * get cleaned up */
     MPI_Comm_set_attr(MPI_COMM_SELF, ADIOI_PVFS2_Initialized, (void *) 0);

--- a/src/mpi/romio/adio/common/ad_end.c
+++ b/src/mpi/romio/adio/common/ad_end.c
@@ -55,13 +55,13 @@ int ADIOI_End_call(MPI_Comm comm, int keyval, void *attribute_val, void
     MPL_UNREFERENCED_ARG(attribute_val);
     MPL_UNREFERENCED_ARG(extra_state);
 
-    MPI_Keyval_free(&keyval);
+    MPI_Comm_free_keyval(&keyval);
 
     /* The end call will be called after all possible uses of this keyval, even
      * if a file was opened with MPI_COMM_SELF.  Note, this assumes LIFO
      * MPI_COMM_SELF attribute destruction behavior mandated by MPI-2.2. */
     if (ADIOI_cb_config_list_keyval != MPI_KEYVAL_INVALID)
-        MPI_Keyval_free(&ADIOI_cb_config_list_keyval);
+        MPI_Comm_free_keyval(&ADIOI_cb_config_list_keyval);
 
     if (ADIOI_Flattened_type_keyval != MPI_KEYVAL_INVALID)
         MPI_Type_free_keyval(&ADIOI_Flattened_type_keyval);

--- a/src/mpi/romio/adio/common/cb_config_list.c
+++ b/src/mpi/romio/adio/common/cb_config_list.c
@@ -123,7 +123,7 @@ int ADIOI_cb_gather_name_array(MPI_Comm comm, MPI_Comm dupcomm, ADIO_cb_name_arr
 
     if (ADIOI_cb_config_list_keyval == MPI_KEYVAL_INVALID) {
         /* cleaned up by ADIOI_End_call */
-        MPI_Keyval_create((MPI_Copy_function *) ADIOI_cb_copy_name_array,
+        MPI_Comm_create_keyval((MPI_Copy_function *) ADIOI_cb_copy_name_array,
                           (MPI_Delete_function *) ADIOI_cb_delete_name_array,
                           &ADIOI_cb_config_list_keyval, NULL);
     } else {

--- a/src/mpi/romio/adio/include/mpipr.h
+++ b/src/mpi/romio/adio/include/mpipr.h
@@ -195,10 +195,10 @@
 #define MPI_Win_lock PMPI_Win_lock
 #undef MPI_Win_unlock
 #define MPI_Win_unlock PMPI_Win_unlock
-#undef MPI_Keyval_create
-#define MPI_Keyval_create PMPI_Keyval_create
-#undef MPI_Keyval_free
-#define MPI_Keyval_free PMPI_Keyval_free
+#undef MPI_Comm_create_keyval
+#define MPI_Comm_create_keyval PMPI_Comm_create_keyval
+#undef MPI_Comm_free_keyval
+#define MPI_Comm_free_keyval PMPI_Comm_free_keyval
 #undef MPI_Name_get
 #define MPI_Name_get PMPI_Name_get
 #undef MPI_Name_put

--- a/src/mpi/romio/mpi-io/mpir-mpioinit.c
+++ b/src/mpi/romio/mpi-io/mpir-mpioinit.c
@@ -37,7 +37,7 @@ void MPIR_MPIOInit(int *error_code)
         }
         /* --END ERROR HANDLING-- */
 
-        MPI_Keyval_create(MPI_NULL_COPY_FN, ADIOI_End_call, &ADIO_Init_keyval, (void *) 0);
+        MPI_Comm_create_keyval(MPI_NULL_COPY_FN, ADIOI_End_call, &ADIO_Init_keyval, (void *) 0);
 
         /* put a dummy attribute on MPI_COMM_SELF, because we want the delete
          * function to be called when MPI_COMM_SELF is freed. Clarified


### PR DESCRIPTION
Replace with MPI_Comm_create_keyval and MPI_Comm_free_keyval
