### PR TITLE
doc: create alias man pages for large count routines

### DIFF
--- a/maint/alias_mancnst
+++ b/maint/alias_mancnst
@@ -25,3 +25,15 @@ while (<In>) {
     }
 }
 close In;
+
+# large count routines
+open In, "grep '^int MPI\\w*_c\\>' man/man3/*.3 |" or die "Failed to grep for large count man pages\n";
+while (<In>) {
+    # e.g. [man/man3/MPI_Recv.3:int MPI_Recv_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source,] 
+    if (/^man\/man3\/(MPI\w+)\.3:int (MPI\w+_c)\(/) {
+        open Out, "> man/man3/$2.3" or die "Can't create man/man3/$2.3\n";
+        print Out ".so man3/$1.3\n";
+        close Out;
+    }
+}
+close In;


### PR DESCRIPTION
## Pull Request Description
We list the large count routines in the same man page of their normal count routines, but the entries are missing. This commit creates the alias man pages for them.

Fixes https://github.com/pmodels/mpich/issues/6973
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
