### PR TITLE
build: Improve GPU support disabling in embedded modules

### DIFF
--- a/confdb/aclocal_modules.m4
+++ b/confdb/aclocal_modules.m4
@@ -69,6 +69,14 @@ AC_DEFUN([PAC_CONFIG_HWLOC_EMBEDDED],[
     hwloc_config_args="$hwloc_config_args --disable-cuda"
     hwloc_config_args="$hwloc_config_args --disable-opencl"
     hwloc_config_args="$hwloc_config_args --disable-rsmi"
+    # disable GPU support in embedded hwloc if explicitly disabled in MPICH
+    # NOTE: there is no --disable-rocm option for the hwloc configure
+    if test $with_ze = "no" ; then
+        hwloc_config_args="$hwloc_config_args --disable-levelzero"
+    fi
+    if test $with_cuda = "no" ; then
+        hwloc_config_args="$hwloc_config_args --disable-cuda"
+    fi
     PAC_CONFIG_SUBDIR_ARGS(hwloc_embedded_dir, [$hwloc_config_args],[], [AC_MSG_ERROR(embedded hwloc configure failed)])
     PAC_POP_FLAG([CFLAGS])
 ])

--- a/src/mpi/datatype/typerep/src/subconfigure.m4
+++ b/src/mpi/datatype/typerep/src/subconfigure.m4
@@ -47,7 +47,7 @@ m4_define([yaksa_embedded_dir],[modules/yaksa])
 PAC_CHECK_HEADER_LIB_EXPLICIT([yaksa],[yaksa.h],[$YAKSALIBNAME],[yaksa_init])
 if test "$with_yaksa" = "embedded" ; then
     yaksalib="modules/yaksa/lib${YAKSALIBNAME}.la"
-    if test ! -e "${use_top_srcdir}/modules/PREBUILT" -o ! -e "$yaksalib"; then
+    if test ! -e "${use_top_srcdir}/modules/PREBUILT"; then
         PAC_PUSH_ALL_FLAGS()
         PAC_RESET_ALL_FLAGS()
         # no need for libtool versioning when embedding YAKSA


### PR DESCRIPTION
## Pull Request Description

1. Unless we are using the special PREBUILT submodule configuration, we always need to reconfigure yaksa along with the rest of MPICH. If not, users may observe unexpected outcomes when reconfiguring MPICH in a previously built directory. See pmodels/mpich#6709.
2. Translate MPICH options for disabling GPU support to the ones used by hwloc when building the embedded module.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
