### PR TITLE
ch4: fix win_shared_query for single process

### DIFF
--- a/src/mpid/ch4/src/mpidig_win.h
+++ b/src/mpid/ch4/src/mpidig_win.h
@@ -537,7 +537,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_fence(int massert, MPIR_Win * win)
 MPL_STATIC_INLINE_PREFIX int MPIDIG_win_shared_query_self(MPIR_Win * win, int rank, MPI_Aint * size,
                                                           int *disp_unit, void *baseptr)
 {
-    if (rank == win->comm_ptr->rank) {
+    if (rank == win->comm_ptr->rank || (rank == MPI_PROC_NULL && win->comm_ptr->local_size == 1)) {
         *size = win->size;
         *disp_unit = win->disp_unit;
         *((void **) baseptr) = win->base;


### PR DESCRIPTION

## Pull Request Description

It was missing the single process case when `rank == MPI_PROC_NULL.`

Fixes #6994 
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
