### PR TITLE
build: Source libtool files before installing wrapper scripts

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -240,6 +240,11 @@ test-clean:
 ## better approach might be to have each Makefile.mk append to a
 ## common set of rules.
 install-exec-hook:
+	if test -e lib/lib@PMPILIBNAME@.la ; then \
+	    . lib/lib@PMPILIBNAME@.la ; \
+	elif test -e lib/lib@MPILIBNAME@.la ; then \
+	    . lib/lib@MPILIBNAME@.la ; \
+	fi ; \
 	for e in ${DESTDIR}${bindir}/@MPICC_NAME@ \
 		${DESTDIR}${bindir}/@MPICXX_NAME@ \
 		${DESTDIR}${bindir}/@MPIFORT_NAME@ ; do \
@@ -289,11 +294,6 @@ if BUILD_ABI_LIB
 		fi ; \
 	fi ;
 endif BUILD_ABI_LIB
-	if test -e lib/lib@PMPILIBNAME@.la ; then \
-	    . lib/lib@PMPILIBNAME@.la ; \
-	elif test -e lib/lib@MPILIBNAME@.la ; then \
-	    . lib/lib@MPILIBNAME@.la ; \
-	fi ; \
 	if test -e ${DESTDIR}${libdir}/lib@MPILIBNAME@@SHLIB_EXT@ ; then \
 		if test "@MPILIBNAME@" != "mpl" ; then \
 			cd ${DESTDIR}${libdir} && ln -f -s lib@MPILIBNAME@@SHLIB_EXT@ libmpl@SHLIB_EXT@ ; \


### PR DESCRIPTION
## Pull Request Description

Make needs to get the dependency libraries from libtool scripts so they can be substituted in the compiler wrappers. This was accidentally broken in [f3e092ab]. See pmodels/mpich#7087.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
