### PR TITLE
abi/errhan: fix wrong union reference in MPIR_handle

### DIFF
--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -189,7 +189,7 @@ int MPIR_call_errhandler(MPIR_Errhandler * errhandler, int errorcode, MPIR_handl
     } else if (h.kind == MPIR_WIN) {
         abi_handle = ABI_Win_from_mpi(h.u.handle);
     } else if (h.kind == MPIR_FILE) {
-        abi_handle = ABI_File_from_mpi(h.u.handle);
+        abi_handle = ABI_File_from_mpi(h.u.fh);
     } else if (h.kind == MPIR_SESSION) {
         abi_handle = ABI_Session_from_mpi(h.u.handle);
     } else {


### PR DESCRIPTION

## Pull Request Description


A typo causes the file handle to be choped to 32-bit.


Fixes #7003 
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
