### PR TITLE
mpl/gpu: Fix typo in HIP memory hook

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -492,7 +492,7 @@ hipError_t hipFree(void *dptr)
     gpu_free_hooks_cb(dptr);
     result = sys_hipFree(dptr);
 
-    MPL_initlock_lock(&free_hook_mutex);
+    MPL_initlock_unlock(&free_hook_mutex);
     return result;
 }
 


### PR DESCRIPTION
## Pull Request Description

Accidental double locking leading to deadlock in the free memory hook.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
