### PR TITLE
ch4/config: refine --with-ch4-shmmods options

### DIFF
--- a/src/mpid/ch4/shm/ipc/gpu/subconfigure.m4
+++ b/src/mpid/ch4/shm/ipc/gpu/subconfigure.m4
@@ -3,20 +3,16 @@ dnl MPICH_SUBCFG_AFTER=src/mpid/ch4
 
 AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
     AM_COND_IF([BUILD_CH4],[
-        for shm in $ch4_shm ; do
-            AS_IF([test "x$shm" = "xgpudirect"],[build_ch4_shm_ipc_gpu=yes],
-                  [test "x$shm" = "xauto"],[build_ch4_shm_ipc_gpu=yes])
-        done
-
-        if test "$build_ch4_shm_ipc_gpu" = "yes" ; then
-            AC_DEFINE([MPIDI_CH4_SHM_ENABLE_GPU],[1],[Define if GPU IPC submodule is enabled])
-        fi
+        build_ch4_shm_ipc_gpu=auto
     ])dnl end of AM_COND_IF(BUILD_CH4,...)
-
-    AM_CONDITIONAL([BUILD_SHM_IPC_GPU],[test "X$build_ch4_shm_ipc_gpu" = "Xyes"])
 ])dnl end of _PREREQ
 
 AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[
+    # GPU_SUPPORT is set by mpl via src/mpl/localdefs.in
+    AM_CONDITIONAL([BUILD_SHM_IPC_GPU],[test -n "$GPU_SUPPORT"])
+    AM_COND_IF([BUILD_SHM_IPC_GPU],[
+        AC_DEFINE([MPIDI_CH4_SHM_ENABLE_GPU],[1],[Define if GPU IPC submodule is enabled])
+    ])
 ])dnl end of _BODY
 
 [#] end of __file__

--- a/src/mpid/ch4/shm/ipc/xpmem/subconfigure.m4
+++ b/src/mpid/ch4/shm/ipc/xpmem/subconfigure.m4
@@ -3,17 +3,12 @@ dnl MPICH_SUBCFG_AFTER=src/mpid/ch4
 
 AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
     AM_COND_IF([BUILD_CH4],[
-        for shm in $ch4_shm ; do
-            AS_IF([test "x$shm" = "xxpmem"],[build_ch4_shm_ipc_xpmem=yes],
-                  [test "x$shm" = "xauto"],[build_ch4_shm_ipc_xpmem=auto])
-        done
+        build_ch4_shm_ipc_xpmem=auto
     ])dnl end AM_COND_IF(BUILD_CH4,...)
-
-    AM_CONDITIONAL([BUILD_SHM_IPC_XPMEM],[test -n "$build_ch4_shm_ipc_xpmem"])
 ])dnl end _PREREQ
 
 AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[
-    AM_COND_IF([BUILD_SHM_IPC_XPMEM],[
+    if test -n "$build_ch4_shm_ipc_xpmem" ; then
         AC_MSG_NOTICE([RUNNING CONFIGURE FOR ch4:shm:xpmem])
         PAC_CHECK_HEADER_LIB_OPTIONAL([xpmem],[xpmem.h],[xpmem],[xpmem_make])
         if test "$pac_have_xpmem" = "yes" ; then
@@ -22,11 +17,9 @@ AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[
                 AC_DEFINE([MPIDI_CH4_SHM_XPMEM_ALLOW_SILENT_FALLBACK],[1],
                           [Silently disable XPMEM, if it fails at runtime])
             fi
-        elif test "$build_ch4_shm_ipc_xpmem" = "yes" ; then
-            AC_MSG_ERROR(['xpmem.h or libxpmem library not found.'])
         fi
-        AM_CONDITIONAL([BUILD_SHM_IPC_XPMEM],[test "$pac_have_xpmem" = "yes"])
-    ])dnl end AM_COND_IF(BUILD_SHM_IPC_XPMEM,...)
+    fi
+    AM_CONDITIONAL([BUILD_SHM_IPC_XPMEM],[test "$pac_have_xpmem" = "yes"])
 ])dnl end _BODY
 
 [#] end of __file__

--- a/src/mpid/ch4/shm/stubshm/subconfigure.m4
+++ b/src/mpid/ch4/shm/stubshm/subconfigure.m4
@@ -3,17 +3,15 @@ dnl MPICH_SUBCFG_AFTER=src/mpid/ch4
 
 AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
     AM_COND_IF([BUILD_CH4],[
-        for shm in $ch4_shm ; do
-            AS_CASE([$shm],[stubshm],[build_ch4_shm_stubshm=yes])
-        done
+        build_ch4_shm_stubshm=no
     ])
-    AM_CONDITIONAL([BUILD_SHM_STUBSHM],[test "X$build_ch4_shm_stubshm" = "Xyes"])
 ])dnl
 
 AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[
-AM_COND_IF([BUILD_SHM_STUBSHM],[
-    AC_MSG_NOTICE([RUNNING CONFIGURE FOR ch4:shm:stubshm])
-])dnl end AM_COND_IF(BUILD_SHM_STUBSHM,...)
+    if test -n "$build_ch4_shm_ipc_stubshm" ; then
+        AC_MSG_NOTICE([RUNNING CONFIGURE FOR ch4:shm:stubshm])
+    fi
+    AM_CONDITIONAL([BUILD_SHM_STUBSHM],[test "X$build_ch4_shm_stubshm" = "Xyes"])
 ])dnl end _BODY
 
 [#] end of __file__

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -262,18 +262,10 @@ AC_ARG_WITH(ch4-shmmods,
     [  --with-ch4-shmmods@<:@=ARG@:>@ Comma-separated list of shared memory modules for MPICH/CH4.
                           Valid options are:
                           auto         - Enable everything that is available/allowed by netmod (default)
-                                         (cannot be combined with other options)
-                          none         - No shmmods, network only (cannot be combined with other options)
-                          posix        - Enable POSIX shmmod
-                          xpmem        - Enable XPMEM IPC (requires posix)
-                          gpudirect    - Enable GPU Direct IPC (requires posix)
+                          none         - No shmmods, network only
                  ],
                  [with_ch4_shmmods=$withval],
                  [with_ch4_shmmods=auto])
-# shmmod0,shmmod1,... format
-# (posix is always enabled thus ch4_shm is not checked in posix module)
-ch4_shm="`echo $with_ch4_shmmods | sed -e 's/,/ /g'`"
-export ch4_shm
 
 # setup default direct communication routine
 if test "${with_ch4_shmmods}" = "auto" -a "${ch4_netmods}" = "ucx" ; then

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -400,18 +400,19 @@ AC_DEFUN([PAC_CH4_CONFIG_SUMMARY], [
     elif test "$ch4_netmods" = "ucx" -a "$with_ucx" = "embedded"; then
         t_netmod="ucx (embedded)"
     fi
-    t_xpmem=""
+    t_ipc=""
     if test "$pac_have_xpmem" = "yes" ; then
-        t_xpmem="xpmem"
+        t_ipc="xpmem"
     fi
     t_gpu="disabled"
     if test -n "${GPU_SUPPORT}" ; then
         t_gpu="${GPU_SUPPORT}"
+        t_ipc="$t_ipc gpudirect"
     fi
     cat <<EOF
 ***
 *** device      : ch4:${t_netmod}
-*** shm feature : ${ch4_shm} $t_xpmem
+*** ipc feature : ${t_ipc}
 *** gpu support : ${t_gpu}
 ***
 EOF    


### PR DESCRIPTION
## Pull Request Description
It is a bit confusing on how to configure shmmods since posix, xpmem, and gpudirect are not equal and are currently configured inconsistently. Instead, we'll simplify --with-ch4-shmmods with "none" and "auto". "auto" is the default, means we will probe and include all shm/ipc features. `--without-ch4-shmmods` or `--with-ch4-shmmod=none" turns on MPIDI_CH4_DIRECT_NETMOD.

We'll detect for individual shmmods. Use `--with-{xpmem,cuda,hip,ze}=` to set library paths. Use `--without-{xpmem,...}` to force the feature out.

GPU support is checked via MPL, reflected as `$GPU_SUPPORT` in mpich configure.

Both `posix` and (future) `cma` are supported by standard linux, thus `--with-{posix,cma}` (without path value) turns the feature on. Posix will default on; CMA will default off -- due to default `ptrace_scope` permission policy. Use `--without-{posix,cma}` to explicitly turn off the feature. `--without-posix` currently is a noop since it cannot be turned off, but IMO it is worth to fix for consistency. We can simply make it equivalent to `MPIDI_CH4_DIRECT_NETMOD`.


[skip warnings]

## Impact
It is backward compatible except the CSV list options e.g. `--with-ch4-shmmods=posix,xpmem,gpudirect`

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
