### PR TITLE
ch4/ofi: fix MPIDI_OFI_CALL_RETRY_AM for vci

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_events.h
@@ -142,7 +142,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_rdma_read(void *dst,
 
         int ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, nic);
         MPIDI_OFI_CALL_RETRY_AM(fi_readmsg(MPIDI_OFI_global.ctx[ctx_idx].tx, &msg, FI_COMPLETION),
-                                rdma_readfrom);
+                                vci_local, rdma_readfrom);
 
         done += curr_len;
         rem -= curr_len;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -156,7 +156,7 @@ MPL_STATIC_INLINE_PREFIX MPIDI_OFI_am_unordered_msg_t
     not grab the lock because the progress engine is already holding the lock.
     This is the case for reply functions such as am_isend_reply.
 */
-#define MPIDI_OFI_CALL_RETRY_AM(FUNC,STR)                               \
+#define MPIDI_OFI_CALL_RETRY_AM(FUNC,vci_,STR)                          \
     do {                                                                \
         ssize_t _ret;                                                   \
         do {                                                            \
@@ -171,7 +171,7 @@ MPL_STATIC_INLINE_PREFIX MPIDI_OFI_am_unordered_msg_t
                                    __LINE__,                            \
                                    __func__,                              \
                                    fi_strerror(-_ret));                 \
-            mpi_errno = MPIDI_OFI_progress_do_queue(0 /* vci_idx */);    \
+            mpi_errno = MPIDI_OFI_progress_do_queue(vci_);              \
             if (mpi_errno != MPI_SUCCESS)                                \
                 MPIR_ERR_CHECK(mpi_errno);                               \
         } while (_ret == -FI_EAGAIN);                                   \
@@ -315,7 +315,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_long(int rank, MPIR_Comm * comm,
 
     MPIDI_OFI_AMREQUEST(sreq, event_id) = MPIDI_OFI_EVENT_AM_SEND_RDMA;
     MPIDI_OFI_CALL_RETRY_AM(fi_send(MPIDI_OFI_global.ctx[ctx_idx].tx, msg_hdr, total_msg_sz, NULL,
-                                    dst_addr, &MPIDI_OFI_AMREQUEST(sreq, context)), send);
+                                    dst_addr, &MPIDI_OFI_AMREQUEST(sreq, context)), vci_src, send);
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -377,7 +377,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_short(int rank, MPIR_Comm * comm
 
     MPI_Aint total_msg_sz = sizeof(MPIDI_OFI_am_header_t) + am_hdr_sz + data_sz;
     MPIDI_OFI_CALL_RETRY_AM(fi_send(MPIDI_OFI_global.ctx[ctx_idx].tx, msg_hdr, total_msg_sz,
-                                    NULL, dst_addr, &MPIDI_OFI_AMREQUEST(sreq, context)), send);
+                                    NULL, dst_addr, &MPIDI_OFI_AMREQUEST(sreq, context)),
+                            vci_src, send);
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -432,7 +433,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_pipeline(int rank, MPIR_Comm * c
     MPIR_Assert(packed_size == seg_sz);
 
     MPIDI_OFI_CALL_RETRY_AM(fi_send(MPIDI_OFI_global.ctx[ctx_idx].tx, msg_hdr, total_msg_sz,
-                                    NULL, dst_addr, &send_req->context), send);
+                                    NULL, dst_addr, &send_req->context), vci_src, send);
 
     MPIDIG_am_send_async_issue_seg(sreq, seg_sz);
     MPIR_ERR_CHECK(mpi_errno);
@@ -573,7 +574,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(MPIR_Comm * comm, fi_a
 
     MPIDI_OFI_CALL_RETRY_AM(fi_send(MPIDI_OFI_global.ctx[ctx_idx].tx, ibuf, len,
                                     NULL /* desc */ , addr, &(MPIDI_OFI_REQUEST(sreq, context))),
-                            send);
+                            vci_src, send);
   fn_exit:
     return mpi_errno;
   fn_fail:
@@ -619,7 +620,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_inject(int rank,
     memcpy(buff + sizeof(msg_hdr), am_hdr, am_hdr_sz);
 
     MPIDI_OFI_CALL_RETRY_AM(fi_inject(MPIDI_OFI_global.ctx[ctx_idx].tx, buff, buff_len, dst_addr),
-                            inject);
+                            vci_src, inject);
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -1855,7 +1855,7 @@ int MPIDI_OFI_am_repost_buffer(int vci, int am_idx)
     int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
     MPIDI_OFI_CALL_RETRY_AM(fi_recvmsg(MPIDI_OFI_global.ctx[ctx_idx].rx,
                                        &MPIDI_OFI_global.per_vci[vci].am_msg[am_idx],
-                                       FI_MULTI_RECV | FI_COMPLETION), prepost);
+                                       FI_MULTI_RECV | FI_COMPLETION), vci, prepost);
 
   fn_exit:
     return mpi_errno;


### PR DESCRIPTION
## Pull Request Description
The macro needs a vci input or it will call MPIDI_OFI_progress_do_queue on the wrong vci and result in deadlock.

Somehow we miss catching this with psm3 provider testing. It is triggered by am fallback in the rma testing. It appears that only the rma testing triggers the am postponing queue path.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
