### PR TITLE
coll: fix MPI_Gather_init using the sched_binomial algo

### DIFF
--- a/src/mpi/coll/igather/igather_intra_sched_binomial.c
+++ b/src/mpi/coll/igather/igather_intra_sched_binomial.c
@@ -92,15 +92,18 @@ int MPIR_Igather_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
 
     if (rank == root) {
         if (sendbuf != MPI_IN_PLACE) {
-            mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,
+            mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
                                        ((char *) recvbuf + extent * recvcount * rank),
-                                       recvcount, recvtype);
+                                        recvcount, recvtype, s);
             MPIR_ERR_CHECK(mpi_errno);
+            MPIR_SCHED_BARRIER(s);
         }
     } else if (tmp_buf_size && (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE)) {
         /* copy from sendbuf into tmp_buf */
-        mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype, tmp_buf, nbytes, MPI_BYTE);
+        mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
+                                    tmp_buf, nbytes, MPI_BYTE, s);
         MPIR_ERR_CHECK(mpi_errno);
+        MPIR_SCHED_BARRIER(s);
     }
     curr_cnt = nbytes;
 


### PR DESCRIPTION
## Pull Request Description
We need schdule the local copy for persistent collective to work.

Fixes #7078 
[skip warnings]




## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
