### PR TITLE
coll: Use strings for tree_type in tuning JSON

### DIFF
--- a/src/mpi/coll/include/coll_impl.h
+++ b/src/mpi/coll/include/coll_impl.h
@@ -44,6 +44,8 @@ extern MPIR_Tree_type_t MPIR_Bcast_tree_type;
 extern void *MPIR_Csel_root;
 extern char MPII_coll_generic_json[];
 
+MPIR_Tree_type_t get_tree_type_from_string(const char *tree_str);
+
 /* Function to initialize communicators for collectives */
 int MPIR_Coll_comm_init(MPIR_Comm * comm);
 

--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -108,7 +108,7 @@ MPIR_Tree_type_t MPIR_Bcast_tree_type = MPIR_TREE_TYPE_KARY;
 MPIR_Tree_type_t MPIR_Ireduce_tree_type = MPIR_TREE_TYPE_KARY;
 void *MPIR_Csel_root = NULL;
 
-static MPIR_Tree_type_t get_tree_type_from_string(const char *tree_str)
+MPIR_Tree_type_t get_tree_type_from_string(const char *tree_str)
 {
     MPIR_Tree_type_t tree_type = MPIR_TREE_TYPE_KARY;
     if (0 == strcmp(tree_str, "kary"))

--- a/src/mpi/coll/src/csel_container.c
+++ b/src/mpi/coll/src/csel_container.c
@@ -22,7 +22,7 @@ static void parse_container_params(struct json_object *obj, MPII_Csel_container_
                         cnt->u.ibcast.intra_tsp_tree.chunk_size =
                             atoi(ckey + strlen("chunk_size="));
                     else if (!strncmp(ckey, "tree_type=", strlen("tree_type=")))
-                        cnt->u.ibcast.intra_tsp_tree.tree_type = atoi(ckey + strlen("tree_type="));
+                        cnt->u.ibcast.intra_tsp_tree.tree_type = get_tree_type_from_string(ckey + strlen("tree_type="));
                     else if (!strncmp(ckey, "k=", strlen("k=")))
                         cnt->u.ibcast.intra_tsp_tree.k = atoi(ckey + strlen("k="));
                     MPL_free(ckey);
@@ -47,7 +47,7 @@ static void parse_container_params(struct json_object *obj, MPII_Csel_container_
                 json_object_object_foreach(obj, key, val) {
                     ckey = MPL_strdup_no_spaces(key);
                     if (!strncmp(ckey, "tree_type=", strlen("tree_type=")))
-                        cnt->u.bcast.intra_tree.tree_type = atoi(ckey + strlen("tree_type="));
+                        cnt->u.bcast.intra_tree.tree_type = get_tree_type_from_string(ckey + strlen("tree_type="));
                     else if (!strncmp(ckey, "k=", strlen("k=")))
                         cnt->u.bcast.intra_tree.k = atoi(ckey + strlen("k="));
                     else if (!strncmp(ckey, "is_non_blocking=", strlen("is_non_blocking=")))
@@ -76,7 +76,7 @@ static void parse_container_params(struct json_object *obj, MPII_Csel_container_
                     ckey = MPL_strdup_no_spaces(key);
                     if (!strncmp(ckey, "tree_type=", strlen("tree_type=")))
                         cnt->u.bcast.intra_pipelined_tree.tree_type =
-                            atoi(ckey + strlen("tree_type="));
+                            get_tree_type_from_string(ckey + strlen("tree_type="));
                     else if (!strncmp(ckey, "k=", strlen("k=")))
                         cnt->u.bcast.intra_pipelined_tree.k = atoi(ckey + strlen("k="));
                     else if (!strncmp(ckey, "is_non_blocking=", strlen("is_non_blocking=")))
@@ -103,7 +103,7 @@ static void parse_container_params(struct json_object *obj, MPII_Csel_container_
                     else if (!strncmp(ckey, "k=", strlen("k=")))
                         cnt->u.ireduce.intra_tsp_tree.k = atoi(ckey + strlen("k="));
                     else if (!strncmp(ckey, "tree_type=", strlen("tree_type=")))
-                        cnt->u.ireduce.intra_tsp_tree.tree_type = atoi(ckey + strlen("tree_type="));
+                        cnt->u.ireduce.intra_tsp_tree.tree_type = get_tree_type_from_string(ckey + strlen("tree_type="));
                     else if (!strncmp(ckey, "chunk_size=", strlen("chunk_size=")))
                         cnt->u.ireduce.intra_tsp_tree.chunk_size =
                             atoi(ckey + strlen("chunk_size="));
@@ -150,7 +150,7 @@ static void parse_container_params(struct json_object *obj, MPII_Csel_container_
                         cnt->u.iallreduce.intra_tsp_tree.k = atoi(ckey + strlen("k="));
                     else if (!strncmp(ckey, "tree_type=", strlen("tree_type=")))
                         cnt->u.iallreduce.intra_tsp_tree.tree_type =
-                            atoi(ckey + strlen("tree_type="));
+                            get_tree_type_from_string(ckey + strlen("tree_type="));
                     else if (!strncmp(ckey, "chunk_size=", strlen("chunk_size=")))
                         cnt->u.iallreduce.intra_tsp_tree.chunk_size =
                             atoi(ckey + strlen("chunk_size="));
@@ -169,7 +169,7 @@ static void parse_container_params(struct json_object *obj, MPII_Csel_container_
                     else if (!strncmp(ckey, "k=", strlen("k=")))
                         cnt->u.allreduce.intra_tree.k = atoi(ckey + strlen("k="));
                     else if (!strncmp(ckey, "tree_type=", strlen("tree_type=")))
-                        cnt->u.allreduce.intra_tree.tree_type = atoi(ckey + strlen("tree_type="));
+                        cnt->u.allreduce.intra_tree.tree_type = get_tree_type_from_string(ckey + strlen("tree_type="));
                     else if (!strncmp(ckey, "chunk_size=", strlen("chunk_size=")))
                         cnt->u.allreduce.intra_tree.chunk_size = atoi(ckey + strlen("chunk_size="));
                     else if (!strncmp(ckey, "topo_overhead=", strlen("topo_overhead=")))


### PR DESCRIPTION
## Pull Request Description

Use strings like "knomial_1", "kary" etc for tree types in the JSON file instead of passing integers.

Currently, MPICH supports passing integers as tree types for the tree algorithms. Eg: 0 represents "kary" tree type, 1 represents "knomial_1" tree type. However, it seems nicer and more readable to use descriptive keys instead of integers.  This is a nice to have and not a bug fix.

The JSON files we generate use strings for tree types.  It is easy to switch to integers using "find and replace", but applying this patch to MPICH makes more sense in my opinion.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
