### PR TITLE
test/bench: add bcast/get/put benchmark

### DIFF
--- a/test/mpi/bench/.gitignore
+++ b/test/mpi/bench/.gitignore
@@ -1,3 +1,4 @@
 /*.c
 /p2p_bw
 /p2p_latency
+/bcast

--- a/test/mpi/bench/Makefile.am
+++ b/test/mpi/bench/Makefile.am
@@ -12,6 +12,8 @@ LDADD += -lm
 noinst_PROGRAMS = \
     p2p_latency \
     p2p_bw \
+    get_bw \
+    put_bw \
     barrier \
     bcast
 

--- a/test/mpi/bench/Makefile.am
+++ b/test/mpi/bench/Makefile.am
@@ -11,7 +11,9 @@ LDADD += -lm
 ## correctly
 noinst_PROGRAMS = \
     p2p_latency \
-    p2p_bw
+    p2p_bw \
+    barrier \
+    bcast
 
 .def.c:
 	mydef_page $<

--- a/test/mpi/bench/barrier.def
+++ b/test/mpi/bench/barrier.def
@@ -1,0 +1,6 @@
+include: macros/bench_frame.def
+include: macros/bench_coll.def
+
+page: barrier, bench_frame
+    $for 0:10
+        bench_barrier(comm)

--- a/test/mpi/bench/bcast.def
+++ b/test/mpi/bench/bcast.def
@@ -5,6 +5,28 @@ include: macros/mtest.def
 page: bcast, bench_frame
     data: buf, size, MPI_CHAR
 
-    &call measure_with_barrier
-        MPI_Bcast($(data), 0, comm)
+    $global root=0
+    $(if:0)
+        &call measure_with_barrier
+            MPI_Bcast($(data), root, comm)
+    $(else)
+        $if grank == 0
+            $call header_coll_latency
+        &call foreach_size
+            $my tf_min, tf_max, tf_avg, tf_sigma
+            $(set:MIN_ITER=0.001/tf_max)
+            &call coll_warmup
+                measure_bcast(iter, root, comm, buf, size, &tf_min, &tf_max, &tf_avg, &tf_sigma)
+                tf_dur = tf_max
+            $if iter < 100
+                iter = 100
+            measure_bcast(iter, root, comm, buf, size, &tf_min, &tf_max, &tf_avg, &tf_sigma)
+            $if grank == 0
+                $call report_coll_latency, size
+
+fncode: measure_bcast(int iter, int root, comm, buf, size, pf_min, pf_max, pf_avg, pf_sigma)
+    &call measure_coll_latency, iter
+        MPI_Bcast($(data), root, comm)
+    $(for:min,max,avg,sigma)
+        *pf_$1 = tf_$1
 

--- a/test/mpi/bench/bcast.def
+++ b/test/mpi/bench/bcast.def
@@ -1,0 +1,10 @@
+include: macros/bench_frame.def
+include: macros/bench_coll.def
+include: macros/mtest.def
+
+page: bcast, bench_frame
+    data: buf, size, MPI_CHAR
+
+    &call measure_with_barrier
+        MPI_Bcast($(data), 0, comm)
+

--- a/test/mpi/bench/macros/bench_coll.def
+++ b/test/mpi/bench/macros/bench_coll.def
@@ -1,0 +1,77 @@
+subcode: coll_warmup
+    $if grank == 0
+        &call warm_up, iter, tf_dur
+            MPI_Bcast(&iter, 1, MPI_INT, 0, comm)
+            BLOCK
+            # $dump tf_dur, iter, num_best
+        $my tn_zero = 0
+        MPI_Bcast(&tn_zero, 1, MPI_INT, 0, comm)
+    $else
+        $while 1
+            MPI_Bcast(&iter, 1, MPI_INT, 0, comm)
+            $if iter == 0 
+                break
+            BLOCK
+
+    MPI_Bcast(&iter, 1, MPI_INT, 0, comm)
+
+subcode: measure_with_barrier
+    tf_barrier = bench_barrier(comm)
+    $if grank == 0
+        $call header_latency
+    &call foreach_size
+        &call coll_warmup
+            &call measure, iter
+                BLOCK
+                MPI_Barrier(comm)
+        &call run_stat, NUM_REPEAT, tf_latency
+            &call measure, iter
+                BLOCK
+                MPI_Barrier(comm)
+            tf_latency = (tf_dur / iter) - tf_barrier
+        $if grank == 0
+            $call report_latency, size, 1
+
+# Measure individual latency after a barrier (as osu_bcast)
+subcode: measure_coll_latency(iter)
+    $my tf_max, tf_min, tf_avg, tf_sigma # output variables
+
+    $(set:RUN_STAT_VARIANCE=1)
+    &call run_stat, $(iter), tf_latency
+        MPI_Barrier(comm)
+        tf_start = MPI_Wtime()
+        BLOCK
+        tf_latency = (MPI_Wtime() - tf_start)
+
+    $(for:max,min,avg and MAX,MIN,SUM)
+        MPI_Reduce(&sum1, &tf_$1, 1, MPI_DOUBLE, MPI_$2, 0, comm)
+    $(for:sigma and SUM)
+        MPI_Reduce(&sum2, &tf_$1, 1, MPI_DOUBLE, MPI_$2, 0, comm)
+    $(if:1)
+        # only for rank 0, but do it collective for simplicity
+        tf_avg /= gsize
+        tf_sigma = sqrt(tf_sigma / gsize)
+
+# Barrier latency is measured cumulatively (as p2p_latency)
+fncode: bench_barrier(comm)
+    $(set:WARM_UP_NUM_BEST=20)
+    $local int iter
+    &call coll_warmup
+        &call measure, iter
+            MPI_Barrier(comm)
+
+    &call run_stat, NUM_REPEAT, tf_latency
+        &call measure, iter
+            MPI_Barrier(comm)
+        tf_latency = (tf_dur / iter)
+
+    $if grank == 0
+        printf("Barrier latency %.3f +/- %.3f us\n", sum1 * 1e6, sum2 * 1e6)
+    return sum1
+
+subcode: header_coll_latency
+    printf("%12s %8s %8s %8s     %6s  (in microseconds)\n", "msgsize", "min", "max", "avg", "sigma")
+
+subcode: report_coll_latency(MSGSIZE)
+    printf("%12d %8.3f %8.3f %8.3f     %6.3f\n", $(MSGSIZE), tf_min*1e6, tf_max*1e6, tf_avg*1e6, tf_sigma*1e6)
+

--- a/test/mpi/bench/macros/bench_frame.def
+++ b/test/mpi/bench/macros/bench_frame.def
@@ -20,7 +20,7 @@ subcode: bench_frame
         $(else)
             MPI_Init(NULL, NULL);
 
-        $my grank, gsize: int
+        $global grank, gsize: int
         MPI_Comm_rank(MPI_COMM_WORLD, &grank);
         MPI_Comm_size(MPI_COMM_WORLD, &gsize);
         $(if:MIN_PROCS)
@@ -54,21 +54,28 @@ subcode: bench_frame
 macros:
     use_double: 1
 
+macros:
+    MAX_BUFSIZE: 5000000  # 5 MB
+
 #----------------------------------------
 subcode: _autoload
     $register_prefix(comm) MPI_Comm
+    $define MAX_BUFSIZE 5000000
+    $define NUM_REPEAT 20
 
 subcode: foreach_size
-    $for int size = 0; size < $(MAX_MSG); size = (size==0)?1:size*2
+    $for int size = 0; size < $(MAX_BUFSIZE); size = (size==0)?1:size*2
         $(set:MSG_SIZE=size)
         BLOCK
 
+# measure tf_dur over iter
 subcode: measure(iter)
     tf_start = MPI_Wtime()
     $for 0:$(iter)
         BLOCK
     tf_dur = MPI_Wtime() - tf_start
 
+# repeat N times and calc avg in sum1 and std in sum2
 subcode: run_stat(N, var)
     $my double sum1=0, double sum2=0
     $for 0:$(N)
@@ -77,17 +84,28 @@ subcode: run_stat(N, var)
         sum2 += $(var) * $(var)
     sum1 /= $(N)
     sum2 /= $(N)
-    sum2 = sqrt(sum2 - sum1 * sum1)
+    $(if:RUN_STAT_VARIANCE)
+        sum2 = (sum2 - sum1 * sum1)
+    $(else)
+        sum2 = sqrt(sum2 - sum1 * sum1)
 
+# repeat until dur stabilize and iter adjusted to last minimum of 1ms
 subcode: warm_up(iter, dur)
-    $(set:MIN_ITER=(int) ($(iter) * 0.001 / $(dur)))
+    # minimum iteration to fill the duration to 1 ms
+    $(if:!WARM_UP_NUM_BEST)
+        $(set:NUM_BEST=10)
+    $(else)
+        $(set:NUM_BEST=$(WARM_UP_NUM_BEST))
+    $(if:!MIN_ITER)
+        $(set:MIN_ITER=(int) ($(iter) * 0.001 / $(dur)))
     $(iter) = 2
     $my double last_dur = 1.0
     $my int num_best = 0
-    $while num_best < 10
+    $while num_best < $(NUM_BEST)
         BLOCK
-        $if $(iter) < $(MIN_ITER)
-            $(iter) = $(MIN_ITER)
+        $my int min_iter = $(MIN_ITER)
+        $if $(iter) < 10000 && $(iter) < min_iter
+            $(iter) = min_iter
             num_best = 0
             continue
         # check that t_dur is no longer monotonically decreasing

--- a/test/mpi/bench/macros/bench_frame.def
+++ b/test/mpi/bench/macros/bench_frame.def
@@ -39,12 +39,22 @@ subcode: bench_frame
             printf("! Failed to allocate buffer (size=%d)\n", MAX_BUFSIZE)
             return 1
 
+        $(if:IS_RMA)
+            $global MPI_Win win
+            $if grank == 0
+                MPI_Win_create(NULL, 0, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win)
+            $else
+                MPI_Win_create(buf, MAX_BUFSIZE, 1, MPI_INFO_NULL, MPI_COMM_WORLD, &win)
+
         $if grank == 0
             printf("TEST $(_pagename):\n")
             $call @report_header
         $call main
         $if grank == 0
             printf("\n")
+
+        $(if:IS_RMA)
+            MPI_Win_free(&win);
 
         $(if:HAS_MTEST)
             MTest_Finalize(0);

--- a/test/mpi/bench/macros/bench_p2p.def
+++ b/test/mpi/bench/macros/bench_p2p.def
@@ -25,6 +25,8 @@ subcode: _autoload
     $register_name(size) int
     $define TAG 0
     $define SYNC_TAG 100
+    $define MAX_BUFSIZE $(MAX_BUFSIZE)
+    $define NUM_REPEAT 20
 
 subcode: report_header
         $call header_latency

--- a/test/mpi/bench/macros/bench_p2p.def
+++ b/test/mpi/bench/macros/bench_p2p.def
@@ -16,7 +16,7 @@
 
 macros:
     MIN_PROCS: 2
-    MAX_BUFSIZE: 5000000  # 5 MB
+    MEM_TYPES: sendrecv
 
 subcode: _autoload
     $register_name(src) int
@@ -25,8 +25,6 @@ subcode: _autoload
     $register_name(size) int
     $define TAG 0
     $define SYNC_TAG 100
-    $define MAX_BUFSIZE 5000000
-    $define NUM_REPEAT 20
 
 subcode: report_header
         $call header_latency

--- a/test/mpi/bench/macros/mtest.def
+++ b/test/mpi/bench/macros/mtest.def
@@ -3,12 +3,19 @@ macros:
 
 subcode: mtest_malloc(size)
     MTestArgList *head = MTestArgListCreate(argc, argv)
-    int send_rank = 0, recv_rank = 1;
-    $(for:a in send,recv)
-        $if grank == $(a)_rank
-            $my mtest_mem_type_e $(a)_memtype, int $(a)_device
-            $(a)_memtype = MTestArgListGetMemType(head, "$(a)mem")
-            $(a)_device = MTestArgListGetInt_with_default(head, "$(a)dev", 0)
-            MTestMalloc($(size), $(a)_memtype, NULL, &buf, $(a)_device)
-            MTestPrintfMsg(1, "Allocating buffer: memtype=%s, device=%d, size=%d\n", MTest_memtype_name($(a)_memtype), $(a)_device, $(size))
+    $(if:MEM_TYPES=sendrecv)
+        int send_rank = 0, recv_rank = 1;
+        $(for:a in send,recv)
+            $if grank == $(a)_rank
+                $call alloc_mem_dev, $(a)mem, $(a)dev
+    $(else)
+        # all procs allocating the same memory types
+        $call alloc_mem_dev, memtype, device
     MTestArgListDestroy(head)
+
+    subcode: alloc_mem_dev(memtype, memdev) # memtype and memdev are parameter names
+        $my mtest_mem_type_e memtype, int device
+        memtype = MTestArgListGetMemType(head, "$(memtype)")
+        device = MTestArgListGetInt_with_default(head, "$(memdev)", grank)
+        MTestMalloc($(size), memtype, NULL, &buf, device)
+        MTestPrintfMsg(1, "Allocating buffer: memtype=%s, device=%d, size=%d\n", MTest_memtype_name(memtype), device, $(size))

--- a/test/mpi/bench/p2p_bw.def
+++ b/test/mpi/bench/p2p_bw.def
@@ -9,7 +9,7 @@ page: p2p_bw, bench_frame
     MULTIPLICITY: WINDOW_SIZE
     data: buf, size, MPI_CHAR
 
-    $for int size = 1; size < MAX_BUFSIZE; size *= 2
+    &call foreach_size
         bench_p2p(comm, 0, 1, buf, size)
 
     subcode: send_side

--- a/test/mpi/bench/p2p_bw.def
+++ b/test/mpi/bench/p2p_bw.def
@@ -3,9 +3,10 @@ include: macros/bench_p2p.def
 include: macros/mtest.def
 
 subcode: _autoload
-    $define WINDOW_SIZE 64
+    $define WINDOW_SIZE $(WINDOW_SIZE)
 
 page: p2p_bw, bench_frame
+    WINDOW_SIZE: 64
     MULTIPLICITY: WINDOW_SIZE
     data: buf, size, MPI_CHAR
 
@@ -25,3 +26,39 @@ page: p2p_bw, bench_frame
             MPI_Irecv($(data), src, TAG, comm, &reqs[j])
         MPI_Waitall(WINDOW_SIZE, reqs, MPI_STATUSES_IGNORE)
         MPI_Send(NULL, 0, MPI_DATATYPE_NULL, src, TAG, comm)
+
+page: get_bw, bench_frame
+    IS_RMA: 1
+    WINDOW_SIZE: 100
+    MULTIPLICITY: WINDOW_SIZE
+
+    $for int size = 1; size < MAX_BUFSIZE; size *= 2
+        bench_p2p(comm, 0, 1, buf, size)
+
+    subcode: send_side
+        MPI_Win_fence(0, win)
+        $for j=0:WINDOW_SIZE
+            MPI_Get(buf, size, MPI_CHAR, dst, 0, size, MPI_CHAR, win)
+        MPI_Win_fence(0, win)
+
+    subcode: recv_side
+        MPI_Win_fence(0, win)
+        MPI_Win_fence(0, win)
+
+page: put_bw, bench_frame
+    IS_RMA: 1
+    WINDOW_SIZE: 100
+    MULTIPLICITY: WINDOW_SIZE
+
+    $for int size = 1; size < MAX_BUFSIZE; size *= 2
+        bench_p2p(comm, 0, 1, buf, size)
+
+    subcode: send_side
+        MPI_Win_fence(0, win)
+        $for j=0:WINDOW_SIZE
+            MPI_Put(buf, size, MPI_CHAR, dst, 0, size, MPI_CHAR, win)
+        MPI_Win_fence(0, win)
+
+    subcode: recv_side
+        MPI_Win_fence(0, win)
+        MPI_Win_fence(0, win)

--- a/test/mpi/bench/p2p_latency.def
+++ b/test/mpi/bench/p2p_latency.def
@@ -6,8 +6,7 @@ page: p2p_latency, bench_frame
     MULTIPLICITY: 2
     data: buf, size, MPI_CHAR
 
-    bench_p2p(comm, 0, 1, buf, 0)
-    $for int size = 1; size < MAX_BUFSIZE; size *= 2
+    &call foreach_size
         bench_p2p(comm, 0, 1, buf, size)
 
     subcode: send_side

--- a/test/mpi/bench/testlist
+++ b/test/mpi/bench/testlist
@@ -1,2 +1,3 @@
 p2p_latency 2 resultTest=TestBench
 p2p_bw 2 resultTest=TestBench
+bcast 16 resultTest=TestBench


### PR DESCRIPTION
## Pull Request Description

Following #6907, this PR adds collective benchmarks, starting with `barrier` and `bcast`.

Also add `get_bw` and `put_bw`. They work almost exactly as `p2p_bw`.

On my desktop:
```
$ export MPITEST_VERBOSE=1
$ mpirun -l -n 8 ./bcast -memtype=device
[7] Allocating buffer: memtype=device, device=7, size=5000000
[0] Allocating buffer: memtype=device, device=0, size=5000000
[0] TEST bcast:
[6] Allocating buffer: memtype=device, device=6, size=5000000
[2] Allocating buffer: memtype=device, device=2, size=5000000
[3] Allocating buffer: memtype=device, device=3, size=5000000
[5] Allocating buffer: memtype=device, device=5, size=5000000
[1] Allocating buffer: memtype=device, device=1, size=5000000
[4] Allocating buffer: memtype=device, device=4, size=5000000
[0] Barrier latency 33.098 +/- 0.743 us
[0]            1    283.896      4.881            0.004
[0]            2    282.667      0.864            0.007
[0]            4    282.172      0.955            0.014
[0]            8    282.547      0.987            0.028
[0]           16    281.973      0.960            0.057
[0]           32    258.795      0.529            0.124
[0]           64    258.640      1.185            0.247
[0]          128    258.742      0.917            0.495
[0]          256    288.946      3.025            0.886
[0]          512    275.079     10.361            1.861
[0]         1024    278.241      3.867            3.680
[0]         2048    276.950      3.892            7.395
[0]         4096    279.772      4.040           14.641
[0]         8192    284.587      3.501           28.786
[0]        16384    293.846      5.354           55.757
[0]        32768    112.957      2.848          290.093
[0]        65536    176.461     26.542          371.392
[0]       131072    279.492     12.952          468.965
[0]       262144    471.296     17.447          556.219
[0]       524288   1091.045     17.324          480.537
[0]      1048576   2338.931     39.098          448.314
[0]      2097152   3355.044     36.571          625.074
[0]      4194304   6950.164     71.623          603.483
[0]
[0]  No Errors[0]

```
```
mpirun -n 2 ./get_bw -sendmem=host -recvmem=host
Allocating buffer: memtype=host, device=0, size=5000000
Allocating buffer: memtype=host, device=1, size=5000000
TEST get_bw:
     msgsize    latency(us)  sigma(us)    bandwidth(MB/s)
           1      1.797      0.153            0.556
           2      1.745      0.007            1.146
           4      1.748      0.005            2.289
           8      1.747      0.005            4.579
          16      1.748      0.005            9.153
          32      1.747      0.005           18.319
          64      1.741      0.005           36.754
         128      1.746      0.006           73.321
         256      1.747      0.003          146.510
         512      1.756      0.005          291.540
        1024      1.850      0.005          553.436
        2048      1.922      0.005         1065.349
        4096      2.054      0.006         1993.963
        8192      2.342      0.008         3497.714
       16384      4.022      0.009         4073.417
       32768      9.231      0.023         3549.756
       65536     16.963      0.027         3863.518
      131072     32.997      0.297         3972.189
      262144     64.729      0.043         4049.897
      524288    128.234      0.089         4088.523
     1048576    167.923      0.535         6244.399
     2097152    346.319      0.630         6055.552
     4194304    744.334     97.164         5634.973

 No Errors
```
```
$ mpirun -n 4 ./barrier
TEST barrier:
Barrier latency 0.897 +/- 0.003 us
Barrier latency 0.900 +/- 0.003 us
Barrier latency 0.901 +/- 0.003 us
Barrier latency 0.895 +/- 0.003 us
Barrier latency 0.900 +/- 0.003 us
Barrier latency 0.899 +/- 0.002 us
Barrier latency 0.901 +/- 0.003 us
Barrier latency 0.894 +/- 0.003 us
Barrier latency 0.898 +/- 0.009 us
Barrier latency 0.901 +/- 0.003 us
```
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
