### PR TITLE
build: more informative failure message

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -727,10 +727,13 @@ AC_INIT
 AC_PREREQ($ver)
 AC_OUTPUT
 EOF
-        if (cd .tmp && $autoreconf $autoreconf_args >/dev/null 2>&1 ) ; then
+        if (cd .tmp && $autoreconf $autoreconf_args >autoreconf.out 2>autoreconf.err) ; then
             echo ">= $ver"
         else
             echo "bad autoconf installation"
+            echo "--- autoreconf diagnositcs ---"
+            $(cat autoreconf.err)
+            echo "--- autoreconf diagnositcs ---"
             cat <<EOF
 You either do not have autoconf in your path or it is too old (version
 $ver or higher required). You may be able to use


### PR DESCRIPTION
If autoconf detection fails, see if we can provide a bit more of a hint than just "bzzt wrong"

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
