### PR TITLE
pm/hydra: Fix inverted logic in Slurm environment inheritance

### DIFF
--- a/src/pm/hydra/lib/tools/bootstrap/external/ll.h
+++ b/src/pm/hydra/lib/tools/bootstrap/external/ll.h
@@ -15,6 +15,6 @@ HYD_status HYDT_bscd_ll_launch_procs(char **args, struct HYD_proxy *proxy_list, 
 HYD_status HYDT_bscd_ll_query_proxy_id(int *proxy_id);
 HYD_status HYDT_bscd_ll_query_native_int(int *ret);
 HYD_status HYDT_bscd_ll_query_node_list(struct HYD_node **node_list);
-HYD_status HYDT_bscd_ll_query_env_inherit(const char *env_name, int *ret);
+HYD_status HYDT_bscd_ll_query_env_inherit(const char *env_name, int *should_inherit);
 
 #endif /* LL_H_INCLUDED */

--- a/src/pm/hydra/lib/tools/bootstrap/external/ll_env.c
+++ b/src/pm/hydra/lib/tools/bootstrap/external/ll_env.c
@@ -7,7 +7,7 @@
 #include "bsci.h"
 #include "common.h"
 
-HYD_status HYDT_bscd_ll_query_env_inherit(const char *env_name, int *ret)
+HYD_status HYDT_bscd_ll_query_env_inherit(const char *env_name, int *should_inherit)
 {
     const char *env_list[] = { "LOADL_STEP_CLASS", "LOADL_STEP_ARGS",
         "LOADL_STEP_ID", "LOADL_STARTD_PORT",
@@ -49,7 +49,7 @@ HYD_status HYDT_bscd_ll_query_env_inherit(const char *env_name, int *ret)
 
     HYDU_FUNC_ENTER();
 
-    *ret = !HYDTI_bscd_in_env_list(env_name, env_list);
+    *should_inherit = !HYDTI_bscd_in_env_list(env_name, env_list);
 
     HYDU_FUNC_EXIT();
 

--- a/src/pm/hydra/lib/tools/bootstrap/external/lsf.h
+++ b/src/pm/hydra/lib/tools/bootstrap/external/lsf.h
@@ -10,6 +10,6 @@
 
 HYD_status HYDT_bscd_lsf_query_native_int(int *ret);
 HYD_status HYDT_bscd_lsf_query_node_list(struct HYD_node **node_list);
-HYD_status HYDT_bscd_lsf_query_env_inherit(const char *env_name, int *ret);
+HYD_status HYDT_bscd_lsf_query_env_inherit(const char *env_name, int *should_inherit);
 
 #endif /* LSF_H_INCLUDED */

--- a/src/pm/hydra/lib/tools/bootstrap/external/lsf_env.c
+++ b/src/pm/hydra/lib/tools/bootstrap/external/lsf_env.c
@@ -7,7 +7,7 @@
 #include "bsci.h"
 #include "common.h"
 
-HYD_status HYDT_bscd_lsf_query_env_inherit(const char *env_name, int *ret)
+HYD_status HYDT_bscd_lsf_query_env_inherit(const char *env_name, int *should_inherit)
 {
     const char *env_list[] = { "DISPLAY", "EGO_SERVERDIR", "LSB_TRAPSIGS",
         "LSF_SERVERDIR", "HOSTTYPE", "LSB_HOSTS",
@@ -30,7 +30,7 @@ HYD_status HYDT_bscd_lsf_query_env_inherit(const char *env_name, int *ret)
 
     HYDU_FUNC_ENTER();
 
-    *ret = !HYDTI_bscd_in_env_list(env_name, env_list);
+    *should_inherit = !HYDTI_bscd_in_env_list(env_name, env_list);
 
     HYDU_FUNC_EXIT();
 

--- a/src/pm/hydra/lib/tools/bootstrap/external/pbs.h
+++ b/src/pm/hydra/lib/tools/bootstrap/external/pbs.h
@@ -21,7 +21,7 @@ extern struct HYDT_bscd_pbs_sys_s *HYDT_bscd_pbs_sys;
 
 HYD_status HYDT_bscd_pbs_launch_procs(char **args, struct HYD_proxy *proxy_list, int num_hosts,
                                       int use_rmk, int *control_fd);
-HYD_status HYDT_bscd_pbs_query_env_inherit(const char *env_name, int *ret);
+HYD_status HYDT_bscd_pbs_query_env_inherit(const char *env_name, int *should_inherit);
 HYD_status HYDT_bscd_pbs_wait_for_completion(int timeout);
 HYD_status HYDT_bscd_pbs_launcher_finalize(void);
 #endif /* if defined(HAVE_TM_H) */

--- a/src/pm/hydra/lib/tools/bootstrap/external/pbs_env.c
+++ b/src/pm/hydra/lib/tools/bootstrap/external/pbs_env.c
@@ -7,7 +7,7 @@
 #include "common.h"
 #include "pbs.h"
 
-HYD_status HYDT_bscd_pbs_query_env_inherit(const char *env_name, int *ret)
+HYD_status HYDT_bscd_pbs_query_env_inherit(const char *env_name, int *should_inherit)
 {
     const char *env_list[] = { "PBSCOREDUMP",
         "PBSDEBUG",
@@ -47,7 +47,7 @@ HYD_status HYDT_bscd_pbs_query_env_inherit(const char *env_name, int *ret)
 
     HYDU_FUNC_ENTER();
 
-    *ret = !HYDTI_bscd_in_env_list(env_name, env_list);
+    *should_inherit = !HYDTI_bscd_in_env_list(env_name, env_list);
 
     HYDU_FUNC_EXIT();
 

--- a/src/pm/hydra/lib/tools/bootstrap/external/rsh.h
+++ b/src/pm/hydra/lib/tools/bootstrap/external/rsh.h
@@ -8,6 +8,6 @@
 
 #include "hydra.h"
 
-HYD_status HYDT_bscd_rsh_query_env_inherit(const char *env_name, int *ret);
+HYD_status HYDT_bscd_rsh_query_env_inherit(const char *env_name, int *should_inherit);
 
 #endif /* RSH_H_INCLUDED */

--- a/src/pm/hydra/lib/tools/bootstrap/external/rsh_env.c
+++ b/src/pm/hydra/lib/tools/bootstrap/external/rsh_env.c
@@ -7,13 +7,13 @@
 #include "bsci.h"
 #include "common.h"
 
-HYD_status HYDT_bscd_rsh_query_env_inherit(const char *env_name, int *ret)
+HYD_status HYDT_bscd_rsh_query_env_inherit(const char *env_name, int *should_inherit)
 {
     const char *env_list[] = { "DISPLAY", NULL };
 
     HYDU_FUNC_ENTER();
 
-    *ret = !HYDTI_bscd_in_env_list(env_name, env_list);
+    *should_inherit = !HYDTI_bscd_in_env_list(env_name, env_list);
 
     HYDU_FUNC_EXIT();
 

--- a/src/pm/hydra/lib/tools/bootstrap/external/sge.h
+++ b/src/pm/hydra/lib/tools/bootstrap/external/sge.h
@@ -10,6 +10,6 @@
 
 HYD_status HYDT_bscd_sge_query_native_int(int *ret);
 HYD_status HYDT_bscd_sge_query_node_list(struct HYD_node **node_list);
-HYD_status HYDT_bscd_sge_query_env_inherit(const char *env_name, int *ret);
+HYD_status HYDT_bscd_sge_query_env_inherit(const char *env_name, int *should_inherit);
 
 #endif /* SGE_H_INCLUDED */

--- a/src/pm/hydra/lib/tools/bootstrap/external/sge_env.c
+++ b/src/pm/hydra/lib/tools/bootstrap/external/sge_env.c
@@ -7,7 +7,7 @@
 #include "bsci.h"
 #include "common.h"
 
-HYD_status HYDT_bscd_sge_query_env_inherit(const char *env_name, int *ret)
+HYD_status HYDT_bscd_sge_query_env_inherit(const char *env_name, int *should_inherit)
 {
     const char *env_list[] = { "DISPLAY", "SGE_ROOT", "SGE_CELL", "SGE_DEBUG_LEVEL",
         "SGE_QMASTER_PORT", "SGE_O_HOME", "SGE_O_HOST",
@@ -26,7 +26,7 @@ HYD_status HYDT_bscd_sge_query_env_inherit(const char *env_name, int *ret)
 
     HYDU_FUNC_ENTER();
 
-    *ret = !HYDTI_bscd_in_env_list(env_name, env_list);
+    *should_inherit = !HYDTI_bscd_in_env_list(env_name, env_list);
 
     HYDU_FUNC_EXIT();
 

--- a/src/pm/hydra/lib/tools/bootstrap/external/slurm.h
+++ b/src/pm/hydra/lib/tools/bootstrap/external/slurm.h
@@ -13,6 +13,6 @@ HYD_status HYDT_bscd_slurm_launch_procs(char **args, struct HYD_proxy *proxy_lis
 HYD_status HYDT_bscd_slurm_query_proxy_id(int *proxy_id);
 HYD_status HYDT_bscd_slurm_query_native_int(int *ret);
 HYD_status HYDT_bscd_slurm_query_node_list(struct HYD_node **node_list);
-HYD_status HYDT_bscd_slurm_query_env_inherit(const char *env_name, int *ret);
+HYD_status HYDT_bscd_slurm_query_env_inherit(const char *env_name, int *should_inherit);
 
 #endif /* SLURM_H_INCLUDED */

--- a/src/pm/hydra/lib/tools/bootstrap/external/slurm_env.c
+++ b/src/pm/hydra/lib/tools/bootstrap/external/slurm_env.c
@@ -14,9 +14,9 @@ HYD_status HYDT_bscd_slurm_query_env_inherit(const char *env_name, int *ret)
     /* check if envvar starts with SBATCH_, SLURMD_, or SLURM_ */
     if (strncmp(env_name, "SBATCH_", 7) == 0 || strncmp(env_name, "SLURMD_", 7) == 0 ||
         strncmp(env_name, "SLURM_", 6) == 0) {
-        *ret = 1;
-    } else {
         *ret = 0;
+    } else {
+        *ret = 1;
     }
 
     HYDU_FUNC_EXIT();

--- a/src/pm/hydra/lib/tools/bootstrap/external/slurm_env.c
+++ b/src/pm/hydra/lib/tools/bootstrap/external/slurm_env.c
@@ -7,16 +7,16 @@
 #include "bsci.h"
 #include "common.h"
 
-HYD_status HYDT_bscd_slurm_query_env_inherit(const char *env_name, int *ret)
+HYD_status HYDT_bscd_slurm_query_env_inherit(const char *env_name, int *should_inherit)
 {
     HYDU_FUNC_ENTER();
 
     /* check if envvar starts with SBATCH_, SLURMD_, or SLURM_ */
     if (strncmp(env_name, "SBATCH_", 7) == 0 || strncmp(env_name, "SLURMD_", 7) == 0 ||
         strncmp(env_name, "SLURM_", 6) == 0) {
-        *ret = 0;
+        *should_inherit = 0;
     } else {
-        *ret = 1;
+        *should_inherit = 1;
     }
 
     HYDU_FUNC_EXIT();

--- a/src/pm/hydra/lib/tools/bootstrap/external/ssh.h
+++ b/src/pm/hydra/lib/tools/bootstrap/external/ssh.h
@@ -32,7 +32,7 @@ extern struct HYDT_bscd_ssh_time *HYDT_bscd_ssh_time;
 
 HYD_status HYDTI_bscd_ssh_store_launch_time(char *hostname);
 
-HYD_status HYDT_bscd_ssh_query_env_inherit(const char *env_name, int *ret);
+HYD_status HYDT_bscd_ssh_query_env_inherit(const char *env_name, int *should_inherit);
 HYD_status HYDT_bscd_ssh_launcher_finalize(void);
 
 #endif /* SSH_H_INCLUDED */

--- a/src/pm/hydra/lib/tools/bootstrap/external/ssh_env.c
+++ b/src/pm/hydra/lib/tools/bootstrap/external/ssh_env.c
@@ -7,13 +7,13 @@
 #include "bsci.h"
 #include "common.h"
 
-HYD_status HYDT_bscd_ssh_query_env_inherit(const char *env_name, int *ret)
+HYD_status HYDT_bscd_ssh_query_env_inherit(const char *env_name, int *should_inherit)
 {
     const char *env_list[] = { "DISPLAY", NULL };
 
     HYDU_FUNC_ENTER();
 
-    *ret = !HYDTI_bscd_in_env_list(env_name, env_list);
+    *should_inherit = !HYDTI_bscd_in_env_list(env_name, env_list);
 
     HYDU_FUNC_EXIT();
 

--- a/src/pm/hydra/lib/tools/bootstrap/include/bsci.h
+++ b/src/pm/hydra/lib/tools/bootstrap/include/bsci.h
@@ -63,7 +63,7 @@ struct HYDT_bsci_fns {
     HYD_status(*query_proxy_id) (int *proxy_id);
 
     /** \brief Query if an environment variable should be inherited */
-    HYD_status(*query_env_inherit) (const char *env_name, int *ret);
+    HYD_status(*query_env_inherit) (const char *env_name, int *should_inherit);
 };
 
 /** \cond */
@@ -186,7 +186,7 @@ HYD_status HYDT_bsci_query_proxy_id(int *proxy_id);
  * from the user's environment is safe to be propagated to the remote
  * processes.
  */
-HYD_status HYDT_bsci_query_env_inherit(const char *env_name, int *ret);
+HYD_status HYDT_bsci_query_env_inherit(const char *env_name, int *should_inherit);
 
 /**
  * \brief HYDT_bsci_query_native_int - Query if the RMK integrates

--- a/src/pm/hydra/lib/utils/env.c
+++ b/src/pm/hydra/lib/utils/env.c
@@ -40,7 +40,7 @@ HYD_status HYDU_env_to_str(struct HYD_env *env, char **str)
 HYD_status HYDU_list_inherited_env(struct HYD_env **env_list)
 {
     char *env_str = NULL, *env_name;
-    int i, ret;
+    int i, should_inherit;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
@@ -51,13 +51,13 @@ HYD_status HYDU_list_inherited_env(struct HYD_env **env_list)
         env_str = MPL_strdup(environ[i]);
         env_name = strtok(env_str, "=");
 
-        status = HYDT_bsci_query_env_inherit(env_name, &ret);
+        status = HYDT_bsci_query_env_inherit(env_name, &should_inherit);
         HYDU_ERR_POP(status, "error querying environment propagation\n");
 
         MPL_free(env_str);
         env_str = NULL;
 
-        if (!ret) {
+        if (!should_inherit) {
             i++;
             continue;
         }

--- a/src/pm/hydra/lib/utils/env.c
+++ b/src/pm/hydra/lib/utils/env.c
@@ -39,37 +39,29 @@ HYD_status HYDU_env_to_str(struct HYD_env *env, char **str)
 
 HYD_status HYDU_list_inherited_env(struct HYD_env **env_list)
 {
-    char *env_str = NULL, *env_name;
-    int i, should_inherit;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();
 
     *env_list = NULL;
-    i = 0;
-    while (environ[i]) {
+    for (int i = 0; environ[i]; i++) {
+        char *env_str, *env_name;
+        int should_inherit;
+
         env_str = MPL_strdup(environ[i]);
         env_name = strtok(env_str, "=");
 
         status = HYDT_bsci_query_env_inherit(env_name, &should_inherit);
+        MPL_free(env_str);
         HYDU_ERR_POP(status, "error querying environment propagation\n");
 
-        MPL_free(env_str);
-        env_str = NULL;
-
-        if (!should_inherit) {
-            i++;
-            continue;
+        if (should_inherit) {
+            status = HYDU_append_env_str_to_list(environ[i], env_list);
+            HYDU_ERR_POP(status, "unable to add env to list\n");
         }
-
-        status = HYDU_append_env_str_to_list(environ[i], env_list);
-        HYDU_ERR_POP(status, "unable to add env to list\n");
-
-        i++;
     }
 
   fn_exit:
-    MPL_free(env_str);
     HYDU_FUNC_EXIT();
     return status;
 


### PR DESCRIPTION
## Pull Request Description

This function should return 0/false if the environment variable is from Slurm and therefore should not be inherited. [95ba4ddc] accidentally implemented the inverse when adding support for additional variable prefixes.

Reported-by: Edric Ellis <eellis@mathworks.com>

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
