### PR TITLE
romio: add special-case DAOS detection logic

### DIFF
--- a/src/mpi/romio/adio/common/ad_fstype.c
+++ b/src/mpi/romio/adio/common/ad_fstype.c
@@ -41,6 +41,14 @@
 #include "gpfs.h"
 #endif
 
+#ifdef ROMIO_DAOS
+#include <daos_types.h>
+#include <daos_obj_class.h>
+#include <daos_cont.h>
+#include <daos_prop.h>
+#include <daos_uns.h>
+#endif
+
 /* Notes on detection process:
  *
  * There are three more "general" mechanisms that we use for detecting
@@ -100,6 +108,10 @@
 
 #if !defined(DAOS_SUPER_MAGIC)
 #define DAOS_SUPER_MAGIC (0xDA05AD10)
+#endif
+
+#if !defined(FUSE_SUPER_MAGIC)
+#define FUSE_SUPER_MAGIC  0x65735546
 #endif
 
 #define UNKNOWN_SUPER_MAGIC (0xDEADBEEF)
@@ -198,6 +210,10 @@ static struct ADIO_FSTypes fstypes[] = {
     /* userspace driver only selected via prefix */
     {&ADIO_QUOBYTEFS_operations, ADIO_QUOBYTEFS, "quobyte:", 0},
 #endif
+    /* we don't have a FUSE ADIO driver, but this data structure is also
+     * helpful in `romio_statfs` where we have to map string identifiers to
+     * file ids */
+    {NULL, 0, "fuse", FUSE_SUPER_MAGIC},
     {0, 0, 0, 0}        /* guard entry */
 };
 
@@ -370,6 +386,23 @@ static int romio_statfs(const char *filename, int64_t * file_id)
         }
     }
 #endif
+    /* fuse is a special case: normally we don't care if a file is on fuse
+     * or not, unless that file is actually a DAOS file */
+    if (*file_id == FUSE_SUPER_MAGIC) {
+        *file_id = UNKNOWN_SUPER_MAGIC;
+#ifdef ROMIO_DAOS
+        int ret;
+        /* DAOS adds a wrinkle here:  fuse overwrites the backend's stat structure
+         * with the fuse filesystem type.  For DAOS, we have to make a special call
+         * to see if a file on FUSE is actually DAOS */
+        struct duns_attr_t attr = { 0 };;
+
+        ret = duns_resolve_path(filename, &attr);
+        if (ret == 0)
+            *file_id = DAOS_SUPER_MAGIC;
+        duns_destroy_attr(&attr);
+#endif
+    }
 
     return err;
 


### PR DESCRIPTION
## Pull Request Description

If users provide the 'daos:' prefix, ROMIO will use the DAOS apis directly no problem.

if users only provide a path to a file that is on daos, ROMIO's auto-detection logic will see the file system is of type "fuse", and that otherwise-unknown file system will be treated as "generic unix" (and perform pretty badly).

There appears to be no way to get FUSE to tell us what's really going on behind the scenes, so we'll look extra-hard at fuse-type files to see if it's DAOS or not.  

I'm not stoked about this abstraction layering violation but I don't think there are other options.  All the fs-detection magic is stuffed in this one part of ROMIO, so if we find ourselves wondering about other FUSE file systems, we can keep on adding to the logic here. 

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
