### PR TITLE
romio/test: fix test/aggregation1 on mac clang

### DIFF
--- a/src/mpi/romio/test/aggregation1.c
+++ b/src/mpi/romio/test/aggregation1.c
@@ -6,7 +6,7 @@
 /* Test case from John Bent (ROMIO req #835)
  * Aggregation code was not handling certain access patterns when collective
  * buffering forced */
-#define _XOPEN_SOURCE 500       /* strdup not in string.h otherwise */
+#define _XOPEN_SOURCE 600       /* strdup not in string.h otherwise */
 #include <unistd.h>
 #include <stdlib.h>
 #include <mpi.h>


### PR DESCRIPTION
## Pull Request Description
Although the manual says we need _XOPEN_SOURCE >= 500 in order for
stdio.h to provide snprintf, apparently on Mac Clang it requires
a strict > 500. Update it to 600 fixes the build error in "make check".




## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
