### PR TITLE
Check constraints before using composition algo

### DIFF
--- a/src/mpid/ch4/src/ch4_coll.h
+++ b/src/mpid/ch4/src/ch4_coll.h
@@ -553,13 +553,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_allcomm_composition_json(const void
                                                                       MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Aint type_size;
+    MPI_Aint type_size, data_size;
     const MPIDI_Csel_container_s *cnt = NULL;
 
     if (sendbuf != MPI_IN_PLACE) {
         MPIR_Datatype_get_size_macro(sendtype, type_size);
+	data_size = sendcount * type_size;
     } else {
         MPIR_Datatype_get_size_macro(recvtype, type_size);
+	data_size = recvcount * type_size;
     }
 
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -591,8 +593,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_allcomm_composition_json(const void
                 MPIDI_Allgather_fill_multi_leads_info(comm);
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank,
                                            MPIDI_COMM_ALLGATHER(comm, use_multi_leads) == 1 &&
-                                           (MPL_MAX(sendcount, recvcount) * type_size <=
-                                            MPIR_CVAR_ALLGATHER_SHM_PER_RANK), mpi_errno,
+                                           data_size <= MPIR_CVAR_ALLGATHER_SHM_PER_RANK, mpi_errno,
                                            "Allgather composition alpha cannot be applied.\n");
 	    mpi_errno =
 		MPIDI_Allgather_intra_composition_alpha(sendbuf, sendcount, sendtype,
@@ -636,14 +637,16 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *sendbuf, MPI_Aint sendco
                                             MPIR_Comm * comm, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Aint type_size;
+    MPI_Aint type_size, data_size;
 
     MPIR_FUNC_ENTER;
 
     if (sendbuf != MPI_IN_PLACE) {
         MPIR_Datatype_get_size_macro(sendtype, type_size);
+	data_size = sendcount * type_size;
     } else {
         MPIR_Datatype_get_size_macro(recvtype, type_size);
+	data_size = recvcount * type_size;
     }
 
     switch (MPIR_CVAR_ALLGATHER_COMPOSITION) {
@@ -653,8 +656,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *sendbuf, MPI_Aint sendco
 
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank,
                                            MPIDI_COMM_ALLGATHER(comm, use_multi_leads) == 1 &&
-                                           (MPL_MAX(sendcount, recvcount) * type_size <=
-                                            MPIR_CVAR_ALLGATHER_SHM_PER_RANK), mpi_errno,
+                                           data_size <= MPIR_CVAR_ALLGATHER_SHM_PER_RANK, mpi_errno,
                                            "Allgather composition alpha cannot be applied.\n");
             /* Multi-leaders based composition can only be used if the comm is spanned over more than
              * 1 node, has equal number of ranks on each node, ranks on a node are consecutive and
@@ -1003,12 +1005,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_allcomm_composition_json(const void 
                                                                      MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Aint type_size;
+    MPI_Aint type_size, data_size;
 
     if (sendbuf != MPI_IN_PLACE) {
         MPIR_Datatype_get_size_macro(sendtype, type_size);
+	data_size = sendcount * type_size;
     } else {
         MPIR_Datatype_get_size_macro(recvtype, type_size);
+	data_size = recvcount * type_size;
     }
 
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1040,8 +1044,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_allcomm_composition_json(const void 
                 MPIDI_Alltoall_fill_multi_leads_info(comm);
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, comm->comm_kind == MPIR_COMM_KIND__INTRACOMM
                                            && MPIDI_COMM_ALLTOALL(comm, use_multi_leads) == 1 &&
-                                           (MPL_MAX(sendcount, recvcount) * type_size <=
-                                            MPIR_CVAR_ALLTOALL_SHM_PER_RANK), mpi_errno,
+                                           data_size <= MPIR_CVAR_ALLTOALL_SHM_PER_RANK, mpi_errno,
                                            "Alltoall composition alpha cannot be applied.\n");
 	    mpi_errno =
 		MPIDI_Alltoall_intra_composition_alpha(sendbuf, sendcount, sendtype,
@@ -1086,14 +1089,16 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcou
                                            MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Aint type_size;
+    MPI_Aint type_size, data_size;
 
     MPIR_FUNC_ENTER;
 
     if (sendbuf != MPI_IN_PLACE) {
         MPIR_Datatype_get_size_macro(sendtype, type_size);
+	data_size = sendcount * type_size;
     } else {
         MPIR_Datatype_get_size_macro(recvtype, type_size);
+	data_size = recvcount * type_size;
     }
 
     switch (MPIR_CVAR_ALLTOALL_COMPOSITION) {
@@ -1103,8 +1108,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcou
 
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, comm->comm_kind == MPIR_COMM_KIND__INTRACOMM
                                            && MPIDI_COMM_ALLTOALL(comm, use_multi_leads) == 1 &&
-                                           (MPL_MAX(sendcount, recvcount) * type_size <=
-                                            MPIR_CVAR_ALLTOALL_SHM_PER_RANK), mpi_errno,
+                                           data_size <= MPIR_CVAR_ALLTOALL_SHM_PER_RANK, mpi_errno,
                                            "Alltoall composition alpha cannot be applied.\n");
             /* Multi-leaders based composition can only be used if the comm is spanned over more than
              * 1 node, has equal number of ranks on each node, ranks on a node are consecutive and

--- a/src/mpid/ch4/src/ch4_coll.h
+++ b/src/mpid/ch4/src/ch4_coll.h
@@ -553,7 +553,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_allcomm_composition_json(const void
                                                                       MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
+    MPI_Aint type_size;
     const MPIDI_Csel_container_s *cnt = NULL;
+
+    if (sendbuf != MPI_IN_PLACE) {
+        MPIR_Datatype_get_size_macro(sendtype, type_size);
+    } else {
+        MPIR_Datatype_get_size_macro(recvtype, type_size);
+    }
 
     MPIR_Csel_coll_sig_s coll_sig = {
         .coll_type = MPIR_CSEL_COLL_TYPE__ALLGATHER,
@@ -579,19 +586,23 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_allcomm_composition_json(const void
 
     switch (cnt->id) {
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Allgather_intra_composition_alpha:
-            MPIDI_Allgather_fill_multi_leads_info(comm);
             /* make sure that the algo can be run */
-            if (MPIDI_COMM_ALLGATHER(comm, use_multi_leads) == 1) {
-                mpi_errno =
-                    MPIDI_Allgather_intra_composition_alpha(sendbuf, sendcount, sendtype,
-                                                            recvbuf, recvcount, recvtype,
-                                                            comm, errflag);
-            } else
-                mpi_errno =
-                    MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
-                                        comm, errflag);
+            if (comm->comm_kind == MPIR_COMM_KIND__INTRACOMM)
+                MPIDI_Allgather_fill_multi_leads_info(comm);
+            MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank,
+                                           MPIDI_COMM_ALLGATHER(comm, use_multi_leads) == 1 &&
+                                           (MPL_MAX(sendcount, recvcount) * type_size <=
+                                            MPIR_CVAR_ALLGATHER_SHM_PER_RANK), mpi_errno,
+                                           "Allgather composition alpha cannot be applied.\n");
+	    mpi_errno =
+		MPIDI_Allgather_intra_composition_alpha(sendbuf, sendcount, sendtype,
+							recvbuf, recvcount, recvtype,
+							comm, errflag);
             break;
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Allgather_intra_composition_beta:
+            MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank,
+                                           comm->comm_kind == MPIR_COMM_KIND__INTRACOMM, mpi_errno,
+                                           "Allgather composition beta cannot be applied.\n");
             mpi_errno =
                 MPIDI_Allgather_intra_composition_beta(sendbuf, sendcount, sendtype,
                                                        recvbuf, recvcount, recvtype, comm, errflag);
@@ -601,6 +612,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_allcomm_composition_json(const void
     }
 
     MPIR_ERR_CHECK(mpi_errno);
+    goto fn_exit;
+
+  fallback:
+    if (comm->comm_kind == MPIR_COMM_KIND__INTERCOMM)
+        mpi_errno =
+            MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm,
+                                errflag);
+    else
+        mpi_errno =
+            MPIDI_Allgather_intra_composition_beta(sendbuf, sendcount, sendtype, recvbuf, recvcount,
+                                                   recvtype, comm, errflag);
 
   fn_exit:
     return mpi_errno;
@@ -981,6 +1003,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_allcomm_composition_json(const void 
                                                                      MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
+    MPI_Aint type_size;
+
+    if (sendbuf != MPI_IN_PLACE) {
+        MPIR_Datatype_get_size_macro(sendtype, type_size);
+    } else {
+        MPIR_Datatype_get_size_macro(recvtype, type_size);
+    }
+
     const MPIDI_Csel_container_s *cnt = NULL;
 
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -1006,27 +1036,43 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_allcomm_composition_json(const void 
 
     switch (cnt->id) {
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Alltoall_intra_composition_alpha:
-            MPIDI_Alltoall_fill_multi_leads_info(comm);
-            /* make sure that the algo can be run */
-            if (MPIDI_COMM_ALLTOALL(comm, use_multi_leads) == 1) {
-                mpi_errno =
-                    MPIDI_Alltoall_intra_composition_alpha(sendbuf, sendcount, sendtype,
-                                                           recvbuf, recvcount, recvtype,
-                                                           comm, errflag);
-            } else
-                mpi_errno = MPIR_Alltoall_impl(sendbuf, sendcount, sendtype,
-                                               recvbuf, recvcount, recvtype, comm, errflag);
+            if (comm->comm_kind == MPIR_COMM_KIND__INTRACOMM)
+                MPIDI_Alltoall_fill_multi_leads_info(comm);
+            MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, comm->comm_kind == MPIR_COMM_KIND__INTRACOMM
+                                           && MPIDI_COMM_ALLTOALL(comm, use_multi_leads) == 1 &&
+                                           (MPL_MAX(sendcount, recvcount) * type_size <=
+                                            MPIR_CVAR_ALLTOALL_SHM_PER_RANK), mpi_errno,
+                                           "Alltoall composition alpha cannot be applied.\n");
+	    mpi_errno =
+		MPIDI_Alltoall_intra_composition_alpha(sendbuf, sendcount, sendtype,
+						       recvbuf, recvcount, recvtype,
+						       comm, errflag);
             break;
+
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Alltoall_intra_composition_beta:
+            MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank,
+                                           comm->comm_kind == MPIR_COMM_KIND__INTRACOMM, mpi_errno,
+                                           "Alltoall composition beta cannot be applied.\n");
             mpi_errno =
                 MPIDI_Alltoall_intra_composition_beta(sendbuf, sendcount, sendtype,
                                                       recvbuf, recvcount, recvtype, comm, errflag);
             break;
+
         default:
             MPIR_Assert(0);
     }
 
     MPIR_ERR_CHECK(mpi_errno);
+    goto fn_exit;
+
+  fallback:
+    if (comm->comm_kind == MPIR_COMM_KIND__INTERCOMM)
+        mpi_errno =
+            MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm,
+                               errflag);
+    else
+        mpi_errno = MPIDI_Alltoall_intra_composition_beta(sendbuf, sendcount, sendtype, recvbuf,
+                                                          recvcount, recvtype, comm, errflag);
 
   fn_exit:
     return mpi_errno;


### PR DESCRIPTION
## Pull Request Description

The memory constraint is not checked when selecting alpha composition from a tuning file. This causes seg fault in Allgather and AlltoAll for intermediate/large messages. This PR fixes it. 


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
