### PR TITLE
ch4/mpidig: refactor update request status at matching 

### DIFF
--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -316,15 +316,6 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
 
     if (status == MPI_STATUS_IGNORE)
         status = &mystatus;
-    switch (errflag) {
-        case MPIR_ERR_NONE:
-            break;
-        case MPIR_ERR_PROC_FAILED:
-            MPIR_TAG_SET_PROC_FAILURE_BIT(sendtag);
-            /* fall through */
-        default:
-            MPIR_TAG_SET_ERROR_BIT(sendtag);
-    }
 
     MPIR_PT2PT_ATTR_SET_CONTEXT_OFFSET(attr, MPIR_CONTEXT_COLL_OFFSET);
 

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -216,9 +216,7 @@ typedef struct MPIDIG_req_t {
             int dest;
         } send;
         struct {
-            int source;
             MPIR_Context_id_t context_id;
-            int tag;
         } recv;
         struct {
             int target_rank;
@@ -270,9 +268,7 @@ typedef struct MPIDI_part_request {
             int dest;
         } send;
         struct {
-            int source;
             MPIR_Context_id_t context_id;
-            int tag;
         } recv;
     } u;
     union {

--- a/src/mpid/ch4/shm/ipc/src/ipc_control.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_control.c
@@ -52,7 +52,7 @@ int MPIDI_IPC_complete(MPIR_Request * rreq, MPIDI_IPCI_type_t ipc_type)
 
     int local_vci = MPIDIG_REQUEST(rreq, req->local_vci);
     int remote_vci = MPIDIG_REQUEST(rreq, req->remote_vci);
-    CH4_CALL(am_send_hdr(MPIDIG_REQUEST(rreq, u.recv.source), rreq->comm, MPIDI_IPC_ACK,
+    CH4_CALL(am_send_hdr(rreq->status.MPI_SOURCE, rreq->comm, MPIDI_IPC_ACK,
                          &am_hdr, sizeof(am_hdr), local_vci, remote_vci), 1, mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -228,10 +228,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPC_hdr * ipc_hdr,
     if (src_data_sz > data_sz)
         rreq->status.MPI_ERROR = MPI_ERR_TRUNCATE;
 
-    /* Set receive status */
+    /* Set receive status. NOTE: MPI_SOURCE/TAG already set at time of matching */
     MPIR_STATUS_SET_COUNT(rreq->status, recv_data_sz);
-    rreq->status.MPI_SOURCE = MPIDIG_REQUEST(rreq, u.recv.source);
-    rreq->status.MPI_TAG = MPIDIG_REQUEST(rreq, u.recv.tag);
 
     MPIDIG_REQUEST(rreq, req->rreq.u.ipc.src_dt_ptr) = NULL;
 
@@ -272,7 +270,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_handle_lmt_recv(MPIDI_IPC_hdr * ipc_hdr,
 
     IPC_TRACE("handle_lmt_recv: handle matched rreq %p [source %d, tag %d, "
               " context_id 0x%x], copy dst %p, bytes %ld\n", rreq,
-              MPIDIG_REQUEST(rreq, u.recv.source), MPIDIG_REQUEST(rreq, u.recv.tag),
+              rreq->status.MPI_SOURCE, rreq->status.MPI_TAG,
               MPIDIG_REQUEST(rreq, u.recv.context_id), (char *) MPIDIG_REQUEST(rreq, buffer),
               recv_data_sz);
 

--- a/src/mpid/ch4/src/mpidig_part.c
+++ b/src/mpid/ch4/src/mpidig_part.c
@@ -32,8 +32,8 @@ static int part_req_create(void *buf, int partitions, MPI_Aint count,
     if (kind == MPIR_REQUEST_KIND__PART_SEND) {
         MPIDI_PART_REQUEST(req, u.send.dest) = rank;
     } else {
-        MPIDI_PART_REQUEST(req, u.recv.source) = rank;
-        MPIDI_PART_REQUEST(req, u.recv.tag) = tag;
+        req->status.MPI_SOURCE = rank;
+        req->status.MPI_TAG = tag;
         MPIDI_PART_REQUEST(req, u.recv.context_id) = comm->context_id;
     }
 
@@ -74,8 +74,6 @@ void MPIDIG_precv_matched(MPIR_Request * part_req)
 
     /* Set status for partitioned req */
     MPIR_STATUS_SET_COUNT(part_req->status, sdata_size);
-    part_req->status.MPI_SOURCE = MPIDI_PART_REQUEST(part_req, u.recv.source);
-    part_req->status.MPI_TAG = MPIDI_PART_REQUEST(part_req, u.recv.tag);
     part_req->status.MPI_ERROR = MPI_SUCCESS;
 
     /* Additional check for partitioned pt2pt: require identical buffer size */

--- a/src/mpid/ch4/src/mpidig_part_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_part_callbacks.c
@@ -10,6 +10,11 @@
 
 static void part_rreq_update_sinfo(MPIR_Request * rreq, MPIDIG_part_send_init_msg_t * msg_hdr)
 {
+    rreq->status.MPI_SOURCE = msg_hdr->src_rank;
+    rreq->status.MPI_TAG = msg_hdr->tag;
+    rreq->status.MPI_ERROR = MPI_SUCCESS;
+    MPIR_STATUS_SET_COUNT(rreq->status, msg_hdr->data_sz);
+
     MPIDIG_PART_REQUEST(rreq, u.recv).sdata_size = msg_hdr->data_sz;
     MPIDIG_PART_REQUEST(rreq, peer_req_ptr) = msg_hdr->sreq_ptr;
 }
@@ -79,8 +84,6 @@ int MPIDIG_part_send_init_target_msg_cb(void *am_hdr, void *data,
         MPIR_ERR_CHKANDSTMT(unexp_req == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail,
                             "**nomemreq");
 
-        MPIDI_PART_REQUEST(unexp_req, u.recv.source) = msg_hdr->src_rank;
-        MPIDI_PART_REQUEST(unexp_req, u.recv.tag) = msg_hdr->tag;
         MPIDI_PART_REQUEST(unexp_req, u.recv.context_id) = msg_hdr->context_id;
         part_rreq_update_sinfo(unexp_req, msg_hdr);
 

--- a/src/mpid/ch4/src/mpidig_part_utils.h
+++ b/src/mpid/ch4/src/mpidig_part_utils.h
@@ -18,7 +18,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_issue_cts(MPIR_Request * rreq_ptr)
     am_hdr.sreq_ptr = MPIDIG_PART_REQUEST(rreq_ptr, peer_req_ptr);
     am_hdr.rreq_ptr = rreq_ptr;
 
-    int source = MPIDI_PART_REQUEST(rreq_ptr, u.recv.source);
+    int source = rreq_ptr->status.MPI_SOURCE;
     CH4_CALL(am_send_hdr_reply(rreq_ptr->comm, source, MPIDIG_PART_CTS, &am_hdr, sizeof(am_hdr),
                                0, 0), MPIDI_REQUEST(rreq_ptr, is_local), mpi_errno);
 

--- a/src/mpid/ch4/src/mpidig_probe.h
+++ b/src/mpid/ch4/src/mpidig_probe.h
@@ -24,9 +24,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_iprobe(int source, int tag, MPIR_Comm * 
 
     if (unexp_req) {
         *flag = 1;
+        /* MPI_SOURCE and MPI_TAG should be already set */
         unexp_req->status.MPI_ERROR = MPI_SUCCESS;
-        unexp_req->status.MPI_SOURCE = MPIDIG_REQUEST(unexp_req, u.recv.source);
-        unexp_req->status.MPI_TAG = MPIDIG_REQUEST(unexp_req, u.recv.tag);
         MPIR_STATUS_SET_COUNT(unexp_req->status, MPIDIG_REQUEST(unexp_req, count));
 
         MPIR_Request_extract_status(unexp_req, status);
@@ -62,9 +61,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_improbe(int source, int tag, MPIR_Comm *
         (*message)->comm = comm;
         MPIR_Comm_add_ref(comm);
 
+        /* MPI_SOURCE and MPI_TAG should be already set */
         unexp_req->status.MPI_ERROR = MPI_SUCCESS;
-        unexp_req->status.MPI_SOURCE = MPIDIG_REQUEST(unexp_req, u.recv.source);
-        unexp_req->status.MPI_TAG = MPIDIG_REQUEST(unexp_req, u.recv.tag);
         MPIR_STATUS_SET_COUNT(unexp_req->status, MPIDIG_REQUEST(unexp_req, count));
         MPIDIG_REQUEST(unexp_req, req->status) |= MPIDIG_REQ_UNEXP_DQUED;
 


### PR DESCRIPTION
## Pull Request Description

The source and tag fields in MPIDIG_REQUEST and MPIDI_PART_REQUEST are
redudant to the MPI_SOURCE and MPI_TAG fields in the status, which needs
to be set anyway. Both the source and tag are confirmed upon receiving
the first active message thus they should be set then.

* remove MPIDIG_REQUEST(rreq, u.recv.{source,tag})and use
rreq->status.{MPI_SOURCE,MPI_TAG} instead.
* set or update the status fields at the time of receiving the first am
packet or at the time of matching.
* remove MPIR_TAG_MASK_ERROR_BITS in MPIDIG_match_request since we do
not set tag error bits in MPIR-layer or MPIDIG-layer (even if error-bits
are enabled).

This is a preparation/cleanup PR before we adding the feature allowing ch4-native netmod requests to transition into mpidig requests to use active messaging ability.

Removing extra variables/fields certainly simplifies the code.


[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
