### PR TITLE
misc: fix warnings for nvc compiler

### DIFF
--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -690,6 +690,22 @@ CFLAGS="$CFLAGS $pac_cc_strict_flags"
 export CFLAGS
 ])
 
+AC_DEFUN([PAC_C_DEFAULT_OPTIONS],[
+    pac_cc_defaut_flags="
+        --diag_suppress=branch_past_initialization
+    "
+    # See if the above options work with the compiler
+    accepted_flags=""
+    for flag in $pac_cc_defaut_flags ; do
+        PAC_PUSH_FLAG([CFLAGS])
+	CFLAGS="$CFLAGS $accepted_flags"
+        PAC_C_CHECK_COMPILER_OPTION([$flag],[accepted_flags="$accepted_flags $flag"],)
+        PAC_POP_FLAG([CFLAGS])
+    done
+    CFLAGS="$CFLAGS $accepted_flags"
+    export CFLAGS
+])
+
 dnl Return the integer structure alignment in pac_cv_c_max_integer_align
 dnl Possible values include
 dnl	packed

--- a/configure.ac
+++ b/configure.ac
@@ -756,6 +756,9 @@ PAC_ARG_CACHING
 # it may influence the output of the other tests
 PAC_ARG_STRICT
 
+# Add options that suppress default warnings, especially those from PGI compilers (now nvc)
+PAC_C_DEFAULT_OPTIONS
+
 # To link C objects with Fortran main program may require -fPIE option
 PAC_C_CHECK_fPIE_OK
 

--- a/src/mpi/datatype/create_f90.c
+++ b/src/mpi/datatype/create_f90.c
@@ -6,6 +6,26 @@
 #include "mpiimpl.h"
 #include "mpif90model.h"
 
+#ifndef HAVE_FORTRAN_BINDING
+int MPIR_Type_create_f90_integer_impl(int range, MPI_Datatype * newtype)
+{
+    *newtype = MPI_DATATYPE_NULL;
+    return MPI_SUCCESS;
+}
+
+int MPIR_Type_create_f90_real_impl(int precision, int range, MPI_Datatype * newtype)
+{
+    *newtype = MPI_DATATYPE_NULL;
+    return MPI_SUCCESS;
+}
+
+int MPIR_Type_create_f90_complex_impl(int precision, int range, MPI_Datatype * newtype)
+{
+    *newtype = MPI_DATATYPE_NULL;
+    return MPI_SUCCESS;
+}
+
+#else /* HAVE_FORTRAN_BINDING */
 typedef struct intModel {
     int range, kind, bytes;
 } intModel;
@@ -21,15 +41,10 @@ static int MPIR_Create_unnamed_predefined(MPI_Datatype old, int combiner,
 int MPIR_Type_create_f90_integer_impl(int range, MPI_Datatype * newtype)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Datatype basetype = MPI_DATATYPE_NULL;
-
-#ifndef HAVE_FORTRAN_BINDING
-    *newtype = MPI_DATATYPE_NULL;
-    goto fn_exit;
-#endif
 
     static intModel f90_integer_map[] = { MPIR_F90_INTEGER_MODEL_MAP {0, 0, 0} };
 
+    MPI_Datatype basetype = MPI_DATATYPE_NULL;
     for (int i = 0; f90_integer_map[i].range > 0; i++) {
         if (f90_integer_map[i].range >= range) {
             /* Find the corresponding INTEGER type */
@@ -76,10 +91,6 @@ int MPIR_Type_create_f90_real_impl(int precision, int range, MPI_Datatype * newt
     int mpi_errno = MPI_SUCCESS;
     MPI_Datatype basetype;
 
-#ifndef HAVE_FORTRAN_BINDING
-    *newtype = MPI_DATATYPE_NULL;
-    goto fn_exit;
-#endif
 
     static int setupPredefTypes = 1;
     static realModel f90_real_model[2] = {
@@ -134,11 +145,6 @@ int MPIR_Type_create_f90_complex_impl(int precision, int range, MPI_Datatype * n
     int mpi_errno = MPI_SUCCESS;
     MPI_Datatype basetype;
 
-#ifndef HAVE_FORTRAN_BINDING
-    *newtype = MPI_DATATYPE_NULL;
-    goto fn_exit;
-#endif
-
     static int setupPredefTypes = 1;
     static realModel f90_real_model[2] = {
         {MPIR_F90_REAL_MODEL, MPI_COMPLEX},
@@ -187,6 +193,7 @@ int MPIR_Type_create_f90_complex_impl(int precision, int range, MPI_Datatype * n
     goto fn_exit;
 }
 
+#ifdef HAVE_FORTRAN_BINDING
 /* The MPI standard requires that the datatypes that are returned from
    the MPI_Create_f90_xxx be both predefined and return the r (and p
    if real/complex) with which it was created.  The following contains routines
@@ -305,6 +312,7 @@ static int MPIR_Create_unnamed_predefined(MPI_Datatype old, int combiner,
   fn_fail:
     return mpi_errno;
 }
+#endif
 
 /*
    The simple approach used here is to store (unordered) the precision and
@@ -389,3 +397,4 @@ static int MPIR_Create_unnamed_predefined(MPI_Datatype old, int combiner,
     return mpi_errno;
 }
 #endif
+#endif /* HAVE_FORTRAN_BINDING */

--- a/src/mpi/group/group_impl.c
+++ b/src/mpi/group/group_impl.c
@@ -526,7 +526,7 @@ int MPIR_Group_translate_ranks_impl(MPIR_Group * gp1, int n, const int ranks1[],
                     if (g2_idx >= 0)
                         l2_pid = gp2->lrank_to_lpid[g2_idx].lpid;
                     else
-                        l2_pid = -1;
+                        l2_pid = (uint64_t) - 1;
                 }
                 if (l1_pid == l2_pid)
                     ranks2[i] = g2_idx;
@@ -619,7 +619,7 @@ int MPIR_Group_union_impl(MPIR_Group * group_ptr1, MPIR_Group * group_ptr2,
     if (group_ptr1->rank == MPI_UNDEFINED && group_ptr2->rank >= 0) {
         mylpid = group_ptr2->lrank_to_lpid[group_ptr2->rank].lpid;
     } else {
-        mylpid = -2;
+        mylpid = (uint64_t) - 2;
     }
     k = size1;
     for (i = 0; i < size2; i++) {

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -191,12 +191,9 @@ static int do_localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
                             MPL_gpu_engine_type_t enginetype, bool commit, MPIR_gpu_req * gpu_req)
 {
     int mpi_errno = MPI_SUCCESS;
-    int mpl_errno = MPL_SUCCESS;
     int sendtype_iscontig, recvtype_iscontig;
     MPI_Aint sendsize, recvsize, sdata_sz, rdata_sz, copy_sz;
     MPI_Aint true_extent, sendtype_true_lb, recvtype_true_lb;
-    int completed = 0;
-    int dev_id = -1;
 
     MPIR_FUNC_ENTER;
 
@@ -227,6 +224,9 @@ static int do_localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
     if (sendtype_iscontig && recvtype_iscontig) {
         /* Remove guard when other backends implement MPL_gpu_imemcpy and MPL_gpu_fast_memcpy */
 #ifdef MPL_HAVE_ZE
+        int mpl_errno = MPL_SUCCESS;
+        int completed = 0;
+        int dev_id = -1;
         MPL_pointer_attr_t sendattr, recvattr;
         if (send_attr == NULL) {
             MPIR_GPU_query_pointer_attr(sendbuf, &sendattr);

--- a/src/mpid/ch4/netmod/ofi/ofi_coll.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_coll.h
@@ -95,7 +95,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MP
             break;
         case MPIR_CVAR_BCAST_OFI_INTRA_ALGORITHM_mpir:
             goto fallback;
-            break;
         case MPIR_CVAR_BCAST_OFI_INTRA_ALGORITHM_auto:
             mpi_errno = MPIDI_OFI_bcast_json(buffer, count, datatype, root, comm, errflag);
             break;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -116,7 +116,8 @@ static int pipeline_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * r, 
     void *wc_buf = NULL;
     int in_use MPL_UNUSED;
     MPIDI_OFI_gpu_task_t *task = NULL;
-    int engine_type = MPIR_CVAR_CH4_OFI_GPU_PIPELINE_H2D_ENGINE_TYPE;
+    MPL_gpu_engine_type_t engine_type =
+        (MPL_gpu_engine_type_t) MPIR_CVAR_CH4_OFI_GPU_PIPELINE_H2D_ENGINE_TYPE;
 
     MPIR_FUNC_ENTER;
 
@@ -166,8 +167,7 @@ static int pipeline_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * r, 
                 /* Post recv for remaining chunks. */
                 MPIR_cc_dec(rreq->cc_ptr);
                 for (i = 0; i < n_chunks; i++) {
-                    int c;
-                    MPIR_cc_incr(rreq->cc_ptr, &c);
+                    MPIR_cc_inc(rreq->cc_ptr);
 
                     size_t chunk_sz = MPIR_CVAR_CH4_OFI_GPU_PIPELINE_BUFFER_SZ;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -908,7 +908,8 @@ static int MPIDI_OFI_gpu_progress_task(MPIDI_OFI_gpu_task_t * gpu_queue[], int v
 static int MPIDI_OFI_gpu_progress_send(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    int engine_type = MPIR_CVAR_CH4_OFI_GPU_PIPELINE_D2H_ENGINE_TYPE;
+    MPL_gpu_engine_type_t engine_type =
+        (MPL_gpu_engine_type_t) MPIR_CVAR_CH4_OFI_GPU_PIPELINE_D2H_ENGINE_TYPE;
 
     while (MPIDI_OFI_global.gpu_send_queue) {
         char *host_buf = NULL;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -508,7 +508,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_fallback(const void *buf, MPI_Aint c
                                                      MPIR_Comm * comm, int context_offset,
                                                      MPIDI_av_entry_t * addr, int vci_src,
                                                      int vci_dst, MPIR_Request ** request,
-                                                     MPIR_Errflag_t err_flag)
+                                                     int err_flag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -580,7 +580,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
                                             int context_offset, MPIDI_av_entry_t * addr,
                                             int vci_src, int vci_dst,
                                             MPIR_Request ** request, int noreq,
-                                            uint64_t syncflag, MPIR_Errflag_t err_flag)
+                                            uint64_t syncflag, int err_flag)
 {
     int dt_contig, mpi_errno;
     size_t data_sz;
@@ -687,7 +687,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf, MPI_Aint count,
     MPIR_FUNC_ENTER;
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-    MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
+    int errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
 
     int vci_src, vci_dst;
     MPIDI_OFI_SEND_VNIS(vci_src, vci_dst);      /* defined just above */

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -47,8 +47,7 @@
 #define MPIDI_OFI_ERR_PROC_FAILED (0x2ULL)
 
 /* Set the error bits */
-MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_idata_set_error_bits(uint64_t * data_field,
-                                                             MPIR_Errflag_t errflag)
+MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_idata_set_error_bits(uint64_t * data_field, int errflag)
 {
     switch (errflag) {
         case MPIR_ERR_OTHER:

--- a/src/mpid/ch4/shm/ipc/src/ipc_control.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_control.c
@@ -42,7 +42,7 @@ int MPIDI_IPC_rndv_cb(MPIR_Request * rreq)
     return mpi_errno;
 }
 
-int MPIDI_IPC_complete(MPIR_Request * rreq, int ipc_type)
+int MPIDI_IPC_complete(MPIR_Request * rreq, MPIDI_IPCI_type_t ipc_type)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -26,7 +26,7 @@
  * and perform direct data transfer.
  */
 
-int MPIDI_IPC_complete(MPIR_Request * rreq, int ipc_type);
+int MPIDI_IPC_complete(MPIR_Request * rreq, MPIDI_IPCI_type_t ipc_type);
 int MPIDI_IPC_rndv_cb(MPIR_Request * rreq);
 int MPIDI_IPC_ack_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
                                 uint32_t attr, MPIR_Request ** req);
@@ -37,7 +37,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_lmt(const void *buf, MPI_Aint count
                                                  int context_offset, MPIDI_av_entry_t * addr,
                                                  MPIDI_IPCI_ipc_attr_t ipc_attr,
                                                  int vci_src, int vci_dst, MPIR_Request ** request,
-                                                 bool syncflag, MPIR_Errflag_t errflag)
+                                                 bool syncflag, int errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -59,7 +59,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint 
     MPIR_FUNC_ENTER;
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-    MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
+    int errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
     bool syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr);
     int vci_src, vci_dst;
     /* note: MPIDI_POSIX_SEND_VSIS defined in posix_send.h */

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -159,7 +159,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
 
 #ifdef MPL_HAVE_GPU
     if (MPIR_CVAR_CH4_IPC_GPU_RMA_ENGINE_TYPE != MPIR_CVAR_CH4_IPC_GPU_RMA_ENGINE_TYPE_yaksa) {
-        int engine_type =
+        MPL_gpu_engine_type_t engine_type =
             MPIDI_RMA_choose_engine(MPL_gpu_query_pointer_is_dev(origin_addr, &origin_attr),
                                     origin_dev_id, MPL_gpu_query_pointer_is_dev(target_addr,
                                                                                 &target_attr),
@@ -251,7 +251,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
 
 #ifdef MPL_HAVE_GPU
     if (MPIR_CVAR_CH4_IPC_GPU_RMA_ENGINE_TYPE != MPIR_CVAR_CH4_IPC_GPU_RMA_ENGINE_TYPE_yaksa) {
-        int engine_type =
+        MPL_gpu_engine_type_t engine_type =
             MPIDI_RMA_choose_engine(MPL_gpu_query_pointer_is_dev(origin_addr, &origin_attr),
                                     origin_dev_id, MPL_gpu_query_pointer_is_dev(target_addr,
                                                                                 &target_attr),

--- a/src/mpid/ch4/shm/posix/posix_send.h
+++ b/src/mpid/ch4/shm/posix/posix_send.h
@@ -33,7 +33,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_isend(const void *buf, MPI_Aint cou
     int mpi_errno = MPI_SUCCESS;
 
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
-    MPIR_Errflag_t errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
+    int errflag = MPIR_PT2PT_ATTR_GET_ERRFLAG(attr);
     bool syncflag = MPIR_PT2PT_ATTR_GET_SYNCFLAG(attr);
 
     int vci_src, vci_dst;

--- a/src/mpid/ch4/shm/posix/release_gather/nb_bcast_release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_bcast_release_gather.h
@@ -88,7 +88,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_root_datacopy_completion(void *v,
     MPL_atomic_uint64_t *rank_0_gather_flag_addr =
         MPIDI_POSIX_RELEASE_GATHER_NB_IBCAST_GATHER_FLAG_ADDR(0, segment, num_ranks);
 
-    if (MPL_atomic_acquire_load_uint64(rank_0_gather_flag_addr) == -1) {
+    if (MPL_atomic_acquire_load_uint64(rank_0_gather_flag_addr) == (uint64_t) - 1) {
         /* Buffer can be overwritten */
         if (root != 0) {
             /* Root sends data to rank 0 */
@@ -109,7 +109,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_root_datacopy_completion(void *v,
             if (rank == 0 &&
                 (last_seq_no == per_call_data->seq_no - num_cells || last_seq_no < num_cells)) {
                 /* Mark the buffer as occupied */
-                MPL_atomic_release_store_uint64(my_gather_flag_addr, -2);
+                MPL_atomic_release_store_uint64(my_gather_flag_addr, (uint64_t) - 2);
                 MPIR_Localcopy(per_call_data->local_buf, per_call_data->count,
                                per_call_data->datatype,
                                MPIDI_POSIX_RELEASE_GATHER_NB_IBCAST_DATA_ADDR(segment),
@@ -179,7 +179,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_finish_send_recv_completion(void 
         } else if (rank == 0) {
             if (MPIR_Request_is_complete(per_call_data->rreq)) {
                 /* Mark the buffer as occupied */
-                MPL_atomic_release_store_uint64(my_gather_flag_addr, -2);
+                MPL_atomic_release_store_uint64(my_gather_flag_addr, (uint64_t) - 2);
                 MPIR_Request_free(per_call_data->rreq);
                 per_call_data->rreq = NULL;
                 /* Rank 0 updates its flag when it arrives and data is ready in shm buffer (if bcast) */
@@ -316,7 +316,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_update_gather_flag_cb(MPIR_Comm *
 
     if (rank == 0 && MPL_atomic_acquire_load_uint64(my_gather_flag_addr) == per_call_data->seq_no) {
         /* If I am rank 0 and all the ranks have arrived, set my_gather_flag to -1 */
-        MPL_atomic_release_store_uint64(my_gather_flag_addr, -1);
+        MPL_atomic_release_store_uint64(my_gather_flag_addr, (uint64_t) - 1);
         nb_release_gather_info_ptr->ibcast_last_seq_no_completed[segment] = per_call_data->seq_no;
     }
     return MPI_SUCCESS;

--- a/src/mpid/ch4/shm/posix/release_gather/nb_reduce_release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_reduce_release_gather.h
@@ -67,12 +67,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_rank0_hold_buf_completion(void *v
         MPIDI_POSIX_RELEASE_GATHER_NB_IREDUCE_GATHER_FLAG_ADDR(rank, segment, num_ranks);
 
     /* Rank 0 keeps checking if the a particular cell is available */
-    if (rank == 0 && (MPL_atomic_acquire_load_uint64(my_gather_flag_addr) == -1) &&
+    if (rank == 0 && (MPL_atomic_acquire_load_uint64(my_gather_flag_addr) == (uint64_t) - 1) &&
         (last_seq_no == per_call_data->seq_no - num_cells || last_seq_no < num_cells)) {
         /* Buffer can be overwritten */
         if (rank == 0) {
             /* Mark the buffer as occupied */
-            MPL_atomic_release_store_uint64(my_gather_flag_addr, -2);
+            MPL_atomic_release_store_uint64(my_gather_flag_addr, (uint64_t) - 2);
             /* Update the release_flag, so that the children ranks can move on */
             MPL_atomic_release_store_uint64(my_release_flag_addr, per_call_data->seq_no);
             *done = 1;
@@ -222,7 +222,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_reduce_data_cb(MPIR_Comm * comm, 
 
     if (rank == 0 && root == 0) {
         /* Mark the buffer as available, if root was rank 0 */
-        MPL_atomic_release_store_uint64(my_gather_flag_addr, -1);
+        MPL_atomic_release_store_uint64(my_gather_flag_addr, (uint64_t) - 1);
     } else {
         /* Update my gather flag to seq_no (so that my parent can be unblocked) */
         MPL_atomic_release_store_uint64(my_gather_flag_addr, per_call_data->seq_no);
@@ -313,7 +313,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_NB_RG_reduce_finish_sendrecv_completion
                 MPIR_Request_free(per_call_data->sreq);
                 per_call_data->sreq = NULL;
                 /* Mark the buffer as available for next use */
-                MPL_atomic_release_store_uint64(my_gather_flag_addr, -1);
+                MPL_atomic_release_store_uint64(my_gather_flag_addr, (uint64_t) - 1);
                 /* Update the last seq no completed */
                 nb_release_gather_info_ptr->ireduce_last_seq_no_completed[segment] =
                     per_call_data->seq_no;

--- a/src/mpid/ch4/shm/posix/release_gather/nb_release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_release_gather.c
@@ -214,9 +214,9 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
         /* Calculate gather and release flag address and initialize to the gather and release states */
         for (i = 0; i < MPIR_CVAR_BCAST_INTRANODE_NUM_CELLS; i++) {
             MPL_atomic_release_store_uint64(MPIDI_POSIX_RELEASE_GATHER_NB_IBCAST_GATHER_FLAG_ADDR
-                                            (rank, i, num_ranks), -1);
+                                            (rank, i, num_ranks), (uint64_t) - 1);
             MPL_atomic_release_store_uint64(MPIDI_POSIX_RELEASE_GATHER_NB_IBCAST_RELEASE_FLAG_ADDR
-                                            (rank, i, num_ranks), -1);
+                                            (rank, i, num_ranks), (uint64_t) - 1);
             nb_release_gather_info_ptr->ibcast_last_seq_no_completed[i] = -1;
         }
         /* Allocate the shared memory for ibcast buffer */
@@ -242,9 +242,9 @@ int MPIDI_POSIX_nb_release_gather_comm_init(MPIR_Comm * comm_ptr,
         MPIR_ERR_CHECK(mpi_errno);
         for (i = 0; i < MPIR_CVAR_REDUCE_INTRANODE_NUM_CELLS; i++) {
             MPL_atomic_release_store_uint64(MPIDI_POSIX_RELEASE_GATHER_NB_IREDUCE_GATHER_FLAG_ADDR
-                                            (rank, i, num_ranks), -1);
+                                            (rank, i, num_ranks), (uint64_t) - 1);
             MPL_atomic_release_store_uint64(MPIDI_POSIX_RELEASE_GATHER_NB_IREDUCE_RELEASE_FLAG_ADDR
-                                            (rank, i, num_ranks), -1);
+                                            (rank, i, num_ranks), (uint64_t) - 1);
             nb_release_gather_info_ptr->ireduce_last_seq_no_completed[i] = -1;
         }
         /* Allocate the shared memory for ireduce buffer */

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.h
@@ -57,8 +57,8 @@ int MPIDI_POSIX_mpi_release_gather_comm_init(MPIR_Comm * comm_ptr,
                                              const MPIDI_POSIX_release_gather_opcode_t operation);
 int MPIDI_POSIX_mpi_release_gather_comm_free(MPIR_Comm * comm_ptr);
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_get_tree_type(const char
-                                                                          *tree_type_name)
+MPL_STATIC_INLINE_PREFIX MPIDI_POSIX_release_gather_tree_type_t
+MPIDI_POSIX_mpi_release_gather_get_tree_type(const char *tree_type_name)
 {
     if (0 == strcmp(tree_type_name, "kary"))
         return MPIDI_POSIX_RELEASE_GATHER_TREE_TYPE_KARY;

--- a/src/mpid/ch4/src/mpidig_send.h
+++ b/src/mpid/ch4/src/mpidig_send.h
@@ -46,7 +46,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_isend_impl(const void *buf, MPI_Aint count,
                                                MPIR_Comm * comm, int context_offset,
                                                MPIDI_av_entry_t * addr, uint8_t flags,
                                                int src_vci, int dst_vci,
-                                               MPIR_Request ** request, MPIR_Errflag_t errflag)
+                                               MPIR_Request ** request, int errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq;
@@ -122,8 +122,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_isend(const void *buf,
                                               int rank,
                                               int tag, MPIR_Comm * comm, int context_offset,
                                               MPIDI_av_entry_t * addr, int src_vci, int dst_vci,
-                                              MPIR_Request ** request,
-                                              bool syncflag, MPIR_Errflag_t errflag)
+                                              MPIR_Request ** request, bool syncflag, int errflag)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;

--- a/src/mpl/include/utarray.h
+++ b/src/mpl/include/utarray.h
@@ -241,7 +241,7 @@ typedef struct {
 #define utarray_front(a) (((a)->i) ? (_utarray_eltptr(a,0)) : NULL)
 #define utarray_next(a,e) (((e)==NULL) ? utarray_front(a) : ((((a)->i) > (utarray_eltidx(a,e)+1)) ? _utarray_eltptr(a,utarray_eltidx(a,e)+1) : NULL))
 #define utarray_back(a) (((a)->i) ? (_utarray_eltptr(a,(a)->i-1)) : NULL)
-#define utarray_eltidx(a,e) (((char*)(e) >= (char*)((a)->d)) ? (((char*)(e) - (char*)((a)->d))/(a)->icd->sz) : -1)
+#define utarray_eltidx(a,e) (((char*)(e) >= (char*)((a)->d)) ? (((char*)(e) - (char*)((a)->d))/(a)->icd->sz) : 0)
 
 /* last we pre-define a few icd for common utarrays of ints and strings */
 static void utarray_str_cpy(void *dst, const void *src)

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -35,6 +35,8 @@ static gpu_free_hook_s *free_hook_chain = NULL;
 
 static CUresult CUDAAPI(*sys_cuMemFree) (CUdeviceptr dptr);
 static cudaError_t CUDARTAPI(*sys_cudaFree) (void *dptr);
+typedef CUresult(*cuMemFree_t) (CUdeviceptr dptr);
+typedef cudaError_t CUDARTAPI(*cudaFree_t) (void *dptr);
 
 static int gpu_mem_hook_init();
 static MPL_initlock_t free_hook_mutex = MPL_INITLOCK_INITIALIZER;
@@ -313,7 +315,8 @@ int MPL_gpu_init(int debug_summary)
         goto fn_exit;
     }
 
-    cudaError_t ret = cudaGetDeviceCount(&device_count);
+    cudaError_t ret;
+    ret = cudaGetDeviceCount(&device_count);
     if (ret == cudaErrorNoDevice) {
         /* call cudaGetLastError() to consume the error */
         ret = cudaGetLastError();
@@ -333,7 +336,8 @@ int MPL_gpu_init(int debug_summary)
     MPL_gpu_info.ipc_handle_type = MPL_GPU_IPC_HANDLE_SHAREABLE;
     MPL_gpu_info.specialized_cache = false;
 
-    char *visible_devices = getenv("CUDA_VISIBLE_DEVICES");
+    char *visible_devices;
+    visible_devices = getenv("CUDA_VISIBLE_DEVICES");
     if (visible_devices) {
         local_to_global_map = MPL_malloc(device_count * sizeof(int), MPL_MEM_OTHER);
 
@@ -487,6 +491,7 @@ static void gpu_free_hooks_cb(void *dptr)
     return;
 }
 
+typedef void (*funcptr_t) (void);
 static int gpu_mem_hook_init()
 {
     void *libcuda_handle;
@@ -497,9 +502,9 @@ static int gpu_mem_hook_init()
     libcudart_handle = dlopen("libcudart.so", RTLD_LAZY | RTLD_GLOBAL);
     assert(libcudart_handle);
 
-    sys_cuMemFree = (void *) dlsym(libcuda_handle, CUDA_SYMBOL_STRING(cuMemFree));
+    sys_cuMemFree = (cuMemFree_t) dlsym(libcuda_handle, CUDA_SYMBOL_STRING(cuMemFree));
     assert(sys_cuMemFree);
-    sys_cudaFree = (void *) dlsym(libcudart_handle, CUDA_SYMBOL_STRING(cudaFree));
+    sys_cudaFree = (cudaFree_t) dlsym(libcudart_handle, CUDA_SYMBOL_STRING(cudaFree));
     assert(sys_cudaFree);
 
     return MPL_SUCCESS;

--- a/src/mpl/src/mpl_rankmap.c
+++ b/src/mpl/src/mpl_rankmap.c
@@ -88,14 +88,14 @@ int MPL_rankmap_str_to_array(char *mapping, int sz, int *out_rankmap)
     RANKMAP_SKIP_SPACE(s);
     RANKMAP_EXPECT_AND_SKIP_C(s, '(');
     RANKMAP_SKIP_SPACE(s);
-    bool flag = RANKMAP_EXPECT_S(s, RANKMAP_VECTOR);
-    if (!flag) {
+    if (!RANKMAP_EXPECT_S(s, RANKMAP_VECTOR)) {
         RANKMAP_PARSE_ERROR();
     }
     s += strlen(RANKMAP_VECTOR);
     RANKMAP_SKIP_SPACE(s);
 
-    bool expect_comma = true;
+    bool expect_comma;
+    expect_comma = true;
     while (*s && rank < sz) {
         RANKMAP_SKIP_SPACE(s);
         if (expect_comma) {

--- a/src/pmi/src/pmi_util.c
+++ b/src/pmi/src/pmi_util.c
@@ -236,8 +236,9 @@ int PMIU_read_cmd(int fd, char **buf_out, int *buflen_out)
     bufsize = MAX_READLINE;
     PMIU_CHK_MALLOC(buf, char *, bufsize, pmi_errno, PMIU_ERR_NOMEM, "buf");
 
-    int wire_version = 0;
-    int pmi2_cmd_len = 0;
+    int wire_version, pmi2_cmd_len;
+    wire_version = 0;
+    pmi2_cmd_len = 0;
     while (1) {
         int n = 0;
         /* -- read more -- */

--- a/src/pmi/src/pmi_v2.c
+++ b/src/pmi/src/pmi_v2.c
@@ -108,13 +108,15 @@ PMI_API_PUBLIC int PMI2_Init(int *spawned, int *size, int *rank, int *appnum)
 
     /* do full PMI2 init */
     const char *s_pmiid;
-    int pmiid = -1;
     s_pmiid = getenv("PMI_ID");
     if (!s_pmiid) {
         s_pmiid = getenv("PMI_RANK");
     }
+    int pmiid;
     if (s_pmiid) {
         pmiid = atoi(s_pmiid);
+    } else {
+        pmiid = -1;
     }
 
     PMIU_msg_set_query_fullinit(&pmicmd, USE_WIRE_VER, no_static, pmiid);
@@ -122,7 +124,7 @@ PMI_API_PUBLIC int PMI2_Init(int *spawned, int *size, int *rank, int *appnum)
     pmi_errno = PMIU_cmd_get_response(PMI_fd, &pmicmd);
     PMIU_ERR_POP(pmi_errno);
 
-    const char *spawner_jobid = NULL;
+    const char *spawner_jobid;
     int verbose;                /* unused */
     PMIU_msg_get_response_fullinit(&pmicmd, rank, size, appnum, &spawner_jobid, &verbose);
     PMIU_ERR_POP(pmi_errno);


### PR DESCRIPTION
## Pull Request Description
The compiler nvc, previously the PGI compiler, spits tons of warnings by default. This PR suppresses them.

[skip warnings]

## Background
Current CI using nvc on polaris:
![image](https://github.com/user-attachments/assets/600b2c74-12b7-4d87-a03c-53cf00721922)

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
