### PR TITLE
errhan: fix NULL reference in MPIR_Err_return_session_init

### DIFF
--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -450,8 +450,8 @@ int MPIR_Err_return_session_init(MPIR_Errhandler * errhandler_ptr, const char fc
 
     /* It's likely nothing is initialized yet. Make sure the builtin error handlers are recognized */
     init_builtins();
-    if (errhandler_ptr->handle == MPI_ERRORS_RETURN ||
-        errhandler_ptr->handle == MPIR_ERRORS_THROW_EXCEPTIONS) {
+    if (errhandler_ptr && (errhandler_ptr->handle == MPI_ERRORS_RETURN ||
+                           errhandler_ptr->handle == MPIR_ERRORS_THROW_EXCEPTIONS)) {
         return errcode;
     }
 


### PR DESCRIPTION
## Pull Request Description
Fix a potential NULL errhandler case in MPIR_Err_return_session_init. It is tricky to handle error when everything may be uninitialized.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
