### PR TITLE
romio: Add basic GPU-awareness

### DIFF
--- a/src/glue/romio/glue_romio.c
+++ b/src/glue/romio/glue_romio.c
@@ -138,6 +138,26 @@ void MPIR_Ext_cs_yield(void)
     MPIR_Ext_cs_enter();
 }
 
+void *MPIR_Ext_gpu_host_alloc(const void *buf, MPI_Aint count, MPI_Datatype datatype)
+{
+    return MPIR_gpu_host_alloc(buf, count, datatype);
+}
+
+void MPIR_Ext_gpu_host_free(void *host_buf, MPI_Aint count, MPI_Datatype datatype)
+{
+    MPIR_gpu_host_free(host_buf, count, datatype);
+}
+
+void *MPIR_Ext_gpu_host_swap(const void *buf, MPI_Aint count, MPI_Datatype datatype)
+{
+    return MPIR_gpu_host_swap(buf, count, datatype);
+}
+
+void MPIR_Ext_gpu_swap_back(void *host_buf, void *gpu_buf, MPI_Aint count, MPI_Datatype datatype)
+{
+    MPIR_gpu_swap_back(host_buf, gpu_buf, count, datatype);
+}
+
 /* will consider MPI_DATATYPE_NULL to be an error */
 static int ext_datatype_iscommitted(MPI_Datatype datatype)
 {

--- a/src/include/mpir_ext.h.in
+++ b/src/include/mpir_ext.h.in
@@ -72,6 +72,12 @@ void MPIR_Ext_cs_yield(void);
 int MPIR_Ext_datatype_iscommitted(MPI_Datatype datatype);
 int MPIR_Ext_datatype_iscontig(MPI_Datatype datatype, int *flag);
 
+/* for device buffer support in ROMIO */
+void *MPIR_Ext_gpu_host_alloc(const void *buf, MPI_Aint count, MPI_Datatype datatype);
+void MPIR_Ext_gpu_host_free(void *host_buf, MPI_Aint count, MPI_Datatype datatype);
+void *MPIR_Ext_gpu_host_swap(const void *buf, MPI_Aint count, MPI_Datatype datatype);
+void MPIR_Ext_gpu_swap_back(void *host_buf, void *gpu_buf, MPI_Aint count, MPI_Datatype datatype);
+
 /* make comm split based on access to a common file system easier */
 int MPIR_Get_node_id(MPI_Comm comm, int rank, int *id);
 

--- a/src/mpi/romio/mpi-io/iread.c
+++ b/src/mpi/romio/mpi-io/iread.c
@@ -142,6 +142,7 @@ int MPIOI_File_iread(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *bu
     ADIO_File adio_fh;
     ADIO_Offset off, bufsize;
     MPI_Offset nbytes = 0;
+    void *xbuf = NULL, *e32_buf = NULL;
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -174,6 +175,17 @@ int MPIOI_File_iread(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *bu
 
     ADIOI_TEST_DEFERRED(adio_fh, myname, &error_code);
 
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        MPI_Aint e32_size = 0;
+        error_code = MPIU_datatype_full_size(datatype, &e32_size);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        e32_buf = ADIOI_Malloc(e32_size * count);
+        xbuf = e32_buf;
+    }
+
     if (buftype_is_contig && filetype_is_contig) {
         /* convert count and offset to bytes */
         bufsize = datatype_size * count;
@@ -185,7 +197,7 @@ int MPIOI_File_iread(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *bu
         }
 
         if (!(adio_fh->atomicity))
-            ADIO_IreadContig(adio_fh, buf, count, datatype, file_ptr_type,
+            ADIO_IreadContig(adio_fh, xbuf, count, datatype, file_ptr_type,
                              off, request, &error_code);
         else {
             /* to maintain strict atomicity semantics with other concurrent
@@ -194,7 +206,7 @@ int MPIOI_File_iread(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *bu
                 ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
             }
 
-            ADIO_ReadContig(adio_fh, buf, count, datatype, file_ptr_type,
+            ADIO_ReadContig(adio_fh, xbuf, count, datatype, file_ptr_type,
                             off, &status, &error_code);
 
             if (ADIO_Feature(adio_fh, ADIO_LOCKS)) {
@@ -206,8 +218,13 @@ int MPIOI_File_iread(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *bu
             MPIO_Completed_request_create(&adio_fh, nbytes, &error_code, request);
         }
     } else
-        ADIO_IreadStrided(adio_fh, buf, count, datatype, file_ptr_type,
+        ADIO_IreadStrided(adio_fh, xbuf, count, datatype, file_ptr_type,
                           offset, request, &error_code);
+
+    if (e32_buf != NULL) {
+        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
+        ADIOI_Free(e32_buf);
+    }
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();

--- a/src/mpi/romio/mpi-io/iread_all.c
+++ b/src/mpi/romio/mpi-io/iread_all.c
@@ -145,7 +145,7 @@ int MPIOI_File_iread_all(MPI_File fh,
     int error_code;
     MPI_Count datatype_size;
     ADIO_File adio_fh;
-    void *xbuf = NULL, *e32_buf = NULL;
+    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -182,6 +182,11 @@ int MPIOI_File_iread_all(MPI_File fh,
 
         e32_buf = ADIOI_Malloc(e32_size * count);
         xbuf = e32_buf;
+    } else {
+        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
     }
 
     ADIO_IreadStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
@@ -196,6 +201,8 @@ int MPIOI_File_iread_all(MPI_File fh,
         error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
         ADIOI_Free(e32_buf);
     }
+
+    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();

--- a/src/mpi/romio/mpi-io/iwrite.c
+++ b/src/mpi/romio/mpi-io/iwrite.c
@@ -147,6 +147,7 @@ int MPIOI_File_iwrite(MPI_File fh,
     MPI_Offset nbytes = 0;
     void *e32buf = NULL;
     const void *xbuf = NULL;
+    void *host_buf = NULL;
 
     ROMIO_THREAD_CS_ENTER();
     adio_fh = MPIO_File_resolve(fh);
@@ -185,6 +186,11 @@ int MPIOI_File_iwrite(MPI_File fh,
             goto fn_exit;
 
         xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
     }
 
     if (buftype_is_contig && filetype_is_contig) {
@@ -222,6 +228,9 @@ int MPIOI_File_iwrite(MPI_File fh,
         ADIO_IwriteStrided(adio_fh, xbuf, count, datatype, file_ptr_type,
                            offset, request, &error_code);
     }
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
+
   fn_exit:
     if (e32buf != NULL)
         ADIOI_Free(e32buf);

--- a/src/mpi/romio/mpi-io/iwrite_all.c
+++ b/src/mpi/romio/mpi-io/iwrite_all.c
@@ -136,6 +136,7 @@ int MPIOI_File_iwrite_all(MPI_File fh,
     ADIO_File adio_fh;
     void *e32buf = NULL;
     const void *xbuf = NULL;
+    void *host_buf = NULL;
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -170,6 +171,11 @@ int MPIOI_File_iwrite_all(MPI_File fh,
             goto fn_exit;
 
         xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
     }
 
     ADIO_IwriteStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
@@ -179,6 +185,8 @@ int MPIOI_File_iwrite_all(MPI_File fh,
     if (error_code != MPI_SUCCESS)
         error_code = MPIO_Err_return_file(adio_fh, error_code);
     /* --END ERROR HANDLING-- */
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
 
   fn_exit:
     if (e32buf != NULL)

--- a/src/mpi/romio/mpi-io/mpioimpl.h
+++ b/src/mpi/romio/mpi-io/mpioimpl.h
@@ -25,6 +25,27 @@
         err_ =  MPIR_Ext_datatype_iscommitted(dtype_); \
     } while (0)
 
+#define MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype)             \
+    do {                                                                \
+        host_buf = MPIR_Ext_gpu_host_alloc(buf, count, datatype);       \
+    } while (0)
+#define MPIO_GPU_HOST_FREE(host_buf, count, datatype)                   \
+    do {                                                                \
+        if (host_buf != NULL) {                                         \
+            MPIR_Ext_gpu_host_free(host_buf, count, datatype);          \
+        }                                                               \
+    } while (0)
+#define MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype)              \
+    do {                                                                \
+        host_buf = MPIR_Ext_gpu_host_swap(buf, count, datatype);        \
+    } while (0)
+#define MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype)              \
+    do {                                                                \
+        if (host_buf != NULL) {                                         \
+            MPIR_Ext_gpu_swap_back(host_buf, buf, count, datatype);     \
+        }                                                               \
+    } while (0)
+
 #else /* not ROMIO_INSIDE_MPICH */
 /* Any MPI implementation that wishes to follow the thread-safety and
    error reporting features provided by MPICH must implement these
@@ -34,6 +55,11 @@
 #define ROMIO_THREAD_CS_EXIT()
 #define ROMIO_THREAD_CS_YIELD()
 #define MPIO_DATATYPE_ISCOMMITTED(dtype_, err_) do {} while (0)
+/* functions for GPU-awareness */
+#define MPIO_GPU_HOST_ALLOC(...) do {} while (0)
+#define MPIO_GPU_HOST_FREE(...) do {} while (0)
+#define MPIO_GPU_HOST_SWAP(...) do {} while (0)
+#define MPIO_GPU_SWAP_BACK(...) do {} while (0)
 #endif /* ROMIO_INSIDE_MPICH */
 
 /* info is a linked list of these structures */

--- a/src/mpi/romio/mpi-io/read.c
+++ b/src/mpi/romio/mpi-io/read.c
@@ -127,7 +127,7 @@ int MPIOI_File_read(MPI_File fh,
     MPI_Count datatype_size;
     ADIO_File adio_fh;
     ADIO_Offset off, bufsize;
-    void *xbuf = NULL, *e32_buf = NULL;
+    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -180,6 +180,11 @@ int MPIOI_File_read(MPI_File fh,
 
         e32_buf = ADIOI_Malloc(e32_size * count);
         xbuf = e32_buf;
+    } else {
+        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
     }
 
     if (buftype_is_contig && filetype_is_contig) {
@@ -219,6 +224,8 @@ int MPIOI_File_read(MPI_File fh,
         error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
         ADIOI_Free(e32_buf);
     }
+
+    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();

--- a/src/mpi/romio/mpi-io/read_all.c
+++ b/src/mpi/romio/mpi-io/read_all.c
@@ -127,7 +127,7 @@ int MPIOI_File_read_all(MPI_File fh,
     int error_code;
     MPI_Count datatype_size;
     ADIO_File adio_fh;
-    void *xbuf = NULL, *e32_buf = NULL;
+    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -164,6 +164,11 @@ int MPIOI_File_read_all(MPI_File fh,
 
         e32_buf = ADIOI_Malloc(e32_size * count);
         xbuf = e32_buf;
+    } else {
+        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
     }
 
     ADIO_ReadStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
@@ -178,6 +183,8 @@ int MPIOI_File_read_all(MPI_File fh,
         error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
         ADIOI_Free(e32_buf);
     }
+
+    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();

--- a/src/mpi/romio/mpi-io/write_all.c
+++ b/src/mpi/romio/mpi-io/write_all.c
@@ -128,6 +128,7 @@ int MPIOI_File_write_all(MPI_File fh,
     ADIO_File adio_fh;
     void *e32buf = NULL;
     const void *xbuf = NULL;
+    void *host_buf = NULL;
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -162,6 +163,11 @@ int MPIOI_File_write_all(MPI_File fh,
             goto fn_exit;
 
         xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
     }
     ADIO_WriteStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
                           offset, status, &error_code);
@@ -170,6 +176,8 @@ int MPIOI_File_write_all(MPI_File fh,
     if (error_code != MPI_SUCCESS)
         error_code = MPIO_Err_return_file(adio_fh, error_code);
     /* --END ERROR HANDLING-- */
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
 
   fn_exit:
     if (e32buf != NULL)

--- a/src/mpi/romio/mpi-io/write_allb.c
+++ b/src/mpi/romio/mpi-io/write_allb.c
@@ -100,6 +100,7 @@ int MPIOI_File_write_all_begin(MPI_File fh,
     ADIO_File adio_fh;
     void *e32buf = NULL;
     const void *xbuf = NULL;
+    void *host_buf = NULL;
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -142,6 +143,11 @@ int MPIOI_File_write_all_begin(MPI_File fh,
             goto fn_exit;
 
         xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
     }
 
     adio_fh->split_datatype = datatype;
@@ -152,6 +158,8 @@ int MPIOI_File_write_all_begin(MPI_File fh,
     if (error_code != MPI_SUCCESS)
         error_code = MPIO_Err_return_file(adio_fh, error_code);
     /* --END ERROR HANDLING-- */
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
 
   fn_exit:
     if (e32buf != NULL)

--- a/src/mpi/romio/mpi-io/write_ord.c
+++ b/src/mpi/romio/mpi-io/write_ord.c
@@ -99,6 +99,7 @@ int MPIOI_File_write_ordered(MPI_File fh, const void *buf, MPI_Aint count,
     ADIO_File adio_fh;
     void *e32buf = NULL;
     const void *xbuf;
+    void *host_buf = NULL;
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -153,6 +154,11 @@ int MPIOI_File_write_ordered(MPI_File fh, const void *buf, MPI_Aint count,
             goto fn_exit;
 
         xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
     }
 
     ADIO_WriteStridedColl(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
@@ -162,6 +168,8 @@ int MPIOI_File_write_ordered(MPI_File fh, const void *buf, MPI_Aint count,
     if (error_code != MPI_SUCCESS)
         error_code = MPIO_Err_return_file(adio_fh, error_code);
     /* --END ERROR HANDLING-- */
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
 
   fn_exit:
     if (e32buf != NULL)

--- a/src/mpi/romio/mpi-io/write_ordb.c
+++ b/src/mpi/romio/mpi-io/write_ordb.c
@@ -93,6 +93,7 @@ int MPIOI_File_write_ordered_begin(MPI_File fh, const void *buf, MPI_Aint count,
     ADIO_File adio_fh;
     void *e32buf = NULL;
     const void *xbuf = NULL;
+    void *host_buf = NULL;
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -154,6 +155,11 @@ int MPIOI_File_write_ordered_begin(MPI_File fh, const void *buf, MPI_Aint count,
             goto fn_exit;
 
         xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
     }
 
     ADIO_WriteStridedColl(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
@@ -163,6 +169,8 @@ int MPIOI_File_write_ordered_begin(MPI_File fh, const void *buf, MPI_Aint count,
     if (error_code != MPI_SUCCESS)
         error_code = MPIO_Err_return_file(adio_fh, error_code);
     /* --END ERROR HANDLING-- */
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();

--- a/src/mpi/romio/mpi-io/write_sh.c
+++ b/src/mpi/romio/mpi-io/write_sh.c
@@ -98,6 +98,7 @@ int MPIOI_File_write_shared(MPI_File fh, const void *buf, MPI_Aint count,
     ADIO_File adio_fh;
     void *e32buf = NULL;
     const void *xbuf = NULL;
+    void *host_buf = NULL;
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -152,6 +153,11 @@ int MPIOI_File_write_shared(MPI_File fh, const void *buf, MPI_Aint count,
             goto fn_exit;
 
         xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
     }
 
     if (buftype_is_contig && filetype_is_contig) {
@@ -181,6 +187,8 @@ int MPIOI_File_write_shared(MPI_File fh, const void *buf, MPI_Aint count,
     if (error_code != MPI_SUCCESS)
         error_code = MPIO_Err_return_file(adio_fh, error_code);
     /* --END ERROR HANDLING-- */
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
 
   fn_exit:
     if (e32buf != NULL)


### PR DESCRIPTION
## Pull Request Description

Allocate and use host buffers to perform I/O, if device buffers are detected. Fixes pmodels/mpich#7044.

For read APIs, the pattern is:
  - allocate host buffer
  - perform read
  - copy data to device

For write APIs:
  - allocate and copy data to host buffer
  - perform write
  - free host buffer

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
