### PR TITLE
ROMIO: avoid using global variables, as not thread-safe

### DIFF
--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_hints.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_hints.c
@@ -83,7 +83,7 @@ void ADIOI_GPFS_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
      */
     if (!fd->hints->initialized) {
 
-        ad_get_env_vars();
+        ad_get_env_vars(fd);
         ad_gpfs_get_env_vars();
         did_anything = 1;
 

--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -171,14 +171,14 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
          * because the difference in starting and ending offsets for 1 byte is
          * 0 the same as 0 bytes so it cannot be distinguished.
          */
-        if ((romio_read_aggmethod == 1) || (romio_read_aggmethod == 2)) {
+        if ((fd->romio_read_aggmethod == 1) || (fd->romio_read_aggmethod == 2)) {
             count_sizes = (ADIO_Offset *) ADIOI_Malloc(nprocs * sizeof(ADIO_Offset));
             MPI_Count buftype_size;
             MPI_Type_size_x(datatype, &buftype_size);
             my_count_size = (ADIO_Offset) count *(ADIO_Offset) buftype_size;
         }
-        if (romio_tunegather) {
-            if ((romio_read_aggmethod == 1) || (romio_read_aggmethod == 2)) {
+        if (fd->romio_tunegather) {
+            if ((fd->romio_read_aggmethod == 1) || (fd->romio_read_aggmethod == 2)) {
                 gpfs_offsets0 = (ADIO_Offset *) ADIOI_Malloc(6 * nprocs * sizeof(ADIO_Offset));
                 gpfs_offsets = gpfs_offsets0 + 3 * nprocs;
                 for (ii = 0; ii < nprocs; ii++) {
@@ -218,7 +218,7 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
         } else {
             MPI_Allgather(&start_offset, 1, ADIO_OFFSET, st_offsets, 1, ADIO_OFFSET, fd->comm);
             MPI_Allgather(&end_offset, 1, ADIO_OFFSET, end_offsets, 1, ADIO_OFFSET, fd->comm);
-            if ((romio_read_aggmethod == 1) || (romio_read_aggmethod == 2)) {
+            if ((fd->romio_read_aggmethod == 1) || (fd->romio_read_aggmethod == 2)) {
                 MPI_Allgather(&count_sizes, 1, ADIO_OFFSET, count_sizes, 1, ADIO_OFFSET, fd->comm);
             }
         }
@@ -278,7 +278,7 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
      *
      */
     int currentNonZeroDataIndex = 0;
-    if ((romio_read_aggmethod == 1) || (romio_read_aggmethod == 2)) {
+    if ((fd->romio_read_aggmethod == 1) || (fd->romio_read_aggmethod == 2)) {
         /* Take out the 0-data offsets by shifting the indexes with data to the
          * front and keeping track of the non-zero data index for use as the
          * length.  By doing this we will optimally use all available aggs
@@ -295,7 +295,7 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
         }
     }
     if (gpfsmpio_tuneblocking) {
-        if ((romio_read_aggmethod == 1) || (romio_read_aggmethod == 2)) {
+        if ((fd->romio_read_aggmethod == 1) || (fd->romio_read_aggmethod == 2)) {
             ADIOI_GPFS_Calc_file_domains(fd, st_offsets, end_offsets, currentNonZeroDataIndex,
                                          nprocs_for_coll, &min_st_offset,
                                          &fd_start, &fd_end, &fd_size, fd->fs_ptr);
@@ -305,7 +305,7 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
                                          &fd_start, &fd_end, &fd_size, fd->fs_ptr);
         }
     } else {
-        if ((romio_read_aggmethod == 1) || (romio_read_aggmethod == 2)) {
+        if ((fd->romio_read_aggmethod == 1) || (fd->romio_read_aggmethod == 2)) {
             ADIOI_Calc_file_domains(st_offsets, end_offsets, currentNonZeroDataIndex,
                                     nprocs_for_coll, &min_st_offset,
                                     &fd_start, &fd_end,
@@ -321,7 +321,7 @@ void ADIOI_GPFS_ReadStridedColl(ADIO_File fd, void *buf, MPI_Aint count,
     }
 
     GPFSMPIO_T_CIO_SET_GET(r, 1, 1, GPFSMPIO_CIO_T_MYREQ, GPFSMPIO_CIO_T_FD_PART);
-    if ((romio_read_aggmethod == 1) || (romio_read_aggmethod == 2)) {
+    if ((fd->romio_read_aggmethod == 1) || (fd->romio_read_aggmethod == 2)) {
         /* If the user has specified to use a one-sided aggregation method then
          * do that at this point instead of the two-phase I/O.
          */

--- a/src/mpi/romio/adio/common/ad_hints.c
+++ b/src/mpi/romio/adio/common/ad_hints.c
@@ -30,7 +30,7 @@ void ADIOI_GEN_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
         *error_code = MPI_SUCCESS;
         return;
     }
-    ad_get_env_vars();
+    ad_get_env_vars(fd);
 
     /* Interpreting MPI-4.0 to mean ROMIO should only return hints it knows
      * about when user calls MPI_File_get_info */

--- a/src/mpi/romio/adio/common/ad_tuning.c
+++ b/src/mpi/romio/adio/common/ad_tuning.c
@@ -17,13 +17,6 @@
 
 #include "ad_tuning.h"
 
-int romio_write_aggmethod;
-int romio_read_aggmethod;
-int romio_onesided_no_rmw;
-int romio_onesided_always_rmw;
-int romio_onesided_inform_rmw;
-int romio_tunegather;
-
 /* set internal variables for tuning environment variables */
 /** \page mpiio_vars MPIIO Configuration
   \section env_sec Environment Variables
@@ -76,39 +69,39 @@ int romio_tunegather;
  *
  */
 
-void ad_get_env_vars(void)
+void ad_get_env_vars(ADIO_File fd)
 {
     char *x;
 
-    romio_write_aggmethod = 0;
+    fd->romio_write_aggmethod = 0;
     x = getenv("ROMIO_WRITE_AGGMETHOD");
     if (x)
-        romio_write_aggmethod = atoi(x);
+        fd->romio_write_aggmethod = atoi(x);
 
-    romio_read_aggmethod = 0;
+    fd->romio_read_aggmethod = 0;
     x = getenv("ROMIO_READ_AGGMETHOD");
     if (x)
-        romio_read_aggmethod = atoi(x);
+        fd->romio_read_aggmethod = atoi(x);
 
-    romio_onesided_no_rmw = 0;
+    fd->romio_onesided_no_rmw = 0;
     x = getenv("ROMIO_ONESIDED_NO_RMW");
     if (x)
-        romio_onesided_no_rmw = atoi(x);
+        fd->romio_onesided_no_rmw = atoi(x);
 
-    romio_onesided_always_rmw = 0;
+    fd->romio_onesided_always_rmw = 0;
     x = getenv("ROMIO_ONESIDED_ALWAYS_RMW");
     if (x)
-        romio_onesided_always_rmw = atoi(x);
-    if (romio_onesided_always_rmw)
-        romio_onesided_no_rmw = 1;
+        fd->romio_onesided_always_rmw = atoi(x);
+    if (fd->romio_onesided_always_rmw)
+        fd->romio_onesided_no_rmw = 1;
 
-    romio_onesided_inform_rmw = 0;
+    fd->romio_onesided_inform_rmw = 0;
     x = getenv("ROMIO_ONESIDED_INFORM_RMW");
     if (x)
-        romio_onesided_inform_rmw = atoi(x);
+        fd->romio_onesided_inform_rmw = atoi(x);
 
-    romio_tunegather = 1;
+    fd->romio_tunegather = 1;
     x = getenv("ROMIO_TUNEGATHER");
     if (x)
-        romio_tunegather = atoi(x);
+        fd->romio_tunegather = atoi(x);
 }

--- a/src/mpi/romio/adio/common/onesided_aggregation.c
+++ b/src/mpi/romio/adio/common/onesided_aggregation.c
@@ -15,6 +15,16 @@
 
 //  #define onesidedtrace 1
 
+/* This data structure holds the number of extents, the index into the flattened buffer and the remnant length
+ * beyond the flattened buffer index corresponding to the base buffer offset for non-contiguous source data
+ * for the range to be written coresponding to the round and target agg.
+ */
+typedef struct NonContigSourceBufOffset {
+    int dataTypeExtent;
+    int flatBufIndice;
+    ADIO_Offset indiceOffset;
+} NonContigSourceBufOffset;
+
 /* This data structure holds the access state of the source buffer for target
  * file domains within aggregators corresponding to the target data blocks.  It
  * is designed to be initialized with a starting point for a given file domain
@@ -890,7 +900,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
     char *write_buf = write_buf0;
     MPI_Win write_buf_window = fd->io_buf_window;
 
-    if (!romio_onesided_no_rmw) {
+    if (!fd->romio_onesided_no_rmw) {
         *hole_found = 0;
     }
 
@@ -981,7 +991,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
         }       // if ((stripeSize>0) && (segmentIter==0))
 
 
-        if (romio_onesided_always_rmw && ((stripeSize == 0) || (segmentIter == 0))) {   // read in the first buffer
+        if (fd->romio_onesided_always_rmw && ((stripeSize == 0) || (segmentIter == 0))) {   // read in the first buffer
             ADIO_Offset tmpCurrentRoundFDEnd = 0;
             if ((fd_end[myAggRank] - currentRoundFDStart) < coll_bufsize) {
                 if (myAggRank == greatestFileDomainAggRank) {
@@ -995,7 +1005,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
                 tmpCurrentRoundFDEnd = currentRoundFDStart + coll_bufsize - (ADIO_Offset) 1;
 #ifdef onesidedtrace
             printf
-                ("romio_onesided_always_rmw - first buffer pre-read for file offsets %ld to %ld total is %d\n",
+                ("fd->romio_onesided_always_rmw - first buffer pre-read for file offsets %ld to %ld total is %d\n",
                  currentRoundFDStart, tmpCurrentRoundFDEnd,
                  (int) (tmpCurrentRoundFDEnd - currentRoundFDStart) + 1);
 #endif
@@ -1019,7 +1029,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
             }
         }
     }   // if iAmUsedAgg
-    if (romio_onesided_always_rmw && ((stripeSize == 0) || (segmentIter == 0))) // wait until the first buffer is read
+    if (fd->romio_onesided_always_rmw && ((stripeSize == 0) || (segmentIter == 0))) // wait until the first buffer is read
         MPI_Barrier(fd->comm);
 
 #ifdef ROMIO_GPFS
@@ -1138,7 +1148,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
                         printf("bufferAmountToSend is %d\n", bufferAmountToSend);
 #endif
                         if (bufferAmountToSend > 0) {   /* we have data to send this round */
-                            if (romio_write_aggmethod == 2) {
+                            if (fd->romio_write_aggmethod == 2) {
                                 /* Only allocate these arrays if we are using method 2 and only do it once for this round/target agg.
                                  */
                                 if (!allocatedDerivedTypeArrays) {
@@ -1193,7 +1203,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
                              * chunk in the target, of source data is non-contiguous then pack the data first.
                              */
 
-                            if (romio_write_aggmethod == 1) {
+                            if (fd->romio_write_aggmethod == 1) {
                                 MPI_Win_lock(MPI_LOCK_SHARED, targetAggsForMyData[aggIter], 0,
                                              write_buf_window);
                                 char *putSourceData = NULL;
@@ -1228,7 +1238,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
                              * to be used subsequently when building the derived type for 1 mpi_put for all the data for this
                              * round/agg.
                              */
-                            else if (romio_write_aggmethod == 2) {
+                            else if (fd->romio_write_aggmethod == 2) {
 
                                 if (bufTypeIsContig) {
                                     targetAggBlockLengths[targetAggContigAccessCount] =
@@ -1275,7 +1285,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
 
                     /* For romio_write_aggmethod of 2 now build the derived type using the data from this round/agg and do 1 single mpi_put.
                      */
-                    if (romio_write_aggmethod == 2) {
+                    if (fd->romio_write_aggmethod == 2) {
 
                         MPI_Datatype sourceBufferDerivedDataType, targetBufferDerivedDataType;
                         MPI_Type_create_struct(targetAggContigAccessCount, targetAggBlockLengths,
@@ -1323,7 +1333,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
                             MPI_Type_free(&targetBufferDerivedDataType);
                         }
                     }
-                    if (!romio_onesided_no_rmw) {
+                    if (!fd->romio_onesided_no_rmw) {
                         MPI_Win_lock(MPI_LOCK_SHARED, targetAggsForMyData[aggIter], 0,
                                      fd->io_buf_put_amounts_window);
                         MPI_Accumulate(&numBytesPutThisAggRound, 1, MPI_INT,
@@ -1391,7 +1401,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
             }
 #endif
             int doWriteContig = 1;
-            if (!romio_onesided_no_rmw) {
+            if (!fd->romio_onesided_no_rmw) {
                 if (stripeSize == 0) {
                     if (fd->io_buf_put_amounts !=
                         ((int) (currentRoundFDEnd - currentRoundFDStart) + 1)) {
@@ -1505,7 +1515,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
         if (iAmUsedAgg && stripeSize == 0) {
             currentRoundFDStart += coll_bufsize;
 
-            if (romio_onesided_always_rmw && (roundIter < (numberOfRounds - 1))) {      // read in the buffer for the next round unless this is the last round
+            if (fd->romio_onesided_always_rmw && (roundIter < (numberOfRounds - 1))) {  // read in the buffer for the next round unless this is the last round
                 ADIO_Offset tmpCurrentRoundFDEnd = 0;
                 if ((fd_end[myAggRank] - currentRoundFDStart) < coll_bufsize) {
                     if (myAggRank == greatestFileDomainAggRank) {
@@ -1519,7 +1529,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
                     tmpCurrentRoundFDEnd = currentRoundFDStart + coll_bufsize - (ADIO_Offset) 1;
 #ifdef onesidedtrace
                 printf
-                    ("romio_onesided_always_rmw - round %d buffer pre-read for file offsets %ld to %ld total is %d\n",
+                    ("fd->romio_onesided_always_rmw - round %d buffer pre-read for file offsets %ld to %ld total is %d\n",
                      roundIter, currentRoundFDStart, tmpCurrentRoundFDEnd,
                      (int) (tmpCurrentRoundFDEnd - currentRoundFDStart) + 1);
 #endif
@@ -2469,7 +2479,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
                         }
 
                         if (bufferAmountToRecv > 0) {   /* we have data to recv this round */
-                            if (romio_read_aggmethod == 2) {
+                            if (fd->romio_read_aggmethod == 2) {
                                 /* Only allocate these arrays if we are using method 2 and only do it once for this round/source agg.
                                  */
                                 if (!allocatedDerivedTypeArrays) {
@@ -2523,7 +2533,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
                              * contiguous chunk from the target, if the source is non-contiguous then unpack the data after
                              * the MPI_Win_unlock is done to make sure the data has arrived first.
                              */
-                            if (romio_read_aggmethod == 1) {
+                            if (fd->romio_read_aggmethod == 1) {
                                 MPI_Win_lock(MPI_LOCK_SHARED, sourceAggsForMyData[aggIter], 0,
                                              read_buf_window);
                                 char *getSourceData = NULL;
@@ -2560,7 +2570,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
                              * to be used subsequently when building the derived type for 1 mpi_put for all the data for this
                              * round/agg.
                              */
-                            else if (romio_read_aggmethod == 2) {
+                            else if (fd->romio_read_aggmethod == 2) {
                                 if (bufTypeIsContig) {
                                     sourceAggBlockLengths[sourceAggContigAccessCount] =
                                         bufferAmountToRecv;
@@ -2590,7 +2600,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
 
                     /* For romio_read_aggmethod of 2 now build the derived type using the data from this round/agg and do 1 single mpi_put.
                      */
-                    if (romio_read_aggmethod == 2) {
+                    if (fd->romio_read_aggmethod == 2) {
                         MPI_Datatype recvBufferDerivedDataType, sourceBufferDerivedDataType;
 
                         MPI_Type_create_struct(sourceAggContigAccessCount, sourceAggBlockLengths,

--- a/src/mpi/romio/adio/common/onesided_aggregation.c
+++ b/src/mpi/romio/adio/common/onesided_aggregation.c
@@ -17,7 +17,7 @@
 
 /* This data structure holds the number of extents, the index into the flattened buffer and the remnant length
  * beyond the flattened buffer index corresponding to the base buffer offset for non-contiguous source data
- * for the range to be written coresponding to the round and target agg.
+ * for the range to be written corresponding to the round and target agg.
  */
 typedef struct NonContigSourceBufOffset {
     int dataTypeExtent;
@@ -74,13 +74,13 @@ int ADIOI_OneSidedCleanup(ADIO_File fd)
     return ret;
 }
 
-/* This function packs a contiguous buffer of data from the non-contgious source
+/* This function packs a contiguous buffer of data from the non-contiguous source
  * buffer for a specified chunk of data and advances the FDSourceBufferState
  * machinery, so subsequent calls with the FDSourceBufferState will return the
  * next linear chunk.
  * Parameters:
  * in:     sourceDataBuffer - pointer to source data buffer.
- * in:    flatBuf - pointer to flattened source data buffer
+ * in:     flatBuf - pointer to flattened source data buffer
  * in:     targetNumBytes - number of bytes to return and advance.
  * in:     packing - whether data is being packed from the source buffer to the
  *         packed buffer (1) or unpacked from the packed buffer to the source
@@ -116,7 +116,7 @@ inline static void nonContigSourceDataBufferAdvance(char *sourceDataBuffer,
 
     int remainingBytesToLoad = targetNumBytes;
     while (remainingBytesToLoad > 0) {
-        if ((flatBuf->blocklens[currentFlatBufIndice] - currentIndiceOffset) >= remainingBytesToLoad) { // we can get the rest of our data from this indice
+        if ((flatBuf->blocklens[currentFlatBufIndice] - currentIndiceOffset) >= remainingBytesToLoad) { // we can get the rest of our data from this index
             ADIO_Offset physicalSourceBufferOffset =
                 (currentDataTypeExtent * bufTypeExtent) + flatBuf->indices[currentFlatBufIndice] +
                 currentIndiceOffset;
@@ -148,7 +148,7 @@ inline static void nonContigSourceDataBufferAdvance(char *sourceDataBuffer,
             }
             remainingBytesToLoad = 0;
 
-        } else {        // we can only get part of our data from this indice
+        } else {        // we can only get part of our data from this index
             int amountDataToLoad = (flatBuf->blocklens[currentFlatBufIndice] - currentIndiceOffset);
             ADIO_Offset physicalSourceBufferOffset =
                 (currentDataTypeExtent * bufTypeExtent) + flatBuf->indices[currentFlatBufIndice] +
@@ -204,7 +204,7 @@ inline static void nonContigSourceDataBufferAdvance(char *sourceDataBuffer,
  * only needs to occur during the actual read from or write to the file system.  In the case of gpfs
  * this function is called just once.  The ADIOI_OneSidedStripeParms parameter is used to save the
  * state and re-use variables thru repetitive calls to help in the case of lustre to avoid costly
- * recomputation, for consistency gpfs utilizes it as well but doesn't use some aspects of it.  This
+ * re-computation, for consistency gpfs utilizes it as well but doesn't use some aspects of it.  This
  * function was originally first written for gpfs only and then modified to support lustre.
  */
 void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
@@ -342,7 +342,7 @@ void ADIOI_OneSidedWriteAggregation(ADIO_File fd,
      */
     int maxNumContigOperations = contig_access_count;
 
-    int myAggRank = -1;         /* if I am an aggregor this is my index into fd->hints->ranklist */
+    int myAggRank = -1;         /* if I am an aggregator this is my index into fd->hints->ranklist */
     int iAmUsedAgg = 0;         /* whether or not this rank is used as an aggregator. */
 
     /* Make coll_bufsize an ADIO_Offset since it is used in calculations with offsets.
@@ -1641,7 +1641,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
     if (fd->io_buf_window == MPI_WIN_NULL || fd->io_buf_put_amounts_window == MPI_WIN_NULL) {
         ADIOI_OneSidedSetup(fd, nprocs);
     }
-    /* This flag denotes whether the source datatype is contiguus, which is referenced throughout the algorithm
+    /* This flag denotes whether the source datatype is contiguous, which is referenced throughout the algorithm
      * and defines how the source buffer offsets and data chunks are determined.  If the value is 1 (true - contiguous data)
      * things are profoundly simpler in that the source buffer offset for a given source offset simply linearly increases
      * by the chunk sizes being read.  If the value is 0 (non-contiguous) then these values are based on calculations
@@ -1727,7 +1727,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
             firstFileOffset = MPL_MIN(firstFileOffset, st_offsets[j]);
     }
 
-    int myAggRank = -1;         /* if I am an aggregor this is my index into fd->hints->ranklist */
+    int myAggRank = -1;         /* if I am an aggregator this is my index into fd->hints->ranklist */
     int iAmUsedAgg = 0;         /* whether or not this rank is used as an aggregator. */
 
     int coll_bufsize = fd->hints->cb_buffer_size;
@@ -2129,7 +2129,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
 #endif
                             }
                         } else if (currentFDSourceBufferState[numSourceAggs].indiceOffset == -1) {
-                            // non-contiguos source buffer
+                            // non-contiguous source buffer
                             ADIOI_Assert(numSourceAggs > 0);
 
                             /* Initialize the source buffer state appropriately and then
@@ -2319,7 +2319,7 @@ void ADIOI_OneSidedReadAggregation(ADIO_File fd,
 
                 }
                 if (useIOBuffer) {      /* use the thread reader for the next round */
-                    /* switch back and forth between the read buffers so that the data aggregation code is diseminating 1 buffer while the thread is reading into the other */
+                    /* switch back and forth between the read buffers so that the data aggregation code is disseminating 1 buffer while the thread is reading into the other */
 
                     if (roundIter > 0)
                         currentRoundFDEnd = nextRoundFDEnd;

--- a/src/mpi/romio/adio/include/ad_tuning.h
+++ b/src/mpi/romio/adio/include/ad_tuning.h
@@ -24,15 +24,7 @@
  *  Global variables for the control of performance tuning.
  *-----------------------------------------*/
 
-/* corresponds to environment variables to select optimizations */
-extern int romio_write_aggmethod;
-extern int romio_read_aggmethod;
-extern int romio_onesided_no_rmw;
-extern int romio_onesided_always_rmw;
-extern int romio_onesided_inform_rmw;
-extern int romio_tunegather;
-
 /* set internal variables for tuning environment variables */
-void ad_get_env_vars(void);
+void ad_get_env_vars(ADIO_File fd);
 
 #endif /* AD_TUNING_H_INCLUDED */

--- a/src/mpi/romio/adio/include/adio.h
+++ b/src/mpi/romio/adio/include/adio.h
@@ -245,6 +245,14 @@ typedef struct ADIOI_FileD {
     struct quobyte_fh *file_handle;     /* file handle for quobytefs */
 #endif
     int dirty_write;            /* this client has written data */
+
+    /* see file adio/common/onesided_aggregation.c for descriptions of the next 6 members */
+    int romio_write_aggmethod;
+    int romio_read_aggmethod;
+    int romio_onesided_no_rmw;
+    int romio_onesided_always_rmw;
+    int romio_onesided_inform_rmw;
+    int romio_tunegather;
 } ADIOI_FileD;
 
 typedef struct ADIOI_FileD *ADIO_File;


### PR DESCRIPTION
move the following global variables defined in ad_tuning.c into ADIOI_FileD struct as members of a file handle.
    int romio_write_aggmethod;
    int romio_read_aggmethod;
    int romio_onesided_no_rmw;
    int romio_onesided_always_rmw;
    int romio_onesided_inform_rmw;
    int romio_tunegather;

