### PR TITLE
romio: implement binding generation for ROMIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -384,6 +384,7 @@ Makefile.am-stamp
 
 # /src/binding/
 /src/binding/c/c_binding.c
+/src/binding/c/io.c
 
 # /src/binding/cxx/
 /src/binding/cxx/Makefile.sm

--- a/Makefile.am
+++ b/Makefile.am
@@ -51,12 +51,20 @@ errnames_txt_files =
 external_subdirs = @mplsrcdir@ @hwlocsrcdir@ @jsonsrcdir@ @yaksasrcdir@ @pmisrcdir@
 external_ldflags = @mpllibdir@ @yaksalibdir@
 external_libs = @WRAPPER_LIBS@
-mpi_convenience_libs =
+
+# convenience libs that do not depend on MPI
 pmpi_convenience_libs = @mpllib@ @hwloclib@ @jsonlib@ @yaksalib@ @pmilib@
+
+# convenience libs that depend on MPI (either MPI functions or MPI constants)
+mpi_convenience_libs =
+abi_convenience_libs =
 
 if BUILD_ROMIO
     external_subdirs += src/mpi/romio
-    pmpi_convenience_libs += src/mpi/romio/libromio.la
+    mpi_convenience_libs += src/mpi/romio/libromio.la
+if BUILD_ABI_LIB
+    abi_convenience_libs += src/mpi/romio/libromio_abi.la
+endif
 endif
 
 # NOTE on our semi-unconventional usage of DIST_SUBDIRS:
@@ -129,8 +137,8 @@ if BUILD_PROFILING_LIB
 lib_LTLIBRARIES += lib/lib@PMPILIBNAME@.la
 lib_lib@PMPILIBNAME@_la_SOURCES = $(mpi_sources) $(mpi_core_sources)
 lib_lib@PMPILIBNAME@_la_LDFLAGS = $(external_ldflags) $(ABIVERSIONFLAGS)
-lib_lib@PMPILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs)
-EXTRA_lib_lib@PMPILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs)
+lib_lib@PMPILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs) $(mpi_convenience_libs)
+EXTRA_lib_lib@PMPILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs) $(mpi_convenience_libs)
 
 # lib@MPILIBNAME@.la might depend on lib@PMPILIBNAME@.la.  We add them
 # in that order to lib_LTLIBRARIES so libtool doesn't get
@@ -139,7 +147,7 @@ lib_LTLIBRARIES += lib/lib@MPILIBNAME@.la
 lib_lib@MPILIBNAME@_la_SOURCES = $(mpi_sources)
 lib_lib@MPILIBNAME@_la_LDFLAGS = $(ABIVERSIONFLAGS)
 lib_lib@MPILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) -DMPICH_MPI_FROM_PMPI
-lib_lib@MPILIBNAME@_la_LIBADD = lib/lib@PMPILIBNAME@.la $(mpi_convenience_libs)
+lib_lib@MPILIBNAME@_la_LIBADD = lib/lib@PMPILIBNAME@.la
 
 else !BUILD_PROFILING_LIB
 
@@ -161,8 +169,8 @@ lib_LTLIBRARIES += lib/lib@PMPIABILIBNAME@.la
 lib_lib@PMPIABILIBNAME@_la_SOURCES = $(mpi_abi_sources) $(mpi_f77_sources) $(mpi_core_sources)
 lib_lib@PMPIABILIBNAME@_la_LDFLAGS = $(external_ldflags) $(ABIVERSIONFLAGS)
 lib_lib@PMPIABILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) -DF77_USE_PMPI $(abi_cppflags)
-lib_lib@PMPIABILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs)
-EXTRA_lib_lib@PMPIABILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs)
+lib_lib@PMPIABILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs) $(abi_convenience_libs)
+EXTRA_lib_lib@PMPIABILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs) $(abi_convenience_libs)
 
 # lib@MPIABILIBNAME@.la might depend on lib@PMPIABILIBNAME@.la.  We add them
 # in that order to lib_LTLIBRARIES so libtool doesn't get
@@ -171,7 +179,7 @@ lib_LTLIBRARIES += lib/lib@MPIABILIBNAME@.la
 lib_lib@MPIABILIBNAME@_la_SOURCES = $(mpi_abi_sources)
 lib_lib@MPIABILIBNAME@_la_LDFLAGS = $(ABIVERSIONFLAGS)
 lib_lib@MPIABILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) -DMPICH_MPI_FROM_PMPI $(abi_cppflags)
-lib_lib@MPIABILIBNAME@_la_LIBADD = lib/lib@PMPIABILIBNAME@.la $(mpi_convenience_libs)
+lib_lib@MPIABILIBNAME@_la_LIBADD = lib/lib@PMPIABILIBNAME@.la
 
 else !BUILD_PROFILING_LIB
 
@@ -179,8 +187,8 @@ lib_LTLIBRARIES += lib/lib@MPIABILIBNAME@.la
 lib_lib@MPIABILIBNAME@_la_SOURCES = $(mpi_abi_sources) $(mpi_core_sources)
 lib_lib@MPIABILIBNAME@_la_LDFLAGS = $(external_ldflags) $(ABIVERSIONFLAGS)
 lib_lib@MPIABILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) $(abi_cppflags)
-lib_lib@MPIABILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs) $(mpi_convenience_libs)
-EXTRA_lib_lib@MPIABILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs) $(mpi_convenience_libs)
+lib_lib@MPIABILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs) $(abi_convenience_libs)
+EXTRA_lib_lib@MPIABILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs) $(abi_convenience_libs)
 
 endif !BUILD_PROFILING_LIB
 endif BUILD_ABI_LIB

--- a/Makefile.am
+++ b/Makefile.am
@@ -54,6 +54,11 @@ external_libs = @WRAPPER_LIBS@
 mpi_convenience_libs =
 pmpi_convenience_libs = @mpllib@ @hwloclib@ @jsonlib@ @yaksalib@ @pmilib@
 
+if BUILD_ROMIO
+    external_subdirs += src/mpi/romio
+    pmpi_convenience_libs += src/mpi/romio/libromio.la
+endif
+
 # NOTE on our semi-unconventional usage of DIST_SUBDIRS:
 # The automake manual recommends thinking of DIST_SUBDIRS as the list of all
 # *configured* subdirectories.  The normal autotools model involves
@@ -136,12 +141,6 @@ lib_lib@MPILIBNAME@_la_LDFLAGS = $(ABIVERSIONFLAGS)
 lib_lib@MPILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) -DMPICH_MPI_FROM_PMPI
 lib_lib@MPILIBNAME@_la_LIBADD = lib/lib@PMPILIBNAME@.la $(mpi_convenience_libs)
 
-if BUILD_ROMIO
-    # libpromio contains the PMPI symbols (unlike libpmpi, which contains MPI
-    # symbols) and should be added to libpmpi
-    lib_lib@PMPILIBNAME@_la_LIBADD += src/mpi/romio/libpromio.la
-    lib_lib@MPILIBNAME@_la_LIBADD += src/mpi/romio/libromio.la
-endif
 else !BUILD_PROFILING_LIB
 
 lib_LTLIBRARIES += lib/lib@MPILIBNAME@.la
@@ -151,9 +150,6 @@ lib_lib@MPILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS)
 lib_lib@MPILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs) $(mpi_convenience_libs)
 EXTRA_lib_lib@MPILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs) $(mpi_convenience_libs)
 
-if BUILD_ROMIO
-    lib_lib@MPILIBNAME@_la_LIBADD += src/mpi/romio/libromio.la
-endif
 endif !BUILD_PROFILING_LIB
 
 if BUILD_ABI_LIB
@@ -177,10 +173,6 @@ lib_lib@MPIABILIBNAME@_la_LDFLAGS = $(ABIVERSIONFLAGS)
 lib_lib@MPIABILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) -DMPICH_MPI_FROM_PMPI $(abi_cppflags)
 lib_lib@MPIABILIBNAME@_la_LIBADD = lib/lib@PMPIABILIBNAME@.la $(mpi_convenience_libs)
 
-if BUILD_ROMIO
-    lib_lib@PMPIABILIBNAME@_la_LIBADD += src/mpi/romio/libpromio_abi.la
-    lib_lib@MPIABILIBNAME@_la_LIBADD += src/mpi/romio/libromio_abi.la
-endif
 else !BUILD_PROFILING_LIB
 
 lib_LTLIBRARIES += lib/lib@MPIABILIBNAME@.la
@@ -190,9 +182,6 @@ lib_lib@MPIABILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) $(abi_cppflags)
 lib_lib@MPIABILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs) $(mpi_convenience_libs)
 EXTRA_lib_lib@MPIABILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs) $(mpi_convenience_libs)
 
-if BUILD_ROMIO
-    lib_lib@MPIABILIBNAME@_la_LIBADD += src/mpi/romio/libromio_abi.la
-endif
 endif !BUILD_PROFILING_LIB
 endif BUILD_ABI_LIB
 

--- a/maint/gen_binding_c.py
+++ b/maint/gen_binding_c.py
@@ -158,10 +158,26 @@ def main():
 
         dump_out(c_dir + "/io.c")
 
+    def dump_io_funcs_abi():
+        G.out = []
+        G.out.append("#include \"mpichconf.h\"")
+        G.out.append("#include \"io_abi_internal.h\"")
+        G.out.append("#include \"mpir_io_impl.h\"")
+        G.out.append("#include <limits.h>")
+        G.out.append("")
+
+        for func in io_func_list:
+            dump_func_abi(func)
+
+        abi_file_path = abi_dir + "/io_abi.c"
+        G.check_write_path(abi_file_path)
+        dump_c_file(abi_file_path, G.out)
+
     # ----
     dump_c_binding()
     dump_c_binding_abi()
     dump_io_funcs()
+    dump_io_funcs_abi()
 
     if 'output-mansrc' in G.opts:
         f = c_dir + '/mansrc/' + 'poly_aliases.lst'

--- a/maint/gen_binding_c.py
+++ b/maint/gen_binding_c.py
@@ -19,6 +19,9 @@ def main():
     abi_dir = "src/binding/abi"
     func_list = load_C_func_list(binding_dir)
 
+    io_func_list = [f for f in func_list if f['dir'] == 'io']
+    func_list = [f for f in func_list if f['dir'] != 'io']
+
     # -- Loading extra api prototypes (needed until other `buildiface` scripts are updated)
     G.mpi_declares = []
 

--- a/maint/gen_binding_f08.py
+++ b/maint/gen_binding_f08.py
@@ -19,13 +19,6 @@ def main():
     G.check_write_path("%s/wrappers_f/" % f08_dir)
     G.check_write_path("%s/wrappers_c/" % f08_dir)
     func_list = load_C_func_list(binding_dir, True) # suppress noise
-    if "no-mpiio" in G.opts:
-        # a few MPI_File_xxx functions are already in (MPI_File_xxx_errhandler)
-        func_list = [f for f in func_list if not f['name'].startswith('MPI_File_')]
-    else:
-        # FIXME: until romio interface is generated
-        func_list.extend(get_mpiio_func_list())
-    func_list.append(G.FUNCS['mpi_f_sync_reg'])
 
     # preprocess
     get_real_POLY_kinds()

--- a/maint/gen_binding_f77.py
+++ b/maint/gen_binding_f77.py
@@ -19,14 +19,7 @@ def main():
 
     func_list = load_C_func_list(binding_dir, True) # suppress noise
 
-    if "no-mpiio" in G.opts:
-        # a few MPI_File_xxx functions are already in (MPI_File_xxx_errhandler)
-        func_list = [f for f in func_list if not f['name'].startswith('MPI_File_')]
-    else:
-        # FIXME: until romio interface is generated
-        func_list.extend(get_mpiio_func_list())
     func_list.extend(get_f77_dummy_func_list())
-    func_list.append(G.FUNCS['mpi_f_sync_reg'])
 
     # preprocess
     for func in func_list:

--- a/maint/gen_binding_f90.py
+++ b/maint/gen_binding_f90.py
@@ -17,10 +17,6 @@ def main():
     f90_dir = "src/binding/fortran/use_mpi"
     G.check_write_path("%s/" % f90_dir)
     func_list = load_C_func_list(binding_dir, True) # suppress noise
-    if "no-mpiio" in G.opts:
-        func_list = [f for f in func_list if not f['name'].startswith('MPI_File_')]
-    else:
-        func_list.extend(get_mpiio_func_list())
     func_list.extend(get_f77_dummy_func_list())
 
     def has_cptr(func):

--- a/maint/local_python/__init__.py
+++ b/maint/local_python/__init__.py
@@ -62,6 +62,7 @@ class MPI_API_Global:
     mpi_sources = []
     mpi_declares = []
     impl_declares = []
+    io_impl_declares = []
     mpi_errnames = []
     mpix_symbols = {}
 

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -208,6 +208,35 @@ def dump_mpir_impl_h(f):
         print("", file=Out)
         print("#endif /* MPIR_IMPL_H_INCLUDED */", file=Out)
 
+def dump_mpir_io_impl_h(f):
+    print("  --> [%s]" %f)
+    with open(f, "w") as Out:
+        for l in G.copyright_c:
+            print(l, file=Out)
+        print("#ifndef MPIR_IO_IMPL_H_INCLUDED", file=Out)
+        print("#define MPIR_IO_IMPL_H_INCLUDED", file=Out)
+
+        print("", file=Out)
+        print("#define MPIR_ERR_RECOVERABLE 0", file=Out)
+        print("#define MPIR_ERR_FATAL 1", file=Out)
+        print("int MPIR_Err_create_code(int, int, const char[], int, int, const char[], const char[], ...);", file=Out)
+        print("void MPIR_Ext_cs_enter(void);", file=Out)
+        print("void MPIR_Ext_cs_exit(void);", file=Out)
+        print("#ifndef HAVE_ROMIO", file=Out)
+        print("int MPIR_Err_return_comm(void *, const char[], int);", file=Out)
+        print("#define MPIO_Err_return_file(fh, errorcode) MPIR_Err_return_comm((void *)0, __func__, errorcode)", file=Out)
+        print("#else", file=Out)
+        print("MPI_Fint MPIR_File_c2f_impl(MPI_File fh);", file=Out)
+        print("MPI_File MPIR_File_f2c_impl(MPI_Fint fh);", file=Out)
+        print("int MPIO_Err_return_file(MPI_File fh, int errorcode);", file=Out)
+        print("#endif", file=Out)
+
+        print("", file=Out)
+        for l in G.io_impl_declares:
+            print(l, file=Out)
+        print("", file=Out)
+        print("#endif /* MPIR_IO_IMPL_H_INCLUDED */", file=Out)
+
 def filter_out_abi():
     funcname = None
     for l in G.out:
@@ -552,8 +581,10 @@ def process_func_parameters(func):
 
         do_handle_ptr = 0
         (kind, name) = (p['kind'], p['name'])
-        if '_has_comm' not in func and kind == "COMMUNICATOR" and p['param_direction'] == 'in':
+        if '_has_comm' not in func and kind == "COMMUNICATOR" and p['param_direction'] == 'in' and func['name'] != "MPI_File_open":
             func['_has_comm'] = name
+        elif kind == "FILE" and p['param_direction'] == 'in' and func['dir'] == 'io':
+            func['_has_file'] = name
         elif name == "win":
             func['_has_win'] = name
         elif name == "session":
@@ -733,7 +764,7 @@ def process_func_parameters(func):
         elif RE.match(r'F90_(COMM|ERRHANDLER|FILE|GROUP|INFO|MESSAGE|OP|REQUEST|SESSION|DATATYPE|WIN)', kind):
             # no validation for these kinds
             pass
-        elif RE.match(r'(POLY)?(DTYPE_STRIDE_BYTES|DISPLACEMENT_AINT_COUNT)$', kind):
+        elif RE.match(r'(POLY)?(DTYPE_STRIDE_BYTES|DISPLACEMENT_AINT_COUNT|OFFSET)$', kind):
             # e.g. stride in MPI_Type_vector, MPI_Type_create_resized
             pass
         elif is_pointer_type(p):
@@ -741,7 +772,11 @@ def process_func_parameters(func):
         else:
             print("Missing error checking: func=%s, name=%s, kind=%s" % (func_name, name, kind), file=sys.stderr)
 
-        if do_handle_ptr == 1:
+        if func['dir'] == 'io':
+            # pass io function parameters as is
+            impl_arg_list.append(name)
+            impl_param_list.append(get_impl_param(func, p))
+        elif do_handle_ptr == 1:
             if p['param_direction'] == 'inout':
                 # assume only one such parameter
                 func['_has_handle_inout'] = p
@@ -1387,6 +1422,25 @@ def check_large_parameters(func):
                 func['_poly_in_list'].append(p)
 
 def dump_function_normal(func):
+    def dump_global_cs_enter():
+        if not '_skip_global_cs' in func:
+            G.out.append("")
+            if func['dir'] == 'mpit':
+                G.out.append("MPIR_T_THREAD_CS_ENTER();")
+            elif func['dir'] == 'io':
+                G.out.append("MPIR_Ext_cs_enter();")
+            else:
+                G.out.append("MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);")
+    def dump_global_cs_exit():
+        if not '_skip_global_cs' in func:
+            G.out.append("")
+            if func['dir'] == 'mpit':
+                G.out.append("MPIR_T_THREAD_CS_EXIT();")
+            elif func['dir'] == 'io':
+                G.out.append("MPIR_Ext_cs_exit();")
+            else:
+                G.out.append("MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);")
+    # ----
     G.out.append("int mpi_errno = MPI_SUCCESS;")
     if '_handle_ptr_list' in func:
         for p in func['_handle_ptr_list']:
@@ -1405,12 +1459,7 @@ def dump_function_normal(func):
         else:
             G.out.append("MPIR_ERRTEST_INITIALIZED_ORDIE();")
 
-    if not '_skip_global_cs' in func:
-        G.out.append("")
-        if func['dir'] == 'mpit':
-            G.out.append("MPIR_T_THREAD_CS_ENTER();")
-        else:
-            G.out.append("MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);")
+    dump_global_cs_enter()
     G.out.append("MPIR_FUNC_TERSE_ENTER;")
 
     if '_handle_ptr_list' in func:
@@ -1476,7 +1525,18 @@ def dump_function_normal(func):
         G.out.append("goto fn_exit;")
         dump_if_close()
 
+    need_endif = False
+    if func['dir'] == 'io' and not 'return' in func:
+        G.out.append("#ifndef HAVE_ROMIO")
+        G.out.append("mpi_errno = MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE, __func__, __LINE__, MPI_ERR_OTHER, \"**notimpl\", 0);")
+        G.out.append("goto fn_fail;")
+        G.out.append("#else")
+        need_endif = True
+
     dump_body_of_routine(func)
+
+    if need_endif:
+        G.out.append("#endif")
 
     G.out.append("/* ... end of body of routine ... */")
 
@@ -1486,12 +1546,8 @@ def dump_function_normal(func):
     for l in func['_clean_up']:
         G.out.append(l)
     G.out.append("MPIR_FUNC_TERSE_EXIT;")
+    dump_global_cs_exit()
 
-    if not '_skip_global_cs' in func:
-        if func['dir'] == 'mpit':
-            G.out.append("MPIR_T_THREAD_CS_EXIT();")
-        else:
-            G.out.append("MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);")
     G.out.append("return mpi_errno;")
     G.out.append("")
     G.out.append("fn_fail:")
@@ -1635,7 +1691,10 @@ def push_impl_decl(func, impl_name=None):
         mpir_name = re.sub(r'^MPIX?_', 'MPIR_', func['name'])
         G.impl_declares.append("int %s(%s);" % (mpir_name, params))
     # dump MPIR_Xxx_impl(...)
-    G.impl_declares.append("int %s(%s);" % (impl_name, params))
+    if func['dir'] == 'io':
+        G.io_impl_declares.append("int %s(%s);" % (impl_name, params))
+    else:
+        G.impl_declares.append("int %s(%s);" % (impl_name, params))
 
 def push_threadcomm_impl_decl(func):
     impl_name = re.sub(r'^mpix?_(comm_)?', 'MPIR_Threadcomm_', func['name'].lower())
@@ -2002,6 +2061,8 @@ def dump_mpi_fn_fail(func):
             G.out.append("mpi_errno = MPIR_Err_return_comm(%s_ptr, __func__, mpi_errno);" % func['_has_comm'])
         elif '_has_win' in func:
             G.out.append("mpi_errno = MPIR_Err_return_win(win_ptr, __func__, mpi_errno);")
+        elif '_has_file' in func:
+            G.out.append("mpi_errno = MPIO_Err_return_file(%s, mpi_errno);" % func['_has_file'])
         elif RE.match(r'mpi_session_init', func['name'], re.IGNORECASE):
             G.out.append("mpi_errno = MPIR_Err_return_session_init(errhandler_ptr, __func__, mpi_errno);")
         elif '_has_session' in func:
@@ -2010,6 +2071,8 @@ def dump_mpi_fn_fail(func):
             G.out.append("mpi_errno = MPIR_Err_return_comm_create_from_group(errhandler_ptr, __func__, mpi_errno);")
         elif '_has_group' in func:
             G.out.append("mpi_errno = MPIR_Err_return_group(%s_ptr, __func__, mpi_errno);" % func['_has_group'])
+        elif re.match(r'MPI_File_(delete|open|close)', func['name']):
+            G.out.append("mpi_errno = MPIO_Err_return_file(MPI_FILE_NULL, mpi_errno);")
         else:
             G.out.append("mpi_errno = MPIR_Err_return_comm(0, __func__, mpi_errno);")
 
@@ -2034,9 +2097,9 @@ def get_fn_fail_create_code(func):
             fmt = 'p'
         elif kind in fmt_codes:
             fmt = fmt_codes[kind]
-        elif mapping[kind] == "int":
+        elif mapping[kind] == "int" or mapping[kind] == "MPI_Fint":
             fmt = 'd'
-        elif mapping[kind] == "MPI_Aint":
+        elif mapping[kind] == "MPI_Aint" or mapping[kind] == "MPI_Offset":
             fmt = 'L'
         elif mapping[kind] == "MPI_Count":
             fmt = 'c'

--- a/maint/local_python/binding_common.py
+++ b/maint/local_python/binding_common.py
@@ -119,7 +119,9 @@ def get_C_param(param, func, mapping):
     if param['func_type']:
         param_type = param['func_type']
         if mapping['_name'].startswith("BIG_"):
-            param_type += "_c"
+            # hard list the limited number of large count function types
+            if re.match(r'MPI_User_function|MPI_Datarep_conversion_function', param_type):
+                param_type += "_c"
 
     if param_type in G.mpix_symbols:
         param_type = re.sub(r'MPI_', 'MPIX_', param_type)

--- a/src/binding/abi/Makefile.mk
+++ b/src/binding/abi/Makefile.mk
@@ -9,6 +9,7 @@ include_HEADERS += src/binding/abi/mpi_abi.h
 
 mpi_abi_sources += \
     src/binding/abi/mpi_abi_util.c \
-    src/binding/abi/c_binding_abi.c
+    src/binding/abi/c_binding_abi.c \
+    src/binding/abi/io_abi.c
 
 endif BUILD_ABI_LIB

--- a/src/binding/c/async_api.txt
+++ b/src/binding/c/async_api.txt
@@ -13,6 +13,7 @@ MPIX_Async_get_state:
     .return: EXTRA_STATE
     async_thing: ASYNC_THING, [opaque pointer for async thing]
     .impl: direct
+    .skip: validate-ASYNC_THING
 {
     return MPIR_Async_thing_get_state(async_thing);
 }
@@ -22,6 +23,7 @@ MPIX_Async_spawn:
     poll_fn: FUNCTION, func_type=MPIX_Async_poll_function, [user defined poll function for progressing async things]
     extra_state: EXTRA_STATE, [extra state for callback function]
     stream: STREAM, [stream object]
+    .skip: validate-ASYNC_THING
 {
     mpi_errno = MPIR_Async_thing_spawn(async_thing, poll_fn, extra_state, stream_ptr);
     if (mpi_errno) goto fn_fail;

--- a/src/binding/c/datatype_api.txt
+++ b/src/binding/c/datatype_api.txt
@@ -201,15 +201,6 @@ MPI_Unpack_external:
     }
 }
 
-MPI_Register_datarep: not_implemented
-    .desc: Register a set of user-provided data conversion
-{
-    /* FIXME UNIMPLEMENTED */
-    mpi_errno =
-        MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__, MPI_ERR_OTHER,
-                             "**notimpl", 0);
-}
-
 MPI_Status_set_elements:
     .desc: Set the number of elements in a status
 {

--- a/src/binding/c/io_api.txt
+++ b/src/binding/c/io_api.txt
@@ -1,0 +1,205 @@
+# vim: set ft=c:
+
+MPI_File_open:
+    .desc: Opens a file
+
+MPI_File_close:
+    .desc: Closes a file
+
+MPI_File_delete:
+    .desc: Deletes a file
+
+MPI_File_c2f:
+    .desc: Translates a C file handle to a Fortran file handle
+    .impl: direct
+{
+#ifndef HAVE_ROMIO
+    return 0;
+#else
+    return MPIR_File_c2f_impl(file);
+#endif
+}
+
+MPI_File_f2c:
+    .desc: Translates a Fortran file handle to a C file handle
+    .impl: direct
+{
+#ifndef HAVE_ROMIO
+    return 0;
+#else
+    return MPIR_File_f2c_impl(file);
+#endif
+}
+
+MPI_File_sync:
+    .desc: Causes all previous writes to be transferred
+
+MPI_File_get_amode:
+    .desc: Returns the file access mode
+    .skip: global_cs
+
+MPI_File_get_atomicity:
+    .desc: Returns the atomicity mode
+    .skip: global_cs
+
+MPI_File_get_byte_offset:
+    .desc: Returns the absolute byte position in
+    .skip: global_cs
+
+MPI_File_get_type_extent:
+    .desc: Returns the extent of datatype in the file
+    .poly_impl: use_aint
+
+MPI_File_get_group:
+    .desc: Returns the group of processes that
+
+MPI_File_get_info:
+    .desc: Returns the hints for a file that are actually being used by MPI
+
+MPI_File_get_position:
+    .desc: Returns the current position of the
+
+MPI_File_get_position_shared:
+    .desc: Returns the current position of the
+
+MPI_File_get_size:
+    .desc: Returns the file size
+    .skip: global_cs
+
+MPI_File_get_view:
+    .desc: Returns the file view
+
+MPI_File_iread_all:
+    .desc: Nonblocking collective read using individual file pointer
+
+MPI_File_iread_at_all:
+    .desc: Nonblocking collective read using explicit offset
+
+MPI_File_iread_at:
+    .desc: Nonblocking read using explicit offset
+
+MPI_File_iread:
+    .desc: Nonblocking read using individual file pointer
+
+MPI_File_iread_shared:
+    .desc: Nonblocking read using shared file pointer
+
+MPI_File_iwrite_all:
+    .desc: Nonblocking collective write using individual file pointer
+
+MPI_File_iwrite_at_all:
+    .desc: Nonblocking collective write using explicit offset
+
+MPI_File_iwrite_at:
+    .desc: Nonblocking write using explicit offset
+
+MPI_File_iwrite:
+    .desc: Nonblocking write using individual file pointer
+
+MPI_File_iwrite_shared:
+    .desc: Nonblocking write using shared file pointer
+
+MPI_File_open:
+    .desc: Opens a file
+
+MPI_File_preallocate:
+    .desc: Preallocates storage space for a file
+
+MPI_File_read_at_all_begin:
+    .desc: Begin a split collective read using explicit offset
+
+MPI_File_read_at_all_end:
+    .desc: Complete a split collective read using
+
+MPI_File_read_all_begin:
+    .desc: Begin a split collective read using individual file pointer
+
+MPI_File_read_all:
+    .desc: Collective read using individual file pointer
+
+MPI_File_read_all_end:
+    .desc: Complete a split collective read using
+
+MPI_File_read_at_all:
+    .desc: Collective read using explicit offset
+
+MPI_File_read_at:
+    .desc: Read using explicit offset
+
+MPI_File_read:
+    .desc: Read using individual file pointer
+
+MPI_File_read_ordered_begin:
+    .desc: Begin a split collective read using shared file pointer
+
+MPI_File_read_ordered:
+    .desc: Collective read using shared file pointer
+
+MPI_File_read_ordered_end:
+    .desc: Complete a split collective read using shared file pointer
+
+MPI_File_read_shared:
+    .desc: Read using shared file pointer
+
+MPI_File_seek:
+    .desc: Updates the individual file pointer
+
+MPI_File_seek_shared:
+    .desc: Updates the shared file pointer
+
+MPI_File_set_atomicity:
+    .desc: Sets the atomicity mode
+
+MPI_File_set_info:
+    .desc: Sets new values for the hints associated with a file
+
+MPI_File_set_size:
+    .desc: Sets the file size
+
+MPI_File_set_view:
+    .desc: Sets the file view
+{ -- error_check -- disp
+    if (disp != MPI_DISPLACEMENT_CURRENT) {
+        MPIR_ERRTEST_ARGNEG(disp, "disp", mpi_errno);
+    }
+}
+
+MPI_File_write_at_all_begin:
+    .desc: Begin a split collective write using
+
+MPI_File_write_at_all_end:
+    .desc: Complete a split collective write using explicit offset
+
+MPI_File_write_all_begin:
+    .desc: Begin a split collective write using
+
+MPI_File_write_all:
+    .desc: Collective write using individual file pointer
+
+MPI_File_write_all_end:
+    .desc: Complete a split collective write using individual file pointer
+
+MPI_File_write_at_all:
+    .desc: Collective write using explicit offset
+
+MPI_File_write_at:
+    .desc: Write using explicit offset
+
+MPI_File_write:
+    .desc: Write using individual file pointer
+
+MPI_File_write_ordered_begin:
+    .desc: Begin a split collective write using shared file pointer
+
+MPI_File_write_ordered:
+    .desc: Collective write using shared file pointer
+
+MPI_File_write_ordered_end:
+    .desc: Complete a split collective write using shared file pointer
+
+MPI_File_write_shared:
+    .desc: Write using shared file pointer
+
+MPI_Register_datarep:
+    .desc: Register a set of user-provided data conversion
+    .poly_impl: separate

--- a/src/binding/c/io_api.txt
+++ b/src/binding/c/io_api.txt
@@ -2,6 +2,7 @@
 
 MPI_File_open:
     .desc: Opens a file
+    .skip: validate-amode
 
 MPI_File_close:
     .desc: Closes a file
@@ -143,9 +144,11 @@ MPI_File_read_shared:
 
 MPI_File_seek:
     .desc: Updates the individual file pointer
+    .skip: validate-whence
 
 MPI_File_seek_shared:
     .desc: Updates the shared file pointer
+    .skip: validate-whence
 
 MPI_File_set_atomicity:
     .desc: Sets the atomicity mode

--- a/src/binding/cxx/buildiface
+++ b/src/binding/cxx/buildiface
@@ -1736,14 +1736,7 @@ sub print_call_args {
 		if (defined($mytopclass{$lctype})) {
 		    $lctype = $mytopclass{$lctype};
 		}
-		# Handle the MPIO_Request problem (temp until ROMIO uses
-		# MPI_Requests)
-		$cast = "";
-		if ($parm =~ /MPI_Request/ &&
-		    $class eq "file") {
-		    $cast = "(MPIO_Request *)";
-		}
-		print $OUTFD "$cast&(v$count.the_real_$lctype)";
+		print $OUTFD "&(v$count.the_real_$lctype)";
 	    }
 	    else {
 		print $OUTFD "&v$count";

--- a/src/glue/romio/all_romio_symbols
+++ b/src/glue/romio/all_romio_symbols
@@ -138,7 +138,9 @@ while (<FD>) {
 
     print OUTFD "${tab}{\n";
     for ($x = 0; $x <= $#arglist; $x++) {
-	print OUTFD "${tab}${tab}$arglist[$x]";
+        my $a = $arglist[$x];
+        $a =~ s/MPIO_Request/MPI_Request/;
+	print OUTFD "${tab}${tab}$a";
 	if ($arglist[$x] =~ /\*/) {
 	    print OUTFD " = NULL;\n";
 	}

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -504,6 +504,9 @@ static const MPI_Datatype mpich_mpi_offset MPICH_ATTR_TYPE_TAG(MPI_Offset) = MPI
 #define MPI_MAX_PSET_NAME_LEN  256
 #define MPI_MAX_INFO_KEY       255
 #define MPI_MAX_INFO_VAL      1024
+#define MPI_MAX_DATAREP_STRING 128
+
+#define MPI_DISPLACEMENT_CURRENT ((MPI_Offset) -54278278)
 
 /* MPI-3 window flavors */
 typedef enum MPIR_Win_flavor {
@@ -621,6 +624,21 @@ enum MPIR_Combiner_enum {
 #define MPI_THREAD_FUNNELED 1
 #define MPI_THREAD_SERIALIZED 2
 #define MPI_THREAD_MULTIPLE 3
+
+/* MPI-IO constants */
+#define MPI_MODE_RDONLY              2  /* ADIO_RDONLY */
+#define MPI_MODE_RDWR                8  /* ADIO_RDWR  */
+#define MPI_MODE_WRONLY              4  /* ADIO_WRONLY  */
+#define MPI_MODE_CREATE              1  /* ADIO_CREATE */
+#define MPI_MODE_EXCL               64  /* ADIO_EXCL */
+#define MPI_MODE_DELETE_ON_CLOSE    16  /* ADIO_DELETE_ON_CLOSE */
+#define MPI_MODE_UNIQUE_OPEN        32  /* ADIO_UNIQUE_OPEN */
+#define MPI_MODE_APPEND            128  /* ADIO_APPEND */
+#define MPI_MODE_SEQUENTIAL        256  /* ADIO_SEQUENTIAL */
+
+#define MPI_SEEK_SET            600
+#define MPI_SEEK_CUR            602
+#define MPI_SEEK_END            604
 
 /* MPI's error classes */
 #define MPI_SUCCESS          0      /* Successful return code */
@@ -1026,8 +1044,6 @@ typedef struct MPIX_Iov {
 #ifndef BUILD_MPI_ABI
 /* We require that the C compiler support prototypes */
 #include <mpi_proto.h>
-
-@HAVE_ROMIO@
 
 /* The f2c and c2f APIs exist as real functions, but these macros allows
  * for backward MPICH ABI compatibility.

--- a/src/mpi/Makefile.mk
+++ b/src/mpi/Makefile.mk
@@ -22,30 +22,5 @@ include $(top_srcdir)/src/mpi/topo/Makefile.mk
 include $(top_srcdir)/src/mpi/stream/Makefile.mk
 include $(top_srcdir)/src/mpi/threadcomm/Makefile.mk
 
-if BUILD_ROMIO
-SUBDIRS += src/mpi/romio
-DIST_SUBDIRS += src/mpi/romio
-MANDOC_SUBDIRS += src/mpi/romio
-HTMLDOC_SUBDIRS += src/mpi/romio
-
-# This was previously a hard copy (not a symlink) performed by config.status
-# (specified via AC_CONFIG_COMMANDS).  Ideally we would eliminate this "copy"
-# altogether and just set -Iromio_include_dir, but MPE2's build system uses
-# $(top_builddir)/bin/mpicc that can't handle more than one include dir.
-#
-# Using a symlink allows us to avoid trying to capture the full dependency chain
-# of MPICH/mpio.h --> ROMIO/mpio.h --> ROMIO/mpio.h.in --> ROMIO/config.status --> ...MORE_AUTOTOOLS...
-BUILT_SOURCES += $(top_builddir)/src/include/mpio.h
-$(top_builddir)/src/include/mpio.h: $(top_builddir)/src/mpi/romio/include/mpio.h
-	if test ! -h $(top_builddir)/src/include/mpio.h ; then \
-	    rm -f $(top_builddir)/src/include/mpio.h ; \
-	    ( cd $(top_builddir)/src/include &&       \
-	        $(LN_S) ../mpi/romio/include/mpio.h ) ; \
-	fi
-
-DISTCLEANFILES += $(top_builddir)/src/include/mpio.h
-
-endif BUILD_ROMIO
-
 # dir is present but currently intentionally unbuilt
 #include $(top_srcdir)/src/mpi/io/Makefile.mk

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -923,8 +923,6 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **mpi_attr_get %C %d %p %p:MPI_Attr_get(%C, keyval=%d, attr_value=%p, flag=%p) failed
 **mpi_attr_delete:MPI_Attr_delete failed
 **mpi_attr_delete %C %d:MPI_Attr_delete(%C, keyval=%d) failed
-**mpi_register_datarep:MPI_Register_datarep failed
-**mpi_register_datarep %s %p %p %p %p:MPI_Register_datarep(datarep=%s, read_conversion_fn=%p, write_conversion_fn=%p, dtype_file_extent_fn=%p, extra_state=%p) failed
 
 # MPIR functions
 

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -21,7 +21,7 @@ dnl AC_CONFIG_AUX_DIR(../../../confdb)
 dnl Set the directory that contains the required install-sh, config.sub,
 dnl and config.guess .  Make sure that these are updated (in MPICH, use
 dnl the top-level confdb files).  This separate directory is used for
-dnl the moment to allow ROMIO to be separatedly distributed.
+dnl the moment to allow ROMIO to be separately distributed.
 dnl scripts.
 AC_CONFIG_AUX_DIR([confdb])
 AC_CONFIG_MACRO_DIR([confdb])
@@ -516,8 +516,6 @@ fi
 ])
 if test "$pac_cv_int_hold_pointer" != yes ; then
     AC_DEFINE(INT_LT_POINTER,1,[Define if int smaller than pointer])
-    dnl Switch to a conforming name (start with HAVE or USE)
-    AC_DEFINE(HAVE_INT_LT_POINTER,1,[Define if int smaller than pointer])
 fi
 
 # LL is the printf-style format name for output of a MPI_Offset.

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -105,6 +105,8 @@ AC_ARG_VAR([FROM_OMPI],[set to "yes" if building ROMIO inside of Open MPI])
 FROM_OMPI=${FROM_OMPI:-no}
 if test "$FROM_OMPI" = 1 ; then FROM_OMPI=yes ; fi
 
+AM_CONDITIONAL([BUILD_BINDING], [test "$FROM_MPICH" != "yes"])
+
 # MPL
 AC_ARG_VAR([MPLLIBNAME],[can be used to override the name of the MPL library (default: "mpl")])
 MPLLIBNAME=${MPLLIBNAME:-"mpl"}
@@ -691,7 +693,9 @@ AM_CONDITIONAL([BUILD_MPIO_ERRHAN],[false])
 
 # if we don't have weak symbol support, we must build a separate convenience
 # library in order to provide the "PMPI_" symbols
-AM_CONDITIONAL([BUILD_PROFILING_LIB],[test "x$HAVE_WEAK_SYMBOLS" = "x0"])
+# MPICH will generate separate binding layer, thus we can skip PROFILING LIB
+# if build inside MPICH
+AM_CONDITIONAL([BUILD_PROFILING_LIB],[test "x$HAVE_WEAK_SYMBOLS" = "x0" -a "$FROM_MPICH" != "yes"])
 # disable visibility if building profiling library
 if test "x$HAVE_WEAK_SYMBOLS" = "x0" ; then
     VISIBILITY_CFLAGS=""

--- a/src/mpi/romio/include/mpio.h.in
+++ b/src/mpi/romio/include/mpio.h.in
@@ -82,6 +82,8 @@ typedef int MPI_Fint;
 # define MPI_MAX_INFO_VAL      1024
 #endif
 
+#ifndef MPI_MODE_RDONLY
+/* only define these if they are not defined in mpi.h */
 #define MPI_MODE_RDONLY              2  /* ADIO_RDONLY */
 #define MPI_MODE_RDWR                8  /* ADIO_RDWR  */
 #define MPI_MODE_WRONLY              4  /* ADIO_WRONLY  */
@@ -92,7 +94,19 @@ typedef int MPI_Fint;
 #define MPI_MODE_APPEND            128  /* ADIO_APPEND */
 #define MPI_MODE_SEQUENTIAL        256  /* ADIO_SEQUENTIAL */
 
+#define MPI_SEEK_SET            600
+#define MPI_SEEK_CUR            602
+#define MPI_SEEK_END            604
+
 #define MPI_DISPLACEMENT_CURRENT   -54278278
+
+/* Open MPI: don't define MPI_MAX_DATAREP_STRING here; it's defined in
+   OMPI's mpi.h. */
+#ifndef OPEN_MPI
+#define MPI_MAX_DATAREP_STRING  128
+#endif
+
+#endif
 
 #ifndef MPICH
 /* FIXME: Make sure that we get a consistent definition of MPI_FILE_NULL
@@ -101,16 +115,6 @@ typedef int MPI_Fint;
 #define MPI_FILE_NULL           ((MPI_File) 0)
 #endif
 #define MPIO_REQUEST_NULL       ((MPIO_Request) 0)
-
-#define MPI_SEEK_SET            600
-#define MPI_SEEK_CUR            602
-#define MPI_SEEK_END            604
-
-/* Open MPI: don't define MPI_MAX_DATAREP_STRING here; it's defined in
-   OMPI's mpi.h. */
-#ifndef OPEN_MPI
-#define MPI_MAX_DATAREP_STRING  128
-#endif
 
 #ifndef HAVE_MPI_DARRAY_SUBARRAY
 /* *INDENT-OFF* */

--- a/src/mpi/romio/mpi-io/Makefile.mk
+++ b/src/mpi/romio/mpi-io/Makefile.mk
@@ -9,6 +9,7 @@ include $(top_srcdir)/mpi-io/fortran/Makefile.mk
 AM_CPPFLAGS += -I$(top_builddir)/mpi-io -I$(top_srcdir)/mpi-io
 noinst_HEADERS += mpi-io/mpioimpl.h mpi-io/mpioprof.h
 
+if BUILD_BINDING
 romio_mpi_sources +=          \
     mpi-io/close.c            \
     mpi-io/delete.c           \
@@ -68,6 +69,7 @@ romio_mpi_sources +=          \
     mpi-io/write_ordb.c       \
     mpi-io/write_orde.c       \
     mpi-io/write_sh.c
+endif BUILD_BINDING
 
 
 # non-MPI/PMPI sources that will be included in libromio

--- a/src/mpi/romio/mpi-io/glue/mpich/mpio_file.c
+++ b/src/mpi/romio/mpi-io/glue/mpich/mpio_file.c
@@ -39,7 +39,7 @@ void MPIO_File_free(MPI_File * mpi_fh)
 MPI_File MPIO_File_f2c(MPI_Fint fh)
 {
 #ifndef INT_LT_POINTER
-    return (MPI_File) ((void *) fh);
+    return (MPI_File) ((void *) (intptr_t) fh);
     /* the extra cast is to get rid of a compiler warning on Exemplar.
      * The warning is because MPI_File points to a structure containing
      * longlongs, which may be 8-byte aligned. But MPI_Fint itself
@@ -58,7 +58,7 @@ MPI_File MPIO_File_f2c(MPI_Fint fh)
 MPI_Fint MPIO_File_c2f(MPI_File fh)
 {
 #ifndef INT_LT_POINTER
-    return (MPI_Fint) fh;
+    return (MPI_Fint) (intptr_t) fh;
 #else
     int i;
 


### PR DESCRIPTION
## Pull Request Description
[note: split preparation PR in #7232]

Integrate ROMIO into MPICH's binding generation framework. This will unify and simplify the IO binding tasks such as large count support, fortran support, man page support.

We'll retain the current stand-alone nature of ROMIO as much as we can in this PR. There shouldn't be any noticeable difference for users who build ROMIO separate from MPICH.

* A refactor in ROMIO splits the top routines (e.g. `MPI_File_open`) into a binding layer and an implementation layer -- `MPI_File_open` in `open.c` and `MPI_File_open_impl` in `io_impl.c`
* Building ROMIO without `FROM_MPICH` defined stays exactly the same
* Building from MPICH will generate the binding layer in `src/binding/c/io.c`, which calls into the `impl` layer that is defined in ROMIO.
* ROMIO is effectively treated the same way as an internal convenience library such as `mpl`.
* We no longer need `#include "mpio.h"` in `mpi.h`
* We no longer need worry about profiling and Fortran bindings in ROMIO
* We no longer need maintain man pages and html docs in ROMIO



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
