### PR TITLE
mpir/pmix: Use wildcard pmix_proc_t for job attribute queries

### DIFF
--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -236,7 +236,7 @@ static bool pmix_get_jobattr(const char *key, char *valbuf)
     int flag = 1;
     PMIx_Info_load(info, PMIX_IMMEDIATE, &flag, PMIX_BOOL);
 
-    int pmi_errno = PMIx_Get(NULL, key, info, 1, &pvalue);
+    int pmi_errno = PMIx_Get(&pmix_wcproc, key, info, 1, &pvalue);
     if (pmi_errno == PMIX_SUCCESS) {
         strncpy(valbuf, pvalue->data.string, pmi_max_val_size);
         PMIX_VALUE_RELEASE(pvalue);

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -184,7 +184,7 @@ static int pmix_get(int src, const char *key, char *val, int val_size)
 
     pmix_value_t *pvalue;
     if (src < 0) {
-        pmi_errno = PMIx_Get(NULL, key, NULL, 0, &pvalue);
+        pmi_errno = PMIx_Get(&pmix_wcproc, key, NULL, 0, &pvalue);
     } else {
         pmix_proc_t proc;
         PMIX_PROC_CONSTRUCT(&proc);
@@ -370,7 +370,7 @@ static int pmix_get_binary(int src, const char *key, char *buf, int *p_size, int
     int bufsize ATTRIBUTE((unused)) = *p_size;
     pmix_value_t *pvalue;
     if (src < 0) {
-        pmi_errno = PMIx_Get(NULL, key, NULL, 0, &pvalue);
+        pmi_errno = PMIx_Get(&pmix_wcproc, key, NULL, 0, &pvalue);
     } else {
         pmix_proc_t proc;
         PMIX_PROC_CONSTRUCT(&proc);


### PR DESCRIPTION
## Pull Request Description

Some version of PMIx have poor support for global attribute queries using PMIX_RANK_UNDEF, which is associated with passing a NULL pointer to the pmix_proc_t argument. Use our internal "wildcard" struct to avoid some extraneous error messages seen on Aurora.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
