### PR TITLE
build: detect python version

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -237,12 +237,23 @@ set_externals() {
 check_python3() {
     echo_n "Checking for Python 3... "
     PYTHON=
-    if test 3 = `python -c 'import sys; print(sys.version_info[0])' 2> /dev/null || echo "0"`; then
-        PYTHON=python
-    fi
 
-    if test -z "$PYTHON" -a 3 = `python3 -c 'import sys; print(sys.version_info[0])' 2> /dev/null || echo "0"`; then
-        PYTHON=python3
+    python_one_liner="import sys; print(sys.version_info[0])"
+    PYTHON_PATH=`command -v python`
+    if test "x$PYTHON_PATH" != x ; then
+        version=`$PYTHON_PATH -c "$python_one_liner"`
+        if test "$version" = 3 ; then
+            PYTHON=$PYTHON_PATH
+        fi
+    fi
+    if test "x$PYTHON" = x ; then
+        PYTHON_PATH=`command -v python3`
+        if test "x$PYTHON_PATH" != x ; then
+            version=`$PYTHON_PATH -c "$python_one_liner"`
+            if test "$version" = 3 ; then
+                PYTHON=$PYTHON_PATH
+            fi
+        fi
     fi
 
     if test -z "$PYTHON" ; then

--- a/confdb/aclocal_misc.m4
+++ b/confdb/aclocal_misc.m4
@@ -3,17 +3,33 @@ dnl
 AC_DEFUN([PAC_CHECK_PYTHON],[
     AC_ARG_VAR([PYTHON], [set to Python 3])
     if test -z "$PYTHON" ; then
-        AC_MSG_CHECKING([Python 3])
         PYTHON=
         python_one_liner="import sys; print(sys.version_info[[0]])"
-        if test 3 = `python -c "$python_one_liner"`; then
-            PYTHON=python
-        elif test 3 = `python3 -c "$python_one_liner"`; then
-            PYTHON=python3
+
+        dnl check command 'python'
+        PYTHON_PATH=
+        AC_PATH_PROG(PYTHON_PATH, python)
+        if test "x$PYTHON_PATH" != x ; then
+            py_version=`$PYTHON_PATH -c "$python_one_liner"`
+            if test "x$py_version" = x3 ; then
+                PYTHON=$PYTHON_PATH
+            fi
         fi
-        AC_MSG_RESULT($PYTHON)
+        dnl PYTHON is still not set, check command 'python3'
+        if test "x$PYTHON" = x ; then
+            PYTHON3_PATH=
+            AC_PATH_PROG(PYTHON3_PATH, python3)
+            if test "x$PYTHON3_PATH" != x ; then
+                py3_version=`$PYTHON3_PATH -c "$python_one_liner"`
+                if test "x$py3_version" = x3 ; then
+                    PYTHON=$PYTHON3_PATH
+                fi
+            fi
+        fi
         if test -z "$PYTHON" ; then
-            AC_MSG_WARN([Python 3 not found! Bindings need to be generated before configure.])
+            AC_MSG_WARN([Python version 3 not found! Bindings need to be generated before configure.])
+        else
+            AC_MSG_NOTICE([Python version 3 is $PYTHON])
         fi
     fi
 ])

--- a/test/mpi/autogen.sh
+++ b/test/mpi/autogen.sh
@@ -12,12 +12,23 @@ echo_n() {
 check_python3() {
     echo_n "Checking for Python 3... "
     PYTHON=
-    if test 3 = `python -c 'import sys; print(sys.version_info[0])' 2> /dev/null || echo "0"`; then
-        PYTHON=python
-    fi
 
-    if test -z "$PYTHON" -a 3 = `python3 -c 'import sys; print(sys.version_info[0])' 2> /dev/null || echo "0"`; then
-        PYTHON=python3
+    python_one_liner="import sys; print(sys.version_info[0])"
+    PYTHON_PATH=`command -v python`
+    if test "x$PYTHON_PATH" != x ; then
+        version=`$PYTHON_PATH -c "$python_one_liner"`
+        if test "$version" = 3 ; then
+            PYTHON=$PYTHON_PATH
+        fi
+    fi
+    if test "x$PYTHON" = x ; then
+        PYTHON_PATH=`command -v python3`
+        if test "x$PYTHON_PATH" != x ; then
+            version=`$PYTHON_PATH -c "$python_one_liner"`
+            if test "$version" = 3 ; then
+                PYTHON=$PYTHON_PATH
+            fi
+        fi
     fi
 
     if test -z "$PYTHON" ; then


### PR DESCRIPTION
Got the following message when running configure.
```
../mpich/configure: line 21398: python: command not found
../mpich/configure: line 21398: test: 3: unary operator expected
```
~~When running that one-line command at Linux prompt:~~
~~% python -c "import sys; print(sys.version_info[[0]])"~~
~~Traceback (most recent call last):~~
~~File "<string>", line 1, in <module>~~
~~TypeError: tuple indices must be integers or slices, not list~~
