### PR TITLE
test/mpi: Fix assertions in mpit_isendrecv.c

### DIFF
--- a/test/mpi/mpi_t/mpit_isendirecv.c
+++ b/test/mpi/mpi_t/mpit_isendirecv.c
@@ -303,22 +303,22 @@ int main(int argc, char *argv[])
 
         nsc_handle = MPI_T_PVAR_HANDLE_NULL;
         MPI_T_pvar_handle_alloc(session, nsc_idx, NULL, &nsc_handle, &count);
-        assert(count = 1);
+        assert(count == 1);
         assert(nsc_handle != MPI_T_PVAR_HANDLE_NULL);
 
         nrc_handle = MPI_T_PVAR_HANDLE_NULL;
         MPI_T_pvar_handle_alloc(session, nrc_idx, NULL, &nrc_handle, &count);
-        assert(count = 1);
+        assert(count == 1);
         assert(nrc_handle != MPI_T_PVAR_HANDLE_NULL);
 
         snsc_handle = MPI_T_PVAR_HANDLE_NULL;
         MPI_T_pvar_handle_alloc(session, snsc_idx, NULL, &snsc_handle, &count);
-        assert(count = 1);
+        assert(count == 1);
         assert(snsc_handle != MPI_T_PVAR_HANDLE_NULL);
 
         snrc_handle = MPI_T_PVAR_HANDLE_NULL;
         MPI_T_pvar_handle_alloc(session, snrc_idx, NULL, &snrc_handle, &count);
-        assert(count = 1);
+        assert(count == 1);
         assert(snrc_handle != MPI_T_PVAR_HANDLE_NULL);
 
         if (!nsc_continuous) {


### PR DESCRIPTION
## Pull Request Description

A typo caused this assertion to not actually check equality (and always evaluate to true).

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
