### PR TITLE
mpid: add MPIR_Data and MPID_{Send,Recv}_data (WIP)

### DIFF
--- a/doc/wiki/developer_guide.md
+++ b/doc/wiki/developer_guide.md
@@ -303,9 +303,7 @@ MPI_Aint MPIDI_[NM|SHM]_am_eager_limit(void)
 MPI_Aint MPIDI_[NM|SHM]_am_eager_buf_limit(void)
 
 /* return true/false if pt2pt message can be sent eagerly */
-bool MPIDI_[NM|SHM]_am_check_eager(MPI_Aint am_hdr_sz, MPI_Aint data_sz,
-                                   const void *data, MPI_Aint count,
-                                   MPI_Datatype datatype, MPIR_Request * sreq)
+bool MPIDI_[NM|SHM]_am_check_eager(MPI_Aint am_hdr_sz, MPI_Aint data_sz, MPIR_Request * sreq)
 
 /****************** Callback APIs ******************/
 

--- a/src/include/mpir_gpu_util.h
+++ b/src/include/mpir_gpu_util.h
@@ -83,7 +83,7 @@ MPL_STATIC_INLINE_PREFIX void MPIR_gpu_host_swap_gpu(const void *buf, MPI_Aint c
                                                      MPL_pointer_attr_t attr, void *host_buf)
 {
     if (host_buf) {
-        MPIR_Localcopy_gpu(buf, count, datatype, 0, &attr, host_buf, count, datatype, 0, NULL,
+        MPIR_Localcopy_gpu(buf, count, datatype, 0, -1, &attr, host_buf, count, datatype, 0, NULL,
                            MPL_GPU_COPY_DIRECTION_NONE, MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH,
                            true);
     }
@@ -99,7 +99,7 @@ MPL_STATIC_INLINE_PREFIX void MPIR_gpu_swap_back(void *host_buf, void *gpu_buf,
 MPL_STATIC_INLINE_PREFIX void MPIR_gpu_swap_back_gpu(void *host_buf, void *gpu_buf, MPI_Aint count,
                                                      MPI_Datatype datatype, MPL_pointer_attr_t attr)
 {
-    MPIR_Localcopy_gpu(host_buf, count, datatype, 0, NULL, gpu_buf, count, datatype, 0, &attr,
+    MPIR_Localcopy_gpu(host_buf, count, datatype, 0, -1, NULL, gpu_buf, count, datatype, 0, &attr,
                        MPL_GPU_COPY_DIRECTION_NONE, MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH, true);
 }
 

--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -84,20 +84,22 @@ typedef struct {
 int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype);
 int MPIR_Ilocalcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                    MPI_Aint sendoffset, MPI_Aint sendlength,
+                    void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, MPI_Aint recvoffset,
                     MPIR_Typerep_req * typerep_req);
 int MPIR_Localcopy_stream(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                           void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype, void *stream);
 int MPIR_Localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                       MPI_Aint sendoffset, MPL_pointer_attr_t * sendattr, void *recvbuf,
-                       MPI_Aint recvcount, MPI_Datatype recvtype, MPI_Aint recvoffset,
-                       MPL_pointer_attr_t * recvattr, MPL_gpu_copy_direction_t dir,
-                       MPL_gpu_engine_type_t enginetype, bool commit);
+                       MPI_Aint sendoffset, MPI_Aint sendlength, MPL_pointer_attr_t * sendattr,
+                       void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                       MPI_Aint recvoffset, MPL_pointer_attr_t * recvattr,
+                       MPL_gpu_copy_direction_t dir, MPL_gpu_engine_type_t enginetype, bool commit);
 int MPIR_Ilocalcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
-                        MPI_Aint sendoffset, MPL_pointer_attr_t * sendattr, void *recvbuf,
-                        MPI_Aint recvcount, MPI_Datatype recvtype, MPI_Aint recvoffset,
-                        MPL_pointer_attr_t * recvattr, MPL_gpu_copy_direction_t dir,
-                        MPL_gpu_engine_type_t enginetype, bool commit, MPIR_gpu_req * req);
+                        MPI_Aint sendoffset, MPI_Aint sendlength, MPL_pointer_attr_t * sendattr,
+                        void *recvbuf, MPI_Aint recvcount, MPI_Datatype recvtype,
+                        MPI_Aint recvoffset, MPL_pointer_attr_t * recvattr,
+                        MPL_gpu_copy_direction_t dir, MPL_gpu_engine_type_t enginetype,
+                        bool commit, MPIR_gpu_req * req);
 
 /* Contiguous datatype calculates buffer address with `(char *) buf + dt_true_lb`.
  * However, dt_true_lb is treated as ptrdiff_t (signed), and when buf is MPI_BOTTOM

--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -14,6 +14,16 @@
 #define MPIR_FINALIZE_CALLBACK_DEFAULT_PRIO 0
 #define MPIR_FINALIZE_CALLBACK_MAX_PRIO 10
 
+/* Misc. declarations that need be included before e.g. mpidpre.h */
+
+typedef struct MPIR_Data {
+    void *buf;
+    MPI_Aint count;
+    MPI_Datatype datatype;
+    MPI_Aint offset;
+    MPI_Aint length;
+} MPIR_Data;
+
 /* Define a typedef for the errflag value used by many internal
  * functions.  If an error needs to be returned, these values can be
  * used to signal such.  More details can be found further down in the

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -138,12 +138,18 @@ Non Native API:
      SHM*: req
 
 Native API:
+  send_data : int
+      NM*: data-2, rank, tag, comm, attr-2, addr, req_p
+     SHM*: data-2, rank, tag, comm, attr-2, addr, req_p
   mpi_isend : int
       NM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p
      SHM*: buf, count, datatype, rank, tag, comm, attr-2, addr, req_p
   mpi_cancel_send : int
       NM*: sreq
      SHM*: sreq
+  recv_data : int
+      NM*: data-2, rank, tag, comm, attr-2, addr, req_p, partner
+     SHM*: data-2, rank, tag, comm, attr-2, req_p
   mpi_irecv : int
       NM*: buf-2, count, datatype, rank, tag, comm, attr-2, addr, req_p, partner
      SHM*: buf-2, count, datatype, rank, tag, comm, attr-2, req_p
@@ -446,6 +452,7 @@ PARAM:
     context_id: MPIR_Context_id_t
     count: MPI_Aint
     data: const void *
+    data-2: MPIR_Data *
     data_sz: MPI_Aint
     datatype: MPI_Datatype
     datatype_p: MPIR_Datatype *

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -76,8 +76,8 @@ Non Native API:
       NM*: void
      SHM*: void
   am_check_eager: bool
-      NM*: am_hdr_sz, data_sz, data, count, datatype, sreq
-     SHM*: am_hdr_sz, data_sz, data, count, datatype, sreq
+      NM*: am_hdr_sz, data_sz, sreq
+     SHM*: am_hdr_sz, data_sz, sreq
   comm_get_gpid : int
       NM*: comm_ptr, idx, gpid_ptr, is_remote
   get_local_upids : int

--- a/src/mpid/ch4/include/mpidch4.h
+++ b/src/mpid/ch4/include/mpidch4.h
@@ -65,12 +65,16 @@ int MPID_Progress_activate(int id);
 int MPID_Progress_deactivate(int id);
 MPL_STATIC_INLINE_PREFIX int MPID_Recv(void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *, int,
                                        MPI_Status *, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Recv_data(MPIR_Data * data, int source, int tag, MPIR_Comm * comm,
+                                            int attr, MPIR_Request ** req) MPL_STATIC_INLINE_SUFFIX;
 int MPID_Recv_init(void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *, int, MPIR_Request **);
 MPL_STATIC_INLINE_PREFIX void MPID_Request_set_completed(MPIR_Request *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Request_complete(MPIR_Request *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Request_is_anysource(MPIR_Request *) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Send(const void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *,
                                        int, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
+MPL_STATIC_INLINE_PREFIX int MPID_Send_data(MPIR_Data * data, int dest, int tag, MPIR_Comm * comm,
+                                            int attr, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Ssend(const void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *,
                                         int, MPIR_Request **) MPL_STATIC_INLINE_SUFFIX;
 MPL_STATIC_INLINE_PREFIX int MPID_Rsend(const void *, MPI_Aint, MPI_Datatype, int, int, MPIR_Comm *,

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -282,9 +282,7 @@ typedef struct MPIDI_part_request {
 /* message queue within "self"-comms, i.e. MPI_COMM_SELF and all communicators with size of 1. */
 
 typedef struct {
-    void *buf;
-    MPI_Aint count;
-    MPI_Datatype datatype;
+    struct MPIR_Data data;
     int tag;
     int context_id;
     MPIR_Request *match_req;    /* for mrecv */

--- a/src/mpid/ch4/netmod/ofi/ofi_am.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am.h
@@ -192,8 +192,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Comm * comm,
 }
 
 MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Aint data_sz,
-                                                      const void *data, MPI_Aint count,
-                                                      MPI_Datatype datatype, MPIR_Request * sreq)
+                                                      MPIR_Request * sreq)
 {
     MPIDI_OFI_AMREQUEST(sreq, data_sz) = data_sz;
     if ((am_hdr_sz + data_sz)

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -150,8 +150,9 @@ static int pipeline_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * r, 
                 MPI_Aint actual_unpack_bytes;
                 MPIR_gpu_req yreq;
                 mpi_errno =
-                    MPIR_Ilocalcopy_gpu(wc_buf, wc->len, MPI_BYTE, 0, NULL, recv_buf, recv_count,
-                                        datatype, 0, NULL, MPL_GPU_COPY_H2D, engine_type, 1, &yreq);
+                    MPIR_Ilocalcopy_gpu(wc_buf, wc->len, MPI_BYTE, 0, -1, NULL, recv_buf,
+                                        recv_count, datatype, 0, NULL, MPL_GPU_COPY_H2D,
+                                        engine_type, 1, &yreq);
                 MPIR_ERR_CHECK(mpi_errno);
                 actual_unpack_bytes = wc->len;
                 task =
@@ -216,7 +217,7 @@ static int pipeline_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * r, 
             MPI_Aint actual_unpack_bytes;
             MPIR_gpu_req yreq;
             mpi_errno =
-                MPIR_Ilocalcopy_gpu(wc_buf, (MPI_Aint) wc->len, MPI_BYTE, 0, NULL,
+                MPIR_Ilocalcopy_gpu(wc_buf, (MPI_Aint) wc->len, MPI_BYTE, 0, -1, NULL,
                                     (char *) recv_buf, (MPI_Aint) recv_count, datatype,
                                     MPIDI_OFI_REQUEST(rreq, pipeline_info.offset), NULL,
                                     MPL_GPU_COPY_H2D, engine_type, 1, &yreq);

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -109,7 +109,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vci, struct fi_cq_tagged_e
             actual_unpack_bytes = wc->len;
             mpi_errno =
                 MPIR_Localcopy_gpu(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer), count,
-                                   MPI_BYTE, 0, NULL, recv_buf, count, MPI_BYTE, 0, &attr,
+                                   MPI_BYTE, 0, -1, NULL, recv_buf, count, MPI_BYTE, 0, &attr,
                                    MPL_GPU_COPY_DIRECTION_NONE, engine, true);
             MPIR_ERR_CHECK(mpi_errno);
         } else {

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -931,8 +931,8 @@ static int MPIDI_OFI_gpu_progress_send(void)
                 commit = 1;
             mpi_errno =
                 MPIR_Ilocalcopy_gpu((char *) send_task->send_buf, send_task->count, datatype,
-                                    send_task->offset, &send_task->attr, host_buf, chunk_sz,
-                                    MPI_BYTE, 0, NULL, MPL_GPU_COPY_D2H, engine_type,
+                                    send_task->offset, chunk_sz, &send_task->attr, host_buf,
+                                    chunk_sz, MPI_BYTE, 0, NULL, MPL_GPU_COPY_D2H, engine_type,
                                     commit, &yreq);
             MPIR_ERR_CHECK(mpi_errno);
             actual_pack_bytes = chunk_sz;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -356,7 +356,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *buf, MPI_Aint cou
                 MPIDI_OFI_gpu_get_send_engine_type(MPIR_CVAR_CH4_OFI_GPU_SEND_ENGINE_TYPE);
             if (dt_contig && engine != MPL_GPU_ENGINE_TYPE_LAST &&
                 MPL_gpu_query_pointer_is_dev(send_buf, &attr)) {
-                mpi_errno = MPIR_Localcopy_gpu(send_buf, data_sz, MPI_BYTE, 0, &attr,
+                mpi_errno = MPIR_Localcopy_gpu(send_buf, data_sz, MPI_BYTE, 0, -1, &attr,
                                                MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer),
                                                data_sz, MPI_BYTE, 0, NULL,
                                                MPL_GPU_COPY_DIRECTION_NONE, engine, true);
@@ -619,7 +619,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
                         MPIDI_OFI_gpu_get_send_engine_type(MPIR_CVAR_CH4_OFI_GPU_SEND_ENGINE_TYPE);
                     if (engine != MPL_GPU_ENGINE_TYPE_LAST) {
                         mpi_errno =
-                            MPIR_Localcopy_gpu(send_buf, data_sz, MPI_BYTE, 0, &attr, host_buf,
+                            MPIR_Localcopy_gpu(send_buf, data_sz, MPI_BYTE, 0, -1, &attr, host_buf,
                                                data_sz, MPI_BYTE, 0, NULL,
                                                MPL_GPU_COPY_DIRECTION_NONE, engine, true);
                         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -261,8 +261,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_send_hdr_reply(MPIR_Comm * comm,
 }
 
 MPL_STATIC_INLINE_PREFIX bool MPIDI_NM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Aint data_sz,
-                                                      const void *data, MPI_Aint count,
-                                                      MPI_Datatype datatype, MPIR_Request * sreq)
+                                                      MPIR_Request * sreq)
 {
 #ifdef HAVE_UCP_AM_NBX
     /* ucx will handle rndv */

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -704,7 +704,7 @@ int MPIDI_GPU_copy_data_async(MPIDI_IPC_hdr * ipc_hdr, MPIR_Request * rreq, MPI_
     MPIR_gpu_req yreq;
     MPL_gpu_engine_type_t engine =
         MPIDI_IPCI_choose_engine(ipc_hdr->ipc_handle.gpu.global_dev_id, dev_id);
-    mpi_errno = MPIR_Ilocalcopy_gpu(src_buf, src_count, src_dt, 0, NULL,
+    mpi_errno = MPIR_Ilocalcopy_gpu(src_buf, src_count, src_dt, 0, -1, NULL,
                                     MPIDIG_REQUEST(rreq, buffer), MPIDIG_REQUEST(rreq, count),
                                     MPIDIG_REQUEST(rreq, datatype), 0, &attr,
                                     MPL_GPU_COPY_DIRECTION_NONE, engine, true, &yreq);

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -167,14 +167,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
         if (winattr & MPIDI_WINATTR_MR_PREFERRED) {
             MPIR_gpu_req yreq;
             mpi_errno =
-                MPIR_Ilocalcopy_gpu(origin_addr, origin_count, origin_datatype, 0, &origin_attr,
+                MPIR_Ilocalcopy_gpu(origin_addr, origin_count, origin_datatype, 0, -1, &origin_attr,
                                     target_addr, target_count, target_datatype, 0, &target_attr,
                                     MPL_GPU_COPY_DIRECTION_NONE, engine_type, 1, &yreq);
             if (yreq.type != MPIR_NULL_REQUEST)
                 MPIDI_POSIX_rma_outstanding_req_enqueu(yreq, &win->dev.shm.posix);
         } else {
             mpi_errno =
-                MPIR_Localcopy_gpu(origin_addr, origin_count, origin_datatype, 0, &origin_attr,
+                MPIR_Localcopy_gpu(origin_addr, origin_count, origin_datatype, 0, -1, &origin_attr,
                                    target_addr, target_count, target_datatype, 0, &target_attr,
                                    MPL_GPU_COPY_DIRECTION_NONE, engine_type, 1);
         }
@@ -186,8 +186,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
          * increase per-op+flush overhead. */
         MPIR_gpu_req yreq;
         yreq.type = MPIR_TYPEREP_REQUEST;
-        mpi_errno = MPIR_Ilocalcopy(origin_addr, origin_count, origin_datatype,
-                                    target_addr, target_count, target_datatype, &yreq.u.y_req);
+        mpi_errno = MPIR_Ilocalcopy(origin_addr, origin_count, origin_datatype, 0, -1,
+                                    target_addr, target_count, target_datatype, 0, &yreq.u.y_req);
         MPIDI_POSIX_rma_outstanding_req_enqueu(yreq, &win->dev.shm.posix);
     } else {
         /* By default issuing blocking copy for lower per-op latency. */
@@ -259,7 +259,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
         if (winattr & MPIDI_WINATTR_MR_PREFERRED) {
             MPIR_gpu_req yreq;
             mpi_errno = MPIR_Ilocalcopy_gpu(target_addr, target_count,
-                                            target_datatype, 0, NULL, origin_addr,
+                                            target_datatype, 0, -1, NULL, origin_addr,
                                             origin_count, origin_datatype, 0, NULL,
                                             MPL_GPU_COPY_DIRECTION_NONE, engine_type, 1, &yreq);
             if (yreq.type != MPIR_NULL_REQUEST)
@@ -278,9 +278,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
          * increase per-op+flush overhead. */
         MPIR_gpu_req yreq;
         yreq.type = MPIR_TYPEREP_REQUEST;
-        mpi_errno = MPIR_Ilocalcopy(target_addr, target_count,
-                                    target_datatype, origin_addr, origin_count, origin_datatype,
-                                    &yreq.u.y_req);
+        mpi_errno = MPIR_Ilocalcopy(target_addr, target_count, target_datatype, 0, -1,
+                                    origin_addr, origin_count, origin_datatype, 0, &yreq.u.y_req);
         MPIDI_POSIX_rma_outstanding_req_enqueu(yreq, &win->dev.shm.posix);
     } else {
         /* By default issuing blocking copy for lower per-op latency. */

--- a/src/mpid/ch4/shm/src/shm_am.h
+++ b/src/mpid/ch4/shm/src/shm_am.h
@@ -110,8 +110,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_SHM_am_request_finalize(MPIR_Request * req)
 }
 
 MPL_STATIC_INLINE_PREFIX bool MPIDI_SHM_am_check_eager(MPI_Aint am_hdr_sz, MPI_Aint data_sz,
-                                                       const void *data, MPI_Aint count,
-                                                       MPI_Datatype datatype, MPIR_Request * sreq)
+                                                       MPIR_Request * sreq)
 {
     /* TODO: add checking for IPC transmission */
     return (am_hdr_sz + data_sz) <= MPIDI_POSIX_am_eager_limit();

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -613,7 +613,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_alpha(const void 
 
     if (host_recvbuf != NULL) {
         recvbuf = in_recvbuf;
-        mpi_errno = MPIR_Localcopy_gpu(host_recvbuf, count, datatype, 0, NULL,
+        mpi_errno = MPIR_Localcopy_gpu(host_recvbuf, count, datatype, 0, -1, NULL,
                                        recvbuf, count, datatype, 0, &recv_attr,
                                        MPL_GPU_COPY_DIRECTION_NONE,
                                        MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH, true);
@@ -662,7 +662,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_beta(const void *
 
     if (host_recvbuf != NULL) {
         recvbuf = in_recvbuf;
-        mpi_errno = MPIR_Localcopy_gpu(host_recvbuf, count, datatype, 0, NULL,
+        mpi_errno = MPIR_Localcopy_gpu(host_recvbuf, count, datatype, 0, -1, NULL,
                                        recvbuf, count, datatype, 0, &recv_attr,
                                        MPL_GPU_COPY_DIRECTION_NONE,
                                        MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH, true);
@@ -714,7 +714,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_gamma(const void 
 
     if (host_recvbuf != NULL) {
         recvbuf = in_recvbuf;
-        mpi_errno = MPIR_Localcopy_gpu(host_recvbuf, count, datatype, 0, NULL,
+        mpi_errno = MPIR_Localcopy_gpu(host_recvbuf, count, datatype, 0, -1, NULL,
                                        recvbuf, count, datatype, 0, &recv_attr,
                                        MPL_GPU_COPY_DIRECTION_NONE,
                                        MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH, true);

--- a/src/mpid/ch4/src/ch4_self.h
+++ b/src/mpid/ch4/src/ch4_self.h
@@ -12,6 +12,10 @@ int MPIDI_Self_isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int
                      MPIR_Comm * comm, int attr, MPIR_Request ** request);
 int MPIDI_Self_irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int rank, int tag,
                      MPIR_Comm * comm, int attr, MPIR_Request ** request);
+int MPIDI_Self_send_data(MPIR_Data * data, int rank, int tag,
+                         MPIR_Comm * comm, int attr, MPIR_Request ** request);
+int MPIDI_Self_recv_data(MPIR_Data * data, int rank, int tag,
+                         MPIR_Comm * comm, int attr, MPIR_Request ** request);
 int MPIDI_Self_iprobe(int rank, int tag, MPIR_Comm * comm, int attr,
                       int *flag, MPI_Status * status);
 int MPIDI_Self_improbe(int rank, int tag, MPIR_Comm * comm, int attr,

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -182,7 +182,33 @@ MPL_STATIC_INLINE_PREFIX int MPID_Send_data(MPIR_Data * data, int rank, int tag,
     MPIDI_av_entry_t *av = NULL;
     MPIR_FUNC_ENTER;
 
-    MPIR_Assert(0);
+    if (MPIR_is_self_comm(comm)) {
+        mpi_errno = MPIDI_Self_send_data(data, rank, tag, comm, attr, request);
+    } else {
+#if 1
+        MPIR_Assert(0);
+#else
+        *(request) = NULL;
+#ifdef MPIDI_CH4_DIRECT_NETMOD
+        mpi_errno = MPIDI_NM_send_data(data, rank, tag, comm, attr, av, req);
+#else
+        int r;
+        if ((r = MPIDI_av_is_local(av)))
+            mpi_errno = MPIDI_SHM_send_data(data, rank, tag, comm, attr, av, req);
+        else
+            mpi_errno = MPIDI_NM_send_data(data, rank, tag, comm, attr, av, req);
+        if (mpi_errno == MPI_SUCCESS)
+            MPIDI_REQUEST(*req, is_local) = r;
+#endif
+        MPIR_ERR_CHECK(mpi_errno);
+#endif
+    }
+
+    MPIR_ERR_CHECK(mpi_errno);
+
+    if (*request) {
+        MPII_SENDQ_REMEMBER(*request, rank, tag, comm->recvcontext_id, buf, count);
+    }
 
   fn_exit:
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -175,4 +175,20 @@ MPL_STATIC_INLINE_PREFIX int MPID_Cancel_send(MPIR_Request * sreq)
     goto fn_exit;
 }
 
+MPL_STATIC_INLINE_PREFIX int MPID_Send_data(MPIR_Data * data, int rank, int tag,
+                                            MPIR_Comm * comm, int attr, MPIR_Request ** request)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIDI_av_entry_t *av = NULL;
+    MPIR_FUNC_ENTER;
+
+    MPIR_Assert(0);
+
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 #endif /* CH4_SEND_H_INCLUDED */

--- a/src/mpid/ch4/src/mpidig_send.h
+++ b/src/mpid/ch4/src/mpidig_send.h
@@ -27,16 +27,15 @@
 #define MPIDIG_AM_SEND_GET_RNDV_ID(flags) (flags >> 8)
 
 MPL_STATIC_INLINE_PREFIX bool MPIDIG_check_eager(int is_local, MPI_Aint am_hdr_sz, MPI_Aint data_sz,
-                                                 const void *buf, MPI_Aint count,
-                                                 MPI_Datatype datatype, MPIR_Request * sreq)
+                                                 MPIR_Request * sreq)
 {
 #ifdef MPIDI_CH4_DIRECT_NETMOD
-    return MPIDI_NM_am_check_eager(am_hdr_sz, data_sz, buf, count, datatype, sreq);
+    return MPIDI_NM_am_check_eager(am_hdr_sz, data_sz, sreq);
 #else
     if (is_local) {
-        return MPIDI_SHM_am_check_eager(am_hdr_sz, data_sz, buf, count, datatype, sreq);
+        return MPIDI_SHM_am_check_eager(am_hdr_sz, data_sz, sreq);
     } else {
-        return MPIDI_NM_am_check_eager(am_hdr_sz, data_sz, buf, count, datatype, sreq);
+        return MPIDI_NM_am_check_eager(am_hdr_sz, data_sz, sreq);
     }
 #endif
 }
@@ -91,7 +90,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
 
     int is_local = MPIDI_av_is_local(addr);
     MPI_Aint am_hdr_sz = (MPI_Aint) sizeof(am_hdr);
-    if (MPIDIG_check_eager(is_local, am_hdr_sz, data_sz, buf, count, datatype, sreq)) {
+    if (MPIDIG_check_eager(is_local, am_hdr_sz, data_sz, sreq)) {
         /* EAGER send */
         CH4_CALL(am_isend(rank, comm, MPIDIG_SEND, &am_hdr, am_hdr_sz, buf, count, datatype,
                           src_vci, dst_vci, sreq), is_local, mpi_errno);

--- a/src/mpid/ch4/src/mpidig_send.h
+++ b/src/mpid/ch4/src/mpidig_send.h
@@ -40,8 +40,7 @@ MPL_STATIC_INLINE_PREFIX bool MPIDIG_check_eager(int is_local, MPI_Aint am_hdr_s
 #endif
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
-                                               MPI_Datatype datatype, int rank, int tag,
+MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(MPIR_Data * data, int rank, int tag,
                                                MPIR_Comm * comm, int context_offset,
                                                MPIDI_av_entry_t * addr, uint8_t flags,
                                                int src_vci, int dst_vci,
@@ -78,29 +77,35 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
         MPIR_cc_inc(sreq->cc_ptr);      /* expecting SSEND_ACK */
     }
     MPI_Aint data_sz;
-    MPIDI_Datatype_check_size(datatype, count, data_sz);
+    if (data->length > 0) {
+        data_sz = data->length;
+    } else {
+        MPIDI_Datatype_check_size(data->datatype, data->count, data_sz);
+    }
     am_hdr.data_sz = data_sz;
     am_hdr.rndv_hdr_sz = 0;
 
 #ifdef HAVE_DEBUGGER_SUPPORT
-    MPIDIG_REQUEST(sreq, datatype) = datatype;
-    MPIDIG_REQUEST(sreq, buffer) = (void *) buf;
-    MPIDIG_REQUEST(sreq, count) = count;
+    /* FIXME: partial data support in debugger */
+    MPIDIG_REQUEST(sreq, datatype) = data->datatype;
+    MPIDIG_REQUEST(sreq, buffer) = data->buf;
+    MPIDIG_REQUEST(sreq, count) = data->count;
 #endif
 
     int is_local = MPIDI_av_is_local(addr);
     MPI_Aint am_hdr_sz = (MPI_Aint) sizeof(am_hdr);
     if (MPIDIG_check_eager(is_local, am_hdr_sz, data_sz, sreq)) {
         /* EAGER send */
-        CH4_CALL(am_isend(rank, comm, MPIDIG_SEND, &am_hdr, am_hdr_sz, buf, count, datatype,
-                          src_vci, dst_vci, sreq), is_local, mpi_errno);
+        CH4_CALL(am_isend(rank, comm, MPIDIG_SEND, &am_hdr, am_hdr_sz,
+                          data->buf, data->count, data->datatype, src_vci, dst_vci, sreq),
+                 is_local, mpi_errno);
     } else {
         /* RNDV send */
-        MPIDIG_REQUEST(sreq, buffer) = (void *) buf;
-        MPIDIG_REQUEST(sreq, count) = count;
-        MPIDIG_REQUEST(sreq, datatype) = datatype;
+        MPIDIG_REQUEST(sreq, buffer) = data->buf;
+        MPIDIG_REQUEST(sreq, count) = data->count;
+        MPIDIG_REQUEST(sreq, datatype) = data->datatype;
         MPIDIG_REQUEST(sreq, u.send.dest) = rank;
-        MPIR_Datatype_add_ref_if_not_builtin(datatype);
+        MPIR_Datatype_add_ref_if_not_builtin(data->datatype);
         MPIDIG_AM_SEND_SET_RNDV(am_hdr.flags, MPIDIG_RNDV_GENERIC);
 
         CH4_CALL(am_send_hdr(rank, comm, MPIDIG_SEND, &am_hdr, am_hdr_sz, src_vci, dst_vci),
@@ -115,10 +120,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_isend(const void *buf,
-                                              MPI_Aint count,
-                                              MPI_Datatype datatype,
-                                              int rank,
+MPL_STATIC_INLINE_PREFIX int MPIDIG_send_data(MPIR_Data * data, int rank,
                                               int tag, MPIR_Comm * comm, int context_offset,
                                               MPIDI_av_entry_t * addr, int src_vci, int dst_vci,
                                               MPIR_Request ** request,
@@ -128,11 +130,32 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_isend(const void *buf,
     MPIR_FUNC_ENTER;
 
     uint8_t flags = syncflag ? MPIDIG_AM_SEND_FLAGS_SYNC : MPIDIG_AM_SEND_FLAGS_NONE;
-    mpi_errno = MPIDIG_isend_impl(buf, count, datatype, rank, tag, comm, context_offset, addr,
+    mpi_errno = MPIDIG_isend_impl(data, rank, tag, comm, context_offset, addr,
                                   flags, src_vci, dst_vci, request, errflag);
 
     MPIR_FUNC_EXIT;
     return mpi_errno;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_isend(const void *buf,
+                                              MPI_Aint count,
+                                              MPI_Datatype datatype,
+                                              int rank,
+                                              int tag, MPIR_Comm * comm, int context_offset,
+                                              MPIDI_av_entry_t * addr, int src_vci, int dst_vci,
+                                              MPIR_Request ** request,
+                                              bool syncflag, MPIR_Errflag_t errflag)
+{
+    MPIR_Data data = {
+        .buf = (void *) buf,
+        .count = count,
+        .datatype = datatype,
+        .offset = 0,
+        .length = -1,
+    };
+
+    return MPIDIG_send_data(&data, rank, tag, comm, context_offset, addr, src_vci, dst_vci,
+                            request, syncflag, errflag);
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_cancel_send(MPIR_Request * sreq)

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -14,6 +14,8 @@ AM_CONDITIONAL([BUILD_CH4],[test "$device_name" = "ch4"])
 AM_COND_IF([BUILD_CH4],[
 AC_MSG_NOTICE([RUNNING PREREQ FOR CH4 DEVICE])
 
+AC_DEFINE([HAVE_MPIR_DATA], 1, [Define if the device layer supports MPIR_Data.])
+
 # check availability of libfabric, ucx (for purpose of setting default)
 m4_define([libfabric_embedded_dir],[modules/libfabric])
 m4_define([ucx_embedded_dir],[modules/ucx])


### PR DESCRIPTION
## Pull Request Description
Add new MPID send/recv interfaces that accept a data pointer rather
than the (buf, count, datatype) triplet. This allows carrying more
information for extensions. For example, we can support data chunks that
often occur in pipelining algorithms. We may also extend MPIR_Data to
add memory attributes.

Replace -
```
MPID_Send(buf, count, datatype, ...);
MPID_Recv(buf, count, datatype, ...);
```
with
```
MPID_Send_data(MPIR_Data *data, ...);
MPID_Recv_data(MPIR_Data *data, ...);
```
, where `MPIR_Data` is defined as 
```
typedef struct MPIR_Data {
    void *buf;
    MPI_Aint count;
    MPI_Datatype datatype;
    MPI_Aint offset;
    MPI_Aint length;
} MPIR_Data;
```

This allows MPIR-layer pipelining-like algorithms to break the data into chunks without worrying about creating new chunk datatypes.


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
