### PR TITLE
mpl/cuda: Fix invalid context error in memory hooks

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -8,6 +8,11 @@
 #include <dlfcn.h>
 #include <assert.h>
 
+// We need to give the pre-processor a chance to replace a function, such as:
+// cuMemFree => cuMemFree_v2
+#define STRINGIFY(x) #x
+#define CUDA_SYMBOL_STRING(x) STRINGIFY(x)
+
 #define CUDA_ERR_CHECK(ret) if (unlikely((ret) != cudaSuccess)) goto fn_fail
 #define CU_ERR_CHECK(ret) if (unlikely((ret) != CUDA_SUCCESS)) goto fn_fail
 
@@ -492,9 +497,9 @@ static int gpu_mem_hook_init()
     libcudart_handle = dlopen("libcudart.so", RTLD_LAZY | RTLD_GLOBAL);
     assert(libcudart_handle);
 
-    sys_cuMemFree = (void *) dlsym(libcuda_handle, "cuMemFree");
+    sys_cuMemFree = (void *) dlsym(libcuda_handle, CUDA_SYMBOL_STRING(cuMemFree));
     assert(sys_cuMemFree);
-    sys_cudaFree = (void *) dlsym(libcudart_handle, "cudaFree");
+    sys_cudaFree = (void *) dlsym(libcudart_handle, CUDA_SYMBOL_STRING(cudaFree));
     assert(sys_cudaFree);
 
     return MPL_SUCCESS;


### PR DESCRIPTION
Use pre-processor to replace a `cuMemFree` function with `cuMemFree_v2` (symbol provided by the cuda.h header file).

## Pull Request Description

Simple CUDA program, that allocates and frees CUDA memory and is compiled with MPICH, results in getting the following CUDA_ERROR_INVALID_CONTEXT error:
```
cuInit(...) returned 0
cuDeviceGet(...) returned 0
cuCtxCreate(...) returned 0
cuCtxPushCurrent(...) returned 0
cuMemAlloc(...) returned 0
cuMemFree(...) returned 201: CUDA_ERROR_INVALID_CONTEXT (invalid device context)
cuCtxPopCurrent(...) returned 0
```

### Root causing the issue:

Based on the dump of the dynamic linker for the case with the error shows:
```
[...]
8609:     symbol=cuMemFree_v2;  lookup in file=./memfree.mpich-main [0]
8609:     symbol=cuMemFree_v2;  lookup in file=[<path-to-compiled-mpich>]/lib/libmpicxx.so.0 [0]
8609:     symbol=cuMemFree_v2;  lookup in file=[<path-to-compiled-mpich>]/lib/libmpi.so.0 [0]
8609:     binding file ./memfree.mpich-main [0] to [<path-to-compiled-mpich>]/lib/libmpi.so.0 [0]: normal symbol `cuMemFree_v2'
[...]
```
It means that the binary and libraries (`libmpicxx.so.0` and `libmpi.so.0`) expose `cuMemFree_v2`. This is consistent with `#define cuMemFree cuMemFree_v2` preprocessor directive just in the beginning of the `cuda.h` file. 

However, when it comes to MPICH CUDA hooks implementation:
```
[...]
8609:     symbol=cuMemFree;  lookup in file=/usr/lib64/libcuda.so.1 [0]
8609:     binding file /usr/lib64/libcuda.so.1 [0] to /usr/lib64/libcuda.so.1 [0]: normal symbol `cuMemFree'
8609:     symbol=cudaFree;  lookup in file=<path-to-cuda>/CUDA/12/lib/libcudart.so.12 [0]
8609:     binding file <path-to-cuda>/CUDA/12/lib/libcudart.so.12 [0] to <path-to-cuda>/software/CUDA/12/lib/libcudart.so.12 [0]: normal symbol `cudaFree'
[...]
cuMemFree(...) returned 201      8609:  symbol=cuGetErrorName;  lookup in file=./memfree.mpich-main [0]
```
linker tries to look for exactly `cuMemFree` symbol which cannot be found and returns `CUDA_ERROR_INVALID_CONTEXT (invalid device context)` error.

### Reproduction
The simplest way to reproduce it is to compile:
```
#include <cuda.h>
#include <cstdio>
#include <string>

void cudaCheckError(std::string func, CUresult err) {
    printf("%s(...) returned %d", func.c_str(), err);
    fflush(stdout);
    if (CUDA_SUCCESS != err) {
        const char* n;
        cuGetErrorName(err, &n);
        const char *s;
        cuGetErrorString(err, &s);
        printf(": %s (%s)", n, s);
    }
    printf("\n");
    fflush(stdout);
}

int main(){
    CUdevice dev;
    CUcontext ctx;
    CUdeviceptr p;
    cudaCheckError("cuInit", cuInit(0));
    cudaCheckError("cuDeviceGet", cuDeviceGet(&dev, 0));
    cudaCheckError("cuCtxCreate", cuCtxCreate(&ctx, 0, dev));
    cudaCheckError("cuCtxPushCurrent", cuCtxPushCurrent(ctx));
    cudaCheckError("cuMemAlloc", cuMemAlloc(&p, 1));
    cudaCheckError("cuMemFree", cuMemFree(p));
    cudaCheckError("cuCtxPopCurrent", cuCtxPopCurrent(nullptr));
}
```
using the following commands:
```
export LD_LIBRARY_PATH=<path-to-mpich-libs>/lib:$LD_LIBRARY_PATH
mpicxx -g -c main.cpp -o main.o
mpicxx -o memfree.mpich-main main.o -lcudart -lcuda
```
and run:
```
export LD_LIBRARY_PATH=<path-to-cuda>/lib:$LD_LIBRARY_PATH
./memfree.mpich-main
```

### Fix:
Use pre-processor to replace a `cuMemFree` function with `cuMemFree_v2` (symbol provided by the cuda.h header file) fixes the issue. As a result MPICH looks for a symbol that is consistent with CUDA library and finds it.

cc: @sonjahapp 

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
