### PR TITLE
mpl/ze: fix pointer query functions to check the correct field

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -2083,12 +2083,12 @@ int MPL_gpu_attr_is_dev(MPL_pointer_attr_t * attr)
     /* Treat all ZE allocations as device objects. This is because even host-registered memory
      * are implemented as device objects in the driver. As such, these allocations don't work
      * properly with XPMEM. */
-    return attr->device_attr.prop.type != ZE_MEMORY_TYPE_UNKNOWN;
+    return attr->type != MPL_GPU_POINTER_UNREGISTERED_HOST;
 }
 
 int MPL_gpu_attr_is_strict_dev(MPL_pointer_attr_t * attr)
 {
-    return attr->device_attr.prop.type == ZE_MEMORY_TYPE_DEVICE;
+    return attr->type == MPL_GPU_POINTER_DEV;
 }
 
 int MPL_gpu_query_is_same_dev(int global_dev1, int global_dev2)


### PR DESCRIPTION
When GPU is disabled (ENABLE_GPU=0), the device type field may not be assigned, so the checking may be problematic.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
