### PR TITLE
misc: Improve scalability of MPI_Init

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1730,6 +1730,7 @@ if test "$pac_3rd_party_pmi" = "yes" ; then
     AC_CHECK_FUNC([PMI2_Init], [enable_pmi2="yes"])
     AC_CHECK_FUNC([PMIx_Init], [enable_pmix="yes"])
     AC_CHECK_FUNC([PMIx_Info_load],[],[AC_DEFINE([NEED_PMIX_INFO_LOAD], 1, [Define if PMIX_INFO_LOAD macro is needed])])
+    AC_CHECK_FUNC([PMIx_Load_topology],[AC_DEFINE([HAS_PMIX_LOAD_TOPOLOGY], 1, [Define if PMIx_Load_topology is available])])
     if test "$enable_pmi2" = "yes"; then
         AC_CHECK_MEMBER([PMI2_keyval_t.key], [], [
             AC_DEFINE([MISSING_PMI2_KEYVAL_T], 1, [Define if PMI2_KEYVAL_T is missing])

--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -58,6 +58,7 @@ char *MPIR_pmi_get_jobattr(const char *key);    /* key must use "PMI_" prefix */
 
 /* * barrier or kvs fence. */
 int MPIR_pmi_barrier(void);
+int MPIR_pmi_barrier_only(void);
 /* * barrier over local set. More efficient for PMIx. Same as MPIR_pmi_barrier for PMI1/2. */
 int MPIR_pmi_barrier_local(void);
 /* * put, to global domain */

--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -107,4 +107,14 @@ int MPIR_pmi_has_local_cliques(void);
 int MPIR_pmi_build_nodemap(int *nodemap, int sz);
 int MPIR_pmi_build_nodemap_fallback(int sz, int myrank, int *out_nodemap);
 
+#ifdef HAVE_HWLOC
+/* A fallback for PMIx_Load_topology. */
+typedef struct MPIR_pmi_topology {
+    const char *source;
+    void *topology;  /* assume hwloc_topology_t is a pointer */
+} MPIR_pmi_topology_t;
+
+int MPIR_pmi_load_hwloc_topology(MPIR_pmi_topology_t *topo);
+#endif
+
 #endif /* MPIR_PMI_H_INCLUDED */

--- a/src/include/mpir_session.h
+++ b/src/include/mpir_session.h
@@ -14,6 +14,7 @@ struct MPIR_Session {
     MPID_Thread_mutex_t mutex;
     MPIR_Errhandler *errhandler;
     struct MPII_BsendBuffer *bsendbuffer;       /* for MPI_Session_attach_buffer */
+    int requested_thread_level;
     int thread_level;
     bool strict_finalize;
     char *memory_alloc_kinds;

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -123,7 +123,7 @@ MPIR_Object_alloc_t MPIR_Errhandler_mem = { 0, 0, 0, 0, 0, 0, MPIR_ERRHANDLER,
     NULL, {0}
 };
 
-void MPIR_Err_init(void)
+static void init_builtins(void)
 {
     /* these are "stub" objects, so the other fields (which are statically
      * initialized to zero) don't really matter */
@@ -131,6 +131,11 @@ void MPIR_Err_init(void)
     MPIR_Errhandler_builtin[1].handle = MPI_ERRORS_RETURN;
     MPIR_Errhandler_builtin[2].handle = MPIR_ERRORS_THROW_EXCEPTIONS;
     MPIR_Errhandler_builtin[3].handle = MPI_ERRORS_ABORT;
+}
+
+void MPIR_Err_init(void)
+{
+    init_builtins();
 
     MPIR_Err_stack_init();
     did_err_init = TRUE;
@@ -442,6 +447,13 @@ int MPIR_Err_return_session_init(MPIR_Errhandler * errhandler_ptr, const char fc
     const int error_class = ERROR_GET_CLASS(errcode);
     checkValidErrcode(error_class, fcname, &errcode);
     int errhandler_handle;
+
+    /* It's likely nothing is initialized yet. Make sure the builtin error handlers are recognized */
+    init_builtins();
+    if (errhandler_ptr->handle == MPI_ERRORS_RETURN ||
+        errhandler_ptr->handle == MPIR_ERRORS_THROW_EXCEPTIONS) {
+        return errcode;
+    }
 
     /* --BEGIN ERROR HANDLING-- */
     if (!MPIR_Errutil_is_initialized()) {

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -438,6 +438,8 @@ int MPII_Finalize(MPIR_Session * session_ptr)
     mpi_errno = MPID_Finalize();
     MPIR_ERR_CHECK(mpi_errno);
 
+    MPIR_pmi_finalize();
+
 #ifdef ENABLE_QMPI
     MPII_qmpi_teardown();
 #endif

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -92,6 +92,16 @@ cvars:
         to prevent remote processes hanging if it has pending communication
         protocols, e.g. a rendezvous send.
 
+    - name        : MPIR_CVAR_INIT_SKIP_PMI_BARRIER
+      category    : DEBUGGER
+      type        : boolean
+      default     : true
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        Skip MPIR_pmi_barrier() in MPI_Init
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
@@ -256,8 +266,10 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
      * add a config option to skip it. But focus on optimize PMI Barrier may
      * be a better effort.
      */
-    mpi_errno = MPIR_pmi_barrier();
-    MPIR_ERR_CHECK(mpi_errno);
+    if (!MPIR_CVAR_INIT_SKIP_PMI_BARRIER) {
+        mpi_errno = MPIR_pmi_barrier_only();
+        MPIR_ERR_CHECK(mpi_errno);
+    }
 
     bool need_init_builtin_comms = true;
 #ifdef ENABLE_LOCAL_SESSION_INIT

--- a/src/mpi/session/session_impl.c
+++ b/src/mpi/session/session_impl.c
@@ -22,7 +22,21 @@ int MPIR_Session_init_impl(MPIR_Info * info_ptr, MPIR_Errhandler * errhandler_pt
     int mpi_errno = MPI_SUCCESS;
     MPIR_Session *session_ptr = NULL;
 
-    int provided;
+    int thread_level;
+    bool strict_finalize;
+    char *memory_alloc_kinds;
+    /* Get the thread level requested by the user via info object (if any) */
+    mpi_errno = MPIR_Session_get_thread_level_from_info(info_ptr, &thread_level);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* Get the strict finalize parameter via info object (if any) */
+    mpi_errno =
+        MPIR_Session_get_strict_finalize_from_info(info_ptr, &strict_finalize);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* Get memory allocation kinds requested by the user (if any) */
+    mpi_errno = MPIR_Session_get_memory_kinds_from_info(info_ptr, &memory_alloc_kinds);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* Remark on MPI_THREAD_SINGLE: Multiple sessions may run in threads
      * concurrently, so significant work is needed to support per-session MPI_THREAD_SINGLE.
@@ -36,22 +50,16 @@ int MPIR_Session_init_impl(MPIR_Info * info_ptr, MPIR_Errhandler * errhandler_pt
      * TODO: support per-session MPI_THREAD_SINGLE, use user-requested thread level here
      * instead of MPI_THREAD_MULTIPLE, and optimize
      */
+    int provided;
+
     mpi_errno = MPII_Init_thread(NULL, NULL, MPI_THREAD_MULTIPLE, &provided, &session_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
     session_ptr->thread_level = provided;
 
-    /* Get the thread level requested by the user via info object (if any) */
-    mpi_errno = MPIR_Session_get_thread_level_from_info(info_ptr, &(session_ptr->thread_level));
-    MPIR_ERR_CHECK(mpi_errno);
-
-    /* Get the strict finalize parameter via info object (if any) */
-    mpi_errno =
-        MPIR_Session_get_strict_finalize_from_info(info_ptr, &(session_ptr->strict_finalize));
-    MPIR_ERR_CHECK(mpi_errno);
-
-    /* Get memory allocation kinds requested by the user (if any) */
-    mpi_errno = MPIR_Session_get_memory_kinds_from_info(info_ptr, &session_ptr->memory_alloc_kinds);
+    session_ptr->requested_thread_level = thread_level;
+    session_ptr->strict_finalize = strict_finalize;
+    session_ptr->memory_alloc_kinds = memory_alloc_kinds;
 
     *p_session_ptr = session_ptr;
 

--- a/src/mpi/session/session_impl.c
+++ b/src/mpi/session/session_impl.c
@@ -59,7 +59,13 @@ int MPIR_Session_init_impl(MPIR_Info * info_ptr, MPIR_Errhandler * errhandler_pt
 
     session_ptr->requested_thread_level = thread_level;
     session_ptr->strict_finalize = strict_finalize;
-    session_ptr->memory_alloc_kinds = memory_alloc_kinds;
+
+    if (memory_alloc_kinds) {
+        session_ptr->memory_alloc_kinds = memory_alloc_kinds;
+    } else {
+        MPIR_Assert(MPIR_Process.memory_alloc_kinds);
+        session_ptr->memory_alloc_kinds = MPL_strdup(MPIR_Process.memory_alloc_kinds);
+    }
 
     *p_session_ptr = session_ptr;
 

--- a/src/mpi/session/session_util.c
+++ b/src/mpi/session/session_util.c
@@ -217,12 +217,12 @@ int MPIR_Session_get_memory_kinds_from_info(MPIR_Info * info_ptr, char **out_kin
             mpi_errno = MPIR_Info_get_string_impl(info_ptr, key, &buflen, user_kinds, &flag);
             MPIR_ERR_CHECK(mpi_errno);
         }
-    } else {
-        user_kinds = MPL_strdup(MPIR_Process.memory_alloc_kinds);
     }
 
-    mpi_errno = MPIR_get_supported_memory_kinds(user_kinds, out_kinds);
-    MPIR_ERR_CHECK(mpi_errno);
+    if (user_kinds) {
+        mpi_errno = MPIR_get_supported_memory_kinds(user_kinds, out_kinds);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
 
   fn_fail:
     MPL_free(user_kinds);

--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -64,12 +64,6 @@ int MPIDI_PG_Finalize(void)
 	MPIU_PG_Printall( stdout );
     }
 
-    /* FIXME - straighten out the use of MPIR_pmi_finalize - no use after 
-       PG_Finalize */
-    if (pg_world->connData) {
-        MPIR_pmi_finalize();
-    }
-
     /* Free the storage associated with the process groups */
     pg = MPIDI_PG_list;
     while (pg) {

--- a/src/mpid/ch4/netmod/ofi/init_addrxchg.c
+++ b/src/mpid/ch4/netmod/ofi/init_addrxchg.c
@@ -190,7 +190,7 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
     MPIR_Comm *comm = MPIR_Process.comm_world;
     int size = MPIR_Process.size;
     int rank = MPIR_Process.rank;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL(3);
 
     int max_vcis;
     int *all_num_vcis;

--- a/src/mpid/ch4/netmod/ofi/ofi_progress.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_progress.h
@@ -92,8 +92,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int *made_progress)
         int num = MPIDI_OFI_get_buffered(vci, wc);
         mpi_errno = MPIDI_OFI_handle_cq_entries(vci, wc, num);
     } else if (likely(1)) {
+        /* FIXME: a better multi-nic progression */
         for (int nic = 0; nic < MPIDI_OFI_global.num_nics; nic++) {
             int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
+            /* not all cq are initialized during mpi init */
+            if (MPIDI_OFI_global.ctx[ctx_idx].cq == NULL)
+                continue;
             ret = fi_cq_read(MPIDI_OFI_global.ctx[ctx_idx].cq, (void *) wc,
                              MPIDI_OFI_NUM_CQ_ENTRIES);
 

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -828,8 +828,6 @@ int MPID_Finalize(void)
     mpi_errno = MPIDU_stream_workq_finalize();
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPIR_pmi_finalize();
-
     for (int i = 0; i < MAX_CH4_MUTEXES; i++) {
         int err;
         MPID_Thread_mutex_destroy(&MPIDI_global.m[i], &err);

--- a/src/mpid/ch4/src/init_comm.c
+++ b/src/mpid/ch4/src/init_comm.c
@@ -46,6 +46,11 @@ int MPIDI_create_init_comm(MPIR_Comm ** comm)
         }
         mpi_errno = MPIDIG_init_comm(init_comm);
         MPIR_ERR_CHECK(mpi_errno);
+        /* hacky, consider a separate MPIDI_{NM,SHM}_init_comm_hook
+	 * to initialize the init_comm, e.g. to eliminate potential
+	 * runtime features for stability during init */
+        mpi_errno = MPIDI_NM_mpi_comm_commit_pre_hook(init_comm);
+        MPIR_ERR_CHECK(mpi_errno);
 
         *comm = init_comm;
     }

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -133,6 +133,8 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
     /* FIXME: rank, size, nodemap parameters are not needed */
     MPIR_Assert(MPIR_Process.rank == rank);
     MPIR_Assert(MPIR_Process.size == size);
+    int local_size = MPIR_Process.local_size;
+    MPIR_Assert(local_size > 0);
 
     int recv_bc_len = bc_len;
     if (!same_len) {
@@ -142,7 +144,9 @@ int MPIDU_bc_table_create(int rank, int size, int *nodemap, void *bc, int bc_len
         *ret_bc_len = recv_bc_len;
     }
 
-    mpi_errno = MPIDU_Init_shm_alloc(recv_bc_len * size, (void **) &segment);
+    /* the allgather is no long in-place, allocate space for both
+     * the node and allgather results for all ranks */
+    mpi_errno = MPIDU_Init_shm_alloc(recv_bc_len * (size + local_size), (void **) &segment);
     MPIR_ERR_CHECK(mpi_errno);
 
     if (size == 1) {

--- a/src/pm/hydra/mpiexec/pmiserv_kvs.c
+++ b/src/pm/hydra/mpiexec/pmiserv_kvs.c
@@ -25,7 +25,8 @@ static HYD_status HYD_pmcd_pmi_v2_queue_req(struct HYD_proxy *proxy, int process
                                             struct PMIU_cmd *pmi, const char *key);
 static HYD_status check_pending_reqs(const char *key);
 
-static const bool is_static = true;
+/* PMI KVS command may exceed static buffer size */
+static const bool is_static = false;
 
 HYD_status HYD_pmiserv_kvs_get(struct HYD_proxy *proxy, int process_fd, int pgid,
                                struct PMIU_cmd *pmi, bool sync)
@@ -90,6 +91,8 @@ HYD_status HYD_pmiserv_kvs_get(struct HYD_proxy *proxy, int process_fd, int pgid
     status = HYD_pmiserv_pmi_reply(proxy, process_fd, &pmi_response);
     HYDU_ERR_POP(status, "error writing PMI line\n");
 
+    PMIU_cmd_free_buf(&pmi_response);
+
   fn_exit:
     HYDU_FUNC_EXIT();
     return status;
@@ -126,6 +129,8 @@ HYD_status HYD_pmiserv_kvs_put(struct HYD_proxy *proxy, int process_fd, int pgid
 
     status = check_pending_reqs(key);
     HYDU_ERR_POP(status, "check_pending_reqs failed\n");
+
+    PMIU_cmd_free_buf(&pmi_response);
 
   fn_exit:
     HYDU_FUNC_EXIT();
@@ -218,6 +223,8 @@ HYD_status HYD_pmiserv_kvs_fence(struct HYD_proxy *proxy, int process_fd, int pg
             }
         }
     }
+
+    PMIU_cmd_free_buf(&pmi_response);
 
   fn_exit:
     HYDU_FUNC_EXIT();

--- a/src/pmi/errnames.txt
+++ b/src/pmi/errnames.txt
@@ -110,6 +110,10 @@
 **pmix_resolve_peers %d: PMIx_Resolve_peers returned %d
 **pmix_spawn: PMIx_Spawn failed
 **pmix_spawn %s: PMIx_Spawn failed with error %s
+**pmix_load_topo: PMIx_Load_topology failed
+**pmix_load_topo %d: PMIx_Load_topology failed with error %d
+**pmix_unknown_topo: PMIx_Load_topology returns unknown topology
+**pmix_unknown_topo %s: PMIx_Load_topology returns unknown topology with error %s
 #
 # PMI finalize exit handler registration
 #

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -359,6 +359,14 @@ int MPIR_pmi_barrier(void)
     return mpi_errno;
 }
 
+int MPIR_pmi_barrier_only(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    SWITCH_PMI(mpi_errno = pmi1_barrier(), mpi_errno = pmi2_barrier(), mpi_errno =
+               pmix_barrier_only());
+    return mpi_errno;
+}
+
 int MPIR_pmi_barrier_local(void)
 {
     int mpi_errno = MPI_SUCCESS;

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -209,6 +209,8 @@ int MPIR_pmi_init(void)
     goto fn_exit;
 }
 
+static void fallback_free_hwloc_topology(void);
+
 void MPIR_pmi_finalize(void)
 {
     /* Finalize of PM interface happens in exit handler,
@@ -225,6 +227,10 @@ void MPIR_pmi_finalize(void)
     MPL_free(hwloc_topology_xmlfile);
     hwloc_topology_xmlfile = NULL;
     MPL_free(MPIR_Process.coords);
+
+#ifdef HAVE_HWLOC
+    fallback_free_hwloc_topology();
+#endif
 
     /* delay PMI_Finalize to the exit hook */
     finalize_pending++;
@@ -777,6 +783,93 @@ int MPIR_pmi_unpublish(const char name[])
                mpi_errno = pmi2_unpublish(name), mpi_errno = pmix_unpublish(name));
     return mpi_errno;
 }
+
+/* ---- hwloc functions ---- */
+#ifdef HAVE_HWLOC
+
+#include "hwloc.h"
+
+enum {
+    GOT_HWLOC_TOPOLOGY_NONE,
+    GOT_HWLOC_TOPOLOGY_FALLBACK,
+    GOT_HWLOC_TOPOLOGY_PMIX,
+};
+static int got_hwloc_topology = GOT_HWLOC_TOPOLOGY_NONE;
+static hwloc_topology_t hwloc_topology;
+
+static int fallback_load_hwloc_topology(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    hwloc_topology_init(&hwloc_topology);
+    char *xmlfile = MPIR_pmi_get_jobattr("PMI_hwloc_xmlfile");
+    if (xmlfile != NULL) {
+        int rc;
+        rc = hwloc_topology_set_xml(hwloc_topology, xmlfile);
+        if (rc == 0) {
+            /* To have hwloc still actually call OS-specific hooks, the
+                * HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM has to be set to assert that the loaded
+                * file is really the underlying system. */
+            hwloc_topology_set_flags(hwloc_topology, HWLOC_TOPOLOGY_FLAG_IS_THISSYSTEM);
+        }
+        MPL_free(xmlfile);
+    }
+
+    hwloc_topology_set_io_types_filter(hwloc_topology, HWLOC_TYPE_FILTER_KEEP_ALL);
+    if (hwloc_topology_load(hwloc_topology) == 0) {
+        got_hwloc_topology = GOT_HWLOC_TOPOLOGY_FALLBACK;
+    } else {
+        mpi_errno = MPI_ERR_INTERN;
+    }
+
+    return mpi_errno;
+}
+
+static void fallback_free_hwloc_topology(void)
+{
+    if (got_hwloc_topology == GOT_HWLOC_TOPOLOGY_FALLBACK) {
+        hwloc_topology_destroy(hwloc_topology);
+        got_hwloc_topology = GOT_HWLOC_TOPOLOGY_NONE;
+    }
+}
+
+int MPIR_pmi_load_hwloc_topology(MPIR_pmi_topology_t *topo)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    if (got_hwloc_topology != GOT_HWLOC_TOPOLOGY_NONE) {
+        goto fn_got;
+    }
+
+#ifdef HAS_PMIX_LOAD_TOPOLOGY
+    if (MPIR_CVAR_PMI_VERSION == MPIR_CVAR_PMI_VERSION_x) {
+        pmix_topology_t ptopo;
+        PMIX_TOPOLOGY_CONSTRUCT(&ptopo);
+        pmix_status_t rc = PMIx_Load_topology(&ptopo);
+        MPIR_ERR_CHKANDJUMP1(rc != PMIX_SUCCESS, mpi_errno, MPI_ERR_INTERN,
+                             "**pmix_load_topo", "**pmix_load_topo %d", rc);
+        MPIR_ERR_CHKANDJUMP1(strcmp(ptopo.source, "hwloc"), mpi_errno, MPI_ERR_INTERN,
+                             "**pmix_unknown_topo", "**pmix_unknown_topo %s", ptopo.source);
+        hwloc_topology = ptopo.topology;
+        got_hwloc_topology = GOT_HWLOC_TOPOLOGY_PMIX;
+        goto fn_got;
+    }
+#endif
+
+    mpi_errno = fallback_load_hwloc_topology();
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_got:
+    topo->source = "hwloc";
+    topo->topology = (void *) hwloc_topology;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+#endif  /* HAVE_HWLOC */
 
 /* ---- static functions ---- */
 

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -15,6 +15,7 @@
 #define PMIX_ERR_NOT_IMPLEMENTED -48
 #endif
 
+/* These are const after init. FIXME: We need a way to guard changes outside init. */
 static pmix_proc_t pmix_proc;
 static pmix_proc_t pmix_wcproc;
 static pmix_proc_t pmix_parent;
@@ -104,9 +105,12 @@ static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
     pmix_value_t value;
     pmix_value_t *val = &value;
 
+    pmix_proc_t proc;
+    PMIX_PROC_CONSTRUCT(&proc);
+    MPL_strncpy(proc.nspace, pmix_proc.nspace, PMIX_MAX_NSLEN);
     for (int i = 0; i < *size; i++) {
-        pmix_proc.rank = i;
-        pmi_errno = PMIx_Get(&pmix_proc, PMIX_FABRIC_COORDINATES, NULL, 0, &val);
+        proc.rank = i;
+        pmi_errno = PMIx_Get(&proc, PMIX_FABRIC_COORDINATES, NULL, 0, &val);
         if (pmi_errno != PMIX_SUCCESS) {
             MPIR_Process.coords = NULL;
             break;

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -33,7 +33,7 @@ static int pmix_build_app_cmd(char *path, char *command, char **app_cmd);
 static int pmix_prep_spawn(int count, char *commands[], char **argvs[], const int maxprocs[],
                            MPIR_Info * info_ptrs[], pmix_app_t * apps, pmix_info_t ** job_info,
                            size_t * njob_info);
-static int pmix_fence_nspace_proc(char *nspace, pmix_proc_t proc);
+static int pmix_fence_nspace_proc(const char *nspace, const char *parent_nspace, int parent_rank);
 
 static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
 {
@@ -215,7 +215,7 @@ static int pmix_get_parent(const char *key, char *val, int val_size)
 
     /* Fence with all other spawned procs in namespace and parent proc to
      * sync with MPIR_pmi_spawn_multiple in parent process */
-    mpi_errno = pmix_fence_nspace_proc(pmix_proc.nspace, pmix_parent);
+    mpi_errno = pmix_fence_nspace_proc(pmix_proc.nspace, pmix_parent.nspace, pmix_parent.rank);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -472,7 +472,7 @@ static int pmix_spawn(int count, char *commands[], char **argvs[], const int max
 
     /* Fence with spawned procs in new nspace (counter part in MPIR_pmi_kvs_parent_get)
      * Preput data in KVS must be read by child procs before is overwritten in next Spawn */
-    mpi_errno = pmix_fence_nspace_proc(new_nspace, pmix_proc);
+    mpi_errno = pmix_fence_nspace_proc(new_nspace, pmix_proc.nspace, pmix_proc.rank);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     /* Free job info */
@@ -864,7 +864,7 @@ int pmix_prep_spawn(int count, char *commands[], char **argvs[], const int maxpr
 }
 
 static
-int pmix_fence_nspace_proc(char *nspace, pmix_proc_t proc)
+int pmix_fence_nspace_proc(const char *nspace, const char *parent_nspace, int parent_rank)
 {
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno = PMIX_SUCCESS;
@@ -888,12 +888,12 @@ int pmix_fence_nspace_proc(char *nspace, pmix_proc_t proc)
     nprocs = pvalue->data.uint32;
     PMIX_VALUE_RELEASE(pvalue);
 
-    /* Create procs array for fence of procs in nspace and proc */
-    PMIX_PROC_CREATE(procs, nprocs + 1);        /* +1 for proc */
+    /* Create procs array for fence of procs in nspace and parent */
+    PMIX_PROC_CREATE(procs, nprocs + 1);        /* +1 for parent */
     for (size_t i = 0; i < nprocs; i++) {
         PMIX_LOAD_PROCID(&(procs[i]), nspace, i);
     }
-    PMIX_PROC_LOAD(&(procs[nprocs]), proc.nspace, proc.rank);
+    PMIX_PROC_LOAD(&(procs[nprocs]), parent_nspace, parent_rank);
 
     /* Fence */
     PMIX_INFO_CREATE(fence_info, 1);

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -265,6 +265,22 @@ static int pmix_barrier(void)
     goto fn_exit;
 }
 
+static int pmix_barrier_only(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    /* use global wildcard proc set */
+    pmi_errno = PMIx_Fence(&pmix_wcproc, 1, NULL, 0);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmix_fence", "**pmix_fence %d", pmi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 static int pmix_barrier_local(void)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -933,6 +949,11 @@ static bool pmix_get_jobattr(const char *key, char *valbuf)
 }
 
 static int pmix_barrier(void)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_barrier_only(void)
 {
     return MPI_ERR_INTERN;
 }

--- a/test/mpi/.gitignore
+++ b/test/mpi/.gitignore
@@ -1150,6 +1150,7 @@
 /impls/mpich/comm/comm_info_hint
 /impls/mpich/comm/testlist
 /impls/mpich/info/memory_alloc_kinds
+/impls/mpich/info/testlist
 /impls/mpich/mpi_t/collparmt
 /impls/mpich/mpi_t/recvq_events
 /impls/mpich/misc/gpu_query

--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -427,6 +427,13 @@ fi
 dnl MPIEXEC is used in the Makefile testing target.
 AC_SUBST([MPIEXEC])
 
+if ($MPIEXEC --version | grep -i hydra) ; then
+    use_hydra=""
+else
+    use_hydra="#"
+fi
+AC_SUBST([use_hydra])
+
 # Make sure we export CC before configuring DTPools, since MPI is
 # needed to build the library.
 export CC
@@ -1881,5 +1888,6 @@ AC_OUTPUT(maint/testmerge \
           impls/mpich/misc/Makefile \
           impls/mpich/ulfm/Makefile \
           impls/mpich/info/Makefile \
+          impls/mpich/info/testlist \
           )
 

--- a/test/mpi/impls/mpich/info/memory_alloc_kinds.c
+++ b/test/mpi/impls/mpich/info/memory_alloc_kinds.c
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include "mpitest.h"
 
-static int verbose = 0;
 static int check_value(const char *value, const char *expected);
 
 int main(int argc, char *argv[])
@@ -28,6 +27,7 @@ int main(int argc, char *argv[])
          * those keys, returning a value for mpi_memory_alloc_kind is
          * optional, and MPICH does not support it at this time. */
         errs++;
+        printf("Key mpi_memory_alloc_kinds was not found in MPI_INFO_ENV.\n");
     }
 
     /* test if MPI_COMM_WORLD gets the right value */
@@ -39,6 +39,7 @@ int main(int argc, char *argv[])
         errs += check_value(value, "mpi,system,mpi:alloc_mem");
     } else {
         errs++;
+        printf("Key mpi_memory_alloc_kinds was not found in info from MPI_COMM_WORLD.\n");
     }
 
     /* test if session gets the right value */
@@ -52,6 +53,7 @@ int main(int argc, char *argv[])
         errs += check_value(value, "mpi,system,mpi:alloc_mem");
     } else {
         errs++;
+        printf("Key mpi_memory_alloc_kinds was not found in info from MPI session.\n");
     }
     MPI_Session_finalize(&session);
 
@@ -66,6 +68,7 @@ int main(int argc, char *argv[])
         errs += check_value(value, "mpi,system,mpi:win_allocate:alloc_mem");
     } else {
         errs++;
+        printf("Key mpi_memory_alloc_kinds was not found in info from MPI_Session_init with info.\n");
     }
     MPI_Info_free(&info_in);
     MPI_Info_free(&sinfo);
@@ -78,8 +81,7 @@ int main(int argc, char *argv[])
 static int check_value(const char *value, const char *expected)
 {
     if (strcmp(value, expected)) {
-        MTestPrintfMsg(verbose, "mpi_memory_alloc_kinds value is \"%s\", expected \"%s\"\n",
-                       value, expected);
+        printf("mpi_memory_alloc_kinds value is \"%s\", expected \"%s\"\n", value, expected);
         return 1;
     }
 

--- a/test/mpi/impls/mpich/info/testlist
+++ b/test/mpi/impls/mpich/info/testlist
@@ -1,1 +1,0 @@
-memory_alloc_kinds 1 mpiexecarg=-memory-alloc-kinds=mpi:alloc_mem

--- a/test/mpi/impls/mpich/info/testlist.in
+++ b/test/mpi/impls/mpich/info/testlist.in
@@ -1,0 +1,1 @@
+@use_hydra@memory_alloc_kinds 1 mpiexecarg=-memory-alloc-kinds=mpi:alloc_mem


### PR DESCRIPTION
## Pull Request Description

A few improvements for MPI_Init to scale to thousands of nodes with high PPN:
1. support PMIx_Load_topology to speed up topology initialization
2. calling a lightweight MPIR_pmi_barrier_only() in MPI_Init, add MPIR_CVAR_INIT_SKIP_PMI_BARRIER to even bypass the barrier
3. fixed various bugs to make MPIR_CVAR_CH4_ROOTS_ONLY_PMI mode working again

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
