### PR TITLE
ch4/ofi: fix case for forcing packing of gpu buffers in netmod pt2pt path

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -182,7 +182,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         }
     }
 
-    if (data_sz && attr.type == MPL_GPU_POINTER_DEV) {
+    if (data_sz && MPL_gpu_query_pointer_is_dev(recv_buf, &attr)) {
         MPIDI_OFI_register_am_bufs();
         if (!MPIDI_OFI_ENABLE_HMEM || !dt_contig || (MPIDI_OFI_ENABLE_MR_HMEM && !register_mem)) {
             /* FIXME: at this point, GPU data takes host-buffer staging

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -253,7 +253,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
         register_mem = true;
     }
 
-    if (data_sz && attr.type == MPL_GPU_POINTER_DEV) {
+    if (data_sz && MPL_gpu_query_pointer_is_dev(send_buf, &attr)) {
         MPIDI_OFI_register_am_bufs();
         if (!MPIDI_OFI_ENABLE_HMEM || !dt_contig || (MPIDI_OFI_ENABLE_MR_HMEM && !register_mem)) {
             /* Force packing of GPU buffer in host memory */
@@ -600,7 +600,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
     if (MPIR_CVAR_CH4_OFI_ENABLE_INJECT && !syncflag && dt_contig &&
         (data_sz <= MPIDI_OFI_global.max_buffered_send)) {
         MPI_Aint actual_pack_bytes = 0;
-        if (attr.type == MPL_GPU_POINTER_DEV && data_sz) {
+        if (MPL_gpu_query_pointer_is_dev(send_buf, &attr) && data_sz) {
             MPIDI_OFI_register_am_bufs();
             if (!MPIDI_OFI_ENABLE_HMEM) {
                 /* Force pack for GPU buffer. */

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -600,14 +600,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
     if (MPIR_CVAR_CH4_OFI_ENABLE_INJECT && !syncflag && dt_contig &&
         (data_sz <= MPIDI_OFI_global.max_buffered_send)) {
         MPI_Aint actual_pack_bytes = 0;
-        if (MPL_gpu_query_pointer_is_dev(send_buf, &attr) && data_sz) {
+        if (data_sz && MPL_gpu_query_pointer_is_dev(send_buf, &attr)) {
             MPIDI_OFI_register_am_bufs();
             if (!MPIDI_OFI_ENABLE_HMEM) {
                 /* Force pack for GPU buffer. */
                 void *host_buf = MPL_malloc(data_sz, MPL_MEM_OTHER);
                 int fast_copy = 0;
-                if (attr.type == MPL_GPU_POINTER_DEV && dt_contig &&
-                    data_sz <= MPIR_CVAR_CH4_IPC_GPU_FAST_COPY_MAX_SIZE) {
+                if (data_sz <= MPIR_CVAR_CH4_IPC_GPU_FAST_COPY_MAX_SIZE) {
                     int mpl_err;
                     mpl_err = MPL_gpu_fast_memcpy(send_buf, &attr, host_buf, NULL, data_sz);
                     if (mpl_err == MPL_SUCCESS) {
@@ -618,8 +617,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
                 if (!fast_copy) {
                     MPL_gpu_engine_type_t engine =
                         MPIDI_OFI_gpu_get_send_engine_type(MPIR_CVAR_CH4_OFI_GPU_SEND_ENGINE_TYPE);
-                    if (dt_contig && engine != MPL_GPU_ENGINE_TYPE_LAST &&
-                        MPL_gpu_query_pointer_is_dev(send_buf, &attr)) {
+                    if (engine != MPL_GPU_ENGINE_TYPE_LAST) {
                         mpi_errno =
                             MPIR_Localcopy_gpu(send_buf, data_sz, MPI_BYTE, 0, &attr, host_buf,
                                                data_sz, MPI_BYTE, 0, NULL,


### PR DESCRIPTION
## Pull Request Description

This PR fixes the case for when GPU packing should be done in the netmod pt2pt path. It was meant to be captured in #6433, but was missed.

In this code path, we must enable packing for any GPU buffer type. For ZE, this includes device, USM host, and USM shared allocations. The last 2 cases were missing. Originally, we implemented this check as follows

```
        if (data_sz &&
            (attr.type == MPL_GPU_POINTER_DEV || attr.type == MPL_GPU_POINTER_MANAGED ||
             attr.type == MPL_GPU_POINTER_REGISTERED_HOST)) {
            ...
```

However, since we have the utility `MPL_gpu_query_pointer_is_dev` which performs this same check, I opted for that solution instead. This is more flexible; if a backend does not treat USM host or USM managed as device memory, then they can still pass this check correctly if the corresponding `MPL_gpu_query_pointer_is_dev` is correctly implemented.

Fixes #7030

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
