### PR TITLE
test: misc testing issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -587,7 +587,7 @@ Makefile.am-stamp
 
 # /test/mpi/
 /test/mpi/libtool
-/test/mpi/coll/testlist.cvar
+/test/mpi/coll/testlist.collalgo
 /test/mpi/attr/testlist.dtp
 /test/mpi/pt2pt/testlist.dtp
 /test/mpi/coll/testlist.dtp

--- a/test/mpi/maint/coll_cvars.txt
+++ b/test/mpi/maint/coll_cvars.txt
@@ -4,7 +4,7 @@
 ##
 
 # This config file is used by maint/gen_coll_cvar.py to generate
-# coll/testlist.cvar, which include tests that test specific collective
+# coll/testlist.collalgo, which include tests that test specific collective
 # algorithms controlled by using CVARs.
 
 # The basic format are indentation-based hierarchy. There are 2 top level

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -102,7 +102,7 @@ mpich-.*-arm.* * * * * /^reduce 10/           xfail=ticket0       coll/testlist.
 * * * * *               /^(inter|sub)comm_abort/   xfail=ticket6634    errors/comm/testlist
 
 # The pipelined_tree bcast algorithm may flood unexpected messages to children processes
-* * * * *               /^bcasttest 10 .*ALGORITHM=pipelined_tree/  xfail=ticket4474
+* * * * *               /^bcasttest 10 .*ALGORITHM=pipelined_tree/  xfail=ticket4474 coll/testlist.collalgo
 
 # IPC read bcast, alltoall, allgather and allgatherv fail as MPL_gpu_imemcpy is not implemented in CUDA
 # https://github.com/pmodels/mpich/issues/6657

--- a/test/mpi/threads/pt2pt/testlist
+++ b/test/mpi/threads/pt2pt/testlist
@@ -46,10 +46,10 @@ mt_iprobe_sendrecv_huge 2 arg=-iter=64 arg=-count=4096 env=MPIR_CVAR_CH4_OFI_EAG
 mt_mprobe_sendrecv_huge 2 arg=-iter=64 arg=-count=4096 env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=16384
 mt_improbe_sendrecv_huge 2 arg=-iter=64 arg=-count=4096 env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=16384
 
-mt_probe_sendrecv_huge 2 arg=-iter=64 arg=-count=4194304 env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=16384
-mt_iprobe_sendrecv_huge 2 arg=-iter=64 arg=-count=4194304 env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=16384
-mt_mprobe_sendrecv_huge 2 arg=-iter=64 arg=-count=4194304 env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=16384
-mt_improbe_sendrecv_huge 2 arg=-iter=64 arg=-count=4194304 env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=16384
+mt_probe_sendrecv_huge 2 arg=-iter=64 arg=-count=65530 env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=16384
+mt_iprobe_sendrecv_huge 2 arg=-iter=64 arg=-count=65530 env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=16384
+mt_mprobe_sendrecv_huge 2 arg=-iter=64 arg=-count=65530 env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=16384
+mt_improbe_sendrecv_huge 2 arg=-iter=64 arg=-count=65530 env=MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE=16384
 
 mt_sendrecv_pers_huge 2 arg=-iter=64 arg=-count=4096
 mt_bsendrecv_pers_huge 2 arg=-iter=8 arg=-count=4096


### PR DESCRIPTION
## Pull Request Description
* Fix typos due to testlist.collalgo renaming
* Lower stress levels in `mt_probe_sendrecv_huge` testing
 
The multithreaded probe huge-path testing with `MPIR_CVAR_CH4_OFI_EAGER_MAX_MSG_SIZE` set to a low threshold is problematic due to its issuing all the `fi_read` for each chunks in a flood fashion.  Combined with multithreading progress contention and CI server congestion, we often see sporadic test failures. To avoid CI distractions, this PR suggest to lower the stress levels for these tests. They should be sufficient to test the correctness of the ofi native huge path.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
