### PR TITLE
mpl: update hipPointerAttribute_t.memoryType

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -1200,6 +1200,10 @@ fi
 if test "X${pac_have_hip}" = "Xyes" ; then
     AC_DEFINE([HAVE_HIP],[1],[Define if HIP is available])
     AC_CHECK_LIB(dl, dlopen, [], AC_MSG_ERROR([dlopen not found.  MPL HIP support requires libdl.]))
+    AC_CHECK_MEMBER([struct hipPointerAttribute_t.memoryType],
+                    [AC_DEFINE(HIP_USE_MEMORYTYPE, 1, [Define if struct hipPointerAttribute_t use memoryType (pre-v6.1)])],
+                    [],
+                    [[#include <hip/hip_runtime_api.h>]])
     have_gpu="yes"
     GPU_SUPPORT="HIP"
 fi

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -91,13 +91,21 @@ int MPL_gpu_init_device_mappings(int max_devid, int max_subdev_id)
     return MPL_SUCCESS;
 }
 
+#ifdef MPL_HIP_USE_MEMORYTYPE
+/* pre-ROCm 6.0 */
+#define DEVICE_ATTR_TYPE attr->device_attr.memoryType
+#else
+/* post-ROCm 6.0 */
+#define DEVICE_ATTR_TYPE attr->device_attr.type
+#endif
+
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
     int mpl_err = MPL_SUCCESS;
     hipError_t ret;
     ret = hipPointerGetAttributes(&attr->device_attr, ptr);
     if (ret == hipSuccess) {
-        switch (attr->device_attr.memoryType) {
+        switch (DEVICE_ATTR_TYPE) {
             case hipMemoryTypeHost:
                 attr->type = MPL_GPU_POINTER_REGISTERED_HOST;
                 attr->device = attr->device_attr.device;


### PR DESCRIPTION
## Pull Request Description
ROCm 6.0 renamed the memoryType field in struct hipPointerAttribute_t to just type.

Fixes #6860
[skip warnings]

## TODO
* [ ] fix yaksa
* [ ] test 


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
