### PR TITLE
ch4/hcoll: fix call hcoll_do_progress

### DIFF
--- a/src/mpid/common/hcoll/hcoll_rte.c
+++ b/src/mpid/common/hcoll/hcoll_rte.c
@@ -55,7 +55,7 @@ static void progress(void)
         /* FIXME: The hcoll library needs to be updated to return
          * error codes.  The progress function pointer right now
          * expects that the function returns void. */
-        ret = hcoll_do_progress(&made_progress);
+        ret = hcoll_do_progress(-1, &made_progress);
         MPIR_Assert(ret == MPI_SUCCESS);
     }
 }


### PR DESCRIPTION

## Pull Request Description

Previously we added a vci parameter to progress hooks. We negelected update one of the two calls to hcoll_do_progress.


[skip warnings]
## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
