### PR TITLE
datatype/dataloop: fix typerep iov routines

### DIFF
--- a/src/mpi/datatype/typerep/src/typerep_dataloop_iov.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_iov.c
@@ -38,9 +38,19 @@ int MPIR_Typerep_to_iov_offset(const void *buf, MPI_Aint count, MPI_Datatype typ
 {
     int mpi_errno = MPI_SUCCESS;
 
+    int is_contig;
+    MPI_Aint typesize;
     if (HANDLE_IS_BUILTIN(type)) {
-        MPI_Aint typesize;
+        is_contig = 1;
         typesize = MPIR_Datatype_get_basic_size(type);
+    } else {
+        MPIR_Datatype *dt_ptr;
+        MPIR_Datatype_get_ptr(type, dt_ptr);
+        is_contig = dt_ptr->is_contig;
+        typesize = dt_ptr->size;
+    }
+
+    if (is_contig) {
         if (max_iov_len >= 1) {
             iov[0].iov_base = (char *) buf;
             iov[0].iov_len = typesize * count;

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_iov.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_iov.c
@@ -43,7 +43,7 @@ int MPIR_Typerep_to_iov_offset(const void *buf, MPI_Aint count, MPI_Datatype typ
         typesize = MPIR_Datatype_get_basic_size(type);
         if (max_iov_len >= 1) {
             iov[0].iov_base = (char *) buf;
-            iov[0].iov_len = typesize;
+            iov[0].iov_len = typesize * count;
             *actual_iov_len = 1;
         } else {
             *actual_iov_len = 0;
@@ -84,7 +84,7 @@ int MPIR_Typerep_iov_len(MPI_Aint count, MPI_Datatype type, MPI_Aint max_iov_byt
     }
 
     if (max_iov_bytes >= count * type_size) {
-        *iov_len = count * num_contig;
+        *iov_len = is_contig ? 1 : count * num_contig;
         if (actual_iov_bytes) {
             *actual_iov_bytes = count * type_size;
         }

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_pack.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_pack.c
@@ -8,6 +8,12 @@
 #include "typerep_pre.h"
 #include "typerep_internal.h"
 
+int MPIR_Typerep_test(MPIR_Typerep_req typerep_req, int *completed)
+{
+    *completed = 1;
+    return MPI_SUCCESS;
+}
+
 int MPIR_Typerep_icopy(void *outbuf, const void *inbuf, MPI_Aint num_bytes,
                        MPIR_Typerep_req * typerep_req, uint32_t flags)
 {

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -54,7 +54,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_gpu_rma_enabled(const void *ptr)
                 return 0;
         }
     }
-    return 0;
+    return 1;
 }
 
 MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_query_acc_atomic_support(MPI_Datatype dt, int query_type,


### PR DESCRIPTION
## Pull Request Description
The typerep iov routines are not implemented correctly in the dataloop engine. It missed the case when datatype is contiguous or builtin-type and count > 1.

Fix `MPIDI_OFI_gpu_rma_enabled` so it won't mistakenly prevent the native path for host buffers.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
