### PR TITLE
autogen: default -yaksa-depth to 2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,8 @@
   hint "port_name_size" that may be larger than MPI_MAX_PORT_NAME. If the port
   name does not fit in "port_name_size", it will return a trunction error.
 
+# Autogen default to use -yaksa-depth=2.
+
 ===============================================================================
                                Changes in 4.2
 ===============================================================================

--- a/autogen.sh
+++ b/autogen.sh
@@ -66,7 +66,7 @@ do_romio=yes
 do_pmi=yes
 do_doc=no
 
-yaksa_depth=
+yaksa_depth=2
 
 do_quick=no
 # Check -quick option. When enabled, skip as much as we can.


### PR DESCRIPTION

## Pull Request Description

Setting yaksa-depth to 2 (vs the default 3) significantly reduces build time and binary size. This may affect the performance on deep nested derived datatypes. But we expect a general distribution will more appreciate the former benefit.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
