### PR TITLE
coll: remove ssend in allgatherv linear algorithm

### DIFF
--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -41,8 +41,6 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
                           MPIR_Comm * comm_ptr, MPI_Status * status, MPIR_Errflag_t errflag);
 int MPIC_Isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
                MPIR_Comm * comm_ptr, MPIR_Request ** request, MPIR_Errflag_t errflag);
-int MPIC_Issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-                MPIR_Comm * comm_ptr, MPIR_Request ** request, MPIR_Errflag_t errflag);
 int MPIC_Irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source,
                int tag, MPIR_Comm * comm_ptr, MPIR_Request ** request);
 int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status * statuses);

--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -31,8 +31,6 @@ int MPIC_Send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, 
               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag);
 int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int tag,
               MPIR_Comm * comm_ptr, MPI_Status * status);
-int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag);
 int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                   int dest, int sendtag, void *recvbuf, MPI_Aint recvcount,
                   MPI_Datatype recvtype, int source, int recvtag,

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -433,41 +433,6 @@ int MPIC_Isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
     goto fn_exit;
 }
 
-int MPIC_Issend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-                MPIR_Comm * comm_ptr, MPIR_Request ** request_ptr, MPIR_Errflag_t errflag)
-{
-    int mpi_errno = MPI_SUCCESS;
-    int attr = 0;
-
-    MPIR_FUNC_ENTER;
-
-    /* Create a completed request and return immediately for dummy process */
-    if (unlikely(dest == MPI_PROC_NULL)) {
-        *request_ptr = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
-        MPIR_ERR_CHKANDSTMT((*request_ptr) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
-                            "**nomemreq");
-        goto fn_exit;
-    }
-
-    MPIR_ERR_CHKANDJUMP1((count < 0), mpi_errno, MPI_ERR_COUNT,
-                         "**countneg", "**countneg %d", count);
-
-    MPIR_PT2PT_ATTR_SET_CONTEXT_OFFSET(attr, MPIR_CONTEXT_COLL_OFFSET);
-    MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
-    MPIR_PT2PT_ATTR_SET_SYNCFLAG(attr);
-
-    DO_MPID_ISEND(buf, count, datatype, dest, tag, comm_ptr, attr, request_ptr);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    MPIR_FUNC_EXIT;
-    return mpi_errno;
-  fn_fail:
-    if (mpi_errno == MPIX_ERR_NOREQ)
-        MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**nomem");
-    goto fn_exit;
-}
-
 int MPIC_Irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source,
                int tag, MPIR_Comm * comm_ptr, MPIR_Request ** request_ptr)
 {

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -215,48 +215,6 @@ int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int 
     /* --END ERROR HANDLING-- */
 }
 
-int MPIC_Ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, int tag,
-               MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
-{
-    int mpi_errno = MPI_SUCCESS;
-    int attr = 0;
-    MPIR_Request *request_ptr = NULL;
-
-    MPIR_FUNC_ENTER;
-
-    /* Return immediately for dummy process */
-    if (unlikely(dest == MPI_PROC_NULL)) {
-        goto fn_exit;
-    }
-
-    MPIR_ERR_CHKANDJUMP1((count < 0), mpi_errno, MPI_ERR_COUNT,
-                         "**countneg", "**countneg %d", count);
-
-    MPIR_PT2PT_ATTR_SET_CONTEXT_OFFSET(attr, MPIR_CONTEXT_COLL_OFFSET);
-    MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
-    MPIR_PT2PT_ATTR_SET_SYNCFLAG(attr);
-
-    DO_MPID_ISEND(buf, count, datatype, dest, tag, comm_ptr, attr, &request_ptr);
-    MPIR_ERR_CHECK(mpi_errno);
-    if (request_ptr) {
-        mpi_errno = MPIC_Wait(request_ptr);
-        MPIR_ERR_CHECK(mpi_errno);
-        MPIR_Request_free(request_ptr);
-    }
-
-  fn_exit:
-    MPIR_FUNC_EXIT;
-    return mpi_errno;
-  fn_fail:
-    /* --BEGIN ERROR HANDLING-- */
-    if (mpi_errno == MPIX_ERR_NOREQ)
-        MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**nomem");
-    if (request_ptr)
-        MPIR_Request_free(request_ptr);
-    goto fn_exit;
-    /* --END ERROR HANDLING-- */
-}
-
 int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                   int dest, int sendtag, void *recvbuf, MPI_Aint recvcount,
                   MPI_Datatype recvtype, int source, int recvtag,

--- a/src/mpi/coll/igatherv/igatherv_allcomm_sched_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_allcomm_sched_linear.c
@@ -21,7 +21,6 @@ int MPIR_Igatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
     int i;
     int comm_size, rank;
     MPI_Aint extent;
-    int min_procs;
 
     rank = comm_ptr->rank;
 
@@ -54,21 +53,7 @@ int MPIR_Igatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
     } else if (root != MPI_PROC_NULL) {
         /* non-root nodes, and in the intercomm. case, non-root nodes on remote side */
         if (sendcount) {
-            /* we want local size in both the intracomm and intercomm cases
-             * because the size of the root's group (group A in the standard) is
-             * irrelevant here. */
-            comm_size = comm_ptr->local_size;
-
-            min_procs = MPIR_CVAR_GATHERV_INTER_SSEND_MIN_PROCS;
-            if (min_procs == -1)
-                min_procs = comm_size + 1;      /* Disable ssend */
-            else if (min_procs == 0)    /* backwards compatibility, use default value */
-                MPIR_CVAR_GET_DEFAULT_INT(GATHERV_INTER_SSEND_MIN_PROCS, &min_procs);
-
-            if (comm_size >= min_procs)
-                mpi_errno = MPIR_Sched_ssend(sendbuf, sendcount, sendtype, root, comm_ptr, s);
-            else
-                mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, root, comm_ptr, s);
+            mpi_errno = MPIR_Sched_send(sendbuf, sendcount, sendtype, root, comm_ptr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }

--- a/src/mpi/coll/igatherv/igatherv_tsp_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_tsp_linear.c
@@ -27,7 +27,6 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcou
     int i, vtx_id;
     int comm_size, rank;
     MPI_Aint extent;
-    int min_procs;
     int tag;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
@@ -67,25 +66,8 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcou
     } else if (root != MPI_PROC_NULL) {
         /* non-root nodes, and in the intercomm. case, non-root nodes on remote side */
         if (sendcount) {
-            /* we want local size in both the intracomm and intercomm cases
-             * because the size of the root's group (group A in the standard) is
-             * irrelevant here. */
-            comm_size = comm_ptr->local_size;
-
-            min_procs = MPIR_CVAR_GATHERV_INTER_SSEND_MIN_PROCS;
-            if (min_procs == -1)
-                min_procs = comm_size + 1;      /* Disable ssend */
-            else if (min_procs == 0)    /* backwards compatibility, use default value */
-                MPIR_CVAR_GET_DEFAULT_INT(GATHERV_INTER_SSEND_MIN_PROCS, &min_procs);
-
-            if (comm_size >= min_procs)
-                mpi_errno =
-                    MPIR_TSP_sched_issend(sendbuf, sendcount, sendtype, root, tag, comm_ptr, sched,
-                                          0, NULL, &vtx_id);
-            else
-                mpi_errno =
-                    MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, root, tag, comm_ptr, sched,
-                                         0, NULL, &vtx_id);
+            mpi_errno = MPIR_TSP_sched_isend(sendbuf, sendcount, sendtype, root, tag, comm_ptr,
+                                             sched, 0, NULL, &vtx_id);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }

--- a/src/mpi/coll/transports/gentran/gentran_types.h
+++ b/src/mpi/coll/transports/gentran/gentran_types.h
@@ -13,7 +13,6 @@ typedef enum {
     MPII_GENUTIL_VTX_KIND__IRECV,
     MPII_GENUTIL_VTX_KIND__IRECV_STATUS,
     MPII_GENUTIL_VTX_KIND__IMCAST,
-    MPII_GENUTIL_VTX_KIND__ISSEND,
     MPII_GENUTIL_VTX_KIND__REDUCE_LOCAL,
     MPII_GENUTIL_VTX_KIND__LOCALCOPY,
     MPII_GENUTIL_VTX_KIND__SELECTIVE_SINK,
@@ -82,15 +81,6 @@ typedef struct MPII_Genutil_vtx_t {
             MPIR_Request **req;
             int last_complete;
         } imcast;
-        struct {
-            const void *buf;
-            MPI_Aint count;
-            MPI_Datatype dt;
-            int dest;
-            int tag;
-            MPIR_Comm *comm;
-            MPIR_Request *req;
-        } issend;
         struct {
             const void *inbuf;
             void *inoutbuf;

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -154,23 +154,6 @@ static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t 
                 }
                 break;
 
-            case MPII_GENUTIL_VTX_KIND__ISSEND:{
-                    MPIC_Issend(vtxp->u.issend.buf,
-                                vtxp->u.issend.count,
-                                vtxp->u.issend.dt,
-                                vtxp->u.issend.dest,
-                                vtxp->u.issend.tag, vtxp->u.issend.comm, &vtxp->u.issend.req,
-                                r->u.nbc.errflag);
-
-                    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                                    (MPL_DBG_FDEST,
-                                     "  --> GENTRAN transport (issend) issued, tag = %d",
-                                     vtxp->u.issend.tag));
-                    vtx_record_issue(vtxp, sched);
-                }
-                break;
-
-
             case MPII_GENUTIL_VTX_KIND__REDUCE_LOCAL:{
                     MPIR_Reduce_local(vtxp->u.reduce_local.inbuf,
                                       vtxp->u.reduce_local.inoutbuf,
@@ -583,26 +566,6 @@ int MPII_Genutil_sched_poke(MPII_Genutil_sched_t * sched, int *is_complete, int 
                 }
                 if (i == vtxp->u.imcast.num_dests)
                     vtx_record_completion(vtxp, sched, 1);
-                break;
-
-            case MPII_GENUTIL_VTX_KIND__ISSEND:
-                if (MPIR_Request_is_complete(vtxp->u.issend.req)) {
-                    MPIR_Request_free(vtxp->u.issend.req);
-                    vtxp->u.issend.req = NULL;
-#ifdef MPL_USE_DBG_LOGGING
-                    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                                    (MPL_DBG_FDEST,
-                                     "  --> GENTRAN transport (vtx_kind=%d) complete",
-                                     vtxp->vtx_kind));
-                    if (vtxp->u.issend.count >= 1)
-                        MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                                        (MPL_DBG_FDEST, "data sent: %d",
-                                         *(int *) (vtxp->u.issend.buf)));
-#endif
-                    vtx_record_completion(vtxp, sched, 1);
-                    if (made_progress)
-                        *made_progress = TRUE;
-                }
                 break;
 
             case MPII_GENUTIL_VTX_KIND__IRECV_STATUS:

--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -66,10 +66,6 @@ int MPIR_TSP_sched_free(MPIR_TSP_sched_t s)
                 MPIR_Comm_release(vtx->u.isend.comm);
                 MPIR_Datatype_release_if_not_builtin(vtx->u.isend.dt);
                 break;
-            case MPII_GENUTIL_VTX_KIND__ISSEND:
-                MPIR_Comm_release(vtx->u.issend.comm);
-                MPIR_Datatype_release_if_not_builtin(vtx->u.issend.dt);
-                break;
             case MPII_GENUTIL_VTX_KIND__IRECV:
                 MPIR_Comm_release(vtx->u.irecv.comm);
                 MPIR_Datatype_release_if_not_builtin(vtx->u.irecv.dt);
@@ -331,39 +327,6 @@ int MPIR_TSP_sched_imcast(const void *buf,
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                     (MPL_DBG_FDEST, "Gentran: schedule [%d] imcast", *vtx_id));
-    return mpi_errno;
-}
-
-int MPIR_TSP_sched_issend(const void *buf,
-                          MPI_Aint count,
-                          MPI_Datatype dt,
-                          int dest,
-                          int tag,
-                          MPIR_Comm * comm_ptr, MPIR_TSP_sched_t s, int n_in_vtcs, int *in_vtcs,
-                          int *vtx_id)
-{
-    MPII_Genutil_sched_t *sched = s;
-    vtx_t *vtxp;
-    int mpi_errno = MPI_SUCCESS;
-    /* assign a new vertex */
-    *vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
-    vtxp->vtx_kind = MPII_GENUTIL_VTX_KIND__ISSEND;
-    MPII_Genutil_vtx_add_dependencies(sched, *vtx_id, n_in_vtcs, in_vtcs);
-
-    /* store the arguments */
-    vtxp->u.issend.buf = buf;
-    vtxp->u.issend.count = count;
-    vtxp->u.issend.dt = dt;
-    vtxp->u.issend.dest = dest;
-    vtxp->u.issend.tag = tag;
-    vtxp->u.issend.comm = comm_ptr;
-
-    MPIR_Comm_add_ref(comm_ptr);
-    MPIR_Datatype_add_ref_if_not_builtin(dt);
-
-    MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                    (MPL_DBG_FDEST, "Gentran: schedule [%d] issend", *vtx_id));
-
     return mpi_errno;
 }
 

--- a/src/mpi/coll/transports/tsp_impl.h
+++ b/src/mpi/coll/transports/tsp_impl.h
@@ -52,15 +52,6 @@ int MPIR_TSP_sched_isend(const void *buf,
                          MPIR_Comm * comm_ptr, MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs,
                          int *vtx_id);
 
-/* Transport function to schedule a issend vertex */
-int MPIR_TSP_sched_issend(const void *buf,
-                          MPI_Aint count,
-                          MPI_Datatype dt,
-                          int dest,
-                          int tag,
-                          MPIR_Comm * comm_ptr,
-                          MPIR_TSP_sched_t sched, int n_in_vtcs, int *in_vtcs, int *vtx_id);
-
 /* Transport function to schedule an irecv vertex */
 int MPIR_TSP_sched_irecv(void *buf,
                          MPI_Aint count,

--- a/src/mpid/ch4/include/mpid_sched.h
+++ b/src/mpid/ch4/include/mpid_sched.h
@@ -23,7 +23,6 @@
 #define MPIR_Sched_recv MPIDU_Sched_recv
 #define MPIR_Sched_pt2pt_recv MPIDU_Sched_pt2pt_recv
 #define MPIR_Sched_recv_status MPIDU_Sched_recv_status
-#define MPIR_Sched_ssend MPIDU_Sched_ssend
 #define MPIR_Sched_reduce MPIDU_Sched_reduce
 #define MPIR_Sched_copy MPIDU_Sched_copy
 #define MPIR_Sched_barrier MPIDU_Sched_barrier

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -229,15 +229,9 @@ static int MPIDU_Sched_start_entry(struct MPIDU_Sched *s, size_t idx, struct MPI
                                        e->u.send.dest, s->tag, comm, &e->u.send.sreq,
                                        r->u.nbc.errflag);
             } else {
-                if (e->u.send.is_sync) {
-                    ret_errno = MPIC_Issend(e->u.send.buf, e->u.send.count, e->u.send.datatype,
-                                            e->u.send.dest, s->tag, comm, &e->u.send.sreq,
-                                            r->u.nbc.errflag);
-                } else {
-                    ret_errno = MPIC_Isend(e->u.send.buf, e->u.send.count, e->u.send.datatype,
-                                           e->u.send.dest, s->tag, comm, &e->u.send.sreq,
-                                           r->u.nbc.errflag);
-                }
+                ret_errno = MPIC_Isend(e->u.send.buf, e->u.send.count, e->u.send.datatype,
+                                       e->u.send.dest, s->tag, comm, &e->u.send.sreq,
+                                       r->u.nbc.errflag);
             }
             /* Check if the error is actually fatal to the NBC or we can continue. */
             if (unlikely(ret_errno)) {
@@ -680,7 +674,6 @@ int MPIDU_Sched_send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int
     e->u.send.dest = dest;
     e->u.send.sreq = NULL;      /* will be populated by _start_entry */
     e->u.send.comm = comm;
-    e->u.send.is_sync = FALSE;
 
     /* the user may free the comm & type after initiating but before the
      * underlying send is actually posted, so we must add a reference here and
@@ -718,7 +711,6 @@ int MPIDU_Sched_pt2pt_send(const void *buf, MPI_Aint count, MPI_Datatype datatyp
     e->u.send.dest = dest;
     e->u.send.sreq = NULL;      /* will be populated by _start_entry */
     e->u.send.comm = comm;
-    e->u.send.is_sync = FALSE;
     e->u.send.tag = tag;
 
     /* the user may free the comm & type after initiating but before the
@@ -736,45 +728,6 @@ int MPIDU_Sched_pt2pt_send(const void *buf, MPI_Aint count, MPI_Datatype datatyp
   fn_fail:
     goto fn_exit;
 }
-
-int MPIDU_Sched_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
-                      MPIR_Comm * comm, MPIR_Sched_t s)
-{
-    int mpi_errno = MPI_SUCCESS;
-    struct MPIDU_Sched_entry *e = NULL;
-
-    mpi_errno = MPIDU_Sched_add_entry(s, NULL, &e);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    e->type = MPIDU_SCHED_ENTRY_SEND;
-    e->status = MPIDU_SCHED_ENTRY_STATUS_NOT_STARTED;
-    e->is_barrier = FALSE;
-
-    e->u.send.buf = buf;
-    e->u.send.count = count;
-    e->u.send.count_p = NULL;
-    e->u.send.datatype = datatype;
-    e->u.send.dest = dest;
-    e->u.send.sreq = NULL;      /* will be populated by _start_entry */
-    e->u.send.comm = comm;
-    e->u.send.is_sync = TRUE;
-
-    /* the user may free the comm & type after initiating but before the
-     * underlying send is actually posted, so we must add a reference here and
-     * release it at entry completion time */
-    MPIR_Comm_add_ref(comm);
-    MPIR_Datatype_add_ref_if_not_builtin(datatype);
-    if (s->kind != MPIR_SCHED_KIND_GENERALIZED) {
-        sched_add_ref(s, comm->handle);
-        sched_add_ref(s, datatype);
-    }
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
 
 int MPIDU_Sched_send_defer(const void *buf, const MPI_Aint * count, MPI_Datatype datatype, int dest,
                            MPIR_Comm * comm, MPIR_Sched_t s)
@@ -796,7 +749,6 @@ int MPIDU_Sched_send_defer(const void *buf, const MPI_Aint * count, MPI_Datatype
     e->u.send.dest = dest;
     e->u.send.sreq = NULL;      /* will be populated by _start_entry */
     e->u.send.comm = comm;
-    e->u.send.is_sync = FALSE;
 
     /* the user may free the comm & type after initiating but before the
      * underlying send is actually posted, so we must add a reference here and

--- a/src/mpid/common/sched/mpidu_sched.h
+++ b/src/mpid/common/sched/mpidu_sched.h
@@ -44,7 +44,6 @@ struct MPIDU_Sched_send {
     int dest;
     struct MPIR_Comm *comm;
     struct MPIR_Request *sreq;
-    int is_sync;                /* TRUE iff this send is an ssend */
 };
 
 struct MPIDU_Sched_recv {
@@ -149,8 +148,6 @@ int MPIDU_Sched_pt2pt_send(const void *buf, MPI_Aint count, MPI_Datatype datatyp
                            int tag, int dest, struct MPIR_Comm *comm, MPIR_Sched_t s);
 int MPIDU_Sched_pt2pt_recv(void *buf, MPI_Aint count, MPI_Datatype datatype,
                            int tag, int src, struct MPIR_Comm *comm, MPIR_Sched_t s);
-int MPIR_Sched_ssend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
-                     struct MPIR_Comm *comm, MPIR_Sched_t s);
 int MPIR_Sched_reduce(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,
                       MPI_Op op, MPIR_Sched_t s);
 int MPIDU_Sched_copy(const void *inbuf, MPI_Aint incount, MPI_Datatype intype, void *outbuf,


### PR DESCRIPTION
## Pull Request Description
The ssend is meant to avoid large messages arriving unexpectedly
overwhelming the root. This was originally an issue on BG/P. Most
modern lower layer, e.g. ucx, will use some sort of rndv or traffic
control for large messages anyway, thus the ssend is unnecessary but
only adds to performance overhead.

Currently, ch4 doesn't implement ssend as an explicit rndv anyway, and
will have the same issue as the direct send.

This commit removes the ssend, just do direct send.

Reference discussions in https://github.com/pmodels/mpich/pull/7121

[skip warnings]

## TODO
* [ ] The ch4:ofi implements `ssend` merely by sending an `ack` upon completion. This is allowed by the MPI spec but kind of defeats the purpose of `MPI_Ssend` as a mean to always use RNDV. Besides, having to issue `ack` inside event loop causes recursive progress issue. I think we should just always fallback `ssend` to active message rndv -- if I fix the double copy issue in current ch4-am.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
