### PR TITLE
test/mpi: Fix argument passing to pt2pt_large test

### DIFF
--- a/src/mpid/ch3/src/ch3u_request.c
+++ b/src/mpid/ch3/src/ch3u_request.c
@@ -393,15 +393,15 @@ int MPIDI_CH3U_Request_load_recv_iov(MPIR_Request * const rreq)
 int MPIDI_CH3U_Request_unpack_srbuf(MPIR_Request * rreq)
 {
     MPI_Aint last;
-    int tmpbuf_last;
+    MPI_Aint tmpbuf_last;
     int mpi_errno = MPI_SUCCESS;
     
     MPIR_FUNC_ENTER;
 
-    tmpbuf_last = (int)(rreq->dev.msg_offset + rreq->dev.tmpbuf_sz);
+    tmpbuf_last = rreq->dev.msg_offset + rreq->dev.tmpbuf_sz;
     if (rreq->dev.msgsize < tmpbuf_last)
     {
-	tmpbuf_last = (int)rreq->dev.msgsize;
+	tmpbuf_last = rreq->dev.msgsize;
     }
 
     MPI_Aint actual_unpack_bytes;
@@ -445,7 +445,7 @@ int MPIDI_CH3U_Request_unpack_srbuf(MPIR_Request * rreq)
     }
     else
     {
-	rreq->dev.tmpbuf_off = (int)(tmpbuf_last - last);
+	rreq->dev.tmpbuf_off = tmpbuf_last - last;
 	if (rreq->dev.tmpbuf_off > 0)
 	{
 	    /* move any remaining data to the beginning of the buffer.  

--- a/test/mpi/pt2pt/testlist.in
+++ b/test/mpi/pt2pt/testlist.in
@@ -77,7 +77,7 @@ precv_anysrc 2 timeLimit=60
 precv_anysrc 2 timeLimit=60 env=MPIR_CVAR_CH4_OFI_AM_LONG_FORCE_PIPELINE=true
 precv_anysrc_exp 2 timeLimit=60
 pt2pt_large 2
-pt2pt_large 2 -option=1 mem=4
-pt2pt_large 2 -option=2 mem=10
+pt2pt_large 2 arg=-option=1 mem=4
+pt2pt_large 2 arg=-option=2 mem=10
 mprobe_self_free 1
 pssend 2


### PR DESCRIPTION
## Pull Request Description

Need to prefix arguments meant for test binaries with arg=.
[2024-09-17] added commit to fix issue exposed by corrected test.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
