### PR TITLE
doc: generate alias doc for large-count APIs (2nd try)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -561,7 +561,7 @@ mandoc-local: $(doc1_src_txt:.txt=.man1-phony) \
 		fi \
 	    fi \
 	done
-	$(srcdir)/maint/alias_mancnst
+	$(srcdir)/maint/alias_mancnst -srcdir=$(top_srcdir)
 
 # use htmldoc-local target to force directory creation before running DOCTEXT
 # Note that the mpi.cit is appended to by each update, so it must be removed
@@ -590,7 +590,7 @@ htmldoc-local: $(doc1_src_txt:.txt=.html1-phony) \
 		fi \
 	    fi \
 	done
-	$(srcdir)/maint/createhtmlindex -wwwroot=$(top_builddir)
+	$(srcdir)/maint/createhtmlindex -wwwroot=$(top_builddir) -srcdir=$(top_srcdir)
 
 # install-man does not have a special "-local" target for some reason
 if INSTALL_DOCS

--- a/maint/alias_mancnst
+++ b/maint/alias_mancnst
@@ -10,6 +10,13 @@
 
 use strict;
 
+my $srcdir = ".";
+foreach my $a (@ARGV) {
+    if ($a =~ /--?srcdir=(.+)/) {
+        $srcdir = $1;
+    }
+}
+
 if (!-e "man/man3/Constants.3") {
     die "man/man3/Constants.3 not found.\n";
 }
@@ -27,10 +34,11 @@ while (<In>) {
 close In;
 
 # large count routines
-open In, "grep '^int MPI\\w*_c\\>' man/man3/*.3 |" or die "Failed to grep for large count man pages\n";
+my $poly_aliases_lst = "$srcdir/src/binding/c/mansrc/poly_aliases.lst";
+open In, $poly_aliases_lst or die "Failed to open $poly_aliases_lst\n";
 while (<In>) {
-    # e.g. [man/man3/MPI_Recv.3:int MPI_Recv_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source,] 
-    if (/^man\/man3\/(MPI\w+)\.3:int (MPI\w+_c)\(/) {
+    # e.g. MPI_Recv - MPI_Recv_c
+    if (/^(MPI\w+) - (MPI\w+)/) {
         open Out, "> man/man3/$2.3" or die "Can't create man/man3/$2.3\n";
         print Out ".so man3/$1.3\n";
         close Out;

--- a/maint/createhtmlindex
+++ b/maint/createhtmlindex
@@ -12,6 +12,10 @@ use strict;
 # Root for the pages
 my $WWWRoot=`pwd`;
 chop $WWWRoot;
+
+# in case for out-of-tree build
+my $srcdir = ".";
+
 # End of line character (\r\n is DOS-friendly)
 my $eol = "\r\n";
 # Number of columns in table of names
@@ -21,6 +25,9 @@ my $TableCols = 3;
 foreach $a (@ARGV) {
     if ($a =~ /-?-wwwroot=(.*)/) {
 	$WWWRoot = $1;
+    }
+    elsif ($a =~ /-?-srcdir=(.*)/) {
+	$srcdir = $1;
     }
     elsif ($a =~ /-?help/) {
 	print STDOUT "createhtmlindex [ -wwwroot=directory ]\n\n";
@@ -34,6 +41,19 @@ foreach $a (@ARGV) {
 	exit 1;
     }
 }
+
+# ---- Create the alias pages for large count functions ----
+my $poly_aliases_lst = "$srcdir/src/binding/c/mansrc/poly_aliases.lst";
+open In, $poly_aliases_lst or die "Failed to open $poly_aliases_lst\n";
+while (<In>) {
+    # e.g. MPI_Recv - MPI_Recv_c
+    if (/^(MPI\w+) - (MPI\w+)/) {
+        open Out, "> www/www3/$2.html" or die "Can't create www/www3/$2.html\n";
+        print Out "<meta http-equiv=\"refresh\" content=\"0; url=$1.html\">\n";
+        close Out;
+    }
+}
+close In;
 
 # ---- Create the main index ----
 open( OUTFD, ">$WWWRoot/www/index.html" ) ||

--- a/maint/gen_binding_c.py
+++ b/maint/gen_binding_c.py
@@ -55,6 +55,7 @@ def main():
     G.out.append("#include \"mpiimpl.h\"")
     G.out.append("")
     G.doc3_src_txt = []
+    G.poly_aliases = [] # large-count mansrc aliases
     G.need_dump_romio_reference = True
 
     # internal function to dump G.out into filepath
@@ -82,6 +83,8 @@ def main():
                 for l in manpage_out:
                     print(l.rstrip(), file=Out)
             G.doc3_src_txt.append(f)
+            if func['_has_poly']:
+                G.poly_aliases.append(func['name'])
 
     def dump_func_abi(func):
         func['_is_abi'] = True
@@ -138,6 +141,12 @@ def main():
     G.check_write_path(abi_file_path)
     dump_c_file(abi_file_path, G.out)
     G.out = []
+
+    if 'output-mansrc' in G.opts:
+        f = c_dir + '/mansrc/' + 'poly_aliases.lst'
+        with open(f, "w") as Out:
+            for name in G.poly_aliases:
+                print("%s - %s_c" % (name, name), file=Out)
 
     # -- Dump other files --
     G.check_write_path("src/include")


### PR DESCRIPTION
## Pull Request Description
Last commit ae7bba3 didn't create html pages for large count routines. That commit was a bit hackish by assuming the content pattern of the man page, and we can't reuse the same hack for html aliases since html docs are independent from man pages in principle.

This commit revise the mechanism by generating a poly_aliases list file during binding/mansrc generation, thus a more robust mechanism.

References #7112
Fixes #7116
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
