### PR TITLE
ch4/ofi: Apply FI_ORDER_SAS hint to rx_attr

### DIFF
--- a/src/mpid/ch4/netmod/ofi/init_settings.c
+++ b/src/mpid/ch4/netmod/ofi/init_settings.c
@@ -187,7 +187,9 @@ int MPIDI_OFI_init_hints(struct fi_info *hints)
         }
     }
     hints->tx_attr->op_flags = FI_COMPLETION;
+    /* apply SAS hint to both tx and rx or else ordering may not be guaranteed */
     hints->tx_attr->msg_order = FI_ORDER_SAS;
+    hints->rx_attr->msg_order = FI_ORDER_SAS;
     /* direct RMA operations supported only with delivery complete mode,
      * else (AM mode) delivery complete is not required */
     if (MPIDI_OFI_ENABLE_RMA || MPIDI_OFI_ENABLE_ATOMICS) {


### PR DESCRIPTION
## Pull Request Description

According to discussion on the OFIWG Slack "...tx_attr at the sender should align with the rx_attr at the receiver". The reason being that the receiver may decide to reorder messages independent of the sender. This was observed with certain providers when using FI_PEEK to probe for messages when rx_attr did not set FI_ORDER_SAS.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
