### PR TITLE
errhan: improve handling error code from user callbacks

### DIFF
--- a/test/mpi/errhan/Makefile.am
+++ b/test/mpi/errhan/Makefile.am
@@ -19,6 +19,7 @@ noinst_PROGRAMS =   \
     errfatal        \
     predef_eh       \
     errstring2      \
+    errcallback     \
     dynamic_errcode_predefined_errclass
 
 if NOT_STRICTMPI

--- a/test/mpi/errhan/errcallback.c
+++ b/test/mpi/errhan/errcallback.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <stdio.h>
+#include "mpi.h"
+#include "mpitest.h"
+
+/* Exercise user callback error propagation. */
+
+static int query_error = MPI_SUCCESS;
+static int query_fn(void *ctx, MPI_Status *s) { return query_error; }
+static int free_fn(void *ctx) { return MPI_SUCCESS; }
+static int cancel_fn (void *ctx, int c) { return MPI_SUCCESS; }
+
+int main(int argc, char **argv)
+{
+    int errs = 0, err, flag;
+    MPI_Request request = MPI_REQUEST_NULL;
+
+#if !defined(USE_STRICT_MPI) && defined(MPICH)
+    int errcls, rlen;
+    char errstr[MPI_MAX_ERROR_STRING], str[64];
+#endif
+
+    MTest_Init(&argc, &argv);
+
+    MPI_Grequest_start(query_fn, free_fn, cancel_fn, NULL, &request);
+    MPI_Grequest_complete(request);
+    MPI_Comm_set_errhandler(MPI_COMM_SELF, MPI_ERRORS_RETURN);
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
+
+    query_error = MPI_SUCCESS;
+    err = MPI_Request_get_status(request, &flag, MPI_STATUS_IGNORE);
+    if (err != MPI_SUCCESS) {
+        errs++;
+        printf("callback return code was not MPI_SUCCESS\n");
+    }
+
+    /* callback returns an error code which is unknown to MPI */
+    query_error = 42000;
+    err = MPI_Request_get_status(request, &flag, MPI_STATUS_IGNORE);
+    if (err == MPI_SUCCESS) {
+        errs++;
+        printf("callback return error code was MPI_SUCCESS\n");
+    }
+#if !defined(USE_STRICT_MPI) && defined(MPICH)
+    MPI_Error_class(err, &errcls);
+    MPI_Error_string(err, errstr, &rlen);
+    snprintf(str, sizeof(str), "error code %d", query_error);
+    if (err == query_error) {
+        errs++;
+        printf("callback return error code was 'query_error'\n");
+    }
+    if (errcls != MPI_ERR_OTHER) {
+        errs++;
+        printf("callback return error class was not MPI_ERR_OTHER\n");
+    }
+    if (strstr(errstr, str) == NULL) {
+        errs++;
+        printf("error string did not contain 'error code %d'\n", query_error);
+    }
+#endif
+
+    /* callback returns a predefined error class */
+    query_error = MPI_ERR_ARG;
+    err = MPI_Request_get_status(request, &flag, MPI_STATUS_IGNORE);
+    if (err == MPI_SUCCESS) {
+        errs++;
+        printf("callback return error code was MPI_SUCCESS\n");
+    }
+#if !defined(USE_STRICT_MPI) && defined(MPICH)
+    MPI_Error_class(err, &errcls);
+    MPI_Error_string(err, errstr, &rlen);
+    snprintf(str, sizeof(str), "error code %d", query_error);
+    if (err == MPI_ERR_ARG) {
+        errs++;
+        printf("callback return error code was MPI_ERR_ARG\n");
+    }
+    if (errcls != MPI_ERR_ARG) {
+        errs++;
+        printf("callback return error class was not MPI_ERR_ARG\n");
+    }
+    if (strstr(errstr, str) == NULL) {
+        errs++;
+        printf("error string did not contain 'error code %d'\n", query_error);
+    }
+#endif
+
+    /* callback returns a dynamic error class */
+    MPI_Add_error_class(&query_error);
+    err = MPI_Request_get_status(request, &flag, MPI_STATUS_IGNORE);
+    if (err != query_error) {
+        errs++;
+        printf("callback return error code was not dynamic error class\n");
+    }
+#if 10*MPI_VERSION+MPI_SUBVERSION >= 41
+    MPI_Remove_error_class(query_error);
+#endif
+
+    /* callback returns a a dynamic error code */
+    MPI_Add_error_code(MPI_ERR_ARG, &query_error);
+    err = MPI_Request_get_status(request, &flag, MPI_STATUS_IGNORE);
+    if (err != query_error) {
+        errs++;
+        printf("callback return error code was not dynamic error code\n");
+    }
+#if 10*MPI_VERSION+MPI_SUBVERSION >= 41
+    MPI_Remove_error_code(query_error);
+#endif
+
+    query_error = MPI_SUCCESS;
+    err = MPI_Request_get_status(request, &flag, MPI_STATUS_IGNORE);
+    if (err != MPI_SUCCESS) {
+        errs++;
+        printf("callback function return code was not MPI_SUCCESS\n");
+    }
+
+    MPI_Comm_set_errhandler(MPI_COMM_SELF, MPI_ERRORS_ARE_FATAL);
+    MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_ARE_FATAL);
+    MPI_Request_free(&request);
+
+    MTest_Finalize(errs);
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/errhan/testlist
+++ b/test/mpi/errhan/testlist
@@ -6,4 +6,5 @@ errfatal 1 resultTest=TestErrFatal
 predef_eh 1
 predef_eh 2
 errstring2 1
+errcallback 1
 dynamic_errcode_predefined_errclass 1


### PR DESCRIPTION
## Pull Request Description

Intended behavior:

* If a user callback returns an non-MPI error code, put it in the error
  string but do not return it back to the caller of the outer MPI routine.
  Otherwise, inspecting a non-MPI error code for error class or string
  is doomed to fail.

* If a user callback returns a predefined error class, still create and
  return error code of that class. This way, the error string will contain
  the stack trace, and the caller can still get the error class out of
  the returned error code.

* Dynamically defined error classes/codes pass through from callbacks to
  the caller of the outer MPI routine. Unfortunately, inspecting the error
  string will not provide the stack trace.

Notes:

* The fist commit is preparatory, consolidating bitmask operations, there is not change in behavior.
* The second commit is the juicy one, it implements the behavior described above.
* The third `fixup!` commit is just removal of an extra level of indentation after the previous changes, there is not change in behavior.
* The fourth commit add tests for the behavior implemented in the second.

Whether to keep these changes in separate commits or squash them is up to the MPICH maintainers.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
