### PR TITLE
coll: nonblocking collective request to use per-comm vci

### DIFF
--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -592,7 +592,7 @@ int MPIR_TSP_sched_start(MPIR_TSP_sched_t s, MPIR_Comm * comm, MPIR_Request ** r
     }
 
     /* Create a request */
-    reqp = MPIR_Request_create(MPIR_REQUEST_KIND__COLL);
+    reqp = MPID_Request_create_from_comm(MPIR_REQUEST_KIND__COLL, comm);
     if (!reqp)
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
     *req = reqp;

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -827,6 +827,7 @@ int MPID_Get_processor_name( char *name, int namelen, int *resultlen);
 int MPID_Get_universe_size(int  * universe_size);
 int MPID_Comm_get_lpid(MPIR_Comm *comm_ptr, int idx, uint64_t *lpid_ptr, bool is_remote);
 
+#define MPID_Request_create_from_comm(kind, comm) MPIR_Request_create(kind)
 void MPID_Request_create_hook(MPIR_Request *);
 void MPID_Request_free_hook(MPIR_Request *);
 void MPID_Request_destroy_hook(MPIR_Request *);

--- a/src/mpid/ch4/include/mpidpost.h
+++ b/src/mpid/ch4/include/mpidpost.h
@@ -9,6 +9,17 @@
 #include "mpir_datatype.h"
 #include "mpidch4.h"
 
+MPL_STATIC_INLINE_PREFIX MPIR_Request *MPID_Request_create_from_comm(MPIR_Request_kind_t kind,
+                                                                     MPIR_Comm * comm)
+{
+    MPIR_Request *req;
+    int vci = MPIDI_get_comm_vci(comm);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    req = MPIR_Request_create_from_pool(kind, vci, 1);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    return req;
+}
+
 MPL_STATIC_INLINE_PREFIX void MPID_Request_create_hook(MPIR_Request * req)
 {
     MPIR_FUNC_ENTER;

--- a/src/mpid/ch4/src/ch4_vci.h
+++ b/src/mpid/ch4/src/ch4_vci.h
@@ -315,4 +315,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_vci(int flag, MPIR_Comm * comm_ptr,
 #error Invalid MPIDI_CH4_VCI_METHOD!
 #endif
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_get_comm_vci(MPIR_Comm * comm_ptr)
+{
+#if MPIDI_CH4_VCI_METHOD == MPICH_VCI__COMM
+    return MPIDI_hash_local_vci(comm_ptr->seq);
+#else
+    return 0;
+#endif
+}
+
 #endif /* CH4_VCI_H_INCLUDED */

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -579,7 +579,7 @@ int MPIDU_Sched_start(struct MPIDU_Sched *s, MPIR_Comm * comm, MPIR_Request ** r
     MPIR_Assert(s->entries != NULL);
 
     /* now create and populate the request */
-    r = MPIR_Request_create(MPIR_REQUEST_KIND__COLL);
+    r = MPID_Request_create_from_comm(MPIR_REQUEST_KIND__COLL, comm);
     if (!r)
         MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**nomem");
     /* FIXME is this right when comm/datatype GC is used? */


### PR DESCRIPTION
## Pull Request Description
When multiple VCIs are enabled, nonblocking collective requests must be created from the same pool as their underlying point-to-point operations, or they won't progress effectively. The current nonblocking colletives depend on global progress -- by default once every 256 times -- to advance. This resulted in nonblocking tests, e.g. `coll/nonblocking3 10`, significantly slow under multiple vci configurations.

This PR adds `MPID_Request_create_from_comm` so MPIR layer can create requests from vci pool that are consistent to their communicators.

In addition, the ofi injected message on some providers -- e.g. `sockets`, `tcp`, etc. -- requires progress despite the operation being marked complete. This is problematic when the application goes into e.g. computation after sending a short message or switching to a different vci (by using a different communicator) and neglects to progress the previous vci. The `coll/nonblocking3` tests suffer from this due to switching between different communicators. The correct solution will require explicit passing of user execution context to MPI to avoid using multiple vcis in a single thread. But for now, there is no good solution. Add `MPIR_CVAR_CH4_OFI_ENABLE_INJECT=0` as a workaround. It will slightly lower small messaging benchmarks, but for real applications, it is more important to avoid hangs.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
