### PR TITLE
doc: correcting mpiexec man page

### DIFF
--- a/src/pm/hydra/mansrc/mpiexec.txt
+++ b/src/pm/hydra/mansrc/mpiexec.txt
@@ -14,28 +14,27 @@
     mpiexec -n 4 a.out
 .ve
 
-The MPI standard specifies the following arguments and their meanings\:
+The MPI standard suggests the following arguments and their meanings\:
 
 + \-n <np> - Specify the number of processes to use
 . \-host <hostname> - Name of host on which to run processes
-. \-arch <architecture name> - Pick hosts with this architecture type
 . \-wdir <working directory> - cd to this one `before` running executable
+- \-configfile <name> - file containing specifications of host/program,
+   one per line, with # as a comment indicator, e.g., the usual
+   mpiexec input. The lines excluding comments are concatenated with newlines
+   replaced with spaces, and are then parsed as command line options.
+
+The following options are reserved by the MPI standard, but they are not
+supported by MPICH (hydra)\:
+
++ \-arch <architecture name> - Pick hosts with this architecture type
 . \-path <pathlist> - use this to find the executable
 . \-soft <triplets> - comma separated triplets that specify requested numbers
    of processes (see the MPI-2 specification for more details)
-. \-file <name> - implementation-defined specification file
-- \-configfile <name> - file containing specifications of host/program,
-   one per line, with # as a comment indicator, e.g., the usual
-   mpiexec input, but with ":" replaced with a newline.  That is,
-   the configfile contains lines with -soft, -n etc.
+- \-file <name> - implementation-defined specification file
 
    Additional arguments that are specific to the MPICH implementation
    are discussed below.
-
-   Note that not all of these parameters are meaningful for all 
-   systems.  For example, the 'gforker' version of 'mpiexec' creates all
-   processes on the same system on which it is running; in that case, the 
-   '\-arch' and '\-host' options are ignored.
 
    The colon character (':') may be used to separate different executables
    for MPMD (multiple program multiple data) programming.  For example,


### PR DESCRIPTION
## Pull Request Description
Not all standard suggested options are supported and the `-configfile` syntax differs from the standard -- FIXME.

The standard lists a set of options as suggestions. Implementations are not required to support all of them.  `hydra` does not support options such as `-soft`, `-arch`, `-path`, `-file`. Thus, we should reflect that in man page rather than to mislead users.

`-configfile` is supported by `hydra`, however, not according to the syntax specified by the standard. For example, the standard suggests the following example:
```
-n 5 ocean
-n 10 atmos
```
, where both `ocean` and `atmos` are executable programs. However, `hydra` simply concatenates the lines and parses as a single command line option, thus not able to parse the above example due to missing `:` between the two programs. I.e. the newline is significant in the standard but insignificant in `hydra`.

This PR updates the man page to reflect the hydra behavior. It is a future `FIXME` to fix the behavior to be consistent with the standard.

Fixes #7086

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
