### PR TITLE
test: restrict tests that generate too many unexpected messages

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -1200,6 +1200,10 @@ fi
 if test "X${pac_have_hip}" = "Xyes" ; then
     AC_DEFINE([HAVE_HIP],[1],[Define if HIP is available])
     AC_CHECK_LIB(dl, dlopen, [], AC_MSG_ERROR([dlopen not found.  MPL HIP support requires libdl.]))
+    AC_CHECK_MEMBER([struct hipPointerAttribute_t.memoryType],
+                    [AC_DEFINE(HIP_USE_MEMORYTYPE, 1, [Define if struct hipPointerAttribute_t use memoryType (pre-v6.1)])],
+                    [],
+                    [[#include <hip/hip_runtime_api.h>]])
     have_gpu="yes"
     GPU_SUPPORT="HIP"
 fi

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -91,13 +91,21 @@ int MPL_gpu_init_device_mappings(int max_devid, int max_subdev_id)
     return MPL_SUCCESS;
 }
 
+#ifdef MPL_HIP_USE_MEMORYTYPE
+/* pre-ROCm 6.0 */
+#define DEVICE_ATTR_TYPE attr->device_attr.memoryType
+#else
+/* post-ROCm 6.0 */
+#define DEVICE_ATTR_TYPE attr->device_attr.type
+#endif
+
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
     int mpl_err = MPL_SUCCESS;
     hipError_t ret;
     ret = hipPointerGetAttributes(&attr->device_attr, ptr);
     if (ret == hipSuccess) {
-        switch (attr->device_attr.memoryType) {
+        switch (DEVICE_ATTR_TYPE) {
             case hipMemoryTypeHost:
                 attr->type = MPL_GPU_POINTER_REGISTERED_HOST;
                 attr->device = attr->device_attr.device;

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1299,7 +1299,6 @@
 /pt2pt/mprobe_self_free
 /pt2pt/multi_psend_derived
 /pt2pt/pingping
-/pt2pt/pingping_barrier
 /pt2pt/precv_anysrc
 /pt2pt/precv_anysrc_exp
 /pt2pt/probenull

--- a/test/mpi/include/mpitest.h
+++ b/test/mpi/include/mpitest.h
@@ -38,6 +38,7 @@ void MTestPrintErrorMsg(const char[], int);
 void MTestPrintfMsg(int, const char[], ...);
 void MTestError(const char[]);
 int MTestReturnValue(int);
+int MTestGetStressLevel(void);
 
 /*
  * Utilities

--- a/test/mpi/maint/dtp-test-config.txt
+++ b/test/mpi/maint/dtp-test-config.txt
@@ -25,7 +25,6 @@ coll/bcast_comm_world_only::262144:timeLimit=360 mem=1.9:10:16::0
 cxx/attr/fkeyvaltypex::1::1:1024::0
 cxx/datatype/packsizex::1::1:1024::0
 pt2pt/pingping::1 512 262144 17 1018 65530::2:8:32:0
-pt2pt/pingping_barrier::1::2:8:32:0
 pt2pt/sendrecv1::1 512 17 1018 65530::2:32:1024:0
 pt2pt/sendrecv1::262144::2:20::0
 pt2pt/sendself::1 512 262144 17 1018 65530::1:32:1024:0

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -1,4 +1,4 @@
-# Contitional XFAIL settings
+# Conditional XFAIL settings
 #
 # Syntax (similar to a cron file):
 #   [jobname] [compiler] [jenkins_configure] [netmod] [queue] [regex] [ticket reference] [testlist]
@@ -46,7 +46,7 @@
 * * * * freebsd32       /^putfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   rma/testlist.dtp
 * * * * ubuntu32        /^getfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   rma/testlist.dtp
 * * * * ubuntu32        /^putfence1 [0-9]* arg=-type=.* arg=-count=16000000/     xfail=ticket0   rma/testlist.dtp
-# intercomm abort test are expected to fail since MPI_Finalize will try to perform Allreduce on all process (includeing the aborted ones)
+# intercomm abort test are expected to fail since MPI_Finalize will try to perform Allreduce on all process (including the aborted ones)
 * * * * *               /^intercomm_abort/       xfail=ticket0   errors/comm/testlist
 # asan glitches with ucx for large buffer (when greater than ~1GB)
 * * asan ch4:ucx *      /^.*262144\|65530\|16000000.*/  xfail=ticket0   coll/testlist.dtp
@@ -63,9 +63,6 @@
 # multi-threading tests failing for ch3 freebsd64
 * * * ch3:tcp *         /^mt_iprobe_isendrecv/          xfail=issue4258         threads/pt2pt/testlist
 * * * ch3:tcp *         /^mt_improbe_isendrecv/         xfail=issue4258         threads/pt2pt/testlist
-# pingping tests with large testsize currently fails async tests due to netmod handling of large message queue
-* * async * *           /^pingping .*testsize=32/        xfail=issue4474        pt2pt/testlist.dtp
-* * async * *           /^pingping .*testsize=32/        xfail=issue4474        part/testlist.dtp
 # ch3:sock sporadicly TIMEOUT on these async tests
 * * async ch3:sock *    /^nonblocking3 /                  xfail=issue6264        coll/testlist
 * * async ch3:sock *    /^i?write(sh|ord|ordbe|all|allbe)f /        xfail=issue6264        f77/io/testlist

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -101,6 +101,9 @@ mpich-.*-arm.* * * * * /^reduce 10/           xfail=ticket0       coll/testlist.
 # MPI_Abort a sub group is not fully working
 * * * * *               /^(inter|sub)comm_abort/   xfail=ticket6634    errors/comm/testlist
 
+# The pipelined_tree bcast algorithm may flood unexpected messages to children processes
+* * * * *               /^bcasttest 10 .*ALGORITHM=pipelined_tree/  xfail=ticket4474
+
 # IPC read bcast, alltoall, allgather and allgatherv fail as MPL_gpu_imemcpy is not implemented in CUDA
 # https://github.com/pmodels/mpich/issues/6657
 * * * * *               /^bcast_gpu/   xfail=ticket6657    coll/testlist.gpu

--- a/test/mpi/part/pingping.c
+++ b/test/mpi/part/pingping.c
@@ -182,15 +182,14 @@ int main(int argc, char *argv[])
             }
             MTest_dtp_destroy(&send);
             MTest_dtp_destroy(&recv);
-#ifdef USE_BARRIER
-            /* NOTE: Without MPI_Barrier, recv side can easily accumulate large unexpected queue
-             * across multiple batches, especially in an async test. Currently, both libfabric and ucx
-             * netmod does not handle large message queue well, resulting in exponential slow-downs.
-             * Adding barrier let the current tests pass.
-             */
-            /* FIXME: fix netmod issues then remove the barrier (and corresponding tests). */
-            MPI_Barrier(comm);
-#endif
+            if (MTestGetStressLevel() == 0) {
+                /* NOTE: Without MPI_Barrier, recv side can easily accumulate large unexpected queue
+                 * across multiple batches, especially in an async test. Currently, both libfabric and ucx
+                 * netmod does not handle large message queue well, resulting in exponential slow-downs.
+                 * Adding barrier let the current tests pass.
+                 */
+                MPI_Barrier(comm);
+            }
         }
         MTestFreeComm(&comm);
     }

--- a/test/mpi/pt2pt/Makefile.am
+++ b/test/mpi/pt2pt/Makefile.am
@@ -65,7 +65,6 @@ noinst_PROGRAMS =  \
     irecv_any   \
     large_tag \
     pingping  \
-    pingping_barrier  \
     sendrecv1 \
     sendself \
     send_tests \
@@ -78,15 +77,3 @@ noinst_PROGRAMS =  \
 
 irecv_any_CPPFLAGS = -DTEST_NB $(AM_CPPFLAGS)
 irecv_any_SOURCES  = recv_any.c
-
-pingping_CPPFLAGS = $(AM_CPPFLAGS)
-pingping_SOURCES = pingping.c
-
-pingping_barrier_CPPFLAGS = $(AM_CPPFLAGS) -DUSE_BARRIER
-pingping_barrier_SOURCES = pingping.c
-
-sendrecv1_CPPFLAGS = $(AM_CPPFLAGS)
-sendrecv1_SOURCES = sendrecv1.c
-
-sendself_CPPFLAGS = $(AM_CPPFLAGS)
-sendself_SOURCES = sendself.c

--- a/test/mpi/pt2pt/pingping.c
+++ b/test/mpi/pt2pt/pingping.c
@@ -129,15 +129,14 @@ static int pingping(int seed, int testsize, int sendcnt, int recvcnt,
             }
             MTest_dtp_destroy(&send);
             MTest_dtp_destroy(&recv);
-#ifdef USE_BARRIER
-            /* NOTE: Without MPI_Barrier, recv side can easily accumulate large unexpected queue
-             * across multiple batches, especially in an async test. Currently, both libfabric and ucx
-             * netmod does not handle large message queue well, resulting in exponential slow-downs.
-             * Adding barrier let the current tests pass.
-             */
-            /* FIXME: fix netmod issues then remove the barrier (and corresponding tests). */
-            MPI_Barrier(comm);
-#endif
+            if (MTestGetStressLevel() == 0) {
+                /* NOTE: Without MPI_Barrier, recv side can easily accumulate large unexpected queue
+                 * across multiple batches, especially in an async test. Currently, both libfabric and ucx
+                 * netmod does not handle large message queue well, resulting in exponential slow-downs.
+                 * Adding barrier let the current tests pass.
+                 */
+                MPI_Barrier(comm);
+            }
         }
         MTestFreeComm(&comm);
     }

--- a/test/mpi/rma/manyget.c
+++ b/test/mpi/rma/manyget.c
@@ -36,8 +36,12 @@ int main(int argc, char *argv[])
 
     MPI_Win_fence(0, win);
 
+    int num_iter = 1000;
+    if (MTestGetStressLevel()) {
+        num_iter = 100000;
+    }
     if (rank == 1) {
-        for (i = 0; i < 100000; i++)
+        for (i = 0; i < num_iter; i++)
             MPI_Get(buf, BUFSIZE / sizeof(int), MPI_INT, 0, 0, BUFSIZE / sizeof(int), MPI_INT, win);
     }
 

--- a/test/mpi/rma/testlist.in
+++ b/test/mpi/rma/testlist.in
@@ -156,7 +156,7 @@ aint 2
 aint_collattach 2
 acc_pairtype 2
 acc_pairtype_shm 2
-manyget 2 timeLimit=300
+manyget 2
 derived_acc_flush_local 3
 large_acc_flush_local 3
 large_small_acc 2

--- a/test/mpi/util/mtest.c
+++ b/test/mpi/util/mtest.c
@@ -39,11 +39,17 @@ static void MTestResourceSummary(FILE *);
    memory testing */
 
 static int dbgflag = 0;         /* Flag used for debugging */
+static int stress = 0;          /* Stress level */
 static int verbose = 0;         /* Message level (0 is none) */
 static int returnWithVal = 1;   /* Allow programs to return with a non-zero
                                  * if there was an error (may cause problems
                                  * with some runtime systems) */
 static int usageOutput = 0;     /* */
+
+int MTestGetStressLevel(void)
+{
+    return stress;
+}
 
 /* Provide backward portability to MPI 1 */
 #ifndef MPI_VERSION
@@ -62,6 +68,8 @@ static int usageOutput = 0;     /* */
 
  Environment Variables:
 + MPITEST_DEBUG - If set (to any value), turns on debugging output
+. MPITEST_STRESS - If set, run tests with increased stress (e.g. more
+                   iterations, larger datatype counts, more processes).
 . MPITEST_THREADLEVEL_DEFAULT - If set, use as the default "provided"
                                 level of thread support.  Applies to
                                 MTest_Init but not MTest_Init_thread.
@@ -90,6 +98,11 @@ void MTest_Init_thread(int *argc, char ***argv, int required, int *provided)
     /* Check for debugging control */
     if (getenv("MPITEST_DEBUG")) {
         dbgflag = 1;
+    }
+
+    /* Check for stress level */
+    if (getenv("MPITEST_STRESS")) {
+        stress = 1;
     }
 
     /* Check for verbose control */


### PR DESCRIPTION
## Pull Request Description
Tests that generate too many unexpected messages should be reserved for performance testing. No design can tolerate unlimited unexpected messages.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
