### PR TITLE
mpir_pmi: Use default appnum value if not found

### DIFF
--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -142,7 +142,7 @@ int MPIR_pmi_init(void)
     MPL_env2int("PMI_VERSION", &pmi_version);
     MPL_env2int("PMI_SUBVERSION", &pmi_subversion);
 
-    int has_parent, rank, size, appnum;
+    int has_parent, rank, size, appnum = -1;
     SWITCH_PMI(mpi_errno = pmi1_init(&has_parent, &rank, &size, &appnum),
                mpi_errno = pmi2_init(&has_parent, &rank, &size, &appnum),
                mpi_errno = pmix_init(&has_parent, &rank, &size, &appnum));

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -93,11 +93,14 @@ static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
 
     /* Get the appnum */
     pmi_errno = PMIx_Get(&pmix_proc, PMIX_APPNUM, NULL, 0, &pvalue);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_get", "**pmix_get %s", PMIx_Error_string(pmi_errno));
-    MPIR_Assert(pvalue->data.uint32 <= INT_MAX);        /* overflow check */
-    *appnum = (int) pvalue->data.uint32;
-    PMIX_VALUE_RELEASE(pvalue);
+    if (pmi_errno != PMIX_ERR_NOT_FOUND) {
+        MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                             "**pmix_get", "**pmix_get %s", PMIx_Error_string(pmi_errno));
+        MPIR_Assert(pvalue->data.uint32 <= INT_MAX);    /* overflow check */
+        *appnum = (int) pvalue->data.uint32;
+        PMIX_VALUE_RELEASE(pvalue);
+    }
+
     pmix_value_t value;
     pmix_value_t *val = &value;
 


### PR DESCRIPTION
## Pull Request Description

If the PMI server does not return an appnum value during initialization, set a default -1 instead of treating it as an error. An attribute query for this value will return "unset" to the application for handling. To date we have only observed this with the Cray PMIx client.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
