### PR TITLE
ofi: fix a bug in gpu pipelining with potentially out of order chunks

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -186,6 +186,7 @@ static int pipeline_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * r, 
                     chunk_req->event_id = MPIDI_OFI_EVENT_RECV_GPU_PIPELINE;
                     chunk_req->parent = rreq;
                     chunk_req->buf = host_buf;
+                    chunk_req->offset = chunk_sz * i;
                     int ret = 0;
                     if (!MPIDI_OFI_global.gpu_recv_queue && host_buf) {
                         ret = fi_trecv
@@ -217,8 +218,7 @@ static int pipeline_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * r, 
             mpi_errno =
                 MPIR_Ilocalcopy_gpu(wc_buf, (MPI_Aint) wc->len, MPI_BYTE, 0, NULL,
                                     (char *) recv_buf, (MPI_Aint) recv_count, datatype,
-                                    MPIDI_OFI_REQUEST(rreq, pipeline_info.offset), NULL,
-                                    MPL_GPU_COPY_H2D, engine_type, 1, &yreq);
+                                    req->offset, NULL, MPL_GPU_COPY_H2D, engine_type, 1, &yreq);
             MPIR_ERR_CHECK(mpi_errno);
             actual_unpack_bytes = wc->len;
             MPIDI_OFI_REQUEST(rreq, pipeline_info.offset) += (size_t) actual_unpack_bytes;

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -1064,16 +1064,16 @@ static int MPIDI_OFI_gpu_progress_task(MPIDI_OFI_gpu_task_t * gpu_queue[], int v
                 chunk_req->parent = request;
                 chunk_req->event_id = MPIDI_OFI_EVENT_SEND_GPU_PIPELINE;
                 chunk_req->buf = task->buf;
-                MPIDI_OFI_CALL_RETRY(fi_tsenddata
-                                     (MPIDI_OFI_global.ctx
-                                      [MPIDI_OFI_REQUEST(request, pipeline_info.ctx_idx)].tx,
-                                      task->buf, task->len, NULL /* desc */ ,
-                                      MPIDI_OFI_REQUEST(request, pipeline_info.cq_data),
-                                      MPIDI_OFI_REQUEST(request, pipeline_info.remote_addr),
-                                      MPIDI_OFI_REQUEST(request,
-                                                        pipeline_info.match_bits) |
-                                      MPIDI_OFI_GPU_PIPELINE_SEND, (void *) &chunk_req->context),
-                                     vni, fi_tsenddata);
+                MPIDI_OFI_CALL(fi_tsenddata
+                               (MPIDI_OFI_global.ctx
+                                [MPIDI_OFI_REQUEST(request, pipeline_info.ctx_idx)].tx,
+                                task->buf, task->len, NULL /* desc */ ,
+                                MPIDI_OFI_REQUEST(request, pipeline_info.cq_data),
+                                MPIDI_OFI_REQUEST(request, pipeline_info.remote_addr),
+                                MPIDI_OFI_REQUEST(request,
+                                                  pipeline_info.match_bits) |
+                                MPIDI_OFI_GPU_PIPELINE_SEND, (void *) &chunk_req->context),
+                               tsenddata);
                 DL_DELETE(gpu_queue[vni], task);
                 MPL_free(task);
             } else {

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -267,16 +267,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
             chunk_req->event_id = MPIDI_OFI_EVENT_RECV_GPU_PIPELINE_INIT;
             chunk_req->parent = rreq;
             chunk_req->buf = host_buf;
-            int ret = 0;
-            ret = fi_trecv(MPIDI_OFI_global.ctx[ctx_idx].rx,
-                           host_buf,
-                           MPIR_CVAR_CH4_OFI_GPU_PIPELINE_BUFFER_SZ,
-                           NULL, remote_addr, match_bits, mask_bits, (void *) &chunk_req->context);
-            if (MPIDI_OFI_global.gpu_recv_queue || !host_buf || ret != 0) {
-                MPIDI_OFI_gpu_pending_recv_t *recv_task =
-                    MPIDI_OFI_create_recv_task(chunk_req, 0, -1);
-                DL_APPEND(MPIDI_OFI_global.gpu_recv_queue, recv_task);
-            }
+            MPIDI_OFI_CALL_RETRY(fi_trecv(MPIDI_OFI_global.ctx[ctx_idx].rx,
+                                          host_buf,
+                                          MPIR_CVAR_CH4_OFI_GPU_PIPELINE_BUFFER_SZ,
+                                          NULL, remote_addr, match_bits, mask_bits,
+                                          (void *) &chunk_req->context), vci_local, trecv);
             goto fn_exit;
         }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -343,6 +343,7 @@ typedef struct {
     int event_id;               /* fixed field, do not move */
     MPIR_Request *parent;       /* Parent request           */
     void *buf;
+    MPI_Aint offset;
 } MPIDI_OFI_gpu_pipeline_request;
 
 typedef struct MPIDI_OFI_gpu_task {


### PR DESCRIPTION
Receiver posts receive for each chunk, and write to GPU buffers in the order of the receive event completion. This however can potentially leads to out of order writing because the completion events may be out of order.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
