### PR TITLE
mpir_pmi: Use PMIX_IMMEDIATE when retrieving job attributes

### DIFF
--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -219,14 +219,25 @@ static int pmix_get_parent(const char *key, char *val, int val_size)
 
 static bool pmix_get_jobattr(const char *key, char *valbuf)
 {
+    bool found = false;
     pmix_value_t *pvalue;
+
+    /* if this is a non-reserved key, we want to make sure not to block
+     * by using PMIX_IMMEDIATE */
+    pmix_info_t *info;
+    PMIX_INFO_CREATE(info, 1);
+    int flag = 1;
+    PMIx_Info_load(info, PMIX_IMMEDIATE, &flag, PMIX_BOOL);
+
     int pmi_errno = PMIx_Get(NULL, key, NULL, 0, &pvalue);
-    if (pmi_errno != PMIX_SUCCESS) {
-        return false;
+    if (pmi_errno == PMIX_SUCCESS) {
+        strncpy(valbuf, pvalue->data.string, pmi_max_val_size);
+        PMIX_VALUE_RELEASE(pvalue);
+        found = true;
     }
-    strncpy(valbuf, pvalue->data.string, pmi_max_val_size);
-    PMIX_VALUE_RELEASE(pvalue);
-    return true;
+    PMIX_INFO_FREE(info, 1);
+
+    return found;
 }
 
 static int pmix_barrier(void)


### PR DESCRIPTION
## Pull Request Description

MPICH looks for some non-standard job attributes using PMIx_Get. These "non-reserved" keys are treated differently than standard "reserved" keys, and could cause an application to block waiting for the key to be available from the server. Use PMIX_IMMEDIATE to let the server know to return key not found rather than wait. Fixes pmodels/mpich#6946.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
