### PR TITLE
romio: Remove support for external MPL library

### DIFF
--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -111,13 +111,6 @@ AC_ARG_VAR([MPLLIBNAME],[can be used to override the name of the MPL library (de
 MPLLIBNAME=${MPLLIBNAME:-"mpl"}
 export MPLLIBNAME
 AC_SUBST(MPLLIBNAME)
-AC_ARG_WITH([mpl-prefix],
-            [AS_HELP_STRING([[--with-mpl-prefix[=DIR]]],
-                            [use the MPL library installed in DIR. Pass
-                             "embedded" to force usage of the MPL source
-                             distributed with Hydra.])],
-            [],dnl action-if-given
-            [with_mpl_prefix=embedded]) dnl action-if-not-given
 mpl_srcdir=""
 AC_SUBST([mpl_srcdir])
 # Controls whether we recurse into the MPL dir when running "dist" rules like
@@ -132,22 +125,12 @@ AC_SUBST([mpl_libdir])
 mpl_lib=""
 AC_SUBST([mpl_lib])
 if test "$FROM_MPICH" = "no" ; then
-    if test "$with_mpl_prefix" = "embedded" ; then
-        mpl_srcdir="mpl"
-        mpl_dist_srcdir="mpl"
-        mpl_subdir_args="--disable-versioning --enable-embedded"
-        PAC_CONFIG_SUBDIR_ARGS([mpl],[$mpl_subdir_args],[],[AC_MSG_ERROR(MPL configure failed)])
-        mpl_includedir='-I$(top_builddir)/mpl/include -I$(top_srcdir)/mpl/include'
-        mpl_lib="mpl/lib${MPLLIBNAME}.la"
-    else
-        # The user specified an already-installed MPL; just sanity check, don't
-        # subconfigure it
-        AS_IF([test -s "${with_mpl_prefix}/include/mplconfig.h"],
-            [:],[AC_MSG_ERROR([the MPL installation in "${with_mpl_prefix}" appears broken])])
-        mpl_includedir="-I${with_mpl_prefix}/include"
-        mpl_libdir="-L${with_mpl_prefix}/lib"
-        mpl_lib="-l${MPLLIBNAME}"
-    fi
+    mpl_srcdir="mpl"
+    mpl_dist_srcdir="mpl"
+    mpl_subdir_args="--disable-versioning --enable-embedded"
+    PAC_CONFIG_SUBDIR_ARGS([mpl],[$mpl_subdir_args],[],[AC_MSG_ERROR(MPL configure failed)])
+    mpl_includedir='-I$(top_builddir)/mpl/include -I$(top_srcdir)/mpl/include'
+    mpl_lib="mpl/lib${MPLLIBNAME}.la"
 else
     # we are configuring romio inside mpich. MPICH should configured MPL already,
     # just set mpl_includedir and source mpl/localdefs if any.


### PR DESCRIPTION
## Pull Request Description

The MPL library does not maintain a stable API, which makes linking with an external one challenging. We removed support for this already in the top-level MPICH configure. Do the same from ROMIO.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
