### PR TITLE
ch4/ipc: initialize ipc_attr in ipc_win.c

### DIFF
--- a/src/mpid/ch4/shm/ipc/src/ipc_win.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_win.c
@@ -77,11 +77,11 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
 
     /* Determine IPC type based on buffer type and submodule availability.
      * We always exchange in case any remote buffer can be shared by IPC. */
+    ipc_attr.ipc_type = MPIDI_IPCI_TYPE__NONE;
     bool done = false;
 
     /* Disable local IPC for zero buffer */
     if (win->size == 0) {
-        ipc_attr.ipc_type = MPIDI_IPCI_TYPE__NONE;
         done = true;
     }
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU


### PR DESCRIPTION
## Pull Request Description
We need to initialize ipc_attr.ipc_type for the case when none of the IPC modules are configured in.

Fixes #7092 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
