### PR TITLE
mpir/pmix: Skip PMI_mpi_memory_alloc_kinds attribute query

### DIFF
--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -229,6 +229,11 @@ static bool pmix_get_jobattr(const char *key, char *valbuf)
     bool found = false;
     pmix_value_t *pvalue;
 
+    /* HACK: avoid extraneous error output with OpenPMIx */
+    if (strcmp(key, "PMI_mpi_memory_alloc_kinds") == 0) {
+       return found;
+    }
+
     /* if this is a non-reserved key, we want to make sure not to block
      * by using PMIX_IMMEDIATE */
     pmix_info_t *info;


### PR DESCRIPTION
## Pull Request Description

This attribute is only supported by the Hydra PMI server. On Aurora, the query causes error output from PALS/PMIx during MPI_INIT:

  [x4019c6s6b0n0:127035] PMIX ERROR: PMIX_ERR_NOT_FOUND in file dstore_base.c at line 1567
  [x4019c6s6b0n0:127035] PMIX ERROR: PMIX_ERROR in file dstore_base.c at line 2334

Instead of confusing users, just skip it when using the PMIx client.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
