### PR TITLE
ch4/xpmem: check MPIR_CVAR_CH4_IPC_XPMEM_P2P_THRESHOLD

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -953,6 +953,7 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **xpmem_segid: xpmem remote segid is unset
 **xpmem_get: xpmem_get failed
 **xpmem_attach: xpmem_attach failed
+**xpmem_attach %p %d: xpmem_attach failed (remote_addr=%p, size=%d)
 **xpmem_detach: xpmem_detach failed
 **xpmem_release: xpmem_release failed
 **xpmem_remove: xpmem_remove failed

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
@@ -26,7 +26,7 @@ cvars:
     - name        : MPIR_CVAR_CH4_IPC_XPMEM_P2P_THRESHOLD
       category    : CH4
       type        : int
-      default     : 16384
+      default     : 1024
       class       : none
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_ALL_EQ
@@ -52,7 +52,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_get_ipc_attr(const void *buf, MPI_Aint 
     int dt_contig;
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, true_lb);
 
-    if (!MPIR_CVAR_CH4_XPMEM_ENABLE || buf == MPI_BOTTOM) {
+    if (!MPIR_CVAR_CH4_XPMEM_ENABLE || buf == MPI_BOTTOM ||
+        data_sz < MPIR_CVAR_CH4_IPC_XPMEM_P2P_THRESHOLD) {
         goto fn_exit;
     } else {
         ipc_attr->ipc_type = MPIDI_IPCI_TYPE__XPMEM;

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.c
@@ -83,7 +83,8 @@ int MPIDI_XPMEMI_seg_regist(int node_rank, uintptr_t size,
         xpmem_addr.apid = segmap->apid;
         xpmem_addr.offset = seg_low;
         att_vaddr = xpmem_attach(xpmem_addr, seg_size, NULL);
-        MPIR_ERR_CHKANDJUMP(att_vaddr == (void *) -1, mpi_errno, MPI_ERR_OTHER, "**xpmem_attach");
+        MPIR_ERR_CHKANDJUMP2(att_vaddr == (void *) -1, mpi_errno, MPI_ERR_OTHER, "**xpmem_attach",
+                             "**xpmem_attach %p %d", remote_vaddr, (int) size);
         seg->remote_align_addr = seg_low;
         seg->att_vaddr = (uintptr_t) att_vaddr;
         MPL_gavl_tree_insert(segcache, (void *) seg_low, seg_size, (void *) seg);


### PR DESCRIPTION
## Pull Request Description
For small messages, IPC adds the synchronization from receiver side,
which is not desirable. For example, applications may assume small
messages will be sent eagerly and have code with potential dead-lock
issue if that eager-assumption is not true.

NOTE: due to amortization of IPC memory registration cost, IPC path may
show performance benefit in micro-benchmarks even for tiny messages.
In practice, small buffers are often allocated from stack, thus are
less-applicable for the IPC benefit.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
