### PR TITLE
hydra: initialise `test_loc` and `user_path` to NULL

### DIFF
--- a/src/pm/hydra/lib/utils/args.c
+++ b/src/pm/hydra/lib/utils/args.c
@@ -60,7 +60,7 @@ static HYD_status get_abs_wd(const char *wd, char **abs_wd)
 
 HYD_status HYDU_find_in_path(const char *execname, char **path)
 {
-    char *tmp[4], *path_loc = NULL, *test_loc, *user_path;
+    char *tmp[4], *path_loc = NULL, *test_loc = NULL, *user_path = NULL;
     HYD_status status = HYD_SUCCESS;
 
     HYDU_FUNC_ENTER();


### PR DESCRIPTION
## Pull Request Description

Initialise pointers to NULL to make sure they aren't freed while pointing to undefined memory.  Should fix #7162.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
