### PR TITLE
doc: fix mansrc generation

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -124,10 +124,7 @@ def get_mansrc_file_path(func, root_dir):
     dir_path = root_dir
     if 'file' in func:
         file_path = dir_path + '/' + func['file'] + ".txt"
-    elif RE.match(r'MPI_T_(\w+)', func['name'], re.IGNORECASE):
-        name = RE.m.group(1)
-        file_path = dir_path + '/' + name.lower() + ".txt"
-    elif RE.match(r'MPIX?_(\w+)', func['name'], re.IGNORECASE):
+    elif RE.match(r'(MPI(X|_T)?_\w+)', func['name'], re.IGNORECASE):
         name = RE.m.group(1)
         file_path = dir_path + '/' + name.lower() + ".txt"
     else:


### PR DESCRIPTION
## Pull Request Description
Just using the name without prefix, e.g. MPI_Send -> send.txt, resulting in duplicated filenames between MPI_/MPI_T_/MPIX_ functions, and they overwrite each other. This resulted in certain man pages missing. For example, MPI_Finalize and MPI_Init_thread man pages were missing because they were overwritten by the MPI_T_ correspondents.

The fix is to use the whole name for mansrc files, e.g. `MPI_Finalize.txt` and `MPI_T_Finalize.txt`.

Fixes #7089 
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
