### PR TITLE
misc: use PMI_HOSTNAME to select preferred interface

### DIFF
--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -51,6 +51,7 @@ int MPIR_pmi_set_threaded(int is_threaded);
 int MPIR_pmi_max_key_size(void);
 int MPIR_pmi_max_val_size(void);
 const char *MPIR_pmi_job_id(void);
+const char *MPIR_pmi_hostname(void);
 char *MPIR_pmi_get_jobattr(const char *key);    /* key must use "PMI_" prefix */
 
 /* PMI wrapper utilities */

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_init.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_init.c
@@ -324,8 +324,11 @@ static int GetSockInterfaceAddr(int myRank, char *ifname, int maxIfname, MPL_soc
     /* Check for a host name supplied through an environment variable */
     ifname_string = MPIR_CVAR_CH3_INTERFACE_HOSTNAME;
     if (!ifname_string) {
+        ifname_string = MPIR_pmi_hostname();
+    }
+    if (!ifname_string) {
         /* See if there is a per-process name for the interfaces (e.g.,
-         * the process manager only delievers the same values for the
+         * the process manager only delivers the same values for the
          * environment to each process.  There's no way to do this with
          * the param interface, so we need to use getenv() here. */
         char namebuf[1024];

--- a/src/pm/hydra/mpiexec/get_parameters.c
+++ b/src/pm/hydra/mpiexec/get_parameters.c
@@ -369,7 +369,7 @@ static HYD_status post_process(void)
         /* If hostname propagation is requested (or not set), set the
          * environment variable for doing that */
         if (HYD_ui_mpich_info.hostname_propagation || HYD_ui_mpich_info.hostname_propagation == -1)
-            HYD_server_info.iface_ip_env_name = MPL_strdup("MPIR_CVAR_CH3_INTERFACE_HOSTNAME");
+            HYD_server_info.iface_ip_env_name = MPL_strdup("PMI_HOSTNAME");
     }
 
   fn_exit:

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -981,6 +981,11 @@ static HYD_status launch_procs(struct pmip_pg *pg)
                 MPL_free(str);
             }
 
+            if (pg->hostname) {
+                status = HYDU_append_env_to_list("PMI_HOSTNAME", pg->hostname, &force_env);
+                HYDU_ERR_POP(status, "unable to add env to list\n");
+            }
+
             HYD_STRING_STASH_INIT(stash);
             for (j = 0; exec->exec[j]; j++)
                 HYD_STRING_STASH(stash, MPL_strdup(exec->exec[j]), status);

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -58,6 +58,7 @@ static int pmi_max_key_size;
 static int pmi_max_val_size;
 
 static char *pmi_kvs_name;
+static char *pmi_hostname;
 
 static char *hwloc_topology_xmlfile;
 
@@ -148,6 +149,11 @@ int MPIR_pmi_init(void)
                mpi_errno = pmix_init(&has_parent, &rank, &size, &appnum));
     MPIR_ERR_CHECK(mpi_errno);
 
+    const char *hostname;
+    if (MPL_env2str("PMI_HOSTNAME", &hostname)) {
+        pmi_hostname = MPL_strdup(hostname);
+    }
+
     unsigned world_id = 0;
     if (pmi_kvs_name) {
         HASH_FNV(pmi_kvs_name, strlen(pmi_kvs_name), world_id);
@@ -209,6 +215,8 @@ void MPIR_pmi_finalize(void)
      * here: free allocated memory */
     MPL_free(pmi_kvs_name);
     pmi_kvs_name = NULL;
+    MPL_free(pmi_hostname);
+    pmi_hostname = NULL;
 
     MPL_free(MPIR_Process.node_map);
     MPL_free(MPIR_Process.node_root_map);
@@ -255,6 +263,11 @@ int MPIR_pmi_max_val_size(void)
 const char *MPIR_pmi_job_id(void)
 {
     return (const char *) pmi_kvs_name;
+}
+
+const char *MPIR_pmi_hostname(void)
+{
+    return (const char *) pmi_hostname;
 }
 
 /* wrapper functions */


### PR DESCRIPTION
## Pull Request Description
We don't have a mechanism for ch4 to select preferred interface as we does in ch3 using `MPIR_CVAR_CH3_INTERFACE_HOSTNAME`. This PR changes the CVAR into `PMI_HOSTNAME`, thus becoming a general PMI mechanism. We use it to select libfabfabric provider when multi-nic is not enabled.

[skip warnings]

Fixes #7028


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
