### PR TITLE
misc: remove duplicated typedef in mpir_err.h

### DIFF
--- a/src/include/mpir_ext.h.in
+++ b/src/include/mpir_ext.h.in
@@ -34,8 +34,10 @@ int MPIR_Err_create_code_valist(int, int, const char[], int, int,
                                 const char[], const char[], va_list);
 int MPIR_Err_is_fatal(int);
 
+#ifndef MPIR_ERR_H_INCLUDED /* avoid duplicate typedef */
 typedef int (*MPIR_Err_get_class_string_func_t) (int error, char *str, int length);
 void MPIR_Err_get_string(int, char *, int, MPIR_Err_get_class_string_func_t);
+#endif
 
 struct MPIR_Comm;
 int MPIR_Abort(MPI_Comm comm, int mpi_errno, int exit_code, const char *error_msg);


### PR DESCRIPTION
## Pull Request Description
Both the typedef of MPIR_Err_get_class_string_func_t and declaration of MPIR_Err_get_string are in mpir_ext.h. Both clang and oneAPI will issue warnings for duplicated typedefs.




## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
