### PR TITLE
ch4/ofi: add cast for potential 32-bit systems

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -679,14 +679,14 @@ static inline void MPIDI_OFI_idata_set_size(uint64_t * data_field, MPI_Aint data
 {
     *data_field &= 0xffffffff;
     if (MPIDI_OFI_global.cq_data_size == 8 && data_sz <= INT32_MAX) {
-        *data_field |= (data_sz << 32);
+        *data_field |= ((uint64_t) data_sz << 32);
     }
 }
 
 static inline uint32_t MPIDI_OFI_idata_get_size(uint64_t idata)
 {
     if (MPIDI_OFI_global.cq_data_size == 8) {
-        return idata >> 32;
+        return (uint32_t) (idata >> 32);
     } else {
         return 0;
     }


### PR DESCRIPTION
## Pull Request Description
The ubsan test will fail if we left shift a 32-bit type by 32. Fix it by cast to uint64_t.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
