### PR TITLE
pmi: increase MAX_TMP_BUF_SIZE to 4096

### DIFF
--- a/src/pmi/src/pmi_wire.c
+++ b/src/pmi/src/pmi_wire.c
@@ -12,7 +12,7 @@
 
 #include <ctype.h>
 
-#define MAX_TMP_BUF_SIZE 1024
+#define MAX_TMP_BUF_SIZE 4096
 static char tmp_buf_for_output[MAX_TMP_BUF_SIZE];
 
 #define IS_SPACE(c) ((c) == ' ')


### PR DESCRIPTION
## Pull Request Description
We ocasionally get assertion erros like -
```
    pmi_wire.c:683: PMIU_cmd_output_v1: Assertion `!PMIU_cmd_is_static(pmicmd)' failed.
```
This is due to PMI command size exceed MAX_TMP_BUF_SIZE and the upper layer is not prepared for dynamic PMI command buffers. It's not clear the exact issue, but I am guessing this is due to various limit in PMI1 such as PMI_MAXVALLEN is also set to 1024, which may result in combined PMI command exceed 1024 limit. Thus, let's increase the internal buffer to 4096 to have plenty of margin. Hopefully, this fixes the issue. If the error continue to show up, then we need proper investigation.



[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
