### PR TITLE
misc: fix issues revealed from ZE testing

### DIFF
--- a/src/include/mpir_gpu.h
+++ b/src/include/mpir_gpu.h
@@ -103,17 +103,20 @@ MPL_STATIC_INLINE_PREFIX int MPIR_GPU_query_pointer_attr(const void *ptr, MPL_po
 MPL_STATIC_INLINE_PREFIX bool MPIR_GPU_query_pointer_is_dev(const void *ptr)
 {
     if (ENABLE_GPU && ptr != NULL) {
-        return MPL_gpu_query_pointer_is_dev(ptr, NULL);
+        MPL_pointer_attr_t attr;
+        MPIR_GPU_query_pointer_attr(ptr, &attr);
+        return MPL_gpu_attr_is_dev(&attr);
     }
 
     return false;
 }
 
-MPL_STATIC_INLINE_PREFIX bool MPIR_GPU_query_pointer_is_strict_dev(const void *ptr,
-                                                                   MPL_pointer_attr_t * attr)
+MPL_STATIC_INLINE_PREFIX bool MPIR_GPU_query_pointer_is_strict_dev(const void *ptr)
 {
     if (ENABLE_GPU && ptr != NULL) {
-        return MPL_gpu_query_pointer_is_strict_dev(ptr, attr);
+        MPL_pointer_attr_t attr;
+        MPIR_GPU_query_pointer_attr(ptr, &attr);
+        return MPL_gpu_attr_is_strict_dev(&attr);
     }
 
     return false;

--- a/src/include/mpir_gpu_util.h
+++ b/src/include/mpir_gpu_util.h
@@ -41,7 +41,8 @@ MPL_STATIC_INLINE_PREFIX void *MPIR_gpu_host_alloc(const void *buf,
     MPL_pointer_attr_t attr;
     MPIR_GPU_query_pointer_attr(buf, &attr);
 
-    if (attr.type != MPL_GPU_POINTER_DEV) {
+    /* FIXME: do we allocate buffer for non-strict dev buffer? */
+    if (!MPL_gpu_attr_is_strict_dev(&attr)) {
         return NULL;
     } else {
         return MPIR_alloc_buffer(count, datatype);

--- a/src/mpi/datatype/typerep/src/typerep_internal.h
+++ b/src/mpi/datatype/typerep/src/typerep_internal.h
@@ -25,7 +25,7 @@ yaksa_type_t MPII_Typerep_get_yaksa_op(MPI_Op op);
 static inline yaksa_info_t MPII_yaksa_get_info(MPL_pointer_attr_t * inattr,
                                                MPL_pointer_attr_t * outattr)
 {
-    if (inattr->type != MPL_GPU_POINTER_DEV && outattr->type != MPL_GPU_POINTER_DEV) {
+    if (!MPL_gpu_attr_is_dev(inattr) && !MPL_gpu_attr_is_dev(outattr)) {
         return MPII_yaksa_info_nogpu;
     }
 

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -134,9 +134,9 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
         MPIR_GPU_query_pointer_attr(sendbuf, &send_attr);
         MPIR_GPU_query_pointer_attr(recvbuf, &recv_attr);
 
-        if (send_attr.type == MPL_GPU_POINTER_DEV && recv_attr.type == MPL_GPU_POINTER_DEV) {
+        if (MPL_gpu_attr_is_strict_dev(&send_attr) && MPL_gpu_attr_is_strict_dev(&recv_attr)) {
             MPL_gpu_malloc((void **) &buf, COPY_BUFFER_SZ, recv_attr.device);
-        } else if (send_attr.type == MPL_GPU_POINTER_DEV || recv_attr.type == MPL_GPU_POINTER_DEV) {
+        } else if (MPL_gpu_attr_is_strict_dev(&send_attr) || MPL_gpu_attr_is_strict_dev(&recv_attr)) {
             MPL_gpu_malloc_host((void **) &buf, COPY_BUFFER_SZ);
         } else {
             MPIR_CHKLMEM_MALLOC(buf, char *, COPY_BUFFER_SZ, mpi_errno, "buf", MPL_MEM_BUFFER);
@@ -179,9 +179,9 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
             }
         }
 
-        if (send_attr.type == MPL_GPU_POINTER_DEV && recv_attr.type == MPL_GPU_POINTER_DEV) {
+        if (MPL_gpu_attr_is_strict_dev(&send_attr) && MPL_gpu_attr_is_strict_dev(&recv_attr)) {
             MPL_gpu_free(buf);
-        } else if (send_attr.type == MPL_GPU_POINTER_DEV || recv_attr.type == MPL_GPU_POINTER_DEV) {
+        } else if (MPL_gpu_attr_is_strict_dev(&send_attr) || MPL_gpu_attr_is_strict_dev(&recv_attr)) {
             MPL_gpu_free_host(buf);
         }
     }
@@ -192,9 +192,9 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
     return mpi_errno;
   fn_fail:
     if (buf) {
-        if (send_attr.type == MPL_GPU_POINTER_DEV && recv_attr.type == MPL_GPU_POINTER_DEV) {
+        if (MPL_gpu_attr_is_strict_dev(&send_attr) && MPL_gpu_attr_is_strict_dev(&recv_attr)) {
             MPL_gpu_free(buf);
-        } else if (send_attr.type == MPL_GPU_POINTER_DEV || recv_attr.type == MPL_GPU_POINTER_DEV) {
+        } else if (MPL_gpu_attr_is_strict_dev(&send_attr) || MPL_gpu_attr_is_strict_dev(&recv_attr)) {
             MPL_gpu_free_host(buf);
         }
     }
@@ -275,12 +275,12 @@ static int do_localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
                 gpu_req->type = MPIR_NULL_REQUEST;
             }
         } else {
-            if (send_attr && send_attr->type == MPL_GPU_POINTER_DEV) {
+            if (MPL_gpu_attr_is_strict_dev(send_attr)) {
                 dev_id = MPL_gpu_get_dev_id_from_attr(send_attr);
             }
 
             if (dev_id == -1) {
-                if (recv_attr->type == MPL_GPU_POINTER_DEV) {
+                if (MPL_gpu_attr_is_strict_dev(recv_attr)) {
                     dev_id = MPL_gpu_get_dev_id_from_attr(recv_attr);
                 } else {
                     /* fallback to do_localcopy */

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -484,9 +484,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_eager(int rank, MPIR_Comm * c
 
         MPL_pointer_attr_t attr;
         MPIR_GPU_query_pointer_attr(buf, &attr);
-        if (attr.type == MPL_GPU_POINTER_DEV) {
+        if (MPL_gpu_attr_is_dev(&attr)) {
             MPIDI_OFI_register_am_bufs();
-            if (!MPIDI_OFI_ENABLE_HMEM) {
+            if (!MPIDI_OFI_ENABLE_HMEM || !MPL_gpu_attr_is_strict_dev(&attr)) {
                 /* Force packing of GPU buffer in host memory */
                 need_packing = true;
             }
@@ -641,9 +641,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_pipeline(int rank, MPIR_Comm 
 
         MPL_pointer_attr_t attr;
         MPIR_GPU_query_pointer_attr(buf, &attr);
-        if (attr.type == MPL_GPU_POINTER_DEV) {
+        if (MPL_gpu_attr_is_dev(&attr)) {
             MPIDI_OFI_register_am_bufs();
-            if (!MPIDI_OFI_ENABLE_HMEM) {
+            if (!MPIDI_OFI_ENABLE_HMEM || !MPL_gpu_attr_is_strict_dev(&attr)) {
                 /* Force packing of GPU buffer in host memory */
                 need_packing = true;
             }
@@ -740,9 +740,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_rdma_read(int rank, MPIR_Comm
 
         MPL_pointer_attr_t attr;
         MPIR_GPU_query_pointer_attr(buf, &attr);
-        if (attr.type == MPL_GPU_POINTER_DEV) {
+        if (MPL_gpu_attr_is_dev(&attr)) {
             MPIDI_OFI_register_am_bufs();
-            if (!MPIDI_OFI_ENABLE_HMEM) {
+            if (!MPIDI_OFI_ENABLE_HMEM || !MPL_gpu_attr_is_strict_dev(&attr)) {
                 /* Force packing of GPU buffer in host memory */
                 need_packing = true;
             }

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -120,7 +120,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_event(int vci, struct fi_cq_tagged_e
                                        MPIDI_OFI_REQUEST(rreq, noncontig.pack.buf),
                                        MPIDI_OFI_REQUEST(rreq, noncontig.pack.count),
                                        MPIDI_OFI_REQUEST(rreq, noncontig.pack.datatype), 0, NULL,
-                                       MPL_GPU_COPY_DIRECTION_NONE,
+                                       MPL_GPU_COPY_H2D,
                                        MPIDI_OFI_gpu_get_recv_engine_type(), true);
         if (mpi_errno) {
             MPIR_ERR_SET(rreq->status.MPI_ERROR, MPI_ERR_TYPE, "**dtypemismatch");

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -794,8 +794,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_gpu_rma_register(const void *buffer, siz
         MPIR_GPU_query_pointer_attr(buffer, &attr_tmp);
         attr = &attr_tmp;
     }
-    if (MPIDI_OFI_ENABLE_HMEM && MPIDI_OFI_ENABLE_MR_HMEM &&
-        MPIR_GPU_query_pointer_is_strict_dev(buffer, attr)) {
+    if (MPIDI_OFI_ENABLE_HMEM && MPIDI_OFI_ENABLE_MR_HMEM && MPL_gpu_attr_is_strict_dev(attr)) {
         MPIDI_OFI_register_memory_and_bind((char *) buffer, size, attr, ctx_idx, &mr);
         if (mr != NULL) {
             *desc = fi_mr_desc(mr);

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -705,17 +705,21 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_register_memory(char *send_buf, size_t da
     mr_attr.requested_key = rkey;
     mr_attr.offset = 0;
     mr_attr.context = NULL;
+    if (MPL_gpu_attr_is_strict_dev(attr)) {
 #ifdef MPL_HAVE_CUDA
-    mr_attr.iface = (attr->type != MPL_GPU_POINTER_DEV) ? FI_HMEM_SYSTEM : FI_HMEM_CUDA;
-    mr_attr.device.cuda =
-        (attr->type != MPL_GPU_POINTER_DEV) ? 0 : MPL_gpu_get_dev_id_from_attr(attr);
+        mr_attr.iface = FI_HMEM_CUDA;
+        mr_attr.device.cuda = MPL_gpu_get_dev_id_from_attr(attr);
 #elif defined MPL_HAVE_ZE
-    /* OFI does not support tiles yet, need to pass the root device. */
-    mr_attr.iface = (attr->type != MPL_GPU_POINTER_DEV) ? FI_HMEM_SYSTEM : FI_HMEM_ZE;
-    mr_attr.device.ze =
-        (attr->type !=
-         MPL_GPU_POINTER_DEV) ? 0 : MPL_gpu_get_root_device(MPL_gpu_get_dev_id_from_attr(attr));
+        /* OFI does not support tiles yet, need to pass the root device. */
+        mr_attr.iface = FI_HMEM_ZE;
+        mr_attr.device.ze = MPL_gpu_get_root_device(MPL_gpu_get_dev_id_from_attr(attr));
+#else
+        /* FIXME: add support for MPL_HAVE_HIP (FI_HMEM_ROCR) */
+        mr_attr.iface = FI_HMEM_SYSTEM;
 #endif
+    } else {
+        mr_attr.iface = FI_HMEM_SYSTEM;
+    }
     MPIDI_OFI_CALL(fi_mr_regattr
                    (MPIDI_OFI_global.ctx[ctx_idx].domain, &mr_attr, 0, mr), mr_regattr);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -171,7 +171,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
 
     if (MPIDI_OFI_ENABLE_HMEM && data_sz >= MPIR_CVAR_CH4_OFI_GPU_RDMA_THRESHOLD &&
         MPIDI_OFI_ENABLE_MR_HMEM && dt_contig) {
-        if (attr.type == MPL_GPU_POINTER_DEV) {
+        if (MPL_gpu_attr_is_strict_dev(&attr)) {
             register_mem = true;
         }
     }

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -472,7 +472,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq, bool 
     fi_cancel((fid_t) MPIDI_OFI_global.ctx[ctx_idx].rx, &(MPIDI_OFI_REQUEST(rreq, context)));
 
     if (is_blocking) {
-        /* progress until the rreq complets, either with cancel-bit set,
+        /* progress until the rreq completes, either with cancel-bit set,
          * or with message received */
         while (!MPIR_cc_is_complete(&rreq->cc)) {
             mpi_errno = MPIDI_OFI_progress_uninlined(vci);

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -287,16 +287,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
                              MPI_ERR_OTHER, "**nomem", "**nomem %s", "Recv Pack Buffer alloc");
         recv_buf = MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer);
         MPIDI_OFI_REQUEST(rreq, noncontig.pack.buf) = buf;
-#ifdef MPL_HAVE_ZE
-        if (dt_contig && attr.type == MPL_GPU_POINTER_DEV) {
-            int mpl_err = MPL_SUCCESS;
-            void *ptr;
-            mpl_err = MPL_ze_mmap_device_pointer(buf, &attr.device_attr, attr.device, &ptr);
-            MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                                "**mpl_ze_mmap_device_ptr");
-            MPIDI_OFI_REQUEST(rreq, noncontig.pack.buf) = ptr;
-        }
-#endif
         MPIDI_OFI_REQUEST(rreq, noncontig.pack.count) = count;
         MPIDI_OFI_REQUEST(rreq, noncontig.pack.datatype) = datatype;
         MPIR_Datatype_add_ref_if_not_builtin(datatype);

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -176,7 +176,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         }
     }
 
-    if (data_sz && MPL_gpu_query_pointer_is_dev(recv_buf, &attr)) {
+    if (data_sz && MPL_gpu_attr_is_dev(&attr)) {
         MPIDI_OFI_register_am_bufs();
         if (!MPIDI_OFI_ENABLE_HMEM || !dt_contig || (MPIDI_OFI_ENABLE_MR_HMEM && !register_mem)) {
             /* FIXME: at this point, GPU data takes host-buffer staging

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -394,8 +394,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_pipeline(const void *buf, MPI_Aint c
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    MPIR_Assert(dt_contig);
-
     int sender_nic =
         MPIDI_OFI_multx_sender_nic_index(comm, comm->context_id, comm->rank, dst_rank, tag);
     int receiver_nic =
@@ -579,7 +577,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
             }
         }
 
-        if (need_pack && dt_contig && MPIR_CVAR_CH4_OFI_ENABLE_GPU_PIPELINE &&
+        if (need_pack && MPIR_CVAR_CH4_OFI_ENABLE_GPU_PIPELINE &&
             data_sz >= MPIR_CVAR_CH4_OFI_GPU_PIPELINE_THRESHOLD) {
             do_gpu_pipelining = true;
             need_pack = false;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -563,7 +563,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
         if (!MPIDI_OFI_ENABLE_HMEM) {
             /* HMEM (any kind) not supported */
             need_pack = true;
-        } else if (attr.type != MPL_GPU_POINTER_DEV) {
+        } else if (!MPL_gpu_attr_is_strict_dev(&attr)) {
             /* non-strict gpu ptr (ZE shared host) */
             need_pack = true;
         } else {

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -553,7 +553,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
     MPL_pointer_attr_t attr;
     void *send_buf = MPIR_get_contig_ptr(buf, dt_true_lb);
     MPIR_GPU_query_pointer_attr(send_buf, &attr);
-    if (data_sz && MPL_gpu_query_pointer_is_dev(send_buf, &attr)) {
+    if (data_sz && MPL_gpu_attr_is_dev(&attr)) {
         is_gpu = true;
         MPIDI_OFI_register_am_bufs();
     }

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -183,10 +183,10 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
             len = (size_t) win->size;
         }
 
-        if (MPIR_GPU_query_pointer_is_strict_dev(base)) {
-            if (MPIDI_OFI_ENABLE_HMEM) {
-                MPL_pointer_attr_t attr;
-                MPIR_GPU_query_pointer_attr(base, &attr);
+        MPL_pointer_attr_t attr;
+        MPIR_GPU_query_pointer_attr(base, &attr);
+        if (MPL_gpu_attr_is_dev(&attr)) {
+            if (MPIDI_OFI_ENABLE_HMEM && MPL_gpu_attr_is_strict_dev(&attr)) {
                 mpi_errno =
                     MPIDI_OFI_register_memory(base, len, &attr, ctx_idx, MPIDI_OFI_WIN(win).mr_key,
                                               &MPIDI_OFI_WIN(win).mr);

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -183,7 +183,7 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
             len = (size_t) win->size;
         }
 
-        if (MPIR_GPU_query_pointer_is_strict_dev(base, NULL)) {
+        if (MPIR_GPU_query_pointer_is_strict_dev(base)) {
             if (MPIDI_OFI_ENABLE_HMEM) {
                 MPL_pointer_attr_t attr;
                 MPIR_GPU_query_pointer_attr(base, &attr);

--- a/src/mpid/ch4/netmod/ucx/ucx_am.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_am.h
@@ -95,7 +95,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_am_isend(int rank,
 
     MPL_pointer_attr_t attr;
     MPIR_GPU_query_pointer_attr(data, &attr);
-    if (attr.type == MPL_GPU_POINTER_DEV) {
+    if (MPL_gpu_attr_is_dev(&attr)) {
         /* Force packing of GPU buffer in host memory */
         dt_contig = 0;
     }

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -22,7 +22,7 @@ static void ipc_handle_free_hook(void *dptr)
         MPIR_Assert(mpl_err == MPL_SUCCESS);
 
         MPIR_GPU_query_pointer_attr(pbase, &gpu_attr);
-        if (gpu_attr.type == MPL_GPU_POINTER_DEV) {
+        if (MPL_gpu_attr_is_strict_dev(&gpu_attr)) {
             local_dev_id = MPL_gpu_get_dev_id_from_attr(&gpu_attr);
 
             for (int i = 0; i < MPIR_Process.local_size; ++i) {

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -324,7 +324,7 @@ int MPIDI_GPU_get_ipc_attr(const void *buf, MPI_Aint count, MPI_Datatype datatyp
         /* if it's a device buffer, we cannot do XPMEM or CMA IPC, so set default to SKIP */
         ipc_attr->ipc_type = MPIDI_IPCI_TYPE__SKIP;
     }
-    if (ipc_attr->u.gpu.gpu_attr.type != MPL_GPU_POINTER_DEV) {
+    if (!MPL_gpu_attr_is_strict_dev(&ipc_attr->u.gpu.gpu_attr)) {
         goto fn_exit;
     }
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -320,7 +320,7 @@ int MPIDI_GPU_get_ipc_attr(const void *buf, MPI_Aint count, MPI_Datatype datatyp
         mem_addr = (char *) buf;
     }
     MPIR_GPU_query_pointer_attr(mem_addr, &ipc_attr->u.gpu.gpu_attr);
-    if (MPL_gpu_query_pointer_is_dev(mem_addr, &ipc_attr->u.gpu.gpu_attr)) {
+    if (MPL_gpu_attr_is_dev(&ipc_attr->u.gpu.gpu_attr)) {
         /* if it's a device buffer, we cannot do XPMEM or CMA IPC, so set default to SKIP */
         ipc_attr->ipc_type = MPIDI_IPCI_TYPE__SKIP;
     }

--- a/src/mpid/ch4/shm/posix/posix_coll.h
+++ b/src/mpid/ch4/shm/posix/posix_coll.h
@@ -240,15 +240,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast(void *buffer, MPI_Aint count,
         case MPIR_CVAR_BCAST_POSIX_INTRA_ALGORITHM_auto:
             if (MPIR_CVAR_COLL_HYBRID_MEMORY) {
                 cnt = MPIR_Csel_search(MPIDI_POSIX_COMM(comm, csel_comm), coll_sig);
-            }
-            else {
+            } else {
                 /* In no hybird case, local memory type can be used to select algorithm */
                 MPL_pointer_attr_t pointer_attr;
                 MPIR_GPU_query_pointer_attr(buffer, &pointer_attr);
-                if (pointer_attr.type == MPL_GPU_POINTER_DEV) {
+                if (MPL_gpu_attr_is_strict_dev(&pointer_attr)) {
                     cnt = MPIR_Csel_search(MPIDI_POSIX_COMM(comm, csel_comm_gpu), coll_sig);
-                }
-                else {
+                } else {
                     cnt = MPIR_Csel_search(MPIDI_POSIX_COMM(comm, csel_comm), coll_sig);
                 }
             }

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -136,14 +136,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
         goto fn_exit;
 
     MPIR_GPU_query_pointer_attr(origin_addr, &origin_attr);
-    if (MPL_gpu_query_pointer_is_dev(origin_addr, &origin_attr))
+    if (MPL_gpu_attr_is_dev(&origin_attr))
         origin_dev_id = MPL_gpu_local_to_global_dev_id(MPL_gpu_get_dev_id_from_attr(&origin_attr));
 
     if (target_rank == MPIDIU_win_comm_rank(win, winattr)) {
         base = win->base;
         disp_unit = win->disp_unit;
         MPIR_GPU_query_pointer_attr(base, &target_attr);
-        if (MPL_gpu_query_pointer_is_dev(base, &target_attr))
+        if (MPL_gpu_attr_is_dev(&target_attr))
             target_dev_id =
                 MPL_gpu_local_to_global_dev_id(MPL_gpu_get_dev_id_from_attr(&target_attr));
     } else {
@@ -160,10 +160,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
 #ifdef MPL_HAVE_GPU
     if (MPIR_CVAR_CH4_IPC_GPU_RMA_ENGINE_TYPE != MPIR_CVAR_CH4_IPC_GPU_RMA_ENGINE_TYPE_yaksa) {
         MPL_gpu_engine_type_t engine_type =
-            MPIDI_RMA_choose_engine(MPL_gpu_query_pointer_is_dev(origin_addr, &origin_attr),
-                                    origin_dev_id, MPL_gpu_query_pointer_is_dev(target_addr,
-                                                                                &target_attr),
-                                    target_dev_id);
+            MPIDI_RMA_choose_engine(MPL_gpu_attr_is_dev(&origin_attr), origin_dev_id,
+                                    MPL_gpu_attr_is_dev(&target_attr), target_dev_id);
         if (winattr & MPIDI_WINATTR_MR_PREFERRED) {
             MPIR_gpu_req yreq;
             mpi_errno =
@@ -228,14 +226,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
         goto fn_exit;
 
     MPIR_GPU_query_pointer_attr(origin_addr, &origin_attr);
-    if (MPL_gpu_query_pointer_is_dev(origin_addr, &origin_attr))
+    if (MPL_gpu_attr_is_dev(&origin_attr))
         origin_dev_id = MPL_gpu_local_to_global_dev_id(MPL_gpu_get_dev_id_from_attr(&origin_attr));
 
     if (target_rank == MPIDIU_win_comm_rank(win, winattr)) {
         base = win->base;
         disp_unit = win->disp_unit;
         MPIR_GPU_query_pointer_attr(base, &target_attr);
-        if (MPL_gpu_query_pointer_is_dev(base, &target_attr))
+        if (MPL_gpu_attr_is_dev(&target_attr))
             target_dev_id =
                 MPL_gpu_local_to_global_dev_id(MPL_gpu_get_dev_id_from_attr(&target_attr));
     } else {
@@ -252,10 +250,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
 #ifdef MPL_HAVE_GPU
     if (MPIR_CVAR_CH4_IPC_GPU_RMA_ENGINE_TYPE != MPIR_CVAR_CH4_IPC_GPU_RMA_ENGINE_TYPE_yaksa) {
         MPL_gpu_engine_type_t engine_type =
-            MPIDI_RMA_choose_engine(MPL_gpu_query_pointer_is_dev(origin_addr, &origin_attr),
-                                    origin_dev_id, MPL_gpu_query_pointer_is_dev(target_addr,
-                                                                                &target_attr),
-                                    target_dev_id);
+            MPIDI_RMA_choose_engine(MPL_gpu_attr_is_dev(&origin_attr), origin_dev_id,
+                                    MPL_gpu_attr_is_dev(&target_attr), target_dev_id);
         if (winattr & MPIDI_WINATTR_MR_PREFERRED) {
             MPIR_gpu_req yreq;
             mpi_errno = MPIR_Ilocalcopy_gpu(target_addr, target_count,

--- a/src/mpid/ch4/src/ch4_coll.h
+++ b/src/mpid/ch4/src/ch4_coll.h
@@ -199,15 +199,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_allcomm_composition_json(void *buffer, 
 
     if (MPIR_CVAR_COLL_HYBRID_MEMORY) {
         cnt = MPIR_Csel_search(MPIDI_COMM(comm, csel_comm), coll_sig);
-    }
-    else {
+    } else {
         /* In no hybird case, local memory type can be used to select algorithm */
         MPL_pointer_attr_t pointer_attr;
         MPIR_GPU_query_pointer_attr(buffer, &pointer_attr);
         if (pointer_attr.type == MPL_GPU_POINTER_DEV) {
             cnt = MPIR_Csel_search(MPIDI_COMM(comm, csel_comm_gpu), coll_sig);
-        }
-        else {
+        } else {
             cnt = MPIR_Csel_search(MPIDI_COMM(comm, csel_comm), coll_sig);
         }
     }
@@ -558,10 +556,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_allcomm_composition_json(const void
 
     if (sendbuf != MPI_IN_PLACE) {
         MPIR_Datatype_get_size_macro(sendtype, type_size);
-	data_size = sendcount * type_size;
+        data_size = sendcount * type_size;
     } else {
         MPIR_Datatype_get_size_macro(recvtype, type_size);
-	data_size = recvcount * type_size;
+        data_size = recvcount * type_size;
     }
 
     MPIR_Csel_coll_sig_s coll_sig = {
@@ -595,10 +593,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allgather_allcomm_composition_json(const void
                                            MPIDI_COMM_ALLGATHER(comm, use_multi_leads) == 1 &&
                                            data_size <= MPIR_CVAR_ALLGATHER_SHM_PER_RANK, mpi_errno,
                                            "Allgather composition alpha cannot be applied.\n");
-	    mpi_errno =
-		MPIDI_Allgather_intra_composition_alpha(sendbuf, sendcount, sendtype,
-							recvbuf, recvcount, recvtype,
-							comm, errflag);
+            mpi_errno =
+                MPIDI_Allgather_intra_composition_alpha(sendbuf, sendcount, sendtype,
+                                                        recvbuf, recvcount, recvtype,
+                                                        comm, errflag);
             break;
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Allgather_intra_composition_beta:
             MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank,
@@ -643,10 +641,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Allgather(const void *sendbuf, MPI_Aint sendco
 
     if (sendbuf != MPI_IN_PLACE) {
         MPIR_Datatype_get_size_macro(sendtype, type_size);
-	data_size = sendcount * type_size;
+        data_size = sendcount * type_size;
     } else {
         MPIR_Datatype_get_size_macro(recvtype, type_size);
-	data_size = recvcount * type_size;
+        data_size = recvcount * type_size;
     }
 
     switch (MPIR_CVAR_ALLGATHER_COMPOSITION) {
@@ -1009,10 +1007,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_allcomm_composition_json(const void 
 
     if (sendbuf != MPI_IN_PLACE) {
         MPIR_Datatype_get_size_macro(sendtype, type_size);
-	data_size = sendcount * type_size;
+        data_size = sendcount * type_size;
     } else {
         MPIR_Datatype_get_size_macro(recvtype, type_size);
-	data_size = recvcount * type_size;
+        data_size = recvcount * type_size;
     }
 
     const MPIDI_Csel_container_s *cnt = NULL;
@@ -1046,10 +1044,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Alltoall_allcomm_composition_json(const void 
                                            && MPIDI_COMM_ALLTOALL(comm, use_multi_leads) == 1 &&
                                            data_size <= MPIR_CVAR_ALLTOALL_SHM_PER_RANK, mpi_errno,
                                            "Alltoall composition alpha cannot be applied.\n");
-	    mpi_errno =
-		MPIDI_Alltoall_intra_composition_alpha(sendbuf, sendcount, sendtype,
-						       recvbuf, recvcount, recvtype,
-						       comm, errflag);
+            mpi_errno =
+                MPIDI_Alltoall_intra_composition_alpha(sendbuf, sendcount, sendtype,
+                                                       recvbuf, recvcount, recvtype, comm, errflag);
             break;
 
         case MPIDI_CSEL_CONTAINER_TYPE__COMPOSITION__MPIDI_Alltoall_intra_composition_beta:
@@ -1095,10 +1092,10 @@ MPL_STATIC_INLINE_PREFIX int MPID_Alltoall(const void *sendbuf, MPI_Aint sendcou
 
     if (sendbuf != MPI_IN_PLACE) {
         MPIR_Datatype_get_size_macro(sendtype, type_size);
-	data_size = sendcount * type_size;
+        data_size = sendcount * type_size;
     } else {
         MPIR_Datatype_get_size_macro(recvtype, type_size);
-	data_size = recvcount * type_size;
+        data_size = recvcount * type_size;
     }
 
     switch (MPIR_CVAR_ALLTOALL_COMPOSITION) {

--- a/src/mpid/ch4/src/ch4_coll.h
+++ b/src/mpid/ch4/src/ch4_coll.h
@@ -203,7 +203,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_allcomm_composition_json(void *buffer, 
         /* In no hybird case, local memory type can be used to select algorithm */
         MPL_pointer_attr_t pointer_attr;
         MPIR_GPU_query_pointer_attr(buffer, &pointer_attr);
-        if (pointer_attr.type == MPL_GPU_POINTER_DEV) {
+        if (MPL_gpu_attr_is_strict_dev(&pointer_attr)) {
             cnt = MPIR_Csel_search(MPIDI_COMM(comm, csel_comm_gpu), coll_sig);
         } else {
             cnt = MPIR_Csel_search(MPIDI_COMM(comm, csel_comm), coll_sig);

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -271,7 +271,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, M
 
     MPIDI_Coll_calculate_size_shift(count, datatype, &size, &shift);
 
-    if (attr.type == MPL_GPU_POINTER_DEV && size <= MPIR_CVAR_CH4_GPU_COLL_SWAP_BUFFER_SZ) {
+    if (MPL_gpu_attr_is_strict_dev(&attr) && size <= MPIR_CVAR_CH4_GPU_COLL_SWAP_BUFFER_SZ) {
         MPIDU_genq_private_pool_alloc_cell(MPIDI_global.gpu_coll_pool, (void **) &host_buffer);
         if (host_buffer != NULL) {
             host_buffer = (char *) host_buffer - shift;
@@ -327,7 +327,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_beta(void *buffer, MP
 
     MPIDI_Coll_calculate_size_shift(count, datatype, &size, &shift);
 
-    if (attr.type == MPL_GPU_POINTER_DEV && size <= MPIR_CVAR_CH4_GPU_COLL_SWAP_BUFFER_SZ) {
+    if (MPL_gpu_attr_is_strict_dev(&attr) && size <= MPIR_CVAR_CH4_GPU_COLL_SWAP_BUFFER_SZ) {
         MPIDU_genq_private_pool_alloc_cell(MPIDI_global.gpu_coll_pool, (void **) &host_buffer);
         if (host_buffer != NULL) {
             host_buffer = (char *) host_buffer - shift;
@@ -396,7 +396,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_gamma(void *buffer, M
 
     MPIDI_Coll_calculate_size_shift(count, datatype, &size, &shift);
 
-    if (attr.type == MPL_GPU_POINTER_DEV && size <= MPIR_CVAR_CH4_GPU_COLL_SWAP_BUFFER_SZ) {
+    if (MPL_gpu_attr_is_strict_dev(&attr) && size <= MPIR_CVAR_CH4_GPU_COLL_SWAP_BUFFER_SZ) {
         MPIDU_genq_private_pool_alloc_cell(MPIDI_global.gpu_coll_pool, (void **) &host_buffer);
         if (host_buffer != NULL) {
             host_buffer = (char *) host_buffer - shift;
@@ -486,7 +486,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_delta(void *buffer, M
     MPIDI_Coll_calculate_size_shift(count, datatype, &size, &shift);
 
     /* only node leaders need to allocate a host buffer */
-    if (attr.type == MPL_GPU_POINTER_DEV && size <= MPIR_CVAR_CH4_GPU_COLL_SWAP_BUFFER_SZ
+    if (MPL_gpu_attr_is_strict_dev(&attr) && size <= MPIR_CVAR_CH4_GPU_COLL_SWAP_BUFFER_SZ
         && comm->node_roots_comm != NULL) {
         MPIDU_genq_private_pool_alloc_cell(MPIDI_global.gpu_coll_pool, (void **) &host_buffer);
         if (host_buffer != NULL) {
@@ -551,7 +551,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_alpha(const void 
 
     MPIDI_Coll_calculate_size_shift(count, datatype, &size, &shift);
 
-    if ((send_attr.type == MPL_GPU_POINTER_DEV || recv_attr.type == MPL_GPU_POINTER_DEV) &&
+    if ((MPL_gpu_attr_is_strict_dev(&send_attr) || MPL_gpu_attr_is_strict_dev(&recv_attr)) &&
         (size <= MPIR_CVAR_CH4_GPU_COLL_SWAP_BUFFER_SZ)) {
         MPIDI_Coll_host_buffer_genq_alloc(sendbuf, recvbuf, count, datatype, &host_sendbuf,
                                           &host_recvbuf, send_attr, recv_attr, shift);
@@ -647,7 +647,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_beta(const void *
 
     MPIDI_Coll_calculate_size_shift(count, datatype, &size, &shift);
 
-    if ((send_attr.type == MPL_GPU_POINTER_DEV || recv_attr.type == MPL_GPU_POINTER_DEV) &&
+    if ((MPL_gpu_attr_is_strict_dev(&send_attr) || MPL_gpu_attr_is_strict_dev(&recv_attr)) &&
         (size <= MPIR_CVAR_CH4_GPU_COLL_SWAP_BUFFER_SZ)) {
         MPIDI_Coll_host_buffer_genq_alloc(sendbuf, recvbuf, count, datatype, &host_sendbuf,
                                           &host_recvbuf, send_attr, recv_attr, shift);
@@ -696,7 +696,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_gamma(const void 
 
     MPIDI_Coll_calculate_size_shift(count, datatype, &size, &shift);
 
-    if ((send_attr.type == MPL_GPU_POINTER_DEV || recv_attr.type == MPL_GPU_POINTER_DEV) &&
+    if ((MPL_gpu_attr_is_strict_dev(&send_attr) || MPL_gpu_attr_is_strict_dev(&recv_attr)) &&
         (size <= MPIR_CVAR_CH4_GPU_COLL_SWAP_BUFFER_SZ)) {
         MPIDI_Coll_host_buffer_genq_alloc(sendbuf, recvbuf, count, datatype, &host_sendbuf,
                                           &host_recvbuf, send_attr, recv_attr, shift);

--- a/src/mpid/ch4/src/mpidig_recv_utils.h
+++ b/src/mpid/ch4/src/mpidig_recv_utils.h
@@ -21,11 +21,8 @@
 
 MPL_STATIC_INLINE_PREFIX void MPIDIG_recv_set_buffer_attr(MPIR_Request * rreq)
 {
-    MPL_pointer_attr_t attr;
-    MPIR_GPU_query_pointer_attr(MPIDIG_REQUEST(rreq, buffer), &attr);
-
     MPIDIG_rreq_async_t *p = &(MPIDIG_REQUEST(rreq, req->recv_async));
-    p->is_device_buffer = (attr.type == MPL_GPU_POINTER_DEV);
+    p->is_device_buffer = MPIR_GPU_query_pointer_is_dev(MPIDIG_REQUEST(rreq, buffer));
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDIG_recv_check_rndv_cb(MPIR_Request * rreq)

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -61,7 +61,7 @@ typedef enum {
     MPL_GPU_COPY_H2D,
     MPL_GPU_COPY_D2D_INCOMING,  /* copy from remote to local */
     MPL_GPU_COPY_D2D_OUTGOING,  /* copy from local to remote */
-    MPL_GPU_COPY_DIRECTION_NONE,  /* copy in any direction and to/from any buffer type */
+    MPL_GPU_COPY_DIRECTION_NONE,        /* copy in any direction and to/from any buffer type */
 } MPL_gpu_copy_direction_t;
 
 #define MPL_GPU_COPY_DIRECTION_TYPES 4
@@ -91,7 +91,12 @@ static inline int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t
     return MPL_SUCCESS;
 }
 
-static inline int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr_t * attr)
+static inline int MPL_gpu_attr_is_dev(MPL_pointer_attr_t * attr)
+{
+    return 0;
+}
+
+static inline int MPL_gpu_attr_is_strict_dev(MPL_pointer_attr_t * attr)
 {
     return 0;
 }
@@ -104,8 +109,8 @@ static inline int MPL_gpu_query_is_same_dev(int dev1, int dev2)
 
 int MPL_gpu_query_support(MPL_gpu_type_t * type);
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr);
-int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr_t * attr);
-int MPL_gpu_query_pointer_is_strict_dev(const void *ptr, MPL_pointer_attr_t * attr);
+int MPL_gpu_attr_is_dev(MPL_pointer_attr_t * attr);
+int MPL_gpu_attr_is_strict_dev(MPL_pointer_attr_t * attr);
 int MPL_gpu_query_is_same_dev(int dev1, int dev2);
 
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -139,25 +139,13 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     goto fn_exit;
 }
 
-int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr_t * attr)
+int MPL_gpu_attr_is_dev(MPL_pointer_attr_t * attr)
 {
-    MPL_pointer_attr_t a;
-
-    if (attr == NULL) {
-        MPL_gpu_query_pointer_attr(ptr, &a);
-        attr = &a;
-    }
     return attr->type == MPL_GPU_POINTER_DEV;
 }
 
-int MPL_gpu_query_pointer_is_strict_dev(const void *ptr, MPL_pointer_attr_t * attr)
+int MPL_gpu_attr_is_strict_dev(MPL_pointer_attr_t * attr)
 {
-    MPL_pointer_attr_t a;
-
-    if (attr == NULL) {
-        MPL_gpu_query_pointer_attr(ptr, &a);
-        attr = &a;
-    }
     return attr->type == MPL_GPU_POINTER_DEV;
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -6,11 +6,6 @@
 #include "mpl.h"
 #include <assert.h>
 
-int MPL_gpu_query_pointer_is_strict_dev(const void *ptr, MPL_pointer_attr_t * attr)
-{
-    return 0;
-}
-
 int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id, int *subdevice_id)
 {
     *dev_cnt = *dev_id = *subdevice_id = -1;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -166,25 +166,13 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 #endif
 
 
-int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr_t * attr)
+int MPL_gpu_attr_is_dev(MPL_pointer_attr_t * attr)
 {
-    MPL_pointer_attr_t a;
-
-    if (attr == NULL) {
-        MPL_gpu_query_pointer_attr(ptr, &a);
-        attr = &a;
-    }
     return attr->type == MPL_GPU_POINTER_DEV;
 }
 
-int MPL_gpu_query_pointer_is_strict_dev(const void *ptr, MPL_pointer_attr_t * attr)
+int MPL_gpu_attr_is_strict_dev(MPL_pointer_attr_t * attr)
 {
-    MPL_pointer_attr_t a;
-
-    if (attr == NULL) {
-        MPL_gpu_query_pointer_attr(ptr, &a);
-        attr = &a;
-    }
     return attr->type == MPL_GPU_POINTER_DEV;
 }
 

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -166,8 +166,8 @@ typedef struct MPL_ze_ipc_lru_mapped_entry_t {
 } MPL_ze_ipc_lru_mapped_entry_t;
 
 typedef struct {
-    void *ipc_buf;  /* key */
-    MPL_ze_ipc_lru_mapped_entry_t *entry;  /* entry in dl ipc_lru_order_head */
+    void *ipc_buf;              /* key */
+    MPL_ze_ipc_lru_mapped_entry_t *entry;       /* entry in dl ipc_lru_order_head */
     UT_hash_handle hh;
 } MPL_ze_ipc_lru_map_t;
 
@@ -606,14 +606,16 @@ int MPL_gpu_init(int debug_summary)
         }
 
         ipc_lru_mapped_order_head =
-            MPL_malloc(local_ze_device_count * sizeof(MPL_ze_ipc_lru_mapped_entry_t *), MPL_MEM_OTHER);
+            MPL_malloc(local_ze_device_count * sizeof(MPL_ze_ipc_lru_mapped_entry_t *),
+                       MPL_MEM_OTHER);
         if (ipc_lru_mapped_order_head == NULL) {
             mpl_err = MPL_ERR_GPU_NOMEM;
             goto fn_fail;
         }
 
         ipc_lru_mapped_order_tail =
-            MPL_malloc(local_ze_device_count * sizeof(MPL_ze_ipc_lru_mapped_entry_t *), MPL_MEM_OTHER);
+            MPL_malloc(local_ze_device_count * sizeof(MPL_ze_ipc_lru_mapped_entry_t *),
+                       MPL_MEM_OTHER);
         if (ipc_lru_mapped_order_tail == NULL) {
             mpl_err = MPL_ERR_GPU_NOMEM;
             goto fn_fail;
@@ -1562,7 +1564,8 @@ static int update_lru_mapped_order(void *ipc_buf, int dev_id)
     MPL_ze_ipc_lru_mapped_entry_t **head = &ipc_lru_mapped_order_head[dev_id];
     MPL_ze_ipc_lru_mapped_entry_t **tail = &ipc_lru_mapped_order_tail[dev_id];
 
-    if (ipc_max_entries[dev_id] == 0) goto fn_exit;
+    if (ipc_max_entries[dev_id] == 0)
+        goto fn_exit;
 
     /* Find the existing entry */
     HASH_FIND_PTR(ipc_lru_map[dev_id], &ipc_buf, map_entry);
@@ -1586,7 +1589,7 @@ static int update_lru_mapped_order(void *ipc_buf, int dev_id)
         /* Allocate a new entry */
         MPL_ze_ipc_lru_mapped_entry_t *entry =
             (MPL_ze_ipc_lru_mapped_entry_t *) MPL_calloc(1, sizeof(MPL_ze_ipc_lru_mapped_entry_t),
-                                                  MPL_MEM_OTHER);
+                                                         MPL_MEM_OTHER);
         if (entry == NULL) {
             mpl_err = MPL_ERR_GPU_NOMEM;
             goto fn_fail;
@@ -3209,7 +3212,8 @@ int MPL_ze_ipc_handle_mmap_host(MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle, int i
     }
 
     if (*ptr == NULL) {
-        mpl_err = MPL_ze_ipc_handle_map(mpl_ipc_handle, is_shared_handle, dev_id, true, size, &fds, ptr);
+        mpl_err =
+            MPL_ze_ipc_handle_map(mpl_ipc_handle, is_shared_handle, dev_id, true, size, &fds, ptr);
         if (mpl_err != MPL_SUCCESS) {
             goto fn_fail;
         }
@@ -3301,7 +3305,7 @@ int MPL_ze_mmap_device_pointer(void *dptr, MPL_gpu_device_attr * attr,
                 memcpy(&fds[i], &cache_entry->ipc_handle.ipc_handles[i], sizeof(int));
         } else {
             /* Only create an IPC handle in case one doesn't already exist */
-            nfds = 0;       /* must be initialized to 0 */
+            nfds = 0;   /* must be initialized to 0 */
             if (zexMemGetIpcHandles) {
                 ret = zexMemGetIpcHandles(ze_context, pbase, &nfds, NULL);
                 ZE_ERR_CHECK(ret);

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -2078,56 +2078,17 @@ int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
     goto fn_exit;
 }
 
-int MPL_gpu_query_pointer_is_dev(const void *ptr, MPL_pointer_attr_t * attr)
+int MPL_gpu_attr_is_dev(MPL_pointer_attr_t * attr)
 {
-    ze_result_t ret ATTRIBUTE((unused));
-    ze_memory_type_t type;
-
-    if (attr == NULL) {
-        ze_memory_allocation_properties_t prop = {
-            .stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES,
-            .pNext = NULL,
-            .type = 0,
-            .id = 0,
-            .pageSize = 0,
-        };
-        ze_device_handle_t device = NULL;
-
-        ret = zeMemGetAllocProperties(ze_context, ptr, &prop, &device);
-        assert(ret == ZE_RESULT_SUCCESS);
-        type = prop.type;
-    } else {
-        type = attr->device_attr.prop.type;
-    }
-
     /* Treat all ZE allocations as device objects. This is because even host-registered memory
      * are implemented as device objects in the driver. As such, these allocations don't work
      * properly with XPMEM. */
-    return type != ZE_MEMORY_TYPE_UNKNOWN;
+    return attr->device_attr.prop.type != ZE_MEMORY_TYPE_UNKNOWN;
 }
 
-int MPL_gpu_query_pointer_is_strict_dev(const void *ptr, MPL_pointer_attr_t * attr)
+int MPL_gpu_attr_is_strict_dev(MPL_pointer_attr_t * attr)
 {
-    ze_result_t ret ATTRIBUTE((unused));
-    ze_memory_type_t type;
-
-    if (attr == NULL) {
-        ze_memory_allocation_properties_t prop = {
-            .stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES,
-            .pNext = NULL,
-            .type = 0,
-            .id = 0,
-            .pageSize = 0,
-        };
-        ze_device_handle_t device = NULL;
-
-        ret = zeMemGetAllocProperties(ze_context, ptr, &prop, &device);
-        assert(ret == ZE_RESULT_SUCCESS);
-        type = prop.type;
-    } else {
-        type = attr->device_attr.prop.type;
-    }
-    return type == ZE_MEMORY_TYPE_DEVICE;
+    return attr->device_attr.prop.type == ZE_MEMORY_TYPE_DEVICE;
 }
 
 int MPL_gpu_query_is_same_dev(int global_dev1, int global_dev2)

--- a/test/mpi/coll/allgather_gpu.c
+++ b/test/mpi/coll/allgather_gpu.c
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
     struct dtp_args dtp_args;
     dtp_args_init(&dtp_args, MTEST_COLL_NOCOUNT, argc, argv);
     while (dtp_args_get_next(&dtp_args)) {
-        errs += test_allgather(dtp_args.u.coll.evenmem, dtp_args.u.coll.oddmem);
+        errs += test_allgather(dtp_args.u.coll.oddmem, dtp_args.u.coll.evenmem);
     }
     dtp_args_finalize(&dtp_args);
 


### PR DESCRIPTION
## Pull Request Description
Clean up and fix misc issues revealed from ZE testing. ZE shared memory can't be directly accessed as system memory and it can't be passed ofi as HMEM either. Multiple places are tripping over this issues. In general, we should use wrapper functions to check whether a pointer attribute is of device or strict device rather than directly checking the type field in the attr.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
