### PR TITLE
info: Return error when modifying MPI_INFO_ENV

### DIFF
--- a/src/binding/c/info_api.txt
+++ b/src/binding/c/info_api.txt
@@ -18,6 +18,10 @@ MPI_Info_delete:
     .desc: Deletes a (key,value) pair from info
     .skip: initcheck
     .extra: NotThreadSafe
+{ -- error_check --
+    MPIR_ERR_CHKANDJUMP((info == MPI_INFO_ENV), mpi_errno, MPI_ERR_INFO,
+                        "**infoenv");
+}
 
 MPI_Info_dup:
     .desc: Returns a duplicate of the info object
@@ -26,6 +30,10 @@ MPI_Info_dup:
 MPI_Info_free:
     .desc: Frees an info object
     .skip: initcheck
+{ -- error_check --
+    MPIR_ERR_CHKANDJUMP((*info == MPI_INFO_ENV), mpi_errno, MPI_ERR_INFO,
+                        "**infoenv");
+}
 
 MPI_Info_get:
     .desc: Retrieves the value associated with a key
@@ -56,6 +64,8 @@ MPI_Info_set:
     .skip: initcheck
     .docnotes: NotThreadSafe
 { -- error_check --
+    MPIR_ERR_CHKANDJUMP((info == MPI_INFO_ENV), mpi_errno, MPI_ERR_INFO,
+                        "**infoenv");
     MPIR_ERR_CHKANDJUMP((strlen(value) > MPI_MAX_INFO_VAL), mpi_errno, MPI_ERR_INFO_VALUE,
                         "**infovallong");
 }

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -371,6 +371,7 @@ be in the range 0 to %d
 **fileinuse:File in use by some process
 **file:Invalid MPI_File
 **info:Invalid MPI_Info
+**infoenv:MPI_INFO_ENV is read-only
 **infonull:Null MPI_Info 
 **infokey:Invalid key for MPI_Info 
 **infokeynull:Null key


### PR DESCRIPTION
## Pull Request Description

MPI_INFO_ENV is a read-only object owned by the implementation. It cannot be modified or freed. Fixes pmodels/mpich#6981.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
