### PR TITLE
build: add config option --with-libfabric=install

### DIFF
--- a/confdb/aclocal_libs.m4
+++ b/confdb/aclocal_libs.m4
@@ -44,7 +44,7 @@ AC_DEFUN([PAC_SET_HEADER_LIB_PATH],[
     # taking priority
 
     case "${with_$1}" in
-        embedded)
+        embedded|install)
             m4_ifndef([$1_embedded_dir],[AC_MSG_ERROR([embedded $1 is requested but we do not have the embedded version])])
             ;;
         yes|no)
@@ -108,7 +108,7 @@ dnl PAC_CHECK_HEADER_LIB_OPTIONAL(with_option, header.h, libname, function)
 dnl Check optional library. The results are in $pac_have_$1.
 AC_DEFUN([PAC_CHECK_HEADER_LIB_OPTIONAL],[
     PAC_SET_HEADER_LIB_PATH($1)
-    if test "${with_$1}" = "embedded" ; then
+    if test "${with_$1}" = "embedded" || test "${with_$1}" = "install"; then
         dnl Caller still need configure the embedded version
         pac_have_$1=yes
     elif test "${with_$1}" = "no" ; then
@@ -143,7 +143,7 @@ dnl This is used in more complex situation, e.g. checking libfabric
 dnl to decide default netmod options
 AC_DEFUN([PAC_PROBE_HEADER_LIB],[
     PAC_SET_HEADER_LIB_PATH($1)
-    if test "${with_$1}" = "embedded" ; then
+    if test "${with_$1}" = "embedded" || test "${with_$1}" = "install"; then
         dnl Caller still need configure the embedded version
         pac_have_$1=yes
     elif test "${with_$1}" = "no" ; then

--- a/confdb/aclocal_libs.m4
+++ b/confdb/aclocal_libs.m4
@@ -184,32 +184,6 @@ AC_DEFUN([PAC_CHECK_HEADER_LIB_FATAL],[
     PAC_LIBS_ADD(-l$3)
 ])
 
-dnl PAC_CHECK_PREFIX(with_option,prefixvar)
-AC_DEFUN([PAC_CHECK_PREFIX],[
-	AC_ARG_WITH([$1-prefix],
-            [AS_HELP_STRING([[--with-$1-prefix[=DIR]]], [use the $1
-                            library installed in DIR, rather than the
-                            one included in the distribution.  Pass
-                            "embedded" to force usage of the included
-                            $1 source.])],
-            [if test "$withval" = "system" ; then
-                 :
-             elif test "$withval" = "embedded" ; then
-                 :
-             elif test "$withval" = "no" ; then
-                 :
-             else
-                 PAC_APPEND_FLAG([-I${with_$1_prefix}/include],[CPPFLAGS])
-                 if test -d "${with_$1_prefix}/lib64" ; then
-                     PAC_APPEND_FLAG([-L${with_$1_prefix}/lib64],[LDFLAGS])
-                 fi
-                 PAC_APPEND_FLAG([-L${with_$1_prefix}/lib],[LDFLAGS])
-             fi
-             ],
-            [with_$1_prefix="embedded"])
-	]
-)
-
 dnl PAC_LIB_DEPS(library_name, library_pc_path)
 dnl library_pc_path is the path to the library pkg-config directory
 AC_DEFUN([PAC_LIB_DEPS],[

--- a/src/mpid/ch4/netmod/ofi/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ofi/subconfigure.m4
@@ -278,10 +278,12 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
     if test "$pac_have_libfabric" = "no" ; then
         with_libfabric=embedded
     fi
-    if test "$with_libfabric" = "embedded" ; then
+    if test "$with_libfabric" = "embedded" || test "$with_libfabric" = "install"; then
         ofi_embedded="yes"
         AC_MSG_NOTICE([CH4 OFI Netmod:  Using an embedded libfabric])
-        ofi_subdir_args="--enable-embedded"
+        if test "$with_libfabric" = "embedded" ; then
+            ofi_subdir_args="--enable-embedded"
+        fi
 
         prov_config=""
         if test "x${netmod_args}" != "x" ; then
@@ -338,7 +340,7 @@ AM_COND_IF([BUILD_CH4_NETMOD_OFI],[
         PAC_LIBS_ADD([-lfabric])
     fi
 
-    # check for libfabric depedence libs
+    # check for libfabric dependence libs
     pcdir=""
     if test "${ofi_embedded}" = "yes" ; then
         pcdir="${main_top_builddir}/modules/libfabric"

--- a/src/mpid/ch4/netmod/ucx/subconfigure.m4
+++ b/src/mpid/ch4/netmod/ucx/subconfigure.m4
@@ -34,7 +34,7 @@ AM_COND_IF([BUILD_CH4_NETMOD_UCX],[
     if test "$pac_have_ucx" = "no" ; then
         with_ucx=embedded
     fi
-    if test "$with_ucx" = "embedded" ; then
+    if test "$with_ucx" = "embedded" || test "$with_ucx" = "install"; then
         ucxlib="modules/ucx/src/ucp/libucp.la"
         if test -e "${use_top_srcdir}/modules/PREBUILT" -a -e "$ucxlib"; then
             ucxdir=""
@@ -47,7 +47,10 @@ AM_COND_IF([BUILD_CH4_NETMOD_UCX],[
             else
                 ucx_opt_flags=""
             fi
-            PAC_CONFIG_SUBDIR_ARGS([modules/ucx],[--disable-static --enable-embedded --with-java=no --with-go=no $ucx_opt_flags],[],[AC_MSG_ERROR(ucx configure failed)])
+            if test "$with_ucx" = "embedded" ; then
+                ucx_opt_flags="$ucx_opt_flags --enable-embedded"
+            fi
+            PAC_CONFIG_SUBDIR_ARGS([modules/ucx],[--disable-static --with-java=no --with-go=no $ucx_opt_flags],[],[AC_MSG_ERROR(ucx configure failed)])
             PAC_POP_ALL_FLAGS()
             ucxdir="modules/ucx"
         fi


### PR DESCRIPTION
## Pull Request Description

As --with-libfabric=embedded, it builds from modules/libfabric, but install it as an external libfabric.so.

Similarly, --with-ucx=embedded will install modules/ucx as an external librabry.

Fixes #6905 

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
