### PR TITLE
pmi: put value key to the end of cmd

### DIFF
--- a/src/pm/hydra/mpiexec/pmiserv_kvs.c
+++ b/src/pm/hydra/mpiexec/pmiserv_kvs.c
@@ -78,9 +78,9 @@ HYD_status HYD_pmiserv_kvs_get(struct HYD_proxy *proxy, int process_fd, int pgid
     struct PMIU_cmd pmi_response;
     if (val) {
         if (sync) {
-            pmi_errno = PMIU_msg_set_response_kvsget(pmi, &pmi_response, is_static, val, true);
+            pmi_errno = PMIU_msg_set_response_kvsget(pmi, &pmi_response, is_static, true, val);
         } else {
-            pmi_errno = PMIU_msg_set_response_get(pmi, &pmi_response, is_static, val, true);
+            pmi_errno = PMIU_msg_set_response_get(pmi, &pmi_response, is_static, true, val);
         }
     } else {
         pmi_errno = PMIU_msg_set_response_fail(pmi, &pmi_response, is_static, 1, "key_not_found");

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -438,7 +438,7 @@ HYD_status fn_get(struct pmip_downstream * p, struct PMIU_cmd * pmi)
 
     if (found) {
         struct PMIU_cmd pmi_response;
-        PMIU_msg_set_response_get(pmi, &pmi_response, is_static, val, found);
+        PMIU_msg_set_response_get(pmi, &pmi_response, is_static, found, val);
 
         status = send_cmd_downstream(p->pmi_fd, &pmi_response);
         HYDU_ERR_POP(status, "error sending PMI response\n");
@@ -715,7 +715,7 @@ HYD_status fn_info_getnodeattr(struct pmip_downstream *p, struct PMIU_cmd *pmi)
 
     struct PMIU_cmd pmi_response;
     if (found) {
-        pmi_errno = PMIU_msg_set_response_getnodeattr(pmi, &pmi_response, is_static, val, true);
+        pmi_errno = PMIU_msg_set_response_getnodeattr(pmi, &pmi_response, is_static, true, val);
     } else {
         pmi_errno = PMIU_msg_set_response_fail(pmi, &pmi_response, is_static, 1, "not_found");
     }

--- a/src/pmi/maint/pmi-1.1.txt
+++ b/src/pmi/maint/pmi-1.1.txt
@@ -94,8 +94,8 @@ GET:
         kvsname: STRING, optional=NULL
         key: STRING
     R: get_result
-        value: STRING
         found: BOOLEAN, optional=true
+        value: STRING
 
 BARRIER:
     Q: barrier_in

--- a/src/pmi/maint/pmi-2.0.txt
+++ b/src/pmi/maint/pmi-2.0.txt
@@ -79,8 +79,8 @@ GETNODEATTR:
         key: STRING
         wait: BOOLEAN, optional=false
     R: info-getnodeattr-response
-        value: STRING
         found: BOOLEAN
+        value: STRING
 
 # PMI2 info-getjobattr is within the semantics of PMI1 get
 GET:
@@ -88,8 +88,8 @@ GET:
         kvsname: STRING, optional=NULL
         key: STRING
     R: info-getjobattr-response
-        value: STRING
         found: BOOLEAN
+        value: STRING
 
 KVSPUT:
     Q: kvs-put
@@ -103,8 +103,8 @@ KVSGET:
         srcid: INTEGER, optional=-1
         key: STRING
     R: kvs-get-response
-        value: STRING
         found: BOOLEAN
+        value: STRING
 
 KVSFENCE:
     Q: kvs-fence

--- a/src/pmi/src/pmi_v1.c
+++ b/src/pmi/src/pmi_v1.c
@@ -469,7 +469,7 @@ PMI_API_PUBLIC int PMI_KVS_Get(const char kvsname[], const char key[], char valu
 
     const char *tmp_val;
     bool found;
-    pmi_errno = PMIU_msg_get_response_get(&pmicmd, &tmp_val, &found);
+    pmi_errno = PMIU_msg_get_response_get(&pmicmd, &found, &tmp_val);
     PMIU_ERR_POP(pmi_errno);
 
     MPL_strncpy(value, tmp_val, length);

--- a/src/pmi/src/pmi_v2.c
+++ b/src/pmi/src/pmi_v2.c
@@ -393,7 +393,7 @@ PMI_API_PUBLIC
 
     const char *tmp_val;
     bool found;
-    pmi_errno = PMIU_msg_get_response_kvsget(&pmicmd, &tmp_val, &found);
+    pmi_errno = PMIU_msg_get_response_kvsget(&pmicmd, &found, &tmp_val);
     PMIU_ERR_POP(pmi_errno || !found);
 
     int ret;
@@ -423,7 +423,7 @@ PMI_API_PUBLIC
     const char *tmp_val;
     bool found;
     if (!pmi_errno) {
-        pmi_errno = PMIU_msg_get_response_getnodeattr(&pmicmd, &tmp_val, &found);
+        pmi_errno = PMIU_msg_get_response_getnodeattr(&pmicmd, &found, &tmp_val);
     }
 
     if (!pmi_errno && found) {
@@ -481,7 +481,7 @@ PMI_API_PUBLIC int PMI2_Info_GetNodeAttrIntArray(const char name[], int array[],
     const char *tmp_val;
     bool found;
     if (!pmi_errno) {
-        pmi_errno = PMIU_msg_get_response_getnodeattr(&pmicmd, &tmp_val, &found);
+        pmi_errno = PMIU_msg_get_response_getnodeattr(&pmicmd, &found, &tmp_val);
     }
 
     if (!pmi_errno && found) {
@@ -530,7 +530,7 @@ PMI_API_PUBLIC int PMI2_Info_GetJobAttr(const char name[], char value[], int val
         bool found;
         const char *tmp_val;
         if (pmi_errno == PMIU_SUCCESS) {
-            pmi_errno = PMIU_msg_get_response_get(&pmicmd, &tmp_val, &found);
+            pmi_errno = PMIU_msg_get_response_get(&pmicmd, &found, &tmp_val);
         }
 
         if (!pmi_errno && found) {
@@ -562,7 +562,7 @@ PMI_API_PUBLIC int PMI2_Info_GetJobAttrIntArray(const char name[], int array[], 
     bool found;
     const char *tmp_val;
     if (pmi_errno == PMIU_SUCCESS) {
-        pmi_errno = PMIU_msg_get_response_get(&pmicmd, &tmp_val, &found);
+        pmi_errno = PMIU_msg_get_response_get(&pmicmd, &found, &tmp_val);
     }
 
     if (!pmi_errno && found) {

--- a/src/pmi/src/pmix.c
+++ b/src/pmi/src/pmix.c
@@ -262,7 +262,7 @@ pmix_status_t PMIx_Get(const pmix_proc_t * proc, const char key[],
         bool found;
         const char *tmp_val;
         if (pmi_errno == PMIU_SUCCESS) {
-            pmi_errno = PMIU_msg_get_response_get(&pmicmd, &tmp_val, &found);
+            pmi_errno = PMIU_msg_get_response_get(&pmicmd, &found, &tmp_val);
         }
 
         if (!pmi_errno && found) {
@@ -298,7 +298,7 @@ pmix_status_t PMIx_Get(const pmix_proc_t * proc, const char key[],
 
     const char *tmp_val;
     bool found;
-    pmi_errno = PMIU_msg_get_response_kvsget(&pmicmd, &tmp_val, &found);
+    pmi_errno = PMIU_msg_get_response_kvsget(&pmicmd, &found, &tmp_val);
     PMIU_ERR_POP(pmi_errno);
 
     if (found) {


### PR DESCRIPTION
## Pull Request Description

Flux currently assumes the value key in a PMI_KVS_Get command will place the value=... at the end of the wire command so that the value can contain arbitary chars including spaces and `=`.  While we don't want to make this the standard protocol, there is no reason that we can't keep Flux working.


Fixes #7050 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
