### PR TITLE
common/genq: fix cell allocation in shmem pool

### DIFF
--- a/src/mpid/common/genq/mpidu_genq_shmem_pool.c
+++ b/src/mpid/common/genq/mpidu_genq_shmem_pool.c
@@ -54,13 +54,14 @@ static int cell_block_alloc(MPIDU_genqi_shmem_pool_s * pool, int block_idx)
 
     new_cell_headers =
         (MPIDU_genqi_shmem_cell_header_s **) MPL_malloc(pool->cells_per_free_queue
+                                                        * pool->num_free_queue
                                                         * sizeof(MPIDU_genqi_shmem_cell_header_s *),
                                                         MPL_MEM_OTHER);
     MPIR_ERR_CHKANDJUMP(!new_cell_headers, rc, MPI_ERR_OTHER, "**nomem");
     pool->cell_headers = new_cell_headers;
 
     /* init cell headers */
-    int cells_per_block = pool->num_free_queue;
+    int cells_per_block = pool->cells_per_free_queue;
     int hdr_idx = 0;
     for (int free_queue_idx = 0; free_queue_idx < pool->num_free_queue; free_queue_idx++) {
         int real_block_idx = block_idx * pool->num_free_queue + free_queue_idx;


### PR DESCRIPTION
## Pull Request Description

The number of cells allocated less than setting which causes performance regression on AMD CPUs (Intel was unaffected). Error was introduced during rebasing shm topo PR (https://github.com/pmodels/mpich/pull/7046).

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
