### PR TITLE
binding/f08: Do not adjust by 1 for MPI_UNDEFINED

### DIFF
--- a/maint/local_python/binding_f08.py
+++ b/maint/local_python/binding_f08.py
@@ -322,7 +322,11 @@ def dump_f08_wrappers_f(func, is_large):
         if p['param_direction'] == 'in' or p['param_direction'] == 'inout':
             convert_list_pre.append("%s = %s - 1" % (arg, p['name']))
         if p['param_direction'] == 'out' or p['param_direction'] == 'inout':
-            convert_list_post.append("%s = %s + 1" % (p['name'], arg))
+            convert_list_post.append("IF (%s == MPI_UNDEFINED) THEN" % arg)
+            convert_list_post.append("    %s = %s" % (p['name'], arg))
+            convert_list_post.append("ELSE")
+            convert_list_post.append("    %s = %s + 1" % (p['name'], arg))
+            convert_list_post.append("END IF")
         return (arg, arg)
 
     def process_string(p):


### PR DESCRIPTION
## Pull Request Description

Same fix as pmodels/mpich#6403 applied to the mpi_f08. MPI_UNDEFINED should not be adjusted by 1 because it is a special value and not an index. Fixes pmodels/mpich#6989.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
