### PR TITLE
Fortran/f08: fix missing conversions when INTEGER is not C int

### DIFF
--- a/maint/local_python/binding_f08.py
+++ b/maint/local_python/binding_f08.py
@@ -17,6 +17,8 @@ def get_cdesc_name(func, is_large):
 
 def get_f08_c_name(func, is_large):
     name = re.sub(r'MPIX?_', r'MPIR_', func['name'] + '_c')
+    if RE.match(r'mpi_(comm|type|win|file)_create_errhandler', func['name'], re.IGNORECASE):
+        name = re.sub(r'MPIR_', r'MPII_', name)
     if is_large:
         name += "_large"
     return name
@@ -791,6 +793,8 @@ def dump_mpi_c_interface_nobuf(func, is_large):
         c_name = re.sub(r'MPIX?_', r'MPII_', func['name'])
         if is_large:
             c_name += "_large"
+    elif RE.match(r'mpi_(comm|type|win|file)_create_errhandler', func['name'], re.IGNORECASE):
+        c_name = re.sub(r'MPI_', r'MPII_', func['name'])
     elif RE.match(r'mpi_comm_spawn(_multiple)?$', func['name'], re.IGNORECASE):
         # use wrapper c functions
         c_name = name

--- a/maint/local_python/binding_f08.py
+++ b/maint/local_python/binding_f08.py
@@ -437,6 +437,7 @@ def dump_f08_wrappers_f(func, is_large):
 
             c_decl_list.append("INTEGER(c_int), TARGET :: %s_c(%s)" % (p['name'], length))
             convert_list_1.append("IF (has_%s) THEN" % p['name'])
+            convert_list_1.append("    %s_c(1:%s) = %s(1:%s)" % (p['name'], length, p['name'], length))
             convert_list_1.append("    %s_cptr = c_loc(%s_c)" % (p['name'], p['name']))
             convert_list_1.append("END IF")
             # output conversion for MPI_Dist_graph_neighbors

--- a/maint/local_python/binding_f08.py
+++ b/maint/local_python/binding_f08.py
@@ -794,6 +794,9 @@ def dump_mpi_c_interface_nobuf(func, is_large):
     elif RE.match(r'mpi_comm_spawn(_multiple)?$', func['name'], re.IGNORECASE):
         # use wrapper c functions
         c_name = name
+    elif RE.match(r'mpi_op_create', func['name'], re.IGNORECASE) and not is_large:
+        # defined in src/binding/fortran/mpif_h/user_proxy.c
+        c_name = "MPII_op_create"
     else:
         # uses PMPI c binding directly
         c_name = 'P' + get_function_name(func, is_large)

--- a/maint/local_python/binding_f08.py
+++ b/maint/local_python/binding_f08.py
@@ -387,6 +387,8 @@ def dump_f08_wrappers_f(func, is_large):
                 uses['MPIR_F08_get_MPI_STATUS_IGNORE_c'] = 1
                 arg_1 = ":STATUS:"
                 arg_2 = ":STATUS:"
+                # currently we preserve status%MPI_ERROR
+                p['_status_convert_in'] = "status_c = status"
                 p['_status_convert'] = "status = status_c"
             elif p['param_direction'] == 'inout':
                 convert_list_1.append("status_c = status")
@@ -722,6 +724,8 @@ def dump_f08_wrappers_f(func, is_large):
             dump_F_else()
             if check_int_kind:
                 s2 = re.sub(r':STATUS:', "c_loc(%s_c)" % p['name'], s)
+                if '_status_convert_in' in p:
+                    G.out.append(p['_status_convert_in'])
             else:
                 s2 = re.sub(r':STATUS:', "c_loc(%s)" % p['name'], s)
             dump_fortran_line(s2)

--- a/maint/local_python/binding_f77.py
+++ b/maint/local_python/binding_f77.py
@@ -475,6 +475,8 @@ def dump_f77_c_func(func, is_cptr=False):
             # Fortran errhandler does not do variadic (...); use MPI_Fint for handle
             # F77_ErrFunction is defined in mpi_fortimpl.h
             c_param_list.append("F77_ErrFunction %s" % v)
+        elif re.match(r'MPI_User_function', func_type, re.IGNORECASE):
+            c_param_list.append("F77_OpFunction *%s" % v)
         else:
             c_param_list.append("%s %s" % (func_type, v))
         c_arg_list_A.append(v)
@@ -1260,7 +1262,7 @@ def dump_fortran_line(s):
 def check_func_directives(func):
     if 'dir' in func and func['dir'] == "mpit":
         func['_skip_fortran'] = 1
-    elif RE.match(r'mpix_(grequest_|type_iov|async_)', func['name'], re.IGNORECASE):
+    elif RE.match(r'mpix_(grequest_|type_iov|async_|(comm|file|win|session)_create_errhandler_x|op_create_x)', func['name'], re.IGNORECASE):
         func['_skip_fortran'] = 1
     elif RE.match(r'mpi_\w+_(f|f08|c)2(f|f08|c)$', func['name'], re.IGNORECASE):
         # implemented in mpi_f08_types.f90

--- a/src/binding/fortran/mpif_h/user_proxy.c
+++ b/src/binding/fortran/mpif_h/user_proxy.c
@@ -123,3 +123,77 @@ int MPII_errhan_create(F77_ErrFunction * err_fn, MPI_Fint * errhandler, enum F77
 
     return ret;
 }
+
+/* For use by MPI_F08 */
+int MPII_Comm_create_errhandler(F77_ErrFunction * err_fn, MPI_Fint * errhandler)
+{
+    struct F77_errhan_state *p = malloc(sizeof(struct F77_errhan_state));
+    p->err_fn = err_fn;
+
+    MPI_Errhandler errhandler_i;
+    int ret = MPI_SUCCESS;
+
+    ret = MPIX_Comm_create_errhandler_x(F77_comm_errhan_proxy, F77_errhan_free, p, &errhandler_i);
+    if (ret == MPI_SUCCESS) {
+        *errhandler = MPI_Errhandler_c2f(errhandler_i);
+    } else {
+        free(p);
+    }
+
+    return ret;
+}
+
+int MPII_File_create_errhandler(F77_ErrFunction * err_fn, MPI_Fint * errhandler)
+{
+    struct F77_errhan_state *p = malloc(sizeof(struct F77_errhan_state));
+    p->err_fn = err_fn;
+
+    MPI_Errhandler errhandler_i;
+    int ret = MPI_SUCCESS;
+
+    ret = MPIX_File_create_errhandler_x(F77_file_errhan_proxy, F77_errhan_free, p, &errhandler_i);
+    if (ret == MPI_SUCCESS) {
+        *errhandler = MPI_Errhandler_c2f(errhandler_i);
+    } else {
+        free(p);
+    }
+
+    return ret;
+}
+
+int MPII_Win_create_errhandler(F77_ErrFunction * err_fn, MPI_Fint * errhandler)
+{
+    struct F77_errhan_state *p = malloc(sizeof(struct F77_errhan_state));
+    p->err_fn = err_fn;
+
+    MPI_Errhandler errhandler_i;
+    int ret = MPI_SUCCESS;
+
+    ret = MPIX_Win_create_errhandler_x(F77_win_errhan_proxy, F77_errhan_free, p, &errhandler_i);
+    if (ret == MPI_SUCCESS) {
+        *errhandler = MPI_Errhandler_c2f(errhandler_i);
+    } else {
+        free(p);
+    }
+
+    return ret;
+}
+
+int MPII_Session_create_errhandler(F77_ErrFunction * err_fn, MPI_Fint * errhandler)
+{
+    struct F77_errhan_state *p = malloc(sizeof(struct F77_errhan_state));
+    p->err_fn = err_fn;
+
+    MPI_Errhandler errhandler_i;
+    int ret = MPI_SUCCESS;
+
+    ret = MPIX_Session_create_errhandler_x(F77_session_errhan_proxy, F77_errhan_free,
+                                           p, &errhandler_i);
+    if (ret == MPI_SUCCESS) {
+        *errhandler = MPI_Errhandler_c2f(errhandler_i);
+    } else {
+        free(p);
+    }
+
+    return ret;
+}

--- a/src/mpi/romio/adio/common/ad_aggregate_new.c
+++ b/src/mpi/romio/adio/common/ad_aggregate_new.c
@@ -179,7 +179,7 @@ void ADIOI_Calc_file_realms_aar(ADIO_File fd, int nprocs_for_coll, int cb_pfr,
 #endif
     }
     if (fd->hints->cb_pfr == ADIOI_HINT_ENABLE) {
-        snprintf(value, sizeof(value), "%lld", fr_size);
+        snprintf(value, sizeof(value), "%lld", (long long) fr_size);
         ADIOI_Info_set(fd->info, "romio_cb_fr_type", value);
     }
 }

--- a/src/mpi/romio/adio/common/ad_coll_build_req_new.c
+++ b/src/mpi/romio/adio/common/ad_coll_build_req_new.c
@@ -1263,7 +1263,8 @@ int ADIOI_Build_client_pre_req(ADIO_File fd,
                  ADIOI_Malloc(agg_ol_ct * sizeof(MPI_Count))) == NULL) {
                 ADIOI_Free(my_mem_view_state_p->pre_disp_arr);
                 fprintf(stderr, "ADIOI_Build_client_pre_req: malloc "
-                        "agg_blk_arr of size %lld failed\n", agg_ol_ct * sizeof(MPI_Count));
+                        "agg_blk_arr of size %lld failed\n",
+                        (long long) agg_ol_ct * sizeof(MPI_Count));
                 return -1;
             }
         }

--- a/test/mpi/f08/pt2pt/pt2pt_largef08.f90
+++ b/test/mpi/f08/pt2pt/pt2pt_largef08.f90
@@ -23,10 +23,10 @@ program pt2pt_large
     else
         if (rank == 0) then
             call init_sendbuf(buf)
-            call MPI_Send(buf, cnt, MPI_INT, 1, tag, comm)
+            call MPI_Send(buf, cnt, MPI_INTEGER, 1, tag, comm)
         else
             call init_recvbuf(buf)
-            call MPI_Recv(buf, cnt, MPI_INT, 0, tag, comm, MPI_STATUS_IGNORE)
+            call MPI_Recv(buf, cnt, MPI_INTEGER, 0, tag, comm, MPI_STATUS_IGNORE)
             call check_recvbuf(buf, errs)
         endif
     endif
@@ -60,6 +60,7 @@ program pt2pt_large
         do i = 1,size(buf)
             if (buf(i) /= i) then
                 errs = errs + 1
+                print *, 'buf at ', i, '  got ', buf(i)
             endif
         enddo
     end subroutine


### PR DESCRIPTION
## Pull Request Description
Fixes for F08 bindings when integers are non standard, such as `gfortran -fdefault-integer-8`
* Status in/out conversion
* Op user function callback
* Alltoall[vw] counts array input
* MPI_Create_dist_graph weights array

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
