### PR TITLE
ch4/shm: Support topology-aware SHM communication

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -443,9 +443,11 @@ AC_ARG_ENABLE(fast,
         ndebug   - Appends -DNDEBUG to MPICHLIB_CFLAGS.
         no-strict-alignment - relax strict alignment requirement
         alwaysinline - Force compiler to always inline performance critical routines
+        sse      - Use SSE2-based copy routines
+        avx      - Use AVX256-based copy routines
         all|yes  - "O2", "ndebug", and "alwaysinline" are enabled
         none     - None of above options, i.e. --disable-fast
-],,enable_fast=O2)
+],,enable_fast=O2,sse)
 
 AC_ARG_ENABLE(interlib-deps,
 	[AS_HELP_STRING([--enable-interlib-deps - Enable interlibrary dependencies])],,enable_interlib_deps=yes)
@@ -900,6 +902,9 @@ for option in $enable_fast ; do
         ;;
         alwaysinline) # No op in MPICH. See mpl/configure.ac
         ;;
+        sse)
+        enable_fast_sse_instr=yes
+        ;;
         avx)
         enable_fast_avx_instr=yes
         ;;
@@ -910,6 +915,7 @@ for option in $enable_fast ; do
         none|no)
         enable_fast_ndebug=no
         enable_fast_opts=O0
+        enable_fast_sse_instr=no
         enable_fast_avx_instr=no
         ;;
         *)
@@ -975,6 +981,39 @@ if test "$enable_fast_avx_instr" = "yes" ; then
     fi
     if test "$pac_cv_found__mm256_stream_si256" = "yes" ; then
         AC_DEFINE(HAVE_MM256_STREAM_SI256,1,[Define if 256 bit streaming memcpy is available])
+        # no need for SSE2 version if AVX is supported
+        enable_fast_sse_instr=no
+    fi
+fi
+
+if test "$enable_fast_sse_instr" = "yes" ; then
+    AC_CACHE_CHECK([whether -msse2 is supported], pac_cv_found_sse2,
+                   [PAC_C_CHECK_COMPILER_OPTION([-msse2],pac_cv_found_sse2=yes,pac_cv_found_sse2=no)],
+                   pac_cv_found_avx=no,pac_cv_found_sse2=yes)
+    if test "$pac_cv_found_sse2" = "yes" ; then
+        PAC_APPEND_FLAG([-msse2],[CFLAGS])
+        AC_MSG_CHECKING([for SSE2 support])
+        AC_CACHE_CHECK([whether SSE2 stream store is supported], pac_cv_found_sse2_stream_store,[
+                        AC_RUN_IFELSE([AC_LANG_SOURCE([[
+                                       #include <immintrin.h>
+
+                                       int main(int argc, char **argv) {
+                                       char source[1024], dest[1024];
+                                       for (int i = 0; i < 1024; i++) source[i] = 'a';
+
+                                           __m128i xmm0 = _mm_loadu_si128((__m128i const *) source);
+                                           _mm_stream_si128((__m128i *) dest, xmm0);
+
+                                           if (dest[0] == source[0]) return 0;
+                                           else return 1;
+                                           }
+                                           ]])], pac_cv_found_sse2_stream_store="yes",
+                                           pac_cv_found_sse2_stream_store"no",
+                                           pac_cv_found_sse2_stream_store="unknown")
+                        ])
+    fi
+    if test "$pac_cv_found_sse2_stream_store" = "yes" ; then
+        AC_DEFINE(HAVE_SSE2,1,[Define if SSE2 128 bit streaming memcpy is available])
     fi
 fi
 

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
@@ -46,11 +46,21 @@ static int init_transport(int vci_src, int vci_dst)
     transport->num_cells = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_NUM_CELLS;
     transport->size_of_cell = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE;
 
-    mpi_errno = MPIDU_genq_shmem_pool_create(transport->size_of_cell, transport->num_cells,
-                                             MPIDI_POSIX_global.num_local,
-                                             MPIDI_POSIX_global.my_local_rank,
-                                             &transport->cell_pool);
-    MPIR_ERR_CHECK(mpi_errno);
+    if (MPIR_CVAR_GENQ_SHMEM_POOL_FREE_QUEUE_SENDER_SIDE) {
+        int queue_type = MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPSC;
+        mpi_errno = MPIDU_genq_shmem_pool_create(transport->size_of_cell, transport->num_cells,
+                                                 MPIDI_POSIX_global.num_local,
+                                                 MPIDI_POSIX_global.my_local_rank,
+                                                 1, &queue_type, &transport->cell_pool);
+        MPIR_ERR_CHECK(mpi_errno);
+    } else {
+        int queue_type = MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPMC;
+        mpi_errno = MPIDU_genq_shmem_pool_create(transport->size_of_cell, transport->num_cells,
+                                                 MPIDI_POSIX_global.num_local,
+                                                 MPIDI_POSIX_global.my_local_rank,
+                                                 1, &queue_type, &transport->cell_pool);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
 
     size_t size_of_terminals;
     /* Create one terminal for each process with which we will be able to communicate. */

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
@@ -46,15 +46,18 @@ static int init_transport(int vci_src, int vci_dst)
     transport->num_cells = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_NUM_CELLS;
     transport->size_of_cell = MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE;
 
-    if (MPIR_CVAR_GENQ_SHMEM_POOL_FREE_QUEUE_SENDER_SIDE) {
-        int queue_type = MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPSC;
+    if (MPIR_CVAR_CH4_SHM_POSIX_TOPO_ENABLE) {
+        int queue_types[2] = {
+            MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPSC,
+            MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPMC
+        };
         mpi_errno = MPIDU_genq_shmem_pool_create(transport->size_of_cell, transport->num_cells,
                                                  MPIDI_POSIX_global.num_local,
                                                  MPIDI_POSIX_global.my_local_rank,
-                                                 1, &queue_type, &transport->cell_pool);
+                                                 2, queue_types, &transport->cell_pool);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
-        int queue_type = MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPMC;
+        int queue_type = MPIDU_GENQ_SHMEM_QUEUE_TYPE__MPSC;
         mpi_errno = MPIDU_genq_shmem_pool_create(transport->size_of_cell, transport->num_cells,
                                                  MPIDI_POSIX_global.num_local,
                                                  MPIDI_POSIX_global.my_local_rank,

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_recv.h
@@ -67,6 +67,7 @@ MPIDI_POSIX_eager_recv_commit(MPIDI_POSIX_eager_recv_transaction_t * transaction
 
     transport = MPIDI_POSIX_eager_iqueue_get_transport(transaction->src_vci, transaction->dst_vci);
     cell = (MPIDI_POSIX_eager_iqueue_cell_t *) transaction->transport.iqueue.pointer_to_cell;
+
     MPIDU_genq_shmem_pool_cell_free(transport->cell_pool, cell);
 
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -55,10 +55,14 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
     /* Try to get a new cell to hold the message */
     /* Select the appropriate pool depending on whether we are using sender-side or receiver-side
      * queuing. */
-    MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell,
-                                     MPIR_CVAR_GENQ_SHMEM_POOL_FREE_QUEUE_SENDER_SIDE ?
-                                     MPIR_Process.local_rank :
-                                     MPIDI_POSIX_global.local_ranks[grank], buf);
+    if (MPIR_CVAR_GENQ_SHMEM_POOL_FREE_QUEUE_SENDER_SIDE) {
+        MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell,
+                                         MPIR_Process.local_rank, 0, buf);
+    } else {
+        int dst_local_rank = MPIDI_POSIX_global.local_ranks[grank];
+        MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell, dst_local_rank, 0,
+                                         buf);
+    }
 
     /* If a cell wasn't available, let the caller know that we weren't able to send the message
      * immediately. */

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -57,7 +57,8 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
      * queuing. */
     MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell,
                                      MPIR_CVAR_GENQ_SHMEM_POOL_FREE_QUEUE_SENDER_SIDE ?
-                                     MPIR_Process.local_rank : grank, buf);
+                                     MPIR_Process.local_rank :
+                                     MPIDI_POSIX_global.local_ranks[grank], buf);
 
     /* If a cell wasn't available, let the caller know that we weren't able to send the message
      * immediately. */

--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_send.h
@@ -53,15 +53,17 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
     transport = MPIDI_POSIX_eager_iqueue_get_transport(src_vci, dst_vci);
 
     /* Try to get a new cell to hold the message */
-    /* Select the appropriate pool depending on whether we are using sender-side or receiver-side
-     * queuing. */
-    if (MPIR_CVAR_GENQ_SHMEM_POOL_FREE_QUEUE_SENDER_SIDE) {
+    /* Select the appropriate free queue depending on whether we are using intra-NUMA or inter-NUMAfree
+     * free queue. */
+    int dst_local_rank = MPIDI_POSIX_global.local_ranks[grank];
+    bool is_topo_local =
+        (MPIDI_POSIX_global.local_rank_dist[dst_local_rank] == MPIDI_POSIX_DIST__LOCAL);
+    if (is_topo_local) {
         MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell,
-                                         MPIR_Process.local_rank, 0, buf);
+                                         MPIR_Process.local_rank, 0 /* intra NUMA */ , buf);
     } else {
-        int dst_local_rank = MPIDI_POSIX_global.local_ranks[grank];
-        MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell, dst_local_rank, 0,
-                                         buf);
+        MPIDU_genq_shmem_pool_cell_alloc(transport->cell_pool, (void **) &cell, dst_local_rank,
+                                         1 /* inter NUMA */ , buf);
     }
 
     /* If a cell wasn't available, let the caller know that we weren't able to send the message
@@ -92,7 +94,11 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
         cell->am_header = *msg_hdr;
         cell->type = MPIDI_POSIX_EAGER_IQUEUE_CELL_TYPE_HDR;
         /* send am_hdr if this is the first segment */
-        MPIR_Typerep_copy(payload, am_hdr, am_hdr_sz, MPIR_TYPEREP_FLAG_STREAM);
+        if (is_topo_local) {
+            MPIR_Typerep_copy(payload, am_hdr, am_hdr_sz, MPIR_TYPEREP_FLAG_NONE);
+        } else {
+            MPIR_Typerep_copy(payload, am_hdr, am_hdr_sz, MPIR_TYPEREP_FLAG_STREAM);
+        }
         /* make sure the data region starts at the boundary of MAX_ALIGNMENT */
         payload = payload + resized_am_hdr_sz;
         cell->payload_size += resized_am_hdr_sz;
@@ -108,8 +114,13 @@ MPIDI_POSIX_eager_send(int grank, MPIDI_POSIX_am_header_t * msg_hdr, const void 
      * not reliable because the derived datatype could have zero block size which contains no
      * data. */
     if (bytes_sent) {
-        MPIR_Typerep_pack(buf, count, datatype, offset, payload, available, &packed_size,
-                          MPIR_TYPEREP_FLAG_STREAM);
+        if (is_topo_local) {
+            MPIR_Typerep_pack(buf, count, datatype, offset, payload, available, &packed_size,
+                              MPIR_TYPEREP_FLAG_NONE);
+        } else {
+            MPIR_Typerep_pack(buf, count, datatype, offset, payload, available, &packed_size,
+                              MPIR_TYPEREP_FLAG_STREAM);
+        }
         cell->payload_size += packed_size;
         *bytes_sent = packed_size;
     }

--- a/src/mpid/ch4/shm/posix/posix_types.h
+++ b/src/mpid/ch4/shm/posix/posix_types.h
@@ -14,6 +14,12 @@ enum {
     MPIDI_POSIX_NOK
 };
 
+enum {
+    MPIDI_POSIX_DIST__LOCAL = 0,
+    MPIDI_POSIX_DIST__NO_SHARED_CACHE,
+    MPIDI_POSIX_DIST__INTER_NUMA
+};
+
 #define MPIDI_POSIX_AM_BUFF_SZ               (1 * 1024 * 1024)
 #define MPIDI_POSIX_AM_HDR_POOL_CELL_SIZE            (1024)
 #define MPIDI_POSIX_AM_HDR_POOL_NUM_CELLS_PER_CHUNK     (1024)
@@ -32,6 +38,12 @@ typedef struct {
 } MPIDI_POSIX_per_vci_t;
 
 typedef struct {
+    int core_id;
+    int l3_cache_id;
+    int numa_id;
+} MPIDI_POSIX_topo_info_t;
+
+typedef struct {
     MPIDI_POSIX_per_vci_t per_vci[MPIDI_CH4_MAX_VCIS];
     void *shm_ptr;
     /* Keep track of all of the local processes in MPI_COMM_WORLD and what their original rank was
@@ -42,6 +54,8 @@ typedef struct {
     int *local_procs;
     int local_rank_0;
     int num_vcis;
+    int *local_rank_dist;
+    MPIDI_POSIX_topo_info_t topo;
 } MPIDI_POSIX_global_t;
 
 extern MPIDI_POSIX_global_t MPIDI_POSIX_global;

--- a/src/mpid/common/genq/mpidu_genq_shmem_pool.h
+++ b/src/mpid/common/genq/mpidu_genq_shmem_pool.h
@@ -14,13 +14,15 @@
 #include <stdint.h>
 #include <string.h>
 
-int MPIDU_genq_shmem_pool_create(uintptr_t cell_size, uintptr_t cells_per_proc,
-                                 uintptr_t num_proc, int rank, MPIDU_genq_shmem_pool_t * pool);
+int MPIDU_genq_shmem_pool_create(uintptr_t cell_size, uintptr_t cells_per_free_queue,
+                                 uintptr_t num_proc, int rank, uintptr_t num_free_queue,
+                                 int *queue_types, MPIDU_genq_shmem_pool_t * pool);
 int MPIDU_genq_shmem_pool_destroy(MPIDU_genq_shmem_pool_t pool);
 int MPIDU_genqi_shmem_pool_register(MPIDU_genqi_shmem_pool_s * pool_obj);
 
 static inline int MPIDU_genq_shmem_pool_cell_alloc(MPIDU_genq_shmem_pool_t pool, void **cell,
-                                                   int block_idx, const void *src_buf)
+                                                   int block_idx, int free_queue_idx,
+                                                   const void *src_buf)
 {
     int rc = MPI_SUCCESS;
     MPIDU_genqi_shmem_pool_s *pool_obj = (MPIDU_genqi_shmem_pool_s *) pool;
@@ -35,7 +37,9 @@ static inline int MPIDU_genq_shmem_pool_cell_alloc(MPIDU_genq_shmem_pool_t pool,
         MPIR_ERR_CHECK(rc);
     }
 
-    rc = MPIDU_genq_shmem_queue_dequeue(pool, &pool_obj->free_queues[block_idx], cell);
+    int idx = block_idx * pool_obj->num_free_queue + free_queue_idx;
+
+    rc = MPIDU_genq_shmem_queue_dequeue(pool, &pool_obj->free_queues[idx], cell);
     MPIR_ERR_CHECK(rc);
 
   fn_exit:

--- a/src/mpid/common/genq/mpidu_genq_shmem_queue.h
+++ b/src/mpid/common/genq/mpidu_genq_shmem_queue.h
@@ -188,6 +188,7 @@ static inline int MPIDU_genqi_nem_mpmc_dequeue(MPIDU_genqi_shmem_pool_s * pool_o
                     MPL_atomic_store_ptr(&queue->q.head.m, next_handle);
                 }
             }
+            break;
         }
     }
 

--- a/src/mpid/common/genq/mpidu_genqi_shmem_types.h
+++ b/src/mpid/common/genq/mpidu_genqi_shmem_types.h
@@ -49,8 +49,9 @@ typedef union MPIDU_genq_shmem_queue {
 typedef struct MPIDU_genqi_shmem_pool {
     uintptr_t cell_size;
     uintptr_t cell_alloc_size;
-    uintptr_t cells_per_proc;
+    uintptr_t cells_per_free_queue;
     uintptr_t num_proc;
+    uintptr_t num_free_queue;
     int rank;
 
     void *slab;

--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -316,10 +316,87 @@ static inline void MPL_Memcpy_stream(void *dest, const void *src, size_t n)
 
 #else
 
+#ifdef HAVE_SSE2
+#include <immintrin.h>
+
+static inline void MPL_Memcpy_stream(void *dest, const void *src, size_t n)
+{
+    /* Anything less than 256 bytes is not worth optimizing */
+    if (n <= 256) {
+        memcpy(dest, src, n);
+        return;
+    }
+
+    char *d = (char *) dest;
+    const char *s = (const char *) src;
+
+    /* Copy the first 63 bytes or less (if the address isn't 64-byte aligned) using a regular memcpy
+     * to make the rest faster */
+    if (((uintptr_t) d) & 63) {
+        const uintptr_t t = 64 - (((uintptr_t) d) & 63);
+        memcpy(d, s, t);
+        d += t;
+        s += t;
+        n -= t;
+    }
+
+    /* Copy 128 bytes at a time by unrolling a series of 16-byte streaming (non-temporal) write. */
+    while (n >= 128) {
+        __m128i xmm0 = _mm_loadu_si128((__m128i const *) (s + (16 * 0)));
+        __m128i xmm1 = _mm_loadu_si128((__m128i const *) (s + (16 * 1)));
+        __m128i xmm2 = _mm_loadu_si128((__m128i const *) (s + (16 * 2)));
+        __m128i xmm3 = _mm_loadu_si128((__m128i const *) (s + (16 * 3)));
+        __m128i xmm4 = _mm_loadu_si128((__m128i const *) (s + (16 * 4)));
+        __m128i xmm5 = _mm_loadu_si128((__m128i const *) (s + (16 * 5)));
+        __m128i xmm6 = _mm_loadu_si128((__m128i const *) (s + (16 * 6)));
+        __m128i xmm7 = _mm_loadu_si128((__m128i const *) (s + (16 * 7)));
+        _mm_stream_si128((__m128i *) (d + (16 * 0)), xmm0);
+        _mm_stream_si128((__m128i *) (d + (16 * 1)), xmm1);
+        _mm_stream_si128((__m128i *) (d + (16 * 2)), xmm2);
+        _mm_stream_si128((__m128i *) (d + (16 * 3)), xmm3);
+        _mm_stream_si128((__m128i *) (d + (16 * 4)), xmm4);
+        _mm_stream_si128((__m128i *) (d + (16 * 5)), xmm5);
+        _mm_stream_si128((__m128i *) (d + (16 * 6)), xmm6);
+        _mm_stream_si128((__m128i *) (d + (16 * 7)), xmm7);
+        d += 128;
+        s += 128;
+        n -= 128;
+    }
+
+    /* Once there are fewer than 128 bytes left to be copied, copy a chunk of 64
+     * bytes (if applicable). */
+    if (n >= 64) {
+        __m128i xmm0 = _mm_loadu_si128((__m128i const *) (s + (16 * 0)));
+        __m128i xmm1 = _mm_loadu_si128((__m128i const *) (s + (16 * 1)));
+        __m128i xmm2 = _mm_loadu_si128((__m128i const *) (s + (16 * 2)));
+        __m128i xmm3 = _mm_loadu_si128((__m128i const *) (s + (16 * 3)));
+        _mm_stream_si128((__m128i *) (d + (16 * 0)), xmm0);
+        _mm_stream_si128((__m128i *) (d + (16 * 1)), xmm1);
+        _mm_stream_si128((__m128i *) (d + (16 * 2)), xmm2);
+        _mm_stream_si128((__m128i *) (d + (16 * 3)), xmm3);
+        d += 64;
+        s += 64;
+        n -= 64;
+    }
+
+    /* If there is any data left, copy it using a regular memcpy */
+    if (n > 0) {
+        _mm_prefetch(s, 0);
+        memcpy(d, s, (n & 63));
+    }
+
+    /* A memory fence is required after the streaming stores above. */
+    _mm_sfence();
+}
+
+#else
+
 static inline void MPL_Memcpy_stream(void *dest, const void *src, size_t n)
 {
     memcpy(dest, src, n);
 }
+
+#endif /* HAVE_SSE2 */
 
 #endif
 


### PR DESCRIPTION
## Pull Request Description

This PR adds the support of detecting node topology and runtime selection of regular/stream memcpy. The PR has four parts:
1. Fixing existing MPMC queue and adding SSE2 version of stream copy for x86 arch without AVX support.
2. Adding node topology detection. Each rank query topology with hwloc and allgather during SHM_post_init. Each rank calculates the topo distance of all its local ranks.
3. Making SHMEM pool to support multiple free queues with different queue types. The number of cells per proc parameter is splited evenly among all free queues. Cell allocation function takes a queue id to indicate which free queue being used in allcoation. No change needed to cell deallcation.
4. Add topology aware SHM communication. A new boolean env `MPIR_CVAR_CH4_SHM_POSIX_TOPO_ENABLE` is added to control this feature. It is disabled by default.

The benefit of using receiver side free queue and non-temporal (stream) store is speed up the inter-NUMA communication (or inter-L3-cache). But non-temporal store is bad for ranks that share the same L3 cache. By making the POSIX topology aware, we can choose non-temporal store inter-NUMA and inter-cache communications.

### Performance
Setup: ALCF Sunspot, Intel Sapphire Rapids x 2. Intel ICX compiler
Configuration: ` --with-device=ch4:ofi --disable-fortran --disable-romio CC=clang CXX=clang++ --enable-fast=all,O3,avx
`
#### `osu_latency`
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/yguo/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/yguo/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{background:#FFC000;
	mso-pattern:black none;}
.xl66
	{background:#E2EFDA;
	mso-pattern:black none;}
.xl67
	{background:#FFF2CC;
	mso-pattern:black none;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">


  | TOPO_ENABLE=0 | TOPO_ENABLE=0 | TOPO_ENABLE=1 | TOPO_ENABLE=1
-- | -- | -- | -- | --
Msg Size | intraNUMA | interNUMA | intraNUMA | interNUMA
1 | 0.58 | 1.07 | 0.59 | 1.05
2 | 0.58 | 1.06 | 0.58 | 1.04
4 | 0.58 | 1.05 | 0.59 | 1.04
8 | 0.58 | 1.06 | 0.58 | 1.06
16 | 0.59 | 1.09 | 0.58 | 1.06
32 | 0.59 | 1.06 | 0.59 | 1.09
64 | 0.64 | 1.15 | 0.64 | 1.18
128 | 0.63 | 1.23 | 0.68 | 1.34
256 | 0.67 | 1.28 | 0.72 | 1.44
512 | 0.74 | 1.43 | 0.74 | 1.72
1024 | 0.85 | 1.57 | 0.84 | 1.79
2048 | 1.05 | 1.92 | 1.08 | 1.9
4096 | 1.35 | 2.45 | 1.48 | 2.29
8192 | 2.04 | 3.48 | 2.23 | 2.86
16384 | 4.67 | 8.51 | 5.05 | 6.46
32768 | 6.56 | 12.54 | 6.7 | 8.64
65536 | 10.4 | 21.29 | 10.62 | 13.5
131072 | 18.03 | 37.82 | 18 | 23.24
262144 | 30.93 | 67.66 | 30.86 | 42.08
524288 | 50.96 | 121.63 | 50.95 | 80.75
1048576 | 103.21 | 238.92 | 104.53 | 166.44
2097152 | 220.66 | 500.53 | 224.46 | 348.91
4194304 | 496.01 | 1028.7 | 503 | 698.85
8388608 | 1052.28 | 2085.34 | 1071.69 | 1401.71
16777216 | 2158.29 | 4196.88 | 2186.18 | 2757.43
33554432 | 5449.36 | 8417.38 | 5632.25 | 5425.01
67108864 | 12167.23 | 17285.89 | 12387.28 | 14177.96
134217728 | 25199.15 | 35931.72 | 25594.35 | 31576.1



</body>

</html>

#### `osu_bw`
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/yguo/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/yguo/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{background:#FFC000;
	mso-pattern:black none;}
.xl66
	{background:#E2EFDA;
	mso-pattern:black none;}
.xl67
	{background:#FFF2CC;
	mso-pattern:black none;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">


  | TOPO_ENABLE=0 | TOPO_ENABLE=0 | TOPO_ENABLE=1 | TOPO_ENABLE=1
-- | -- | -- | -- | --
Msg Size | intraNUMA | interNUMA | intraNUMA | interNUMA
1 | 4.78 | 1.81 | 4.45 | 1.99
2 | 10.31 | 3.79 | 8.73 | 3.95
4 | 20.22 | 7.71 | 17.84 | 7.75
8 | 39.87 | 15.22 | 35.68 | 16.81
16 | 80.7 | 29.2 | 71.08 | 31.76
32 | 181.01 | 59.5 | 142.21 | 70.94
64 | 320.14 | 118.57 | 240.56 | 132.9
128 | 675.7 | 252.36 | 471.39 | 307.58
256 | 1059.65 | 502.16 | 897.68 | 604.37
512 | 1944.73 | 923.67 | 1692.81 | 476.3
1024 | 3404.64 | 1148.46 | 2966.03 | 861.42
2048 | 3893.98 | 1707.74 | 4403.79 | 1689.73
4096 | 4872.1 | 2649.02 | 5273.76 | 3184.43
8192 | 6435.87 | 3708.21 | 6759.22 | 5681.12
16384 | 5895.42 | 2966.55 | 6377.65 | 5384.48
32768 | 6350.58 | 3092.99 | 6573 | 6558.38
65536 | 6529.19 | 3265.93 | 6856.04 | 7306.86
131072 | 6778.2 | 3418.82 | 7052.65 | 7899.33
262144 | 6919.02 | 3527.45 | 7201.67 | 8034.9
524288 | 6997.38 | 3591.29 | 7393.26 | 8237.02
1048576 | 8090.02 | 4053.7 | 8279.48 | 9055.35
2097152 | 7296.57 | 3940.11 | 7022.39 | 10202.08
4194304 | 7320.59 | 3916.27 | 5989.3 | 8275.19
8388608 | 7324.49 | 3967.97 | 6111 | 8852
16777216 | 7306.44 | 3973.63 | 6509.18 | 9186.05
33554432 | 7321.26 | 3973.26 | 7239.55 | 9348.05
67108864 | 6021.43 | 3968.32 | 6206.13 | 9389.08
134217728 | 5393.47 | 3855.42 | 5611.83 | 5941.02



</body>

</html>



## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
