### PR TITLE
util/async: avoid calling PMPIX_Stream_progress

### DIFF
--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -479,7 +479,7 @@ static int gpu_ipc_async_poll(MPIX_Async_thing thing)
     int err;
     int is_done = 0;
 
-    struct gpu_ipc_async *p = MPIX_Async_get_state(thing);
+    struct gpu_ipc_async *p = MPIR_Async_thing_get_state(thing);
     switch (p->yreq.type) {
         case MPIR_NULL_REQUEST:
             /* a dummy, immediately complete */

--- a/src/util/mpir_async_things.c
+++ b/src/util/mpir_async_things.c
@@ -32,7 +32,7 @@ int MPIR_Async_things_finalize(void)
 
     for (int vci = 0; vci < MPIR_MAX_VCIS + 1; vci++) {
         while (async_things_list[vci] != NULL) {
-            PMPIX_Stream_progress(MPIX_STREAM_NULL);
+            MPID_Progress_test(NULL);
         }
     }
 


### PR DESCRIPTION
## Pull Request Description
We should avoid calling MPI/PMPI functions internally. In this case, PMPIX_Stream_progress is not defined in the mpi-abi build.


Fixes #7034 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
