### PR TITLE
ch4/request: enhance progress debugging

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -297,7 +297,7 @@ extern MPIR_Request MPIR_Request_direct[MPIR_REQUEST_PREALLOC];
 #ifdef MPICH_DEBUG_PROGRESS
 #define MPIR_REQUEST_SET_INFO(req, ...) \
     do { \
-        MPL_snprintf((req)->info, 100, __VA_ARGS__); \
+        MPL_snprintf_nowarn((req)->info, 100, __VA_ARGS__); \
     } while (0)
 
 #define MPIR_REQUEST_DEBUG(req) \
@@ -308,7 +308,7 @@ extern MPIR_Request MPIR_Request_direct[MPIR_REQUEST_PREALLOC];
     } while (0)
 #else
 
-#define MPIR_REQUEST_SET_INFO(req, info) do { } while (0)
+#define MPIR_REQUEST_SET_INFO(req, ...) do { } while (0)
 #define MPIR_REQUEST_DEBUG(req) do { } while (0)
 #endif
 

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -193,6 +193,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         }
     }
 
+    MPIR_REQUEST_SET_INFO(rreq, "MPIDI_OFI_do_irecv: source=%d, tag=%d, data_sz=%ld", rank, tag,
+                          data_sz);
     if (!dt_contig || force_gpu_pack) {
         if (MPIDI_OFI_ENABLE_PT2PT_NOPACK && !force_gpu_pack &&
             ((data_sz < MPIDI_OFI_global.max_msg_size && !MPIDI_OFI_COMM(comm).enable_striping) ||

--- a/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
@@ -207,6 +207,8 @@ static int create_unexp_rreq(int rank, int tag, MPIR_Context_id_t context_id,
 
     MPIR_Request *rreq = MPIDIG_request_create(MPIR_REQUEST_KIND__RECV, 2, local_vci, remote_vci);
     MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+    MPIR_REQUEST_SET_INFO(rreq, "create_unexp_rreq: source=%d, tag=%d, data_sz=%ld", rank, tag,
+                          data_sz);
 
     *req = rreq;
 

--- a/src/mpid/ch4/src/mpidig_recv.h
+++ b/src/mpid/ch4/src/mpidig_recv.h
@@ -285,6 +285,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
         MPIR_Datatype_add_ref_if_not_builtin(datatype);
         MPIDIG_prepare_recv_req(rank, tag, context_id, buf, count, datatype, rreq);
         MPIDIG_enqueue_request(rreq, &MPIDI_global.per_vci[vci].posted_list, MPIDIG_PT2PT_POSTED);
+        MPIR_REQUEST_SET_INFO(rreq, "MPIDIG_do_irecv: source=%d, tag=%d, count=%ld, datatype=%x",
+                              rank, tag, count, datatype);
     }
 
   fn_exit:


### PR DESCRIPTION
## Pull Request Description
Continue enhancing the debugging feature based on last PR #7084 
* add request info for receives, since most progress hungs are from receiver not receiving message
* automatically abort after double the timeout value (`MPIR_CVAR_DEBUG_PROGRESS_TIMEOUT`). It's annoying one has to manually stop the job after it hangs. Just make sure to set copious amount of time for timeout in order to catch information from all pending processes. I would start with 1 sec and increase to 10 and higher if that's insufficient.

[skip warnings]

Example:
```
~/work/pull_requests/2408_debug_progress/temp$ MPIR_CVAR_DEBUG_PROGRESS_TIMEOUT=1 mpirun -n 3 ./t
2 pending requests in pool 0
    ac000000: MPIDIG_do_irecv: source=1, tag=0, count=1, datatype=4c000405
    ac000001: create_unexp_rreq: source=2, tag=1, data_sz=0
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(MPL_backtrace_show+0x39) [0x7ff500f13a59]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x2faf06) [0x7ff500ddcf06]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x2fb090) [0x7ff500ddd090]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(MPI_Recv+0x46d) [0x7ff500c42efd]
./t(+0x125f) [0x5603973bd25f]
/lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7ff5008c2d90]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7ff5008c2e40]
./t(+0x1125) [0x5603973bd125]
1 pending requests in pool 0
    ac000000: MPIDIG_do_irecv: source=0, tag=1, count=0, datatype=4c00010d
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(MPL_backtrace_show+0x39) [0x7f89e7370a59]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x2faf06) [0x7f89e7239f06]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x2fb090) [0x7f89e723a090]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x1e226b) [0x7f89e712126b]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x1e2d15) [0x7f89e7121d15]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x1c42fe) [0x7f89e71032fe]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x2251be) [0x7f89e71641be]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x2252bb) [0x7f89e71642bb]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x2254db) [0x7f89e71644db]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x22590b) [0x7f89e716490b]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x229ca0) [0x7f89e7168ca0]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(MPI_Barrier+0x30a) [0x7f89e70021ea]
./t(+0x126d) [0x561ec9f0c26d]
/lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7f89e6d1fd90]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7f89e6d1fe40]
./t(+0x1125) [0x561ec9f0c125]
2 pending requests in pool 0
    ac000000: MPIDIG_do_irecv: source=0, tag=1, count=0, datatype=4c00010d
    ac000001: create_unexp_rreq: source=2, tag=1, data_sz=0
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(MPL_backtrace_show+0x39) [0x7f01b58cda59]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x2faf06) [0x7f01b5796f06]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x2fb090) [0x7f01b5797090]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x1e226b) [0x7f01b567e26b]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x1e2d15) [0x7f01b567ed15]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x1c42fe) [0x7f01b56602fe]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x2251be) [0x7f01b56c11be]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x2252bb) [0x7f01b56c12bb]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x2254db) [0x7f01b56c14db]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x22590b) [0x7f01b56c190b]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(+0x229ca0) [0x7f01b56c5ca0]
/home/hzhou/work/pull_requests/2408_debug_progress/_inst/lib/libmpi.so.0(MPI_Barrier+0x30a) [0x7f01b555f1ea]
./t(+0x126d) [0x5589af1e026d]
/lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x7f01b527cd90]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7f01b527ce40]
./t(+0x1125) [0x5589af1e0125]
```

* [ ] I am not sure why the following code didn't result the above test to show the usual error stack.
```
 } else if (time_diff > MPIR_CVAR_DEBUG_PROGRESS_TIMEOUT * 2) { \
     MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**timeout"); \
 } \
 ```
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
