### PR TITLE
mpl/gpu/ze: add ipc mapped cache limit options and fix ipc cleanup

### DIFF
--- a/src/mpi/init/init_gpu.c
+++ b/src/mpi/init/init_gpu.c
@@ -26,6 +26,7 @@ int MPII_init_gpu(void)
         MPL_gpu_info.specialized_cache = specialized_cache;
         MPL_gpu_info.use_immediate_cmdlist = MPIR_CVAR_GPU_USE_IMMEDIATE_COMMAND_LIST;
         MPL_gpu_info.roundrobin_cmdq = MPIR_CVAR_GPU_ROUND_ROBIN_COMMAND_QUEUES;
+        MPL_gpu_info.max_cache_entries = MPIR_CVAR_CH4_IPC_GPU_MAX_CACHE_ENTRIES;
 
         int mpl_errno = MPL_gpu_init(debug_summary);
         MPIR_ERR_CHKANDJUMP(mpl_errno != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_init");

--- a/src/mpi/init/init_gpu.c
+++ b/src/mpi/init/init_gpu.c
@@ -26,7 +26,21 @@ int MPII_init_gpu(void)
         MPL_gpu_info.specialized_cache = specialized_cache;
         MPL_gpu_info.use_immediate_cmdlist = MPIR_CVAR_GPU_USE_IMMEDIATE_COMMAND_LIST;
         MPL_gpu_info.roundrobin_cmdq = MPIR_CVAR_GPU_ROUND_ROBIN_COMMAND_QUEUES;
-        MPL_gpu_info.max_cache_entries = MPIR_CVAR_CH4_IPC_GPU_MAX_CACHE_ENTRIES;
+
+        /* Note max_cache_entries currently only affects the specialized cache */
+        switch (MPIR_CVAR_CH4_IPC_GPU_CACHE_SIZE) {
+            case MPIR_CVAR_CH4_IPC_GPU_CACHE_SIZE_unlimited:
+                MPL_gpu_info.max_cache_entries = -1;
+                break;
+            case MPIR_CVAR_CH4_IPC_GPU_CACHE_SIZE_limited:
+                MPL_gpu_info.max_cache_entries = MPIR_CVAR_CH4_IPC_GPU_MAX_CACHE_ENTRIES;
+                break;
+            case MPIR_CVAR_CH4_IPC_GPU_CACHE_SIZE_disabled:
+                MPL_gpu_info.max_cache_entries = 0;
+                break;
+            default:
+                MPIR_ERR_CHKANDJUMP(true, mpi_errno, MPI_ERR_OTHER, "**gpu_init");
+        }
 
         int mpl_errno = MPL_gpu_init(debug_summary);
         MPIR_ERR_CHKANDJUMP(mpl_errno != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_init");

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -31,7 +31,21 @@ cvars:
       scope       : MPI_T_SCOPE_ALL_EQ
       description : >-
         The maximum number of entries to hold per device in the cache containing IPC mapped buffers.
-        When an entry is evicted, the corresponding IPC handle is closed.
+        When an entry is evicted, the corresponding IPC handle is closed. This value is relevant
+        only when MPIR_CVAR_CH4_IPC_GPU_CACHE_SIZE=limited.
+
+    - name        : MPIR_CVAR_CH4_IPC_GPU_CACHE_SIZE
+      category    : CH4
+      type        : enum
+      default     : limited
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : |-
+        The behavior of the cache containing IPC mapped buffers.
+        unlimited - don't restrict the cache size
+        limited - limit the cache size based on MPIR_CVAR_CH4_IPC_GPU_MAX_CACHE_ENTRIES
+        disabled - don't cache mapped IPC buffers
 
     - name        : MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD
       category    : CH4
@@ -553,7 +567,9 @@ int MPIDI_GPU_ipc_handle_unmap(void *vaddr, MPIDI_GPU_ipc_handle_t handle, int d
 
     MPIR_FUNC_ENTER;
 
-    if (MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE == MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE_disabled) {
+    if (MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE == MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE_disabled ||
+        (MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE == MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE_specialized &&
+         MPIR_CVAR_CH4_IPC_GPU_MAX_CACHE_ENTRIES == 0)) {
         int mpl_err = MPL_SUCCESS;
         mpl_err = MPL_gpu_ipc_handle_unmap((void *) ((uintptr_t) vaddr - handle.offset));
         MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -22,6 +22,17 @@ cvars:
         specialized - use the cache mechanism in a gpu-specific mpl layer (if applicable)
         disabled - disable caching completely
 
+    - name        : MPIR_CVAR_CH4_IPC_GPU_MAX_CACHE_ENTRIES
+      category    : CH4
+      type        : int
+      default     : 16
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        The maximum number of entries to hold per device in the cache containing IPC mapped buffers.
+        When an entry is evicted, the corresponding IPC handle is closed.
+
     - name        : MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD
       category    : CH4
       type        : int

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -69,6 +69,7 @@ typedef enum {
 typedef struct {
     /* Input */
     int debug_summary;
+    int max_cache_entries;
     bool use_immediate_cmdlist;
     bool roundrobin_cmdq;
     /* Output */

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -63,7 +63,7 @@ void MPL_ze_ipc_remove_cache_handle(void *dptr);
 int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, int local_dev_id,
                              int use_shared_fd, MPL_gpu_ipc_mem_handle_t * ipc_handle);
 int MPL_ze_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * ipc_handle, int is_shared_handle, int dev_id,
-                          int is_mmap, size_t size, void **ptr);
+                          int is_mmap, size_t size, int (*fds)[2], void **ptr);
 int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t * ipc_handle, int shared_handle,
                                 int dev_id, size_t size, void **ptr);
 int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -1574,22 +1574,20 @@ int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr)
     if (physical_device_states != NULL) {
         MPL_ze_gem_hash_entry_t *entry = NULL;
         HASH_FIND_PTR(gem_hash, &ptr, entry);
-        if (entry == NULL) {
-            /* This might get called for pointers that didn't have IPC handles created */
-            goto fn_exit;
-        }
 
-        HASH_DEL(gem_hash, entry);
+        if (entry) {
+            HASH_DEL(gem_hash, entry);
 
-        /* close GEM handle */
-        for (int i = 0; i < entry->nhandles; i++) {
-            status = close_handle(physical_device_states[entry->dev_id].fd, entry->handles[i]);
-            if (status) {
-                goto fn_fail;
+            /* close GEM handle */
+            for (int i = 0; i < entry->nhandles; i++) {
+                status = close_handle(physical_device_states[entry->dev_id].fd, entry->handles[i]);
+                if (status) {
+                    break;
+                }
             }
-        }
 
-        MPL_free(entry);
+            MPL_free(entry);
+        }
     }
 
     if (likely(MPL_gpu_info.specialized_cache)) {

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -2798,7 +2798,6 @@ int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, in
     }
     ZE_ERR_CHECK(ret);
 
-    h.nfds = nfds;
     if (physical_device_states != NULL) {
         if (use_shared_fd) {
             int shared_dev_id = get_physical_device(local_dev_id);
@@ -2851,6 +2850,7 @@ int MPL_ze_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr, in
 
     h.pid = mypid;
     h.mem_id = mem_id;
+    h.nfds = nfds;
 
     for (int i = 0; i < nfds; i++) {
         memcpy(&mpl_ipc_handle->ipc_handles[i], &ze_ipc_handle[i], sizeof(ze_ipc_mem_handle_t));

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -1516,7 +1516,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
     if (cache_entry && cache_entry->handle_cached) {
         memcpy(ipc_handle, &cache_entry->ipc_handle, sizeof(MPL_gpu_ipc_mem_handle_t));
     } else {
-        mpl_err = MPL_ze_ipc_handle_create(ptr, ptr_attr, local_dev_id, true, ipc_handle);
+        mpl_err = MPL_ze_ipc_handle_create(pbase, ptr_attr, local_dev_id, true, ipc_handle);
         if (mpl_err != MPL_SUCCESS) {
             goto fn_fail;
         }

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -3116,7 +3116,7 @@ int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,
                 /* store only the basic ze_ipc_handle info, missing the
                  * fd_pid_t data as shareable IPC handle */
                 for (int i = 0; i < nfds; i++) {
-                    memcpy(&cache_entry->ipc_handle.ipc_handles[0], &ze_ipc_handle[i],
+                    memcpy(&cache_entry->ipc_handle.ipc_handles[i], &ze_ipc_handle[i],
                            sizeof(ze_ipc_mem_handle_t));
                 }
                 HASH_ADD(hh, ipc_cache_tracked[local_dev_id], mem_id, sizeof(uint64_t), cache_entry,

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -1757,12 +1757,12 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
     ret = zeMemGetAllocProperties(ze_context, ptr, &ptr_attr, &device);
     ZE_ERR_CHECK(ret);
 
-    dev_id = device_to_dev_id(device);
-    if (dev_id == -1) {
-        goto fn_fail;
-    }
-
     if (likely(MPL_gpu_info.specialized_cache)) {
+        dev_id = device_to_dev_id(device);
+        if (dev_id == -1) {
+            goto fn_fail;
+        }
+
         /* Remove from the caches */
         HASH_FIND(hh, ipc_cache_removal[dev_id], &ptr, sizeof(void *), cache_entry);
 


### PR DESCRIPTION
## Pull Request Description

The IPC cache in ZE which holds mapped IPC info is currently unbound in size. This may cause unbound growth in memory usage in an application because the mapped buffers remain open even if the origin buffer is freed. For applications which use a static number of allocated GPU buffers, this may not be an issue. But not all apps can reuse GPU allocations.

This PR fixes some cleanup issues related to both the created and mapped IPC handles/buffers to ensure GPU memory can be properly freed. Additionally, it adds the flexibility of defining a maximum cache size for the IPC mapped buffers. This is configurable in two stages: `MPIR_CVAR_CH4_IPC_GPU_CACHE_SIZE` and `MPIR_CVAR_CH4_IPC_GPU_MAX_ENTRIES`.

`MPIR_CVAR_CH4_IPC_GPU_CACHE_SIZE` can be set to `limited`, `unlimited`, or `disabled`, with the following behaviors:

* `limited` (default): the maximum cache size (per remote device) is defined by `MPIR_CVAR_CH4_IPC_GPU_MAX_ENTRIES` (default: 16)
* `unlimited` : there is no maximum cache size
* `disabled` : do not cache mapped IPC handles/buffers (cleanup immediately after the IPC protocol is complete)

In the `limited` case, an LRU replacement policy is used to determine which entries in the IPC mapped cache should be cleaned up.

The intention is for most users to control the cache behavior via `MPIR_CVAR_CH4_IPC_GPU_CACHE_SIZE`, while providing an option for fine-tuning the `limit` case if necessary (via `MPIR_CVAR_CH4_IPC_GPU_MAX_ENTRIES`)

Fixes #6959 

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
