### PR TITLE
ch4/ipc: fix premature free of src_dt_ptr

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -88,10 +88,13 @@ typedef enum {
 #define MPIDI_MAX_KVS_VALUE_LEN  4096
 
 typedef struct MPIDIG_rreq_t {
-    /* mrecv fields */
-    void *mrcv_buffer;
-    uint64_t mrcv_count;
-    MPI_Datatype mrcv_datatype;
+    union {
+        struct {
+            void *buffer;
+            MPI_Aint count;
+            MPI_Datatype datatype;
+        } mrcv;
+    } u;
 
     MPIR_Request *peer_req_ptr;
     MPIR_Request *match_req;
@@ -646,7 +649,7 @@ typedef struct MPIDI_Devcomm_t {
         int shm_size_per_lead;
 
         void *csel_comm;        /* collective selection handle */
-        void *csel_comm_gpu;    /* collective selection handle for gpu*/
+        void *csel_comm_gpu;    /* collective selection handle for gpu */
     } ch4;
 } MPIDI_Devcomm_t;
 

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -94,6 +94,9 @@ typedef struct MPIDIG_rreq_t {
             MPI_Aint count;
             MPI_Datatype datatype;
         } mrcv;
+        struct {
+            MPIR_Datatype *src_dt_ptr;
+        } ipc;
     } u;
 
     MPIR_Request *peer_req_ptr;

--- a/src/mpid/ch4/shm/ipc/src/ipc_control.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_control.c
@@ -56,6 +56,10 @@ int MPIDI_IPC_complete(MPIR_Request * rreq, int ipc_type)
                          &am_hdr, sizeof(am_hdr), local_vci, remote_vci), 1, mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
 
+    if (MPIDIG_REQUEST(rreq, req->rreq.u.ipc.src_dt_ptr)) {
+        MPIR_Datatype_free(MPIDIG_REQUEST(rreq, req->rreq.u.ipc.src_dt_ptr));
+    }
+
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) (rreq);
 
   fn_exit:

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -246,6 +246,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPC_hdr * ipc_hdr,
             src_count = ipc_hdr->count;
             src_dt = src_dt_ptr->handle;
         }
+        MPIDIG_REQUEST(rreq, req->rreq.u.ipc.src_dt_ptr) = src_dt_ptr;
+
         MPIR_gpu_req yreq;
         MPL_gpu_engine_type_t engine =
             MPIDI_IPCI_choose_engine(ipc_hdr->ipc_handle.gpu.global_dev_id, dev_id);
@@ -254,9 +256,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPC_hdr * ipc_hdr,
                                         MPIDIG_REQUEST(rreq, datatype), 0, &attr,
                                         MPL_GPU_COPY_DIRECTION_NONE, engine, true, &yreq);
         MPIR_ERR_CHECK(mpi_errno);
-        if (src_dt_ptr) {
-            MPIR_Datatype_free(src_dt_ptr);
-        }
 
         mpi_errno = MPIDI_GPU_ipc_async_start(rreq, &yreq, src_buf, ipc_hdr->ipc_handle.gpu);
         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/src/mpidig_recv.h
+++ b/src/mpid/ch4/src/mpidig_recv.h
@@ -165,13 +165,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_handle_unexpected(void *buf, MPI_Aint count,
 MPL_STATIC_INLINE_PREFIX int MPIDIG_handle_unexp_mrecv(MPIR_Request * rreq)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Datatype mrcv_dt = MPIDIG_REQUEST(rreq, req->rreq.mrcv_datatype);
+    MPI_Datatype mrcv_dt = MPIDIG_REQUEST(rreq, req->rreq.u.mrcv.datatype);
 
     MPIR_FUNC_ENTER;
 
-    mpi_errno = MPIDIG_handle_unexpected(MPIDIG_REQUEST(rreq, req->rreq.mrcv_buffer),
-                                         MPIDIG_REQUEST(rreq, req->rreq.mrcv_count),
-                                         MPIDIG_REQUEST(rreq, req->rreq.mrcv_datatype), rreq);
+    mpi_errno = MPIDIG_handle_unexpected(MPIDIG_REQUEST(rreq, req->rreq.u.mrcv.buffer),
+                                         MPIDIG_REQUEST(rreq, req->rreq.u.mrcv.count),
+                                         MPIDIG_REQUEST(rreq, req->rreq.u.mrcv.datatype), rreq);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Datatype_release_if_not_builtin(mrcv_dt);
 
@@ -306,9 +306,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_imrecv(void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    MPIDIG_REQUEST(message, req->rreq.mrcv_buffer) = buf;
-    MPIDIG_REQUEST(message, req->rreq.mrcv_count) = count;
-    MPIDIG_REQUEST(message, req->rreq.mrcv_datatype) = datatype;
+    MPIDIG_REQUEST(message, req->rreq.u.mrcv.buffer) = buf;
+    MPIDIG_REQUEST(message, req->rreq.u.mrcv.count) = count;
+    MPIDIG_REQUEST(message, req->rreq.u.mrcv.datatype) = datatype;
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
 
     if (MPIDIG_REQUEST(message, req->status) & MPIDIG_REQ_PEER_SSEND) {


### PR DESCRIPTION
## Pull Request Description
Apparently, the datatype may not be held while it is in
`MPIR_Ilocalcopy_gpu` -- likely due to one of yaksa bypass paths. Save the datatype and only free it in
`MPIDI_IPC_complete`.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
