### PR TITLE
ch4: move av_table to DDR

### DIFF
--- a/src/mpid/ch4/src/ch4_proc.c
+++ b/src/mpid/ch4/src/ch4_proc.c
@@ -11,6 +11,8 @@
  * Refer to comment in ch4_proc.h
  */
 
+#define MPIDI_CH4_AVTABLE_USE_DDR    1
+
 static int get_next_avtid(void);
 
 int MPIDIU_get_node_id(MPIR_Comm * comm, int rank, int *id_p)
@@ -164,6 +166,13 @@ int MPIDIU_avt_init(void)
     size_t table_size = sizeof(MPIDI_av_table_t) + size * sizeof(MPIDI_av_entry_t);
     MPIDI_global.avt_mgr.av_table0 = (MPIDI_av_table_t *) MPL_malloc(table_size, MPL_MEM_ADDRESS);
     MPIR_Assert(MPIDI_global.avt_mgr.av_table0);
+
+#if MPIDI_CH4_AVTABLE_USE_DDR
+    MPIR_hwtopo_gid_t mem_gid = MPIR_hwtopo_get_obj_by_type(MPIR_HWTOPO_TYPE__DDR);
+    if (mem_gid != MPIR_HWTOPO_GID_ROOT) {
+        MPIR_hwtopo_mem_bind(MPIDI_global.avt_mgr.av_table0, table_size, mem_gid);
+    }
+#endif
 
     MPIDI_global.avt_mgr.av_table0->size = size;
     MPIR_cc_set(&MPIDI_global.avt_mgr.av_table0->ref_count, 1);


### PR DESCRIPTION
av_table memory usage scales with the number of ranks and it can be very large to stay in HBM. Move it to DDR to save the HBM for applications.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
