### PR TITLE
misc: remove MPIR_Context_id_t

### DIFF
--- a/doc/wiki/design/Communicators_and_Context_IDs.md
+++ b/doc/wiki/design/Communicators_and_Context_IDs.md
@@ -32,9 +32,6 @@ fields of the context ID indicated by letter and color:
   (`MPI_Send/MPI_Recv`) occur in a different context than collective
   messages (`MPI_Bcast, etc`). This also [explained further below](#context-type-suffix).
 
-The actual type of a context ID is `MPIR_Context_id_t`, which is
-`typedef`ed to `uint16_t`.
-
 All members of a communicator use the same context ID for that
 communicator, but a context ID is not a globally unique ID. That is, the
 communicator's group information combined with the context ID constitute
@@ -155,7 +152,7 @@ Finds the highest bit of the lowest word that is set in the given mask
 and returns the corresponding context ID.
 
 ```
-static int MPIR_Allocate_context_bit(uint32_t mask[], MPIR_Context_id_t id)
+static int MPIR_Allocate_context_bit(uint32_t mask[], int id)
 ```
 
 Clears the bit in `mask` corresponding to the given context `id`.
@@ -169,7 +166,7 @@ It resets that bit **in the `context_mask`** and returns the found ID
 prefix.
 
 ```
-int MPIR_Get_contextid(MPID_Comm *comm_ptr, MPIR_Context_id_t *context_id)
+int MPIR_Get_contextid(MPID_Comm *comm_ptr, int *context_id)
 ```
 
 Allocates a new context ID prefix collectively over the given
@@ -182,7 +179,7 @@ participating processes. The result of this reduction is fed to
 prefix.
 
 ```
-int MPIR_Get_intercomm_contextid( MPID_Comm *comm_ptr, MPIR_Context_id_t *context_id, MPIR_Context_id_t *recvcontext_id)
+int MPIR_Get_intercomm_contextid( MPID_Comm *comm_ptr, int *context_id, int *recvcontext_id)
 ```
 
 Called by `MPIR_Comm_copy` to get context IDs for a new

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -160,8 +160,8 @@ enum MPIR_COMM_HINT_PREDEFINED_t {
 struct MPIR_Comm {
     MPIR_OBJECT_HEADER;         /* adds handle and ref_count fields */
     MPID_Thread_mutex_t mutex;
-    MPIR_Context_id_t context_id;       /* Send context id.  See notes */
-    MPIR_Context_id_t recvcontext_id;   /* Recv context id (locally allocated).  See notes */
+    int context_id;             /* Send context id.  See notes */
+    int recvcontext_id;         /* Recv context id (locally allocated).  See notes */
     int remote_size;            /* Value of MPI_Comm_(remote)_size */
     int rank;                   /* Value of MPI_Comm_rank */
     MPIR_Attribute *attributes; /* List of attributes */
@@ -378,7 +378,7 @@ int MPIR_Comm_commit(MPIR_Comm *);
 int MPIR_Comm_is_parent_comm(MPIR_Comm *);
 
 /* peer intercomm is an internal 1-to-1 intercomm used for connecting dynamic processes */
-int MPIR_peer_intercomm_create(MPIR_Context_id_t context_id, MPIR_Context_id_t recvcontext_id,
+int MPIR_peer_intercomm_create(int context_id, int recvcontext_id,
                                uint64_t remote_lpid, int is_low_group, MPIR_Comm ** newcomm);
 
 #define MPIR_Comm_rank(comm_ptr) ((comm_ptr)->rank)

--- a/src/include/mpir_contextid.h
+++ b/src/include/mpir_contextid.h
@@ -6,21 +6,13 @@
 #ifndef MPIR_CONTEXTID_H_INCLUDED
 #define MPIR_CONTEXTID_H_INCLUDED
 
+#define MPIR_INVALID_CONTEXT_ID (-1)
+#define MPIR_CONTEXT_ID_T_DATATYPE MPI_INT
+
 #ifdef HAVE_EXTENDED_CONTEXT_BITS
-#define MPIR_CONTEXT_ID_T_DATATYPE MPI_UINT32_T
-typedef uint32_t MPIR_Context_id_t;
-#define MPIR_INVALID_CONTEXT_ID ((MPIR_Context_id_t)0xffffffff)
 #define MPIR_CONTEXT_ID_BITS (20)
-#define CONTEXT_ID_FMT PRIu32
 #else
-/* Default context id type is uint16_t. Instead of always using uint32_t, we take a conservative
- * approach to ensure the smallest possible packet header size for ch3 and ch4 active messages.
- */
-#define MPIR_CONTEXT_ID_T_DATATYPE MPI_UINT16_T
-typedef uint16_t MPIR_Context_id_t;
-#define MPIR_INVALID_CONTEXT_ID ((MPIR_Context_id_t)0xffff)
 #define MPIR_CONTEXT_ID_BITS (16)
-#define CONTEXT_ID_FMT PRIu16
 #endif
 
 /* The following preprocessor macros provide bitfield access information for
@@ -105,14 +97,14 @@ void MPIR_context_id_init(void);
    with the other comm routines (src/mpi/comm, in mpicomm.h).  However,
    to create a new communicator after a spawn or connect-accept operation,
    the device may need to create a new contextid */
-int MPIR_Get_contextid_sparse(MPIR_Comm * comm_ptr, MPIR_Context_id_t * context_id, int ignore_id);
+int MPIR_Get_contextid_sparse(MPIR_Comm * comm_ptr, int *context_id, int ignore_id);
 int MPIR_Get_contextid_sparse_group(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, int tag,
-                                    MPIR_Context_id_t * context_id, int ignore_id);
+                                    int *context_id, int ignore_id);
 
 int MPIR_Get_contextid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newcommp, MPIR_Request ** req);
 int MPIR_Get_intercomm_contextid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newcommp,
                                           MPIR_Request ** req);
 
-void MPIR_Free_contextid(MPIR_Context_id_t);
+void MPIR_Free_contextid(int context_id);
 
 #endif /* MPIR_CONTEXTID_H_INCLUDED */

--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -313,7 +313,7 @@ int MPII_Comm_create_map(int local_n,
 int MPIR_Comm_create_intra(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Comm ** newcomm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Context_id_t new_context_id = 0;
+    int new_context_id = 0;
     int *mapping = NULL;
     int n;
 
@@ -400,7 +400,7 @@ int MPIR_Comm_create_intra(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Co
 int MPIR_Comm_create_inter(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Comm ** newcomm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Context_id_t new_context_id;
+    int new_context_id;
     int *mapping = NULL;
     int *remote_mapping = NULL;
     MPIR_Comm *mapping_comm = NULL;
@@ -581,7 +581,7 @@ int MPIR_Comm_create_group_impl(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, in
                                 MPIR_Comm ** newcomm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Context_id_t new_context_id = 0;
+    int new_context_id = 0;
     int *mapping = NULL;
     int n;
 
@@ -988,7 +988,7 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
                                MPIR_Comm ** new_intercomm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Context_id_t final_context_id, recvcontext_id;
+    int final_context_id, recvcontext_id;
     int remote_size = 0;
     uint64_t *remote_lpids = NULL;
     int comm_info[3];
@@ -1024,7 +1024,7 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
     /* Leaders can now swap context ids and then broadcast the value
      * to the local group of processes */
     if (local_comm_ptr->rank == local_leader) {
-        MPIR_Context_id_t remote_context_id;
+        int remote_context_id;
 
         mpi_errno =
             MPIC_Sendrecv(&recvcontext_id, 1, MPIR_CONTEXT_ID_T_DATATYPE, remote_leader, tag,
@@ -1103,7 +1103,7 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
 /* Peer intercomm is a 1-to-1 intercomm, internally created by device layer
  * to facilitate connecting dynamic processes */
 
-int MPIR_peer_intercomm_create(MPIR_Context_id_t context_id, MPIR_Context_id_t recvcontext_id,
+int MPIR_peer_intercomm_create(int context_id, int recvcontext_id,
                                uint64_t remote_lpid, int is_low_group, MPIR_Comm ** newcomm)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -1180,7 +1180,7 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm * comm_ptr, int high, MPIR_Comm ** new_i
 {
     int mpi_errno = MPI_SUCCESS;
     int local_high, remote_high, new_size;
-    MPIR_Context_id_t new_context_id;
+    int new_context_id;
 
     MPIR_FUNC_ENTER;
     /* Make sure that we have a local intercommunicator */

--- a/src/mpi/comm/comm_split.c
+++ b/src/mpi/comm/comm_split.c
@@ -88,7 +88,7 @@ int MPIR_Comm_split_impl(MPIR_Comm * comm_ptr, int color, int key, MPIR_Comm ** 
     int rank, size, remote_size, i, new_size, new_remote_size,
         first_entry = 0, first_remote_entry = 0, *last_ptr;
     int in_newcomm;             /* TRUE iff *newcomm should be populated */
-    MPIR_Context_id_t new_context_id, remote_context_id;
+    int new_context_id, remote_context_id;
     MPIR_Comm_map_t *mapper;
     MPIR_CHKLMEM_DECL(4);
 

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -917,7 +917,7 @@ int MPII_Comm_dup(MPIR_Comm * comm_ptr, MPIR_Info * info, MPIR_Comm ** newcomm_p
 int MPII_Comm_copy(MPIR_Comm * comm_ptr, int size, MPIR_Info * info, MPIR_Comm ** outcomm_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Context_id_t new_context_id, new_recvcontext_id;
+    int new_context_id, new_recvcontext_id;
     MPIR_Comm *newcomm_ptr = NULL;
     MPIR_Comm_map_t *map = NULL;
 

--- a/src/mpi/comm/mpicomm.h
+++ b/src/mpi/comm/mpicomm.h
@@ -7,7 +7,7 @@
 #define MPICOMM_H_INCLUDED
 
 /* Function prototypes for communicator helper functions */
-int MPIR_Get_intercomm_contextid(MPIR_Comm *, MPIR_Context_id_t *, MPIR_Context_id_t *);
+int MPIR_Get_intercomm_contextid(MPIR_Comm *, int *, int *);
 
 /* Utitlity function that retrieves an info key and ensures it is collectively equal */
 int MPII_collect_info_key(MPIR_Comm * comm_ptr, MPIR_Info * info_ptr, const char *key,

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -1413,7 +1413,7 @@ int MPIDI_CH3U_Receive_data_unexpected(MPIR_Request * rreq, void *buf, intptr_t 
 int MPIDI_CH3I_Comm_init(void);
 
 int MPIDI_CH3I_Comm_handle_failed_procs(MPIR_Group *new_failed_procs);
-void MPIDI_CH3I_Comm_find(MPIR_Context_id_t context_id, MPIR_Comm **comm);
+void MPIDI_CH3I_Comm_find(int context_id, MPIR_Comm **comm);
 
 /* The functions below allow channels to register functions to be
    called immediately after a communicator has been created, and

--- a/src/mpid/ch3/include/mpidpkt.h
+++ b/src/mpid/ch3/include/mpidpkt.h
@@ -847,7 +847,7 @@ typedef MPIDI_CH3_Pkt_conn_ack_t MPIDI_CH3_Pkt_accept_ack_t;
 
 typedef struct MPIDI_CH3_Pkt_revoke {
     MPIDI_CH3_Pkt_type_t type;
-    MPIR_Context_id_t revoked_comm;
+    int revoked_context_id;
 } MPIDI_CH3_Pkt_revoke_t;
 
 typedef union MPIDI_CH3_Pkt {

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -106,7 +106,7 @@ typedef int32_t MPIDI_Rank_t;
 typedef struct MPIDI_Message_match_parts {
     int32_t tag;
     MPIDI_Rank_t rank;
-    MPIR_Context_id_t context_id;
+    int context_id;
 } MPIDI_Message_match_parts_t;
 typedef union {
     MPIDI_Message_match_parts_t parts;

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -75,10 +75,12 @@ typedef unsigned long MPID_Seqnum_t;
 
 #include "mpichconf.h"
 
-#if CH3_RANK_BITS == 16
+#if CH3_RANK_BITS == 16 && !defined(HAVE_EXTENDED_CONTEXT_BITS)
 typedef int16_t MPIDI_Rank_t;
-#elif CH3_RANK_BITS == 32
+typedef int16_t MPIDI_Context_id_t;
+#else
 typedef int32_t MPIDI_Rank_t;
+typedef int32_t MPIDI_Context_id_t;
 #endif /* CH3_RANK_BITS */
 
 /* For the typical communication system for which the ch3 channel is
@@ -106,7 +108,7 @@ typedef int32_t MPIDI_Rank_t;
 typedef struct MPIDI_Message_match_parts {
     int32_t tag;
     MPIDI_Rank_t rank;
-    int context_id;
+    MPIDI_Context_id_t context_id;
 } MPIDI_Message_match_parts_t;
 typedef union {
     MPIDI_Message_match_parts_t parts;

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -566,7 +566,7 @@ int MPIDI_CH3I_Comm_handle_failed_procs(MPIR_Group *new_failed_procs)
     goto fn_exit;
 }
 
-void MPIDI_CH3I_Comm_find(MPIR_Context_id_t context_id, MPIR_Comm **comm)
+void MPIDI_CH3I_Comm_find(int context_id, MPIR_Comm **comm)
 {
     MPIR_FUNC_ENTER;
 

--- a/src/mpid/ch3/src/ch3u_handle_revoke_pkt.c
+++ b/src/mpid/ch3/src/ch3u_handle_revoke_pkt.c
@@ -16,7 +16,7 @@ int MPIDI_CH3_PktHandler_Revoke(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt,
     MPL_DBG_MSG_D(MPIDI_CH3_DBG_OTHER, VERBOSE, "Received revoke pkt from %d", vc->pg_rank);
 
     /* Search through all of the communicators to find the right context_id */
-    MPIDI_CH3I_Comm_find(revoke_pkt->revoked_comm, &comm_ptr);
+    MPIDI_CH3I_Comm_find(revoke_pkt->revoked_context_id, &comm_ptr);
     if (comm_ptr == NULL)
         MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**ch3|postrecv",
                 "**ch3|postrecv %s", "MPIDI_CH3_PKT_REVOKE");

--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -585,7 +585,7 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
     pg_translation *local_translation = NULL, *remote_translation = NULL;
     pg_node *pg_list = NULL;
     MPIDI_PG_t **remote_pg = NULL;
-    MPIR_Context_id_t recvcontext_id = MPIR_INVALID_CONTEXT_ID;
+    int recvcontext_id = MPIR_INVALID_CONTEXT_ID;
     MPIR_CHKLMEM_DECL(3);
 
     MPIR_FUNC_ENTER;

--- a/src/mpid/ch3/src/mpid_comm_revoke.c
+++ b/src/mpid/ch3/src/mpid_comm_revoke.c
@@ -43,7 +43,7 @@ int MPID_Comm_revoke(MPIR_Comm *comm_ptr, int is_remote)
 
         /* Send out the revoke message */
         MPIDI_Pkt_init(revoke_pkt, MPIDI_CH3_PKT_REVOKE);
-        revoke_pkt->revoked_comm = comm_ptr->context_id;
+        revoke_pkt->revoked_context_id = comm_ptr->context_id;
 
         size = comm_ptr->remote_size;
         my_rank = comm_ptr->rank;

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -452,7 +452,7 @@ PARAM:
     comm: MPIR_Comm *
     comm_ptr: MPIR_Comm *
     compare_addr: const void *
-    context_id: MPIR_Context_id_t
+    context_id: int
     count: MPI_Aint
     data: const void *
     data_sz: MPI_Aint

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -216,7 +216,7 @@ typedef struct MPIDIG_req_t {
             int dest;
         } send;
         struct {
-            MPIR_Context_id_t context_id;
+            int context_id;
         } recv;
         struct {
             int target_rank;
@@ -268,7 +268,7 @@ typedef struct MPIDI_part_request {
             int dest;
         } send;
         struct {
-            MPIR_Context_id_t context_id;
+            int context_id;
         } recv;
     } u;
     union {

--- a/src/mpid/ch4/netmod/ofi/ofi_huge.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_huge.c
@@ -196,7 +196,7 @@ int MPIDI_OFI_recv_huge_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Reque
     } else {
         /* Check for remote control info */
         MPIDI_OFI_huge_recv_list_t *list_ptr;
-        MPIR_Context_id_t comm_id = comm_ptr->recvcontext_id;
+        int comm_id = comm_ptr->recvcontext_id;
         int rank = MPIDI_OFI_cqe_get_source(wc, false);
         int tag = (MPIDI_OFI_TAG_MASK & wc->tag);
 
@@ -241,7 +241,7 @@ int MPIDI_OFI_recv_huge_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Reque
 }
 
 /* This function is called when we receive a huge control message */
-int MPIDI_OFI_recv_huge_control(int vci, MPIR_Context_id_t comm_id, int rank, int tag,
+int MPIDI_OFI_recv_huge_control(int vci, int comm_id, int rank, int tag,
                                 MPIDI_OFI_huge_remote_info_t * info_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -314,7 +314,7 @@ int MPIDI_OFI_peek_huge_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Reque
      * with this and return the size in that. */
     LL_FOREACH(MPIDI_OFI_global.per_vci[vci].huge_ctrl_head, list_ptr) {
         /* FIXME: fix the type of comm_id */
-        MPIR_Context_id_t comm_id = rreq->comm->recvcontext_id;
+        int comm_id = rreq->comm->recvcontext_id;
         int rank = MPIDI_OFI_cqe_get_source(wc, false);
         int tag = (int) (MPIDI_OFI_TAG_MASK & wc->tag);
         if (list_ptr->comm_id == comm_id && list_ptr->rank == rank && list_ptr->tag == tag) {

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -301,7 +301,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_mr_bind(struct fi_info *prov, struct fid_
 #define MPIDI_OFI_INVALID_MR_KEY 0xFFFFFFFFFFFFFFFFULL
 int MPIDI_OFI_retry_progress(void);
 int MPIDI_OFI_recv_huge_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
-int MPIDI_OFI_recv_huge_control(int vci, MPIR_Context_id_t comm_id, int rank, int tag,
+int MPIDI_OFI_recv_huge_control(int vci, int comm_id, int rank, int tag,
                                 MPIDI_OFI_huge_remote_info_t * info);
 int MPIDI_OFI_peek_huge_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * rreq);
 int MPIDI_OFI_huge_chunk_done_event(int vci, struct fi_cq_tagged_entry *wc, void *req);
@@ -487,8 +487,7 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_OFI_is_tag_rndv(uint64_t match_bits)
     return ((match_bits & MPIDI_OFI_PROTOCOL_MASK) == MPIDI_OFI_RNDV_SEND);
 }
 
-MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_OFI_init_sendtag(MPIR_Context_id_t contextid,
-                                                         int source, int tag)
+MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_OFI_init_sendtag(int contextid, int source, int tag)
 {
     uint64_t match_bits;
     match_bits = contextid;
@@ -505,8 +504,7 @@ MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_OFI_init_sendtag(MPIR_Context_id_t conte
 
 /* receive posting */
 MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_OFI_init_recvtag(uint64_t * mask_bits,
-                                                         MPIR_Context_id_t contextid,
-                                                         int source, int tag)
+                                                         int contextid, int source, int tag)
 {
     uint64_t match_bits = 0;
     *mask_bits = MPIDI_OFI_PROTOCOL_MASK;
@@ -568,7 +566,7 @@ struct MPIDI_OFI_contig_blocks_params {
  * tag - The tag of the message being sent.
  */
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_multx_sender_nic_index(MPIR_Comm * comm,
-                                                              MPIR_Context_id_t ctxid_in_effect,
+                                                              int ctxid_in_effect,
                                                               int sender_rank, int receiver_rank,
                                                               int tag)
 {
@@ -596,7 +594,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_multx_sender_nic_index(MPIR_Comm * comm,
  * tag - The tag of the message being sent.
  */
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_multx_receiver_nic_index(MPIR_Comm * comm,
-                                                                MPIR_Context_id_t ctxid_in_effect,
+                                                                int ctxid_in_effect,
                                                                 int sender_rank, int receiver_rank,
                                                                 int tag)
 {

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -66,7 +66,7 @@ typedef enum {
 typedef struct {
     /* context id and src rank so the target side can
      * issue RDMA read operation */
-    MPIR_Context_id_t context_id;
+    int context_id;
     int src_rank;
 
     uint64_t src_offset;
@@ -120,7 +120,7 @@ typedef struct {
     void *unpack_buffer;
     MPI_Aint pack_size;
     uint64_t src_offset;
-    MPIR_Context_id_t context_id;
+    int context_id;
     int src_rank;
 } MPIDI_OFI_lmt_unpack_t;
 
@@ -207,7 +207,7 @@ typedef struct {
 
     /* for recv request */
     MPL_atomic_int_t peek_status;
-    MPIR_Context_id_t context_id;
+    int context_id;
 
     enum MPIDI_OFI_req_kind kind;
     union {

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -24,7 +24,7 @@
 */
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_iov(void *buf, MPI_Aint count, MPI_Datatype datatype, size_t data_sz,       /* data_sz passed in here for reusing */
                                                 int rank, uint64_t match_bits, uint64_t mask_bits,
-                                                MPIR_Comm * comm, MPIR_Context_id_t context_id,
+                                                MPIR_Comm * comm, int context_id,
                                                 MPIDI_av_entry_t * addr, int vci_src, int vci_dst,
                                                 MPIR_Request * rreq,
                                                 MPIR_Datatype * dt_ptr, uint64_t flags)
@@ -109,7 +109,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq;
-    MPIR_Context_id_t context_id = comm->recvcontext_id + context_offset;
+    int context_id = comm->recvcontext_id + context_offset;
     size_t data_sz;
     int dt_contig;
     MPI_Aint dt_true_lb;

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -532,7 +532,7 @@ typedef struct {
 } MPIDI_OFI_global_t;
 
 typedef struct {
-    MPIR_Context_id_t comm_id;
+    int comm_id;
     int origin_rank;
     int tag;
     MPIR_Request *ackreq;
@@ -660,7 +660,7 @@ typedef struct MPIDI_OFI_read_chunk {
  * data from the remote memory region and we need a way of matching up the
  * control messages with the "real" requests. */
 typedef struct MPIDI_OFI_huge_recv_list {
-    MPIR_Context_id_t comm_id;
+    int comm_id;
     int rank;
     int tag;
     union {

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -41,8 +41,7 @@
         } \
     } while (0)
 
-MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_UCX_init_tag(MPIR_Context_id_t contextid, int source,
-                                                     uint64_t tag)
+MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_UCX_init_tag(int contextid, int source, uint64_t tag)
 {
     uint64_t ucp_tag = 0;
     ucp_tag = contextid;
@@ -66,8 +65,7 @@ MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_UCX_tag_mask(int mpi_tag, int src)
     return tag_mask;
 }
 
-MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_UCX_recv_tag(int mpi_tag, int src,
-                                                     MPIR_Context_id_t contextid)
+MPL_STATIC_INLINE_PREFIX uint64_t MPIDI_UCX_recv_tag(int mpi_tag, int src, int contextid)
 {
     uint64_t ucp_tag = contextid;
 

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -56,29 +56,29 @@ uint64_t MPIDIG_generate_win_id(MPIR_Comm * comm_ptr);
 
 /* Static inlines */
 
-MPL_STATIC_INLINE_PREFIX MPIR_Context_id_t MPIDIG_win_id_to_context(uint64_t win_id)
+MPL_STATIC_INLINE_PREFIX int MPIDIG_win_id_to_context(uint64_t win_id)
 {
-    MPIR_Context_id_t ret;
+    int context_id;
 
     MPIR_FUNC_ENTER;
 
     /* pick the lower 32-bit to extract context id */
-    ret = (win_id - 1) & 0xffffffff;
+    context_id = (win_id - 1) & 0xffffffff;
 
     MPIR_FUNC_EXIT;
-    return ret;
+    return context_id;
 }
 
-MPL_STATIC_INLINE_PREFIX MPIR_Context_id_t MPIDIG_win_to_context(const MPIR_Win * win)
+MPL_STATIC_INLINE_PREFIX int MPIDIG_win_to_context(const MPIR_Win * win)
 {
-    MPIR_Context_id_t ret;
+    int context_id;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDIG_win_id_to_context(MPIDIG_WIN(win, win_id));
+    context_id = MPIDIG_win_id_to_context(MPIDIG_WIN(win, win_id));
 
     MPIR_FUNC_EXIT;
-    return ret;
+    return context_id;
 }
 
 MPL_STATIC_INLINE_PREFIX MPIDIG_win_target_t *MPIDIG_win_target_add(MPIR_Win * win, int rank)

--- a/src/mpid/ch4/src/ch4_spawn.c
+++ b/src/mpid/ch4/src/ch4_spawn.c
@@ -280,7 +280,7 @@ static int dynamic_intercomm_create(const char *port_name, MPIR_Info * info, int
                                     MPIR_Comm ** newcomm);
 
 struct dynproc_conn_hdr {
-    MPIR_Context_id_t context_id;
+    int context_id;
     int addrname_len;
     char addrname[MPIDI_DYNPROC_NAME_MAX];
 };
@@ -289,7 +289,7 @@ static int peer_intercomm_create(char *remote_addrname, int len, int tag,
                                  int timeout, bool is_sender, MPIR_Comm ** newcomm)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Context_id_t context_id, recvcontext_id;
+    int context_id, recvcontext_id;
     uint64_t remote_gpid;
 
     mpi_errno = MPIR_Get_contextid_sparse(MPIR_Process.comm_self, &recvcontext_id, FALSE);

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -58,7 +58,7 @@ enum {
 typedef struct MPIDIG_hdr_t {
     int src_rank;
     int tag;
-    MPIR_Context_id_t context_id;
+    int context_id;
     int error_bits;
     int flags;
     MPIR_Request *sreq_ptr;
@@ -83,7 +83,7 @@ typedef struct MPIDIG_ssend_ack_msg_t {
 typedef struct MPIDIG_part_send_init_msg_t {
     int src_rank;
     int tag;
-    MPIR_Context_id_t context_id;
+    int context_id;
     MPIR_Request *sreq_ptr;
     MPI_Aint data_sz;           /* size of entire send data */
 } MPIDIG_part_send_init_msg_t;

--- a/src/mpid/ch4/src/ch4_vci.h
+++ b/src/mpid/ch4/src/ch4_vci.h
@@ -135,26 +135,25 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_vci(int flag, MPIR_Comm * comm_ptr,
 #elif MPIDI_CH4_VCI_METHOD == MPICH_VCI__IMPLICIT
 
 /* Map comm to vci_idx */
-MPL_STATIC_INLINE_PREFIX int MPIDI_map_contextid_to_vci(MPIR_Context_id_t context_id)
+MPL_STATIC_INLINE_PREFIX int MPIDI_map_contextid_to_vci(int context_id)
 {
     return MPIR_CONTEXT_READ_FIELD(PREFIX, context_id);
 }
 
 /* Map comm and rank to vci_idx */
-MPL_STATIC_INLINE_PREFIX int MPIDI_map_contextid_rank_to_vci(MPIR_Context_id_t context_id, int rank)
+MPL_STATIC_INLINE_PREFIX int MPIDI_map_contextid_rank_to_vci(int context_id, int rank)
 {
     return MPIR_CONTEXT_READ_FIELD(PREFIX, context_id) + rank;
 }
 
 /* Map comm and tag to vci_idx */
-MPL_STATIC_INLINE_PREFIX int MPIDI_map_contextid_tag_to_vci(MPIR_Context_id_t context_id, int tag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_map_contextid_tag_to_vci(int context_id, int tag)
 {
     return MPIR_CONTEXT_READ_FIELD(PREFIX, context_id) + tag;
 }
 
 /* Map comm, rank, and tag to vci_idx */
-MPL_STATIC_INLINE_PREFIX int MPIDI_map_contextid_rank_tag_to_vci(MPIR_Context_id_t context_id,
-                                                                 int rank, int tag)
+MPL_STATIC_INLINE_PREFIX int MPIDI_map_contextid_rank_tag_to_vci(int context_id, int rank, int tag)
 {
     return MPIR_CONTEXT_READ_FIELD(PREFIX, context_id) + rank + tag;
 }
@@ -190,7 +189,7 @@ static bool is_vci_restricted_to_zero(MPIR_Comm * comm)
  * Otherwise (receiver side), it should be comm->recvcontext_id.
  */
 MPL_STATIC_INLINE_PREFIX int MPIDI_get_sender_vci(MPIR_Comm * comm,
-                                                  MPIR_Context_id_t ctxid_in_effect,
+                                                  int ctxid_in_effect,
                                                   int sender_rank, int receiver_rank, int tag)
 {
 #if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
@@ -232,7 +231,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_get_sender_vci(MPIR_Comm * comm,
  * Otherwise (receiver side), it should be comm->recvcontext_id.
  */
 MPL_STATIC_INLINE_PREFIX int MPIDI_get_receiver_vci(MPIR_Comm * comm,
-                                                    MPIR_Context_id_t ctxid_in_effect,
+                                                    int ctxid_in_effect,
                                                     int sender_rank, int receiver_rank, int tag)
 {
 #if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI

--- a/src/mpid/ch4/src/mpidig_probe.h
+++ b/src/mpid/ch4/src/mpidig_probe.h
@@ -16,7 +16,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_iprobe(int source, int tag, MPIR_Comm * 
     MPIR_Request *unexp_req;
     MPIR_FUNC_ENTER;
 
-    MPIR_Context_id_t context_id = comm->recvcontext_id + context_offset;
+    int context_id = comm->recvcontext_id + context_offset;
 
     unexp_req =
         MPIDIG_rreq_find(source, tag, context_id, &MPIDI_global.per_vci[vci].unexp_list,
@@ -47,7 +47,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_improbe(int source, int tag, MPIR_Comm *
 
     MPIR_FUNC_ENTER;
 
-    MPIR_Context_id_t context_id = comm->recvcontext_id + context_offset;
+    int context_id = comm->recvcontext_id + context_offset;
 
     unexp_req =
         MPIDIG_rreq_dequeue(source, tag, context_id, &MPIDI_global.per_vci[vci].unexp_list,

--- a/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
@@ -205,7 +205,7 @@ int MPIDIG_send_data_origin_cb(MPIR_Request * sreq)
  *
  */
 
-static int match_posted_rreq(int rank, int tag, MPIR_Context_id_t context_id, int vci,
+static int match_posted_rreq(int rank, int tag, int context_id, int vci,
                              bool is_local, MPIR_Request ** req)
 {
 #ifdef MPIDI_CH4_DIRECT_NETMOD
@@ -240,7 +240,7 @@ static int match_posted_rreq(int rank, int tag, MPIR_Context_id_t context_id, in
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
 }
 
-static int create_unexp_rreq(int rank, int tag, MPIR_Context_id_t context_id,
+static int create_unexp_rreq(int rank, int tag, int context_id,
                              MPI_Aint data_sz, int error_bits, int is_local,
                              int local_vci, int remote_vci, MPIR_Request ** req)
 {
@@ -326,8 +326,7 @@ static void call_rndv_cb(MPIR_Request * rreq, int flags)
 }
 
 static void set_matched_rreq_fields(MPIR_Request * rreq, int rank, int tag,
-                                    MPIR_Context_id_t context_id,
-                                    MPI_Aint data_sz, int error_bits, int is_local)
+                                    int context_id, MPI_Aint data_sz, int error_bits, int is_local)
 {
     MPIR_FUNC_ENTER;
     MPIDIG_REQUEST(rreq, u.recv.context_id) = context_id;

--- a/src/mpid/ch4/src/mpidig_recv.h
+++ b/src/mpid/ch4/src/mpidig_recv.h
@@ -10,7 +10,7 @@
 #include "ch4_proc.h"
 
 MPL_STATIC_INLINE_PREFIX void MPIDIG_prepare_recv_req(int rank, int tag,
-                                                      MPIR_Context_id_t context_id, void *buf,
+                                                      int context_id, void *buf,
                                                       MPI_Aint count, MPI_Datatype datatype,
                                                       MPIR_Request * rreq)
 {
@@ -189,7 +189,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_irecv(void *buf, MPI_Aint count, MPI_Data
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *rreq = NULL, *unexp_req = NULL;
-    MPIR_Context_id_t context_id = comm->recvcontext_id + context_offset;
+    int context_id = comm->recvcontext_id + context_offset;
     MPIR_FUNC_ENTER;
 
     if (*request) {

--- a/src/mpid/ch4/src/mpidig_recvq.h
+++ b/src/mpid/ch4/src/mpidig_recvq.h
@@ -94,7 +94,7 @@ enum MPIDIG_queue_type {
 
 /* match and search functions */
 MPL_STATIC_INLINE_PREFIX bool MPIDIG_match_request(int rank, int tag,
-                                                   MPIR_Context_id_t context_id, MPIR_Request * req,
+                                                   int context_id, MPIR_Request * req,
                                                    bool is_local, enum MPIDIG_queue_type qtype)
 {
 #ifndef MPIDI_CH4_DIRECT_NETMOD
@@ -133,7 +133,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDIG_enqueue_request(MPIR_Request * req, MPIR_Re
 }
 
 MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_recvq_search(int rank, int tag,
-                                                           MPIR_Context_id_t context_id,
+                                                           int context_id,
                                                            MPIR_Request ** list,
                                                            bool is_local,
                                                            enum MPIDIG_queue_type qtype,
@@ -162,7 +162,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_recvq_search(int rank, int tag,
 }
 
 MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_rreq_find(int rank, int tag,
-                                                        MPIR_Context_id_t context_id,
+                                                        int context_id,
                                                         MPIR_Request ** list,
                                                         bool is_local, enum MPIDIG_queue_type qtype)
 {
@@ -170,7 +170,7 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_rreq_find(int rank, int tag,
 }
 
 MPL_STATIC_INLINE_PREFIX MPIR_Request *MPIDIG_rreq_dequeue(int rank, int tag,
-                                                           MPIR_Context_id_t context_id,
+                                                           int context_id,
                                                            MPIR_Request ** list,
                                                            bool is_local,
                                                            enum MPIDIG_queue_type qtype)


### PR DESCRIPTION
## Pull Request Description
[This is one step toward merging #6189]

Using shorter integer type for context id has little benefit since nearly all expressions will default to int and then the type truncation will be either ignored or cast away, thus serve no additional safety. It only creates noise when we do want to check conversion warnings.

The original purpose (according to comments) is to conserve header space in active messages. We still can do that, just add cast -- better yet, add bound check -- when we fill the am header.

Thus, replace `MPIR_Context_id_t` with int for simpler code.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
