### PR TITLE
ch4: default MPIR_CVAR_CH4_ROOTS_ONLY_PMI on

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -823,9 +823,6 @@ int MPIDI_OFI_init_world(void)
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    if (MPIR_CVAR_DEBUG_SUMMARY && MPIR_Process.rank == 0) {
-        dump_dynamic_settings();
-    }
   fn_exit:
     return mpi_errno;
   fn_fail:
@@ -865,6 +862,10 @@ int MPIDI_OFI_init_vcis(int num_vcis, int *num_vcis_actual)
 int MPIDI_OFI_post_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
+
+    if (MPIR_CVAR_DEBUG_SUMMARY && MPIR_Process.rank == 0) {
+        dump_dynamic_settings();
+    }
 
     /* Since we allow different process to have different num_vcis, we always need run exchange. */
     mpi_errno = MPIDI_OFI_addr_exchange_all_ctx();

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -113,9 +113,8 @@ static int initial_address_exchange(void)
         /* insert new addresses, skipping over node roots */
         for (int i = 0; i < MPIR_Process.size; i++) {
             if (rank_map[i] >= 0) {
-
                 ep_params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
-                ep_params.address = (ucp_address_t *) ((char *) table + i * recv_bc_len);
+                ep_params.address = (ucp_address_t *) ((char *) table + rank_map[i] * recv_bc_len);
                 ucx_status = ucp_ep_create(MPIDI_UCX_global.ctx[0].worker, &ep_params,
                                            &MPIDI_UCX_AV(&MPIDIU_get_av(0, i)).dest[0][0]);
                 MPIDI_UCX_CHK_STATUS(ucx_status);

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -46,7 +46,7 @@ cvars:
     - name        : MPIR_CVAR_CH4_ROOTS_ONLY_PMI
       category    : CH4
       type        : boolean
-      default     : false
+      default     : true
       class       : none
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_LOCAL

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -83,15 +83,16 @@ int MPIDU_bc_allgather(MPIR_Comm * allgather_comm, void *bc, int bc_len, int sam
         int root_rank = MPIR_Process.node_root_map[i];
         rank_map[root_rank] = -1;
     }
-    /* prepare for Allgatherv */
-    for (i = 0; i < num_nodes; i++) {
-        recv_cnts[i] *= bc_len;
-        recv_offs[i] *= bc_len;
-    }
 
+    /* prepare for Allgatherv */
     int recv_bc_len = bc_len;
     if (!same_len) {
         recv_bc_len = MPID_MAX_BC_SIZE;
+    }
+
+    for (i = 0; i < num_nodes; i++) {
+        recv_cnts[i] *= recv_bc_len;
+        recv_offs[i] *= recv_bc_len;
     }
 
     mpi_errno = MPIDU_Init_shm_barrier();


### PR DESCRIPTION
## Pull Request Description
Using ROOTS_ONLY_PMI significantly improves the large-scale init time. It is about time to make it default.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
