### PR TITLE
coll: fix bcast_intra_pipelined_tree.c

### DIFF
--- a/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
@@ -149,10 +149,10 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                 mpi_errno = MPIC_Wait(reqs[i]);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_Get_count_impl(&reqs[i]->status, MPI_BYTE, &recvd_size);
-                MPIR_ERR_CHKANDJUMP2(recvd_size != nbytes, mpi_errno, MPI_ERR_OTHER,
+                MPIR_ERR_CHKANDJUMP2(recvd_size != msgsize, mpi_errno, MPI_ERR_OTHER,
                                      "**collective_size_mismatch",
                                      "**collective_size_mismatch %d %d",
-                                     (int) recvd_size, (int) nbytes);
+                                     (int) recvd_size, (int) msgsize);
             }
         } else if (num_chunks > 3 && is_nb && i < 3 && !recv_pre_posted) {
             /* Wait to receive the chunk before it can be sent to the children */
@@ -160,10 +160,10 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                 mpi_errno = MPIC_Wait(reqs[i]);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_Get_count_impl(&reqs[i]->status, MPI_BYTE, &recvd_size);
-                MPIR_ERR_CHKANDJUMP2(recvd_size != nbytes, mpi_errno, MPI_ERR_OTHER,
+                MPIR_ERR_CHKANDJUMP2(recvd_size != msgsize, mpi_errno, MPI_ERR_OTHER,
                                      "**collective_size_mismatch",
                                      "**collective_size_mismatch %d %d",
-                                     (int) recvd_size, (int) nbytes);
+                                     (int) recvd_size, (int) msgsize);
             }
         } else {
             /* Receive message from parent */
@@ -173,10 +173,10 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                               src, MPIR_BCAST_TAG, comm_ptr, &status);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
-                MPIR_ERR_CHKANDJUMP2(recvd_size != nbytes, mpi_errno, MPI_ERR_OTHER,
+                MPIR_ERR_CHKANDJUMP2(recvd_size != msgsize, mpi_errno, MPI_ERR_OTHER,
                                      "**collective_size_mismatch",
                                      "**collective_size_mismatch %d %d",
-                                     (int) recvd_size, (int) nbytes);
+                                     (int) recvd_size, (int) msgsize);
             }
         }
         if (tree_type == MPIR_TREE_TYPE_KARY) {

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -105,9 +105,6 @@ mpich-.*-arm.* * * * * /^reduce 10/           xfail=ticket0       coll/testlist.
 # MPI_Abort a sub group is not fully working
 * * * * *               /^(inter|sub)comm_abort/   xfail=ticket6634    errors/comm/testlist
 
-# The pipelined_tree bcast algorithm may flood unexpected messages to children processes
-* * * * *               /^bcasttest 10 .*ALGORITHM=pipelined_tree/  xfail=ticket4474 coll/testlist.collalgo
-
 # IPC read bcast, alltoall, allgather and allgatherv fail as MPL_gpu_imemcpy is not implemented in CUDA
 # https://github.com/pmodels/mpich/issues/6657
 * * * * *               /^bcast_gpu/   xfail=ticket6657    coll/testlist.gpu


### PR DESCRIPTION
## Pull Request Description
It was accidentally broken in commit e1c2ee8. We need check the received count against msgsize rather than nbytes.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
