### PR TITLE
warnings/fortran: add missing prototypes for MPII functions

### DIFF
--- a/src/binding/fortran/mpif_h/mpi_fortimpl.h
+++ b/src/binding/fortran/mpif_h/mpi_fortimpl.h
@@ -403,6 +403,10 @@ typedef void (FORT_CALL F77_ErrFunction) (MPI_Fint *, MPI_Fint *);
 void MPII_Keyval_set_f90_proxy(int keyval);
 int MPII_op_create(F77_OpFunction * opfn, MPI_Fint commute, MPI_Fint * op);
 int MPII_errhan_create(F77_ErrFunction * err_fn, MPI_Fint * errhandler, enum F77_handle_type type);
+int MPII_Comm_create_errhandler(F77_ErrFunction * err_fn, MPI_Fint * errhandler);
+int MPII_File_create_errhandler(F77_ErrFunction * err_fn, MPI_Fint * errhandler);
+int MPII_Win_create_errhandler(F77_ErrFunction * err_fn, MPI_Fint * errhandler);
+int MPII_Session_create_errhandler(F77_ErrFunction * err_fn, MPI_Fint * errhandler);
 
 extern FORT_DLL_SPEC void FORT_CALL mpi_alloc_mem_cptr_(MPI_Aint * size, MPI_Fint * info,
                                                         void **baseptr, MPI_Fint * ierr);


### PR DESCRIPTION

## Pull Request Description
The newly added internal functions,
MPII_{Comm,File,Win,Session)_create_errhandler, need to decleare prototypes or the compiler will warn.



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
