### PR TITLE
romio: refactor mpi-io layer

### DIFF
--- a/src/mpi/romio/adio/include/adioi.h
+++ b/src/mpi/romio/adio/include/adioi.h
@@ -715,7 +715,7 @@ typedef struct ADIOI_OneSidedStripeParms {
     ADIO_Offset *stripeWriteLens;
     int amountOfStripedDataExpected;    /* used to determine holes in this segment thereby requiring a rmw */
     /* These 2 elements enable ADIOI_OneSidedWriteAggregation to be called multiple times but only */
-    /* perform the potientially computationally costly flattening of the source buffer just once */
+    /* perform the potentially computationally costly flattening of the source buffer just once */
     MPI_Aint bufTypeExtent;
     ADIOI_Flatlist_node *flatBuf;
     /* These three elements track the state of the source buffer advancement through multiple calls */
@@ -785,68 +785,6 @@ void ADIOI_FAKE_IwriteStrided(ADIO_File fd, const void *buf, MPI_Aint count,
                               MPI_Datatype datatype, int file_ptr_type,
                               ADIO_Offset offset, ADIO_Request * request, int *error_code);
 void ADIOI_FAKE_IOComplete(ADIO_Request * request, ADIO_Status * status, int *error_code);
-
-
-/* File I/O common functionality */
-int MPIOI_File_read(MPI_File fh,
-                    MPI_Offset offset,
-                    int file_ptr_type,
-                    void *buf, MPI_Aint count, MPI_Datatype datatype, char *myname,
-                    MPI_Status * status);
-int MPIOI_File_write(MPI_File fh, MPI_Offset offset, int file_ptr_type, const void *buf,
-                     MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Status * status);
-int MPIOI_File_read_all(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *buf,
-                        MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Status * status);
-int MPIOI_File_write_all(MPI_File fh, MPI_Offset offset, int file_ptr_type, const void *buf,
-                         MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Status * status);
-int MPIOI_File_read_all_begin(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *buf,
-                              MPI_Aint count, MPI_Datatype datatype, char *myname);
-int MPIOI_File_write_all_begin(MPI_File fh, MPI_Offset offset, int file_ptr_type, const void *buf,
-                               MPI_Aint count, MPI_Datatype datatype, char *myname);
-int MPIOI_File_read_all_end(MPI_File fh, void *buf, char *myname, MPI_Status * status);
-int MPIOI_File_write_all_end(MPI_File fh, const void *buf, char *myname, MPI_Status * status);
-int MPIOI_File_iwrite(MPI_File fh,
-                      MPI_Offset offset,
-                      int file_ptr_type,
-                      const void *buf,
-                      MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Request * request);
-int MPIOI_File_iread(MPI_File fh,
-                     MPI_Offset offset,
-                     int file_ptr_type,
-                     void *buf,
-                     MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Request * request);
-int MPIOI_File_iwrite_all(MPI_File fh,
-                          MPI_Offset offset,
-                          int file_ptr_type,
-                          const void *buf,
-                          MPI_Aint count, MPI_Datatype datatype, char *myname,
-                          MPI_Request * request);
-int MPIOI_File_iread_all(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *buf,
-                         MPI_Aint count, MPI_Datatype datatype, char *myname,
-                         MPI_Request * request);
-
-int MPIOI_File_read_ordered(MPI_File fh, void *buf, MPI_Aint count,
-                            MPI_Datatype datatype, MPI_Status * status);
-int MPIOI_File_read_ordered_begin(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype);
-int MPIOI_File_read_shared(MPI_File fh, void *buf, MPI_Aint count,
-                           MPI_Datatype datatype, MPI_Status * status);
-int MPIOI_File_iread_shared(MPI_File fh, void *buf, MPI_Aint count,
-                            MPI_Datatype datatype, MPI_Request * request);
-int MPIOI_File_write_ordered(MPI_File fh, const void *buf, MPI_Aint count,
-                             MPI_Datatype datatype, MPI_Status * status);
-int MPIOI_File_write_ordered_begin(MPI_File fh, const void *buf, MPI_Aint count,
-                                   MPI_Datatype datatype);
-int MPIOI_File_write_shared(MPI_File fh, const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                            MPI_Status * status);
-int MPIOI_File_iwrite_shared(MPI_File fh, const void *buf, MPI_Aint count, MPI_Datatype datatype,
-                             MPIO_Request * request);
-
-typedef void (*MPIOI_VOID_FN) (void *);
-int MPIOI_Register_datarep(const char *datarep,
-                           MPIOI_VOID_FN * read_conversion_fn,
-                           MPIOI_VOID_FN * write_conversion_fn,
-                           MPI_Datarep_extent_function * dtype_file_extent_fn,
-                           void *extra_state, int is_large);
 
 /* Unix-style file locking */
 

--- a/src/mpi/romio/adio/include/adioi_error.h
+++ b/src/mpi/romio/adio/include/adioi_error.h
@@ -19,8 +19,7 @@
                                           myname, __LINE__,             \
                                           MPI_ERR_FILE,                 \
                                           "**iobadfh", 0);              \
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);   \
-        goto fn_exit;                                                   \
+        goto fn_fail;                                                   \
     }
 
 /* TODO could add more glue code to help check for handle validity, or perhaps
@@ -33,8 +32,7 @@
                                               (myname_), __LINE__,      \
                                               MPI_ERR_COMM,             \
                                               "**commnull", 0);         \
-            error_code_ = MPIO_Err_return_file(MPI_FILE_NULL, (error_code_)); \
-            goto fn_exit;                                               \
+            goto fn_fail;                                               \
         }                                                               \
     } while (0)
 
@@ -45,8 +43,7 @@
                                           myname, __LINE__,     \
                                           MPI_ERR_COUNT,        \
                                           "**iobadcount", 0);   \
-        error_code = MPIO_Err_return_file(fh, error_code);      \
-        goto fn_exit;                                           \
+        goto fn_fail;                                           \
     }
 
 #define MPIO_CHECK_COUNT_SIZE(fh, count, datatype_size, myname, error_code) \
@@ -56,8 +53,7 @@
                                           myname, __LINE__,             \
                                           MPI_ERR_ARG,                  \
                                           "**iobadcount", 0);           \
-        error_code = MPIO_Err_return_file(fh, error_code);              \
-        goto fn_exit;                                                   \
+        goto fn_fail;                                                   \
     }
 
 #define MPIO_CHECK_DATATYPE(fh, datatype, myname, error_code)           \
@@ -74,8 +70,7 @@
             MPIO_DATATYPE_ISCOMMITTED(datatype, error_code);            \
         }                                                               \
         if (error_code != MPI_SUCCESS) {                                \
-            error_code = MPIO_Err_return_file(fh, error_code);          \
-            goto fn_exit;                                               \
+            goto fn_fail;                                               \
         }                                                               \
     } while (0)
 
@@ -86,8 +81,7 @@
                                           myname, __LINE__,     \
                                           MPI_ERR_ACCESS,       \
                                           "**iowronly", 0);     \
-        error_code = MPIO_Err_return_file(fh, error_code);      \
-        goto fn_exit;                                           \
+        goto fn_fail;                                           \
     }
 
 #define MPIO_CHECK_WRITABLE(fh, myname, error_code)             \
@@ -98,8 +92,7 @@
                                           MPI_ERR_READ_ONLY,    \
                                           "**iordonly",         \
                                           0);                   \
-        error_code = MPIO_Err_return_file(fh, error_code);      \
-        goto fn_exit;                                           \
+        goto fn_fail;                                           \
     }
 
 #define MPIO_CHECK_NOT_SEQUENTIAL_MODE(fh, myname, error_code)          \
@@ -109,8 +102,7 @@
                                           myname, __LINE__,             \
                                           MPI_ERR_UNSUPPORTED_OPERATION, \
                                           "**ioamodeseq", 0);           \
-        error_code = MPIO_Err_return_file(fh, error_code);              \
-        goto fn_exit;                                                   \
+        goto fn_fail;                                                   \
     }
 
 #define MPIO_CHECK_INTEGRAL_ETYPE(fh, count, dtype_size, myname, error_code) \
@@ -118,8 +110,7 @@
         error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, \
                                           myname, __LINE__, MPI_ERR_IO, \
                                           "**ioetype", 0);              \
-        error_code = MPIO_Err_return_file(fh, error_code);              \
-        goto fn_exit;                                                   \
+        goto fn_fail;                                                   \
     }
 
 #define MPIO_CHECK_FS_SUPPORTS_SHARED(fh, myname, error_code)           \
@@ -130,8 +121,7 @@
                                           myname, __LINE__,             \
                                           MPI_ERR_UNSUPPORTED_OPERATION, \
                                           "**iosharedunsupported", 0);  \
-        error_code = MPIO_Err_return_file(fh, error_code);              \
-        goto fn_exit;                                                   \
+        goto fn_fail;                                                   \
     }
 
 /* MPIO_ERR_CREATE_CODE_XXX macros are used to clean up creation of

--- a/src/mpi/romio/adio/include/adioi_error.h
+++ b/src/mpi/romio/adio/include/adioi_error.h
@@ -165,7 +165,7 @@
 /* Check MPI_Info object by calling MPI_Info_dup, if the info object is valid
 then the dup operation will succeed */
 /* a collective check for error makes this macro collective */
-#define MPIO_CHECK_INFO_ALL(info, error_code, comm) {                   \
+#define MPIO_CHECK_INFO_ALL(info, myname, error_code, comm) {                   \
         MPI_Info dupinfo;                                               \
         int tmp_err = MPI_SUCCESS;                                      \
         if (info == MPI_INFO_NULL) {                                    \

--- a/src/mpi/romio/mpi-io/Makefile.mk
+++ b/src/mpi/romio/mpi-io/Makefile.mk
@@ -72,6 +72,7 @@ romio_mpi_sources +=          \
 
 # non-MPI/PMPI sources that will be included in libromio
 romio_other_sources +=       \
+    mpi-io/io_impl.c         \
     mpi-io/mpich_fileutil.c \
     mpi-io/mpir-mpioinit.c   \
     mpi-io/mpiu_greq.c \

--- a/src/mpi/romio/mpi-io/close.c
+++ b/src/mpi/romio/mpi-io/close.c
@@ -34,59 +34,21 @@ Input Parameters:
 int MPI_File_close(MPI_File * fh)
 {
     int error_code;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_CLOSE";
 
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(*fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    if (ADIO_Feature(adio_fh, ADIO_SHARED_FP)) {
-        ADIOI_Free((adio_fh)->shared_fp_fname);
-        /* POSIX semantics say a deleted file remains available until all
-         * processes close the file.  But since when was NFS posix-compliant?
-         */
-        /* this used to be gated by the lack of the UNLINK_AFTER_CLOSE feature,
-         * but a race condition in GPFS necessated this.  See ticket #2214 */
-        MPI_Barrier((adio_fh)->comm);
-        if ((adio_fh)->shared_fp_fd != ADIO_FILE_NULL) {
-            MPI_File *fh_shared = &(adio_fh->shared_fp_fd);
-            ADIO_Close((adio_fh)->shared_fp_fd, &error_code);
-            MPIO_File_free(fh_shared);
-            /* --BEGIN ERROR HANDLING-- */
-            if (error_code != MPI_SUCCESS)
-                goto fn_fail;
-            /* --END ERROR HANDLING-- */
-        }
-    }
-
-    /* Because ROMIO expects the MPI library to provide error handler management
-     * routines but it doesn't ever participate in MPI_File_close, we have to
-     * somehow inform the MPI library that we no longer hold a reference to any
-     * user defined error handler.  We do this by setting the errhandler at this
-     * point to MPI_ERRORS_RETURN. */
-    error_code = MPI_File_set_errhandler(*fh, MPI_ERRORS_RETURN);
-    if (error_code != MPI_SUCCESS)
-        goto fn_fail;
-
-    ADIO_Close(adio_fh, &error_code);
-    MPIO_File_free(fh);
+    error_code = MPIR_File_close_impl(fh);
     /* --BEGIN ERROR HANDLING-- */
     if (error_code != MPI_SUCCESS)
         goto fn_fail;
     /* --END ERROR HANDLING-- */
-
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
     return error_code;
   fn_fail:
     /* --BEGIN ERROR HANDLING-- */
-    error_code = MPIO_Err_return_file(adio_fh, error_code);
+    error_code = MPIO_Err_return_file(MPIO_File_resolve(*fh), error_code);
     goto fn_exit;
     /* --END ERROR HANDLING-- */
 }

--- a/src/mpi/romio/mpi-io/close.c
+++ b/src/mpi/romio/mpi-io/close.c
@@ -36,11 +36,6 @@ int MPI_File_close(MPI_File * fh)
     int error_code;
     ADIO_File adio_fh;
     static char myname[] = "MPI_FILE_CLOSE";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_WSTART(fl_xmpi, BLKMPIFILECLOSE, TRDTBLOCK, *adio_fh);
-#endif /* MPI_hpux */
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -85,9 +80,6 @@ int MPI_File_close(MPI_File * fh)
         goto fn_fail;
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_WEND(fl_xmpi);
-#endif /* MPI_hpux */
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();

--- a/src/mpi/romio/mpi-io/delete.c
+++ b/src/mpi/romio/mpi-io/delete.c
@@ -38,11 +38,6 @@ int MPI_File_delete(ROMIO_CONST char *filename, MPI_Info info)
     int error_code, file_system, known_fstype;
     char *tmp;
     ADIOI_Fns *fsops;
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEDELETE, TRDTBLOCK, MPI_FILE_NULL, MPI_DATATYPE_NULL, -1);
-#endif /* MPI_hpux */
 
     MPL_UNREFERENCED_ARG(info);
 
@@ -85,9 +80,6 @@ int MPI_File_delete(ROMIO_CONST char *filename, MPI_Info info)
         error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, MPI_FILE_NULL, MPI_DATATYPE_NULL, -1);
-#endif /* MPI_hpux */
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();

--- a/src/mpi/romio/mpi-io/fsync.c
+++ b/src/mpi/romio/mpi-io/fsync.c
@@ -35,29 +35,17 @@ Input Parameters:
 int MPI_File_sync(MPI_File fh)
 {
     int error_code;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_SYNC";
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-    /* --BEGIN ERROR HANDLING-- */
-    if ((adio_fh == NULL) || ((adio_fh)->cookie != ADIOI_FILE_COOKIE)) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iobadfh", 0);
-        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_sync_impl(fh);
+    if (error_code) {
+        goto fn_fail;
     }
-    MPIO_CHECK_WRITABLE(fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIO_Flush(adio_fh, &error_code);
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/fsync.c
+++ b/src/mpi/romio/mpi-io/fsync.c
@@ -37,11 +37,6 @@ int MPI_File_sync(MPI_File fh)
     int error_code;
     ADIO_File adio_fh;
     static char myname[] = "MPI_FILE_SYNC";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILESYNC, TRDTBLOCK, adio_fh, MPI_DATATYPE_NULL, -1);
-#endif /* MPI_hpux */
     ROMIO_THREAD_CS_ENTER();
 
     adio_fh = MPIO_File_resolve(fh);
@@ -61,9 +56,6 @@ int MPI_File_sync(MPI_File fh)
         error_code = MPIO_Err_return_file(adio_fh, error_code);
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, adio_fh, MPI_DATATYPE_NULL, -1);
-#endif /* MPI_hpux */
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();

--- a/src/mpi/romio/mpi-io/get_amode.c
+++ b/src/mpi/romio/mpi-io/get_amode.c
@@ -37,18 +37,16 @@ Output Parameters:
 @*/
 int MPI_File_get_amode(MPI_File fh, int *amode)
 {
-    int error_code = MPI_SUCCESS;
-    static char myname[] = "MPI_FILE_GET_AMODE";
-    ADIO_File adio_fh;
+    int error_code;
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    *amode = adio_fh->orig_access_mode;
+    error_code = MPIR_File_get_amode_impl(fh, amode);
+    if (error_code) {
+        goto fn_fail;
+    }
 
   fn_exit:
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/get_atom.c
+++ b/src/mpi/romio/mpi-io/get_atom.c
@@ -38,17 +38,15 @@ Output Parameters:
 int MPI_File_get_atomicity(MPI_File fh, int *flag)
 {
     int error_code;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_GET_ATOMICITY";
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    *flag = adio_fh->atomicity;
+    error_code = MPIR_File_get_atomicity_impl(fh, flag);
+    if (error_code) {
+        goto fn_fail;
+    }
 
   fn_exit:
-    return MPI_SUCCESS;
+    return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/get_bytoff.c
+++ b/src/mpi/romio/mpi-io/get_bytoff.c
@@ -42,27 +42,15 @@ Output Parameters:
 int MPI_File_get_byte_offset(MPI_File fh, MPI_Offset offset, MPI_Offset * disp)
 {
     int error_code;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_GET_BYTE_OFFSET";
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-
-    if (offset < 0) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_get_byte_offset_impl(fh, offset, disp);
+    if (error_code) {
+        goto fn_fail;
     }
 
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_Get_byte_offset(adio_fh, offset, disp);
-
   fn_exit:
-
-    return MPI_SUCCESS;
+    return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/get_extent.c
+++ b/src/mpi/romio/mpi-io/get_extent.c
@@ -51,23 +51,17 @@ Output Parameters:
 int MPI_File_get_type_extent(MPI_File fh, MPI_Datatype datatype, MPI_Aint * extent)
 {
     int error_code;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_GET_TYPE_EXTENT";
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    /* FIXME: handle other file data representations */
-
-    MPI_Aint lb;
-    error_code = PMPI_Type_get_extent(datatype, &lb, extent);
+    error_code = MPIR_File_get_type_extent_impl(fh, datatype, extent);
+    if (error_code) {
+        goto fn_fail;
+    }
 
   fn_exit:
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -88,22 +82,18 @@ Output Parameters:
 int MPI_File_get_type_extent_c(MPI_File fh, MPI_Datatype datatype, MPI_Count * extent)
 {
     int error_code;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_GET_TYPE_EXTENT";
 
-    adio_fh = MPIO_File_resolve(fh);
+    MPI_Aint extent_i;
+    error_code = MPIR_File_get_type_extent_impl(fh, datatype, &extent_i);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    /* FIXME: handle other file data representations */
-
-    MPI_Aint lb_i, extent_i;
-    error_code = PMPI_Type_get_extent(datatype, &lb_i, &extent_i);
     *extent = extent_i;
 
   fn_exit:
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/get_group.c
+++ b/src/mpi/romio/mpi-io/get_group.c
@@ -39,25 +39,17 @@ Output Parameters:
 int MPI_File_get_group(MPI_File fh, MPI_Group * group)
 {
     int error_code;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_GET_GROUP";
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-
-    /* note: this will return the group of processes that called open, but
-     * with deferred open this might not be the group of processes that
-     * actually opened the file from the file system's perspective
-     */
-    error_code = MPI_Comm_group(adio_fh->comm, group);
+    error_code = MPIR_File_get_group_impl(fh, group);
+    if (error_code) {
+        goto fn_fail;
+    }
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/get_info.c
+++ b/src/mpi/romio/mpi-io/get_info.c
@@ -38,24 +38,17 @@ Output Parameters:
 int MPI_File_get_info(MPI_File fh, MPI_Info * info_used)
 {
     int error_code;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_GET_INFO";
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    error_code = MPI_Info_dup(adio_fh->info, info_used);
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
+    error_code = MPIR_File_get_info_impl(fh, info_used);
+    if (error_code) {
+        goto fn_fail;
+    }
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/get_posn.c
+++ b/src/mpi/romio/mpi-io/get_posn.c
@@ -41,18 +41,17 @@ Output Parameters:
 int MPI_File_get_position(MPI_File fh, MPI_Offset * offset)
 {
     int error_code;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_GET_POSITION";
+    ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_Get_position(adio_fh, offset);
+    error_code = MPIR_File_get_position_impl(fh, offset);
+    if (error_code) {
+        goto fn_fail;
+    }
 
   fn_exit:
-    return MPI_SUCCESS;
+    ROMIO_THREAD_CS_EXIT();
+    return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/get_posn_sh.c
+++ b/src/mpi/romio/mpi-io/get_posn_sh.c
@@ -39,25 +39,17 @@ Output Parameters:
 int MPI_File_get_position_shared(MPI_File fh, MPI_Offset * offset)
 {
     int error_code;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_GET_POSITION_SHARED";
+    ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_TEST_DEFERRED(adio_fh, myname, &error_code);
-
-    ADIO_Get_shared_fp(adio_fh, 0, offset, &error_code);
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
+    error_code = MPIR_File_get_position_shared_impl(fh, offset);
+    if (error_code) {
+        goto fn_fail;
+    }
 
   fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/get_size.c
+++ b/src/mpi/romio/mpi-io/get_size.c
@@ -41,11 +41,6 @@ int MPI_File_get_size(MPI_File fh, MPI_Offset * size)
     ADIO_File adio_fh;
     ADIO_Fcntl_t *fcntl_struct;
     static char myname[] = "MPI_FILE_GET_SIZE";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEGETSIZE, TRDTBLOCK, adio_fh, MPI_DATATYPE_NULL, -1);
-#endif /* MPI_hpux */
 
     adio_fh = MPIO_File_resolve(fh);
 
@@ -70,9 +65,6 @@ int MPI_File_get_size(MPI_File fh, MPI_Offset * size)
     *size = fcntl_struct->fsize;
     ADIOI_Free(fcntl_struct);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, adio_fh, MPI_DATATYPE_NULL, -1);
-#endif /* MPI_hpux */
 
   fn_exit:
     return error_code;

--- a/src/mpi/romio/mpi-io/get_size.c
+++ b/src/mpi/romio/mpi-io/get_size.c
@@ -38,39 +38,15 @@ Output Parameters:
 int MPI_File_get_size(MPI_File fh, MPI_Offset * size)
 {
     int error_code;
-    ADIO_File adio_fh;
-    ADIO_Fcntl_t *fcntl_struct;
-    static char myname[] = "MPI_FILE_GET_SIZE";
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    if (size == NULL) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG,
-                                          "**nullptr", "**nullptr %s", "size");
+    error_code = MPIR_File_get_size_impl(fh, size);
+    if (error_code) {
         goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_TEST_DEFERRED(adio_fh, myname, &error_code);
-
-    fcntl_struct = (ADIO_Fcntl_t *) ADIOI_Malloc(sizeof(ADIO_Fcntl_t));
-    ADIO_Fcntl(adio_fh, ADIO_FCNTL_GET_FSIZE, fcntl_struct, &error_code);
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-    *size = fcntl_struct->fsize;
-    ADIOI_Free(fcntl_struct);
-
 
   fn_exit:
     return error_code;
   fn_fail:
-    /* --BEGIN ERROR HANDLING-- */
     error_code = MPIO_Err_return_file(fh, error_code);
     goto fn_exit;
-    /* --END ERROR HANDLING-- */
 }

--- a/src/mpi/romio/mpi-io/io_impl.c
+++ b/src/mpi/romio/mpi-io/io_impl.c
@@ -1238,6 +1238,16 @@ int MPIR_Register_datarep_large_impl(ROMIO_CONST char *datarep,
                                   dtype_file_extent_fn, extra_state, is_large);
 }
 
+MPI_Fint MPIR_File_c2f_impl(MPI_File fh)
+{
+    return MPIO_File_c2f(fh);
+}
+
+MPI_File MPIR_File_f2c_impl(MPI_Fint fh)
+{
+    return MPIO_File_f2c(fh);
+}
+
 /* internal routines */
 
 static int MPIOI_File_iread(MPI_File fh, MPI_Offset offset, int file_ptr_type,

--- a/src/mpi/romio/mpi-io/io_impl.c
+++ b/src/mpi/romio/mpi-io/io_impl.c
@@ -1,0 +1,3071 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpioimpl.h"
+
+/* for user-definde reduce operator */
+#include "adio_extern.h"
+
+static int MPIOI_File_iread(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                            void *buf, MPI_Aint count, MPI_Datatype datatype,
+                            MPI_Request * request);
+static int MPIOI_File_iread_all(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                                void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                MPI_Request * request);
+static int MPIOI_File_iread_shared(MPI_File fh, void *buf, MPI_Aint count,
+                                   MPI_Datatype datatype, MPI_Request * request);
+static int MPIOI_File_iwrite(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                             const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                             MPI_Request * request);
+static int MPIOI_File_iwrite_all(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                                 const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                 MPI_Request * request);
+static int MPIOI_File_iwrite_shared(MPI_File fh, const void *buf, MPI_Aint count,
+                                    MPI_Datatype datatype, MPIO_Request * request);
+static int MPIOI_File_read(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                           void *buf, MPI_Aint count, MPI_Datatype datatype, MPI_Status * status);
+static int MPIOI_File_read_all(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                               void *buf, MPI_Aint count, MPI_Datatype datatype,
+                               MPI_Status * status);
+static int MPIOI_File_read_all_begin(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                                     void *buf, MPI_Aint count, MPI_Datatype datatype);
+static int MPIOI_File_read_all_end(MPI_File fh, void *buf, MPI_Status * status);
+static int MPIOI_File_read_ordered(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                   MPI_Status * status);
+static int MPIOI_File_read_ordered_begin(MPI_File fh,
+                                         void *buf, MPI_Aint count, MPI_Datatype datatype);
+static int MPIOI_File_read_ordered_end(MPI_File fh, void *buf, MPI_Status * status);
+static int MPIOI_File_read_shared(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                  MPI_Status * status);
+static int MPIOI_File_write(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                            const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                            MPI_Status * status);
+static int MPIOI_File_write_all(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                                const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                MPI_Status * status);
+static int MPIOI_File_write_all_begin(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                                      const void *buf, MPI_Aint count, MPI_Datatype datatype);
+static int MPIOI_File_write_all_end(MPI_File fh, const void *buf, MPI_Status * status);
+static int MPIOI_File_write_ordered(MPI_File fh, const void *buf, MPI_Aint count,
+                                    MPI_Datatype datatype, MPI_Status * status);
+static int MPIOI_File_write_ordered_begin(MPI_File fh, const void *buf, MPI_Aint count,
+                                          MPI_Datatype datatype);
+static int MPIOI_File_write_ordered_end(MPI_File fh, const void *buf, MPI_Status * status);
+static int MPIOI_File_write_shared(MPI_File fh, const void *buf, MPI_Aint count,
+                                   MPI_Datatype datatype, MPI_Status * status);
+
+typedef void (*MPIOI_VOID_FN) (void *);
+static int MPIOI_Register_datarep(const char *datarep,
+                                  MPIOI_VOID_FN * read_conversion_fn,
+                                  MPIOI_VOID_FN * write_conversion_fn,
+                                  MPI_Datarep_extent_function * dtype_file_extent_fn,
+                                  void *extra_state, int is_large);
+
+int MPIR_File_open_impl(MPI_Comm comm, ROMIO_CONST char *filename, int amode,
+                        MPI_Info info, MPI_File * fh)
+{
+    int error_code = MPI_SUCCESS;
+    MPI_Comm dupcomm = MPI_COMM_NULL;
+
+    MPIO_CHECK_COMM(comm, __func__, error_code);
+    MPIO_CHECK_INFO_ALL(info, __func__, error_code, comm);
+
+    int flag;
+    error_code = MPI_Comm_test_inter(comm, &flag);
+    if (error_code || flag) {
+        error_code = MPIO_Err_create_code(error_code, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_COMM, "**commnotintra", 0);
+        goto fn_fail;
+    }
+
+    if (((amode & MPI_MODE_RDONLY) ? 1 : 0) + ((amode & MPI_MODE_RDWR) ? 1 : 0) +
+        ((amode & MPI_MODE_WRONLY) ? 1 : 0) != 1) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_AMODE, "**fileamodeone", 0);
+        goto fn_fail;
+    }
+
+    if ((amode & MPI_MODE_RDONLY) && ((amode & MPI_MODE_CREATE) || (amode & MPI_MODE_EXCL))) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_AMODE, "**fileamoderead", 0);
+        goto fn_fail;
+    }
+
+    if ((amode & MPI_MODE_RDWR) && (amode & MPI_MODE_SEQUENTIAL)) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_AMODE, "**fileamodeseq", 0);
+        goto fn_fail;
+    }
+
+    MPI_Comm_dup(comm, &dupcomm);
+
+    /* Check if ADIO has been initialized. If not, initialize it */
+    MPIR_MPIOInit(&error_code);
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+
+    /* check if amode is the same on all processes: at first glance, one might try
+     * to use a built-in operator like MPI_BAND, but we need every mpi process to
+     * agree the amode was not the same.  Consider process A with
+     * MPI_MODE_CREATE|MPI_MODE_RDWR, and B with MPI_MODE_RDWR:  MPI_BAND yields
+     * MPI_MODE_RDWR.  A determines amodes are different, but B proceeds having not
+     * detected an error */
+    int tmp_amode = 0;
+    MPI_Allreduce(&amode, &tmp_amode, 1, MPI_INT, ADIO_same_amode, dupcomm);
+
+    if (tmp_amode == ADIO_AMODE_NOMATCH) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_NOT_SAME, "**fileamodediff",
+                                          0);
+        goto fn_fail;
+    }
+
+    int file_system = -1, known_fstype;
+    ADIOI_Fns *fsops;
+    /* resolve file system type from file name; this is a collective call */
+    known_fstype = ADIO_ResolveFileType(dupcomm, filename, &file_system, &fsops, &error_code);
+    if (error_code != MPI_SUCCESS) {
+        /* ADIO_ResolveFileType() will print as informative a message as it
+         * possibly can or call MPIO_Err_setmsg.  We just need to propagate
+         * the error up.
+         */
+        goto fn_fail;
+    }
+
+    if (known_fstype) {
+        /* filename contains a known file system type prefix, such as "ufs:".
+         * strip off prefix if there is one, but only skip prefixes
+         * if they are greater than length one to allow for windows
+         * drive specifications (e.g. c:\...)
+         */
+        char *tmp = strchr(filename, ':');
+        if (tmp > filename + 1) {
+            filename = tmp + 1;
+        }
+    }
+
+    /* use default values for disp, etype, filetype */
+    *fh = ADIO_Open(comm, dupcomm, filename, file_system, fsops, amode, 0,
+                    MPI_BYTE, MPI_BYTE, info, ADIO_PERM_NULL, &error_code);
+
+    if (error_code != MPI_SUCCESS) {
+        goto fn_fail;
+    }
+
+    /* if MPI_MODE_SEQUENTIAL requested, file systems cannot do explicit offset
+     * or independent file pointer accesses, leaving not much else aside from
+     * shared file pointer accesses. */
+    if (!ADIO_Feature((*fh), ADIO_SHARED_FP) && (amode & MPI_MODE_SEQUENTIAL)) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__,
+                                          MPI_ERR_UNSUPPORTED_OPERATION, "**iosequnsupported", 0);
+        ADIO_Close(*fh, &error_code);
+        goto fn_fail;
+    }
+
+    /* determine name of file that will hold the shared file pointer */
+    /* can't support shared file pointers on a file system that doesn't
+     * support file locking. */
+    if ((error_code == MPI_SUCCESS) && ADIO_Feature((*fh), ADIO_SHARED_FP)) {
+        int rank;
+        MPI_Comm_rank(dupcomm, &rank);
+        ADIOI_Shfp_fname(*fh, rank, &error_code);
+        if (error_code != MPI_SUCCESS)
+            goto fn_fail;
+
+        /* if MPI_MODE_APPEND, set the shared file pointer to end of file.
+         * indiv. file pointer already set to end of file in ADIO_Open.
+         * Here file view is just bytes. */
+        if ((*fh)->access_mode & MPI_MODE_APPEND) {
+            if (rank == (*fh)->hints->ranklist[0])      /* only one person need set the sharedfp */
+                ADIO_Set_shared_fp(*fh, (*fh)->fp_ind, &error_code);
+            MPI_Barrier(dupcomm);
+        }
+    }
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    if (dupcomm != MPI_COMM_NULL)
+        MPI_Comm_free(&dupcomm);
+    goto fn_exit;
+}
+
+int MPIR_File_close_impl(MPI_File * fh)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh;
+    adio_fh = MPIO_File_resolve(*fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    if (ADIO_Feature(adio_fh, ADIO_SHARED_FP)) {
+        ADIOI_Free((adio_fh)->shared_fp_fname);
+        /* POSIX semantics say a deleted file remains available until all
+         * processes close the file.  But since when was NFS posix-compliant?
+         */
+        /* this used to be gated by the lack of the UNLINK_AFTER_CLOSE feature,
+         * but a race condition in GPFS necessated this.  See ticket #2214 */
+        MPI_Barrier((adio_fh)->comm);
+        if ((adio_fh)->shared_fp_fd != ADIO_FILE_NULL) {
+            MPI_File *fh_shared = &(adio_fh->shared_fp_fd);
+            ADIO_Close((adio_fh)->shared_fp_fd, &error_code);
+            MPIO_File_free(fh_shared);
+            /* --BEGIN ERROR HANDLING-- */
+            if (error_code != MPI_SUCCESS)
+                goto fn_fail;
+            /* --END ERROR HANDLING-- */
+        }
+    }
+
+    /* Because ROMIO expects the MPI library to provide error handler management
+     * routines but it doesn't ever participate in MPI_File_close, we have to
+     * somehow inform the MPI library that we no longer hold a reference to any
+     * user defined error handler.  We do this by setting the errhandler at this
+     * point to MPI_ERRORS_RETURN. */
+    error_code = PMPI_File_set_errhandler(*fh, MPI_ERRORS_RETURN);
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+
+    ADIO_Close(adio_fh, &error_code);
+    MPIO_File_free(fh);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_delete_impl(const char *filename, MPI_Info info)
+{
+    int error_code = MPI_SUCCESS;
+    int file_system, known_fstype;
+    char *tmp;
+    ADIOI_Fns *fsops;
+
+    MPL_UNREFERENCED_ARG(info);
+
+    MPIR_MPIOInit(&error_code);
+    if (error_code != MPI_SUCCESS)
+        goto fn_exit;
+
+    /* resolve file system type from file name; this is a collective call */
+    known_fstype = ADIO_ResolveFileType(MPI_COMM_SELF, filename, &file_system, &fsops, &error_code);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS) {
+        /* ADIO_ResolveFileType() will print as informative a message as it
+         * possibly can or call MPIR_Err_setmsg.  We just need to propagate
+         * the error up.  In the PRINT_ERR_MSG case MPI_Abort has already
+         * been called as well, so we probably didn't even make it this far.
+         */
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    if (known_fstype) {
+        /* filename contains a known file system type prefix, such as "ufs:".
+         * skip prefixes on file names if they have more than one character;
+         * single-character prefixes are assumed to be windows drive
+         * specifications (e.g. c:\foo) and are left alone.
+         */
+        tmp = strchr(filename, ':');
+        if (tmp > filename + 1)
+            filename = tmp + 1;
+    }
+
+    /* call the fs-specific delete function */
+    (fsops->ADIOI_xxx_Delete) (filename, &error_code);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_get_amode_impl(MPI_File fh, int *amode)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    *amode = adio_fh->orig_access_mode;
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_get_atomicity_impl(MPI_File fh, int *flag)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    *flag = adio_fh->atomicity;
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_get_byte_offset_impl(MPI_File fh, MPI_Offset offset, MPI_Offset * disp)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    if (offset < 0) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
+        goto fn_fail;
+    }
+
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    ADIOI_Get_byte_offset(adio_fh, offset, disp);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_get_group_impl(MPI_File fh, MPI_Group * group)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    /* note: this will return the group of processes that called open, but
+     * with deferred open this might not be the group of processes that
+     * actually opened the file from the file system's perspective
+     */
+    error_code = MPI_Comm_group(adio_fh->comm, group);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_get_info_impl(MPI_File fh, MPI_Info * info_used)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    error_code = MPI_Info_dup(adio_fh->info, info_used);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_get_position_impl(MPI_File fh, MPI_Offset * offset)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+
+    ADIOI_Get_position(adio_fh, offset);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_get_position_shared_impl(MPI_File fh, MPI_Offset * offset)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, __func__, error_code);
+
+    ADIOI_TEST_DEFERRED(adio_fh, __func__, &error_code);
+
+    ADIO_Get_shared_fp(adio_fh, 0, offset, &error_code);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_get_size_impl(MPI_File fh, MPI_Offset * size)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    if (size == NULL) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG,
+                                          "**nullptr", "**nullptr %s", "size");
+        goto fn_fail;
+    }
+
+    ADIOI_TEST_DEFERRED(adio_fh, __func__, &error_code);
+
+    ADIO_Fcntl_t *fcntl_struct;
+    fcntl_struct = (ADIO_Fcntl_t *) ADIOI_Malloc(sizeof(ADIO_Fcntl_t));
+    ADIO_Fcntl(adio_fh, ADIO_FCNTL_GET_FSIZE, fcntl_struct, &error_code);
+    if (error_code != MPI_SUCCESS) {
+        goto fn_fail;
+    }
+
+    *size = fcntl_struct->fsize;
+    ADIOI_Free(fcntl_struct);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_get_type_extent_impl(MPI_File fh, MPI_Datatype datatype, MPI_Aint * extent)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+
+    /* FIXME: handle other file data representations */
+
+    MPI_Aint lb_i, extent_i;
+    error_code = PMPI_Type_get_extent(datatype, &lb_i, &extent_i);
+    *extent = extent_i;
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_get_view_impl(MPI_File fh, MPI_Offset * disp, MPI_Datatype * etype,
+                            MPI_Datatype * filetype, char *datarep)
+{
+    int error_code = MPI_SUCCESS;
+    int is_predef;
+    MPI_Datatype copy_etype, copy_filetype;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    if (datarep == NULL) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iodatarepnomem", 0);
+        goto fn_exit;
+    }
+    /* --END ERROR HANDLING-- */
+
+    *disp = adio_fh->disp;
+    ADIOI_Strncpy(datarep,
+                  (adio_fh->is_external32 ? "external32" : "native"), MPI_MAX_DATAREP_STRING);
+
+    ADIOI_Type_ispredef(adio_fh->etype, &is_predef);
+    if (is_predef)
+        *etype = adio_fh->etype;
+    else {
+#ifdef MPIIMPL_HAVE_MPI_COMBINER_DUP
+        MPI_Type_dup(adio_fh->etype, &copy_etype);
+#else
+        MPI_Type_contiguous(1, adio_fh->etype, &copy_etype);
+#endif
+
+        MPI_Type_commit(&copy_etype);
+        *etype = copy_etype;
+    }
+    ADIOI_Type_ispredef(adio_fh->filetype, &is_predef);
+    if (is_predef)
+        *filetype = adio_fh->filetype;
+    else {
+#ifdef MPIIMPL_HAVE_MPI_COMBINER_DUP
+        MPI_Type_dup(adio_fh->filetype, &copy_filetype);
+#else
+        MPI_Type_contiguous(1, adio_fh->filetype, &copy_filetype);
+#endif
+
+        MPI_Type_commit(&copy_filetype);
+        *filetype = copy_filetype;
+    }
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_iread_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                         MPI_Request * request)
+{
+    return MPIOI_File_iread(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf, count, datatype, request);
+}
+
+int MPIR_File_iread_all_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                             MPI_Request * request)
+{
+    return MPIOI_File_iread_all(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf, count, datatype, request);
+}
+
+int MPIR_File_iread_at_impl(MPI_File fh, MPI_Offset offset, void *buf, MPI_Aint count,
+                            MPI_Datatype datatype, MPI_Request * request)
+{
+    return MPIOI_File_iread(fh, offset, ADIO_EXPLICIT_OFFSET, buf, count, datatype, request);
+}
+
+int MPIR_File_iread_at_all_impl(MPI_File fh, MPI_Offset offset, void *buf, MPI_Aint count,
+                                MPI_Datatype datatype, MPI_Request * request)
+{
+    return MPIOI_File_iread_all(fh, offset, ADIO_EXPLICIT_OFFSET, buf, count, datatype, request);
+}
+
+int MPIR_File_iread_shared_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                MPI_Request * request)
+{
+    return MPIOI_File_iread_shared(fh, buf, count, datatype, request);
+}
+
+int MPIR_File_iwrite_impl(MPI_File fh, const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                          MPI_Request * request)
+{
+    return MPIOI_File_iwrite(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf, count, datatype, request);
+}
+
+int MPIR_File_iwrite_all_impl(MPI_File fh, const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                              MPI_Request * request)
+{
+    return MPIOI_File_iwrite_all(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
+                                 buf, count, datatype, request);
+}
+
+int MPIR_File_iwrite_at_impl(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Aint count,
+                             MPI_Datatype datatype, MPI_Request * request)
+{
+    return MPIOI_File_iwrite(fh, offset, ADIO_EXPLICIT_OFFSET, buf, count, datatype, request);
+}
+
+int MPIR_File_iwrite_at_all_impl(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Aint count,
+                                 MPI_Datatype datatype, MPI_Request * request)
+{
+    return MPIOI_File_iwrite_all(fh, offset, ADIO_EXPLICIT_OFFSET, buf, count, datatype, request);
+}
+
+int MPIR_File_iwrite_shared_impl(MPI_File fh, const void *buf, MPI_Aint count,
+                                 MPI_Datatype datatype, MPI_Request * request)
+{
+    return MPIOI_File_iwrite_shared(fh, buf, count, datatype, request);
+}
+
+int MPIR_File_preallocate_impl(MPI_File fh, MPI_Offset size)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    if (size < 0) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobadsize", 0);
+        goto fn_fail;
+    }
+
+    MPI_Offset tmp_sz, max_sz, min_sz;
+    tmp_sz = size;
+    MPI_Allreduce(&tmp_sz, &max_sz, 1, ADIO_OFFSET, MPI_MAX, adio_fh->comm);
+    MPI_Allreduce(&tmp_sz, &min_sz, 1, ADIO_OFFSET, MPI_MIN, adio_fh->comm);
+
+    if (max_sz != min_sz) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**notsame", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    if (size == 0)
+        goto fn_exit;
+
+    ADIOI_TEST_DEFERRED(adio_fh, __func__, &error_code);
+
+    int mynod = 0;
+    MPI_Comm_rank(adio_fh->comm, &mynod);
+    if (!mynod) {
+        ADIO_Fcntl_t *fcntl_struct;
+        fcntl_struct = (ADIO_Fcntl_t *) ADIOI_Malloc(sizeof(ADIO_Fcntl_t));
+        fcntl_struct->diskspace = size;
+        ADIO_Fcntl(adio_fh, ADIO_FCNTL_SET_DISKSPACE, fcntl_struct, &error_code);
+        ADIOI_Free(fcntl_struct);
+    }
+    MPI_Barrier(adio_fh->comm);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_read_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                        MPI_Status * status)
+{
+    return MPIOI_File_read(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf, count, datatype, status);
+}
+
+int MPIR_File_read_all_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                            MPI_Status * status)
+{
+    return MPIOI_File_read_all(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf, count, datatype, status);
+}
+
+int MPIR_File_read_all_begin_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype)
+{
+    return MPIOI_File_read_all_begin(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf, count, datatype);
+}
+
+int MPIR_File_read_all_end_impl(MPI_File fh, void *buf, MPI_Status * status)
+{
+    return MPIOI_File_read_all_end(fh, buf, status);
+}
+
+int MPIR_File_read_at_impl(MPI_File fh, MPI_Offset offset, void *buf, MPI_Aint count,
+                           MPI_Datatype datatype, MPI_Status * status)
+{
+    return MPIOI_File_read(fh, offset, ADIO_EXPLICIT_OFFSET, buf, count, datatype, status);
+}
+
+int MPIR_File_read_at_all_impl(MPI_File fh, MPI_Offset offset, void *buf, MPI_Aint count,
+                               MPI_Datatype datatype, MPI_Status * status)
+{
+    return MPIOI_File_read_all(fh, offset, ADIO_EXPLICIT_OFFSET, buf, count, datatype, status);
+}
+
+int MPIR_File_read_at_all_begin_impl(MPI_File fh, MPI_Offset offset, void *buf, MPI_Aint count,
+                                     MPI_Datatype datatype)
+{
+    return MPIOI_File_read_all_begin(fh, offset, ADIO_EXPLICIT_OFFSET, buf, count, datatype);
+}
+
+int MPIR_File_read_at_all_end_impl(MPI_File fh, void *buf, MPI_Status * status)
+{
+    return MPIOI_File_read_all_end(fh, buf, status);
+}
+
+int MPIR_File_read_ordered_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                MPI_Status * status)
+{
+    return MPIOI_File_read_ordered(fh, buf, count, datatype, status);
+}
+
+int MPIR_File_read_ordered_begin_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype)
+{
+    return MPIOI_File_read_ordered_begin(fh, buf, count, datatype);
+}
+
+int MPIR_File_read_ordered_end_impl(MPI_File fh, void *buf, MPI_Status * status)
+{
+    return MPIOI_File_read_ordered_end(fh, buf, status);
+}
+
+int MPIR_File_read_shared_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                               MPI_Status * status)
+{
+    return MPIOI_File_read_shared(fh, buf, count, datatype, status);
+}
+
+int MPIR_File_seek_impl(MPI_File fh, MPI_Offset offset, int whence)
+{
+    int error_code = MPI_SUCCESS;
+    MPI_Offset curr_offset, eof_offset;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+
+    switch (whence) {
+        case MPI_SEEK_SET:
+            /* --BEGIN ERROR HANDLING-- */
+            if (offset < 0) {
+                error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                                  MPIR_ERR_RECOVERABLE, __func__,
+                                                  __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
+                goto fn_fail;
+            }
+            /* --END ERROR HANDLING-- */
+            break;
+        case MPI_SEEK_CUR:
+            /* find offset corr. to current location of file pointer */
+            ADIOI_Get_position(adio_fh, &curr_offset);
+            offset += curr_offset;
+
+            /* --BEGIN ERROR HANDLING-- */
+            if (offset < 0) {
+                error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                                  MPIR_ERR_RECOVERABLE, __func__,
+                                                  __LINE__, MPI_ERR_ARG, "**ionegoffset", 0);
+                goto fn_fail;
+            }
+            /* --END ERROR HANDLING-- */
+
+            break;
+        case MPI_SEEK_END:
+            /* we can in many cases do seeks w/o a file actually opened, but not in
+             * the MPI_SEEK_END case */
+            ADIOI_TEST_DEFERRED(adio_fh, "MPI_File_seek", &error_code);
+
+            /* find offset corr. to end of file */
+            ADIOI_Get_eof_offset(adio_fh, &eof_offset);
+            offset += eof_offset;
+
+            /* --BEGIN ERROR HANDLING-- */
+            if (offset < 0) {
+                error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                                  MPIR_ERR_RECOVERABLE, __func__,
+                                                  __LINE__, MPI_ERR_ARG, "**ionegoffset", 0);
+                goto fn_fail;
+            }
+            /* --END ERROR HANDLING-- */
+
+            break;
+        default:
+            /* --BEGIN ERROR HANDLING-- */
+            error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                              __func__, __LINE__, MPI_ERR_ARG, "**iobadwhence", 0);
+            goto fn_fail;
+            /* --END ERROR HANDLING-- */
+    }
+
+    ADIO_SeekIndividual(adio_fh, offset, ADIO_SEEK_SET, &error_code);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_seek_shared_impl(MPI_File fh, MPI_Offset offset, int whence)
+{
+    int error_code = MPI_SUCCESS;
+    MPI_Offset curr_offset, eof_offset;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    MPI_Offset tmp_offset;
+    tmp_offset = offset;
+    MPI_Bcast(&tmp_offset, 1, ADIO_OFFSET, 0, adio_fh->comm);
+    /* --BEGIN ERROR HANDLING-- */
+    if (tmp_offset != offset) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**notsame", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    int tmp_whence;
+    tmp_whence = whence;
+    MPI_Bcast(&tmp_whence, 1, MPI_INT, 0, adio_fh->comm);
+    /* --BEGIN ERROR HANDLING-- */
+    if (tmp_whence != whence) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobadwhence", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    ADIOI_TEST_DEFERRED(adio_fh, "MPI_File_seek_shared", &error_code);
+
+    int myrank;
+    MPI_Comm_rank(adio_fh->comm, &myrank);
+
+    if (!myrank) {
+        switch (whence) {
+            case MPI_SEEK_SET:
+                /* --BEGIN ERROR HANDLING-- */
+                if (offset < 0) {
+                    error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                                      MPIR_ERR_RECOVERABLE,
+                                                      __func__, __LINE__,
+                                                      MPI_ERR_ARG, "**iobadoffset", 0);
+                    goto fn_fail;
+                }
+                /* --END ERROR HANDLING-- */
+                break;
+            case MPI_SEEK_CUR:
+                /* get current location of shared file pointer */
+                ADIO_Get_shared_fp(adio_fh, 0, &curr_offset, &error_code);
+                /* --BEGIN ERROR HANDLING-- */
+                if (error_code != MPI_SUCCESS) {
+                    error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                                      MPIR_ERR_FATAL,
+                                                      __func__, __LINE__,
+                                                      MPI_ERR_INTERN, "**iosharedfailed", 0);
+                    goto fn_fail;
+                }
+                /* --END ERROR HANDLING-- */
+                offset += curr_offset;
+                /* --BEGIN ERROR HANDLING-- */
+                if (offset < 0) {
+                    error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                                      MPIR_ERR_RECOVERABLE,
+                                                      __func__, __LINE__,
+                                                      MPI_ERR_ARG, "**ionegoffset", 0);
+                    goto fn_fail;
+                }
+                /* --END ERROR HANDLING-- */
+                break;
+            case MPI_SEEK_END:
+                /* find offset corr. to end of file */
+                ADIOI_Get_eof_offset(adio_fh, &eof_offset);
+                offset += eof_offset;
+                /* --BEGIN ERROR HANDLING-- */
+                if (offset < 0) {
+                    error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                                      MPIR_ERR_RECOVERABLE,
+                                                      __func__, __LINE__,
+                                                      MPI_ERR_ARG, "**ionegoffset", 0);
+                    goto fn_fail;
+                }
+                /* --END ERROR HANDLING-- */
+                break;
+            default:
+                /* --BEGIN ERROR HANDLING-- */
+                error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                                  MPIR_ERR_RECOVERABLE,
+                                                  __func__, __LINE__, MPI_ERR_ARG,
+                                                  "**iobadwhence", 0);
+                goto fn_fail;
+                /* --END ERROR HANDLING-- */
+        }
+
+        ADIO_Set_shared_fp(adio_fh, offset, &error_code);
+        /* --BEGIN ERROR HANDLING-- */
+        if (error_code != MPI_SUCCESS) {
+            error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                              MPIR_ERR_FATAL,
+                                              __func__, __LINE__,
+                                              MPI_ERR_INTERN, "**iosharedfailed", 0);
+            goto fn_fail;
+        }
+        /* --END ERROR HANDLING-- */
+
+    }
+
+    /* FIXME: explain why the barrier is necessary */
+    MPI_Barrier(adio_fh->comm);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_set_atomicity_impl(MPI_File fh, int flag)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    ADIOI_TEST_DEFERRED(adio_fh, __func__, &error_code);
+
+    if (flag)
+        flag = 1;       /* take care of non-one values! */
+
+    /* check if flag is the same on all processes */
+    int tmp_flag;
+    tmp_flag = flag;
+    MPI_Bcast(&tmp_flag, 1, MPI_INT, 0, adio_fh->comm);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (tmp_flag != flag) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**notsame", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    if (adio_fh->atomicity == flag) {
+        error_code = MPI_SUCCESS;
+        goto fn_exit;
+    }
+
+    ADIO_Fcntl_t *fcntl_struct;
+    fcntl_struct = (ADIO_Fcntl_t *) ADIOI_Malloc(sizeof(ADIO_Fcntl_t));
+    fcntl_struct->atomicity = flag;
+    ADIO_Fcntl(adio_fh, ADIO_FCNTL_SET_ATOMICITY, fcntl_struct, &error_code);
+    /* TODO: what do we do with this error code? */
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    ADIOI_Free(fcntl_struct);
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_set_info_impl(MPI_File fh, MPI_Info info)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    MPIO_CHECK_INFO_ALL(info, __func__, error_code, fh->comm);
+
+    /* set new info */
+    ADIO_SetInfo(adio_fh, info, &error_code);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_set_size_impl(MPI_File fh, MPI_Offset size)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+
+    if (size < 0) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobadsize", 0);
+        goto fn_fail;
+    }
+    MPIO_CHECK_WRITABLE(fh, __func__, error_code);
+
+    MPI_Offset tmp_sz, max_sz, min_sz;
+    tmp_sz = size;
+    MPI_Allreduce(&tmp_sz, &max_sz, 1, ADIO_OFFSET, MPI_MAX, adio_fh->comm);
+    MPI_Allreduce(&tmp_sz, &min_sz, 1, ADIO_OFFSET, MPI_MIN, adio_fh->comm);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (max_sz != min_sz) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**notsame", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    if (!ADIO_Feature(adio_fh, ADIO_SCALABLE_RESIZE)) {
+        /* rare stupid file systems (like NFS) need to carry out resize on all
+         * processes */
+        ADIOI_TEST_DEFERRED(adio_fh, "MPI_File_set_size", &error_code);
+    }
+
+    ADIO_Resize(adio_fh, size, &error_code);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_set_view_impl(MPI_File fh, MPI_Offset disp, MPI_Datatype etype, MPI_Datatype filetype,
+                            const char *datarep, MPI_Info info)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    if ((disp < 0) && (disp != MPI_DISPLACEMENT_CURRENT)) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobaddisp", 0);
+        goto fn_fail;
+    }
+
+    /* rudimentary checks for incorrect etype/filetype. */
+    if (etype == MPI_DATATYPE_NULL) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**ioetype", 0);
+        goto fn_fail;
+    }
+    MPIO_DATATYPE_ISCOMMITTED(etype, error_code);
+    if (error_code != MPI_SUCCESS) {
+        goto fn_fail;
+    }
+
+    if (filetype == MPI_DATATYPE_NULL) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iofiletype", 0);
+        goto fn_fail;
+    }
+    MPIO_DATATYPE_ISCOMMITTED(filetype, error_code);
+    if (error_code != MPI_SUCCESS) {
+        goto fn_fail;
+    }
+
+    if ((adio_fh->access_mode & MPI_MODE_SEQUENTIAL) && (disp != MPI_DISPLACEMENT_CURRENT)) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iodispifseq", 0);
+        goto fn_fail;
+    }
+
+    if ((disp == MPI_DISPLACEMENT_CURRENT) && !(adio_fh->access_mode & MPI_MODE_SEQUENTIAL)) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iodispifseq", 0);
+        goto fn_fail;
+    }
+    MPIO_CHECK_INFO_ALL(info, __func__, error_code, adio_fh->comm);
+    /* --END ERROR HANDLING-- */
+
+    MPI_Count filetype_size, etype_size;
+    MPI_Type_size_x(filetype, &filetype_size);
+    MPI_Type_size_x(etype, &etype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (etype_size != 0 && filetype_size % etype_size != 0) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iofiletype", 0);
+        goto fn_fail;
+    }
+
+    if ((datarep == NULL) || (strcmp(datarep, "native") &&
+                              strcmp(datarep, "NATIVE") &&
+                              strcmp(datarep, "external32") &&
+                              strcmp(datarep, "EXTERNAL32") &&
+                              strcmp(datarep, "internal") && strcmp(datarep, "INTERNAL"))) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__,
+                                          MPI_ERR_UNSUPPORTED_DATAREP, "**unsupporteddatarep", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    if (disp == MPI_DISPLACEMENT_CURRENT) {
+        ADIO_Offset shared_fp, byte_off;
+
+        MPI_Barrier(adio_fh->comm);
+        ADIO_Get_shared_fp(adio_fh, 0, &shared_fp, &error_code);
+        /* TODO: check error code */
+
+        MPI_Barrier(adio_fh->comm);
+        ADIOI_Get_byte_offset(adio_fh, shared_fp, &byte_off);
+        /* TODO: check error code */
+
+        disp = byte_off;
+    }
+
+    ADIO_Set_view(adio_fh, disp, etype, filetype, info, &error_code);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS) {
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    /* reset shared file pointer to zero */
+    if (ADIO_Feature(adio_fh, ADIO_SHARED_FP) && (adio_fh->shared_fp_fd != ADIO_FILE_NULL)) {
+        /* only one process needs to set it to zero, but I don't want to
+         * create the shared-file-pointer file if shared file pointers have
+         * not been used so far. Therefore, every process that has already
+         * opened the shared-file-pointer file sets the shared file pointer
+         * to zero. If the file was not opened, the value is automatically
+         * zero. Note that shared file pointer is stored as no. of etypes
+         * relative to the current view, whereas indiv. file pointer is
+         * stored in bytes. */
+
+        ADIO_Set_shared_fp(adio_fh, 0, &error_code);
+        /* --BEGIN ERROR HANDLING-- */
+        if (error_code != MPI_SUCCESS)
+            goto fn_fail;
+        /* --END ERROR HANDLING-- */
+    }
+
+    if (ADIO_Feature(adio_fh, ADIO_SHARED_FP)) {
+        MPI_Barrier(adio_fh->comm);     /* for above to work correctly */
+    }
+    if (strcmp(datarep, "external32") && strcmp(datarep, "EXTERNAL32"))
+        adio_fh->is_external32 = 0;
+    else
+        adio_fh->is_external32 = 1;
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_sync_impl(MPI_File fh)
+{
+    int error_code = MPI_SUCCESS;
+
+    ADIO_File adio_fh = MPIO_File_resolve(fh);
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    if ((adio_fh == NULL) || ((adio_fh)->cookie != ADIOI_FILE_COOKIE)) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobadfh", 0);
+        goto fn_fail;
+    }
+
+    MPIO_CHECK_WRITABLE(fh, __func__, error_code);
+
+    ADIO_Flush(adio_fh, &error_code);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIR_File_write_impl(MPI_File fh, const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                         MPI_Status * status)
+{
+    return MPIOI_File_write(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf, count, datatype, status);
+}
+
+int MPIR_File_write_all_impl(MPI_File fh, const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                             MPI_Status * status)
+{
+    return MPIOI_File_write_all(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf, count, datatype, status);
+}
+
+int MPIR_File_write_all_begin_impl(MPI_File fh, const void *buf, MPI_Aint count,
+                                   MPI_Datatype datatype)
+{
+    return MPIOI_File_write_all_begin(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf, count, datatype);
+}
+
+int MPIR_File_write_all_end_impl(MPI_File fh, const void *buf, MPI_Status * status)
+{
+    return MPIOI_File_write_all_end(fh, buf, status);
+}
+
+int MPIR_File_write_at_impl(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Aint count,
+                            MPI_Datatype datatype, MPI_Status * status)
+{
+    return MPIOI_File_write(fh, offset, ADIO_EXPLICIT_OFFSET, buf, count, datatype, status);
+}
+
+int MPIR_File_write_at_all_impl(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Aint count,
+                                MPI_Datatype datatype, MPI_Status * status)
+{
+    return MPIOI_File_write_all(fh, offset, ADIO_EXPLICIT_OFFSET, buf, count, datatype, status);
+}
+
+int MPIR_File_write_at_all_begin_impl(MPI_File fh, MPI_Offset offset, const void *buf,
+                                      MPI_Aint count, MPI_Datatype datatype)
+{
+    return MPIOI_File_write_all_begin(fh, offset, ADIO_EXPLICIT_OFFSET, buf, count, datatype);
+}
+
+int MPIR_File_write_at_all_end_impl(MPI_File fh, const void *buf, MPI_Status * status)
+{
+    return MPIOI_File_write_all_end(fh, buf, status);
+}
+
+int MPIR_File_write_ordered_impl(MPI_File fh, const void *buf, MPI_Aint count,
+                                 MPI_Datatype datatype, MPI_Status * status)
+{
+    return MPIOI_File_write_ordered(fh, buf, count, datatype, status);
+}
+
+int MPIR_File_write_ordered_begin_impl(MPI_File fh, const void *buf, MPI_Aint count,
+                                       MPI_Datatype datatype)
+{
+    return MPIOI_File_write_ordered_begin(fh, buf, count, datatype);
+}
+
+int MPIR_File_write_ordered_end_impl(MPI_File fh, const void *buf, MPI_Status * status)
+{
+    return MPIOI_File_write_ordered_end(fh, buf, status);
+}
+
+int MPIR_File_write_shared_impl(MPI_File fh, const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                MPI_Status * status)
+{
+    return MPIOI_File_write_shared(fh, buf, count, datatype, status);
+}
+
+int MPIR_Register_datarep_impl(ROMIO_CONST char *datarep,
+                               MPI_Datarep_conversion_function * read_conversion_fn,
+                               MPI_Datarep_conversion_function * write_conversion_fn,
+                               MPI_Datarep_extent_function * dtype_file_extent_fn,
+                               void *extra_state)
+{
+    int is_large = false;
+    return MPIOI_Register_datarep(datarep, (MPIOI_VOID_FN *) read_conversion_fn,
+                                  (MPIOI_VOID_FN *) write_conversion_fn,
+                                  dtype_file_extent_fn, extra_state, is_large);
+}
+
+int MPIR_Register_datarep_large_impl(ROMIO_CONST char *datarep,
+                                     MPI_Datarep_conversion_function_c * read_conversion_fn,
+                                     MPI_Datarep_conversion_function_c * write_conversion_fn,
+                                     MPI_Datarep_extent_function * dtype_file_extent_fn,
+                                     void *extra_state)
+{
+    int is_large = true;
+    return MPIOI_Register_datarep(datarep, (MPIOI_VOID_FN *) read_conversion_fn,
+                                  (MPIOI_VOID_FN *) write_conversion_fn,
+                                  dtype_file_extent_fn, extra_state, is_large);
+}
+
+/* internal routines */
+
+static int MPIOI_File_iread(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                            void *buf, MPI_Aint count, MPI_Datatype datatype, MPI_Request * request)
+{
+    int error_code, buftype_is_contig, filetype_is_contig;
+    MPI_Count datatype_size;
+    ADIO_Status status;
+    ADIO_File adio_fh;
+    ADIO_Offset off, bufsize;
+    MPI_Offset nbytes = 0;
+    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+
+    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    MPI_Type_size_x(datatype, &datatype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_READABLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    ADIOI_Datatype_iscontig(datatype, &buftype_is_contig);
+    ADIOI_Datatype_iscontig(adio_fh->filetype, &filetype_is_contig);
+
+    ADIOI_TEST_DEFERRED(adio_fh, __func__, &error_code);
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        MPI_Aint e32_size = 0;
+        error_code = MPIU_datatype_full_size(datatype, &e32_size);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        e32_buf = ADIOI_Malloc(e32_size * count);
+        xbuf = e32_buf;
+    } else {
+        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+    if (buftype_is_contig && filetype_is_contig) {
+        /* convert count and offset to bytes */
+        bufsize = datatype_size * count;
+
+        if (file_ptr_type == ADIO_EXPLICIT_OFFSET) {
+            off = adio_fh->disp + adio_fh->etype_size * offset;
+        } else {
+            off = adio_fh->fp_ind;
+        }
+
+        if (!(adio_fh->atomicity))
+            ADIO_IreadContig(adio_fh, xbuf, count, datatype, file_ptr_type,
+                             off, request, &error_code);
+        else {
+            /* to maintain strict atomicity semantics with other concurrent
+             * operations, lock (exclusive) and call blocking routine */
+            if (ADIO_Feature(adio_fh, ADIO_LOCKS)) {
+                ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
+            }
+
+            ADIO_ReadContig(adio_fh, xbuf, count, datatype, file_ptr_type,
+                            off, &status, &error_code);
+
+            if (ADIO_Feature(adio_fh, ADIO_LOCKS)) {
+                ADIOI_UNLOCK(adio_fh, off, SEEK_SET, bufsize);
+            }
+            if (error_code == MPI_SUCCESS) {
+                nbytes = count * datatype_size;
+            }
+            MPIO_Completed_request_create(&adio_fh, nbytes, &error_code, request);
+        }
+    } else
+        ADIO_IreadStrided(adio_fh, xbuf, count, datatype, file_ptr_type,
+                          offset, request, &error_code);
+
+    if (e32_buf != NULL) {
+        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
+        ADIOI_Free(e32_buf);
+    }
+
+    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_iread_all(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                                void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                MPI_Request * request)
+{
+    int error_code;
+    MPI_Count datatype_size;
+    ADIO_File adio_fh;
+    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+
+    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    MPI_Type_size_x(datatype, &datatype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_READABLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        MPI_Aint e32_size = 0;
+        error_code = MPIU_datatype_full_size(datatype, &e32_size);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        e32_buf = ADIOI_Malloc(e32_size * count);
+        xbuf = e32_buf;
+    } else {
+        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+    ADIO_IreadStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
+                          offset, request, &error_code);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    if (e32_buf != NULL) {
+        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
+        ADIOI_Free(e32_buf);
+    }
+
+    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_iread_shared(MPI_File fh, void *buf, MPI_Aint count,
+                                   MPI_Datatype datatype, MPI_Request * request)
+{
+    int error_code, buftype_is_contig, filetype_is_contig;
+    ADIO_Offset bufsize;
+    ADIO_File adio_fh;
+    MPI_Count datatype_size, incr;
+    MPI_Status status;
+    ADIO_Offset off, shared_fp;
+    MPI_Offset nbytes = 0;
+    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    MPI_Type_size_x(datatype, &datatype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    ADIOI_Datatype_iscontig(datatype, &buftype_is_contig);
+    ADIOI_Datatype_iscontig(adio_fh->filetype, &filetype_is_contig);
+
+    ADIOI_TEST_DEFERRED(adio_fh, __func__, &error_code);
+
+    incr = (count * datatype_size) / adio_fh->etype_size;
+    ADIO_Get_shared_fp(adio_fh, incr, &shared_fp, &error_code);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS) {
+        /* note: ADIO_Get_shared_fp should have set up error code already? */
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        MPI_Aint e32_size = 0;
+        error_code = MPIU_datatype_full_size(datatype, &e32_size);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        e32_buf = ADIOI_Malloc(e32_size * count);
+        xbuf = e32_buf;
+    } else {
+        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+    if (buftype_is_contig && filetype_is_contig) {
+        /* convert count and shared_fp to bytes */
+        bufsize = datatype_size * count;
+        off = adio_fh->disp + adio_fh->etype_size * shared_fp;
+        if (!(adio_fh->atomicity)) {
+            ADIO_IreadContig(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
+                             off, request, &error_code);
+        } else {
+            /* to maintain strict atomicity semantics with other concurrent
+             * operations, lock (exclusive) and call blocking routine */
+
+            if (adio_fh->file_system != ADIO_NFS) {
+                ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
+            }
+
+            ADIO_ReadContig(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
+                            off, &status, &error_code);
+
+            if (adio_fh->file_system != ADIO_NFS) {
+                ADIOI_UNLOCK(adio_fh, off, SEEK_SET, bufsize);
+            }
+            if (error_code == MPI_SUCCESS) {
+                nbytes = count * datatype_size;
+            }
+            MPIO_Completed_request_create(&adio_fh, nbytes, &error_code, request);
+        }
+    } else {
+        ADIO_IreadStrided(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
+                          shared_fp, request, &error_code);
+    }
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    if (e32_buf != NULL) {
+        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
+        ADIOI_Free(e32_buf);
+    }
+
+    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_iwrite(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                             const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                             MPI_Request * request)
+{
+    int error_code, buftype_is_contig, filetype_is_contig;
+    MPI_Count datatype_size;
+    ADIO_Status status;
+    ADIO_Offset off, bufsize;
+    ADIO_File adio_fh;
+    MPI_Offset nbytes = 0;
+    void *e32buf = NULL;
+    const void *xbuf = NULL;
+    void *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+
+    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    MPI_Type_size_x(datatype, &datatype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_WRITABLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    ADIOI_Datatype_iscontig(datatype, &buftype_is_contig);
+    ADIOI_Datatype_iscontig(adio_fh->filetype, &filetype_is_contig);
+
+    ADIOI_TEST_DEFERRED(adio_fh, __func__, &error_code);
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+    if (buftype_is_contig && filetype_is_contig) {
+        /* convert sizes to bytes */
+        bufsize = datatype_size * count;
+        if (file_ptr_type == ADIO_EXPLICIT_OFFSET) {
+            off = adio_fh->disp + adio_fh->etype_size * offset;
+        } else {
+            off = adio_fh->fp_ind;
+        }
+
+        if (!(adio_fh->atomicity)) {
+            ADIO_IwriteContig(adio_fh, xbuf, count, datatype, file_ptr_type,
+                              off, request, &error_code);
+        } else {
+            /* to maintain strict atomicity semantics with other concurrent
+             * operations, lock (exclusive) and call blocking routine */
+            if (ADIO_Feature(adio_fh, ADIO_LOCKS)) {
+                ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
+            }
+
+            ADIO_WriteContig(adio_fh, xbuf, count, datatype, file_ptr_type, off,
+                             &status, &error_code);
+
+            if (ADIO_Feature(adio_fh, ADIO_LOCKS)) {
+                ADIOI_UNLOCK(adio_fh, off, SEEK_SET, bufsize);
+            }
+            if (error_code == MPI_SUCCESS) {
+                nbytes = count * datatype_size;
+            }
+
+            MPIO_Completed_request_create(&adio_fh, nbytes, &error_code, request);
+        }
+    } else {
+        ADIO_IwriteStrided(adio_fh, xbuf, count, datatype, file_ptr_type,
+                           offset, request, &error_code);
+    }
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
+
+  fn_exit:
+    if (e32buf != NULL)
+        ADIOI_Free(e32buf);
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_iwrite_all(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                                 const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                 MPI_Request * request)
+{
+    int error_code;
+    MPI_Count datatype_size;
+    ADIO_File adio_fh;
+    void *e32buf = NULL;
+    const void *xbuf = NULL;
+    void *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+
+    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    MPI_Type_size_x(datatype, &datatype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_WRITABLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+    ADIO_IwriteStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
+                           offset, request, &error_code);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
+
+  fn_exit:
+    if (e32buf != NULL)
+        ADIOI_Free(e32buf);
+
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_iwrite_shared(MPI_File fh, const void *buf, MPI_Aint count,
+                                    MPI_Datatype datatype, MPIO_Request * request)
+{
+    int error_code, buftype_is_contig, filetype_is_contig;
+    ADIO_File adio_fh;
+    ADIO_Offset incr, bufsize;
+    MPI_Count datatype_size;
+    ADIO_Status status;
+    ADIO_Offset off, shared_fp;
+    void *e32buf = NULL;
+    const void *xbuf = NULL;
+    void *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    MPI_Type_size_x(datatype, &datatype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    ADIOI_Datatype_iscontig(datatype, &buftype_is_contig);
+    ADIOI_Datatype_iscontig(adio_fh->filetype, &filetype_is_contig);
+
+    ADIOI_TEST_DEFERRED(adio_fh, __func__, &error_code);
+
+    incr = (count * datatype_size) / adio_fh->etype_size;
+    ADIO_Get_shared_fp(adio_fh, incr, &shared_fp, &error_code);
+    if (error_code != MPI_SUCCESS) {
+        /* note: ADIO_Get_shared_fp should have set up error code already? */
+        goto fn_fail;
+    }
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+    /* contiguous or strided? */
+    if (buftype_is_contig && filetype_is_contig) {
+        /* convert sizes to bytes */
+        bufsize = datatype_size * count;
+        off = adio_fh->disp + adio_fh->etype_size * shared_fp;
+        if (!(adio_fh->atomicity))
+            ADIO_IwriteContig(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
+                              off, request, &error_code);
+        else {
+            /* to maintain strict atomicity semantics with other concurrent
+             * operations, lock (exclusive) and call blocking routine */
+
+            if (adio_fh->file_system != ADIO_NFS)
+                ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
+
+            ADIO_WriteContig(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
+                             off, &status, &error_code);
+
+            if (adio_fh->file_system != ADIO_NFS)
+                ADIOI_UNLOCK(adio_fh, off, SEEK_SET, bufsize);
+
+            MPIO_Completed_request_create(&adio_fh, bufsize, &error_code, request);
+        }
+    } else
+        ADIO_IwriteStrided(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
+                           shared_fp, request, &error_code);
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
+
+  fn_exit:
+    if (e32buf != NULL)
+        ADIOI_Free(e32buf);
+
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_read(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                           void *buf, MPI_Aint count, MPI_Datatype datatype, MPI_Status * status)
+{
+    int error_code, buftype_is_contig, filetype_is_contig;
+    MPI_Count datatype_size;
+    ADIO_File adio_fh;
+    ADIO_Offset off, bufsize;
+    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+
+    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    MPI_Type_size_x(datatype, &datatype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    if (count * datatype_size == 0) {
+#ifdef HAVE_STATUS_SET_BYTES
+        MPIR_Status_set_bytes(status, datatype, 0);
+#endif
+        error_code = MPI_SUCCESS;
+        goto fn_exit;
+    }
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_READABLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    ADIOI_Datatype_iscontig(datatype, &buftype_is_contig);
+    ADIOI_Datatype_iscontig(adio_fh->filetype, &filetype_is_contig);
+
+    ADIOI_TEST_DEFERRED(adio_fh, __func__, &error_code);
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        MPI_Aint e32_size = 0;
+        error_code = MPIU_datatype_full_size(datatype, &e32_size);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        e32_buf = ADIOI_Malloc(e32_size * count);
+        xbuf = e32_buf;
+    } else {
+        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+    if (buftype_is_contig && filetype_is_contig) {
+        /* convert count and offset to bytes */
+        bufsize = datatype_size * count;
+        if (file_ptr_type == ADIO_EXPLICIT_OFFSET) {
+            off = adio_fh->disp + adio_fh->etype_size * offset;
+        } else {        /* ADIO_INDIVIDUAL */
+
+            off = adio_fh->fp_ind;
+        }
+
+        /* if atomic mode requested, lock (exclusive) the region, because
+         * there could be a concurrent noncontiguous request.
+         */
+        if ((adio_fh->atomicity) && ADIO_Feature(adio_fh, ADIO_LOCKS)) {
+            ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
+        }
+
+        ADIO_ReadContig(adio_fh, xbuf, count, datatype, file_ptr_type, off, status, &error_code);
+
+        if ((adio_fh->atomicity) && ADIO_Feature(adio_fh, ADIO_LOCKS)) {
+            ADIOI_UNLOCK(adio_fh, off, SEEK_SET, bufsize);
+        }
+    } else {
+        ADIO_ReadStrided(adio_fh, xbuf, count, datatype, file_ptr_type,
+                         offset, status, &error_code);
+        /* For strided and atomic mode, locking is done in ADIO_ReadStrided */
+    }
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    if (e32_buf != NULL) {
+        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
+        ADIOI_Free(e32_buf);
+    }
+
+    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_read_all(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                               void *buf, MPI_Aint count, MPI_Datatype datatype,
+                               MPI_Status * status)
+{
+    int error_code;
+    MPI_Count datatype_size;
+    ADIO_File adio_fh;
+    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+
+    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    MPI_Type_size_x(datatype, &datatype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_READABLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        MPI_Aint e32_size = 0;
+        error_code = MPIU_datatype_full_size(datatype, &e32_size);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        e32_buf = ADIOI_Malloc(e32_size * count);
+        xbuf = e32_buf;
+    } else {
+        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+    ADIO_ReadStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
+                         offset, status, &error_code);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    if (e32_buf != NULL) {
+        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
+        ADIOI_Free(e32_buf);
+    }
+
+    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_read_all_begin(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                                     void *buf, MPI_Aint count, MPI_Datatype datatype)
+{
+    int error_code;
+    MPI_Count datatype_size;
+    ADIO_File adio_fh;
+    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+
+    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    MPI_Type_size_x(datatype, &datatype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_READABLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+
+    if (adio_fh->split_coll_count) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_IO, "**iosplitcoll", 0);
+        goto fn_fail;
+    }
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    adio_fh->split_coll_count = 1;
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        MPI_Aint e32_size = 0;
+        error_code = MPIU_datatype_full_size(datatype, &e32_size);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        e32_buf = ADIOI_Malloc(e32_size * count);
+        xbuf = e32_buf;
+    } else {
+        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+    ADIO_ReadStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
+                         offset, &adio_fh->split_status, &error_code);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    if (e32_buf != NULL) {
+        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
+        ADIOI_Free(e32_buf);
+    }
+
+    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_read_all_end(MPI_File fh, void *buf, MPI_Status * status)
+{
+    int error_code = MPI_SUCCESS;
+    ADIO_File adio_fh;
+
+    MPL_UNREFERENCED_ARG(buf);
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    if (!(adio_fh->split_coll_count)) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_IO, "**iosplitcollnone", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+#ifdef HAVE_STATUS_SET_BYTES
+    if (status != MPI_STATUS_IGNORE)
+        *status = adio_fh->split_status;
+#endif
+    adio_fh->split_coll_count = 0;
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_read_ordered(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                   MPI_Status * status)
+{
+    int error_code, nprocs, myrank;
+    ADIO_Offset incr;
+    MPI_Count datatype_size;
+    int source, dest;
+    ADIO_Offset shared_fp = 0;
+    ADIO_File adio_fh;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    MPI_Type_size_x(datatype, &datatype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    ADIOI_TEST_DEFERRED(adio_fh, "MPI_File_read_ordered", &error_code);
+
+    MPI_Comm_size(adio_fh->comm, &nprocs);
+    MPI_Comm_rank(adio_fh->comm, &myrank);
+
+    incr = (count * datatype_size) / adio_fh->etype_size;
+
+    /* Use a message as a 'token' to order the operations */
+    source = myrank - 1;
+    dest = myrank + 1;
+    if (source < 0)
+        source = MPI_PROC_NULL;
+    if (dest >= nprocs)
+        dest = MPI_PROC_NULL;
+    MPI_Recv(NULL, 0, MPI_BYTE, source, 0, adio_fh->comm, MPI_STATUS_IGNORE);
+
+    ADIO_Get_shared_fp(adio_fh, incr, &shared_fp, &error_code);
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS) {
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    MPI_Send(NULL, 0, MPI_BYTE, dest, 0, adio_fh->comm);
+
+    ADIO_ReadStridedColl(adio_fh, buf, count, datatype, ADIO_EXPLICIT_OFFSET,
+                         shared_fp, status, &error_code);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+  fn_exit:
+    /* FIXME: Check for error code from ReadStridedColl? */
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_read_ordered_begin(MPI_File fh,
+                                         void *buf, MPI_Aint count, MPI_Datatype datatype)
+{
+    int error_code, nprocs, myrank;
+    MPI_Count datatype_size;
+    int source, dest;
+    ADIO_Offset shared_fp, incr;
+    ADIO_File adio_fh;
+    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+
+    if (adio_fh->split_coll_count) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_IO, "**iosplitcoll", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    adio_fh->split_coll_count = 1;
+
+
+    MPI_Type_size_x(datatype, &datatype_size);
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    ADIOI_TEST_DEFERRED(adio_fh, __func__, &error_code);
+
+    MPI_Comm_size(adio_fh->comm, &nprocs);
+    MPI_Comm_rank(adio_fh->comm, &myrank);
+
+    incr = (count * datatype_size) / adio_fh->etype_size;
+    /* Use a message as a 'token' to order the operations */
+    source = myrank - 1;
+    dest = myrank + 1;
+    if (source < 0)
+        source = MPI_PROC_NULL;
+    if (dest >= nprocs)
+        dest = MPI_PROC_NULL;
+    MPI_Recv(NULL, 0, MPI_BYTE, source, 0, adio_fh->comm, MPI_STATUS_IGNORE);
+
+    ADIO_Get_shared_fp(adio_fh, incr, &shared_fp, &error_code);
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS) {
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    MPI_Send(NULL, 0, MPI_BYTE, dest, 0, adio_fh->comm);
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        MPI_Aint e32_size = 0;
+        error_code = MPIU_datatype_full_size(datatype, &e32_size);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        e32_buf = ADIOI_Malloc(e32_size * count);
+        xbuf = e32_buf;
+    } else {
+        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+
+    ADIO_ReadStridedColl(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
+                         shared_fp, &adio_fh->split_status, &error_code);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    if (e32_buf != NULL) {
+        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
+        ADIOI_Free(e32_buf);
+    }
+
+    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_read_ordered_end(MPI_File fh, void *buf, MPI_Status * status)
+{
+    int error_code = MPI_SUCCESS;
+    ADIO_File adio_fh;
+
+    MPL_UNREFERENCED_ARG(buf);
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    if (!(adio_fh->split_coll_count)) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_IO, "**iosplitcollnone", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+#ifdef HAVE_STATUS_SET_BYTES
+    if (status != MPI_STATUS_IGNORE)
+        *status = adio_fh->split_status;
+#endif
+    adio_fh->split_coll_count = 0;
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_read_shared(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                  MPI_Status * status)
+{
+    int error_code, buftype_is_contig, filetype_is_contig;
+    MPI_Count datatype_size;
+    ADIO_Offset off, shared_fp, incr, bufsize;
+    ADIO_File adio_fh;
+    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    MPI_Type_size_x(datatype, &datatype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    if (count * datatype_size == 0) {
+#ifdef HAVE_STATUS_SET_BYTES
+        MPIR_Status_set_bytes(status, datatype, 0);
+#endif
+        error_code = MPI_SUCCESS;
+        goto fn_exit;
+    }
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_READABLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    ADIOI_Datatype_iscontig(datatype, &buftype_is_contig);
+    ADIOI_Datatype_iscontig(adio_fh->filetype, &filetype_is_contig);
+
+    ADIOI_TEST_DEFERRED(adio_fh, __func__, &error_code);
+
+    incr = (count * datatype_size) / adio_fh->etype_size;
+
+    ADIO_Get_shared_fp(adio_fh, incr, &shared_fp, &error_code);
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS) {
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        MPI_Aint e32_size = 0;
+        error_code = MPIU_datatype_full_size(datatype, &e32_size);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        e32_buf = ADIOI_Malloc(e32_size * count);
+        xbuf = e32_buf;
+    } else {
+        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+    /* contiguous or strided? */
+    if (buftype_is_contig && filetype_is_contig) {
+        /* convert count and shared_fp to bytes */
+        bufsize = datatype_size * count;
+        off = adio_fh->disp + adio_fh->etype_size * shared_fp;
+
+        /* if atomic mode requested, lock (exclusive) the region, because there
+         * could be a concurrent noncontiguous request. On NFS, locking
+         * is done in the ADIO_ReadContig. */
+
+        if ((adio_fh->atomicity) && (adio_fh->file_system != ADIO_NFS))
+            ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
+
+        ADIO_ReadContig(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
+                        off, status, &error_code);
+
+        if ((adio_fh->atomicity) && (adio_fh->file_system != ADIO_NFS))
+            ADIOI_UNLOCK(adio_fh, off, SEEK_SET, bufsize);
+    } else {
+        ADIO_ReadStrided(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
+                         shared_fp, status, &error_code);
+        /* For strided and atomic mode, locking is done in ADIO_ReadStrided */
+    }
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    if (e32_buf != NULL) {
+        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
+        ADIOI_Free(e32_buf);
+    }
+
+    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_write(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                            const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                            MPI_Status * status)
+{
+    int error_code, buftype_is_contig, filetype_is_contig;
+    MPI_Count datatype_size;
+    ADIO_Offset off, bufsize;
+    ADIO_File adio_fh;
+    void *e32buf = NULL;
+    const void *xbuf = NULL;
+    void *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+
+    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    MPI_Type_size_x(datatype, &datatype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    if (count * datatype_size == 0) {
+#ifdef HAVE_STATUS_SET_BYTES
+        MPIR_Status_set_bytes(status, datatype, 0);
+#endif
+        error_code = MPI_SUCCESS;
+        goto fn_exit;
+    }
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_WRITABLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    ADIOI_Datatype_iscontig(datatype, &buftype_is_contig);
+    ADIOI_Datatype_iscontig(adio_fh->filetype, &filetype_is_contig);
+
+    ADIOI_TEST_DEFERRED(adio_fh, __func__, &error_code);
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+    if (buftype_is_contig && filetype_is_contig) {
+        /* convert bufcount and offset to bytes */
+        bufsize = datatype_size * count;
+        if (file_ptr_type == ADIO_EXPLICIT_OFFSET) {
+            off = adio_fh->disp + adio_fh->etype_size * offset;
+        } else {        /* ADIO_INDIVIDUAL */
+
+            off = adio_fh->fp_ind;
+        }
+
+        /* if atomic mode requested, lock (exclusive) the region, because
+         * there could be a concurrent noncontiguous request. Locking doesn't
+         * work on some parallel file systems, and on NFS it is done in the
+         * ADIO_WriteContig.
+         */
+
+        if ((adio_fh->atomicity) && ADIO_Feature(adio_fh, ADIO_LOCKS)) {
+            ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
+        }
+
+        ADIO_WriteContig(adio_fh, xbuf, count, datatype, file_ptr_type, off, status, &error_code);
+
+        if ((adio_fh->atomicity) && ADIO_Feature(adio_fh, ADIO_LOCKS)) {
+            ADIOI_UNLOCK(adio_fh, off, SEEK_SET, bufsize);
+        }
+    } else {
+        /* For strided and atomic mode, locking is done in ADIO_WriteStrided */
+        ADIO_WriteStrided(adio_fh, xbuf, count, datatype, file_ptr_type,
+                          offset, status, &error_code);
+    }
+
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
+
+  fn_exit:
+    if (e32buf != NULL)
+        ADIOI_Free(e32buf);
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_write_all(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                                const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                MPI_Status * status)
+{
+    int error_code;
+    MPI_Count datatype_size;
+    ADIO_File adio_fh;
+    void *e32buf = NULL;
+    const void *xbuf = NULL;
+    void *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+
+    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    MPI_Type_size_x(datatype, &datatype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_WRITABLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+    ADIO_WriteStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
+                          offset, status, &error_code);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
+
+  fn_exit:
+    if (e32buf != NULL)
+        ADIOI_Free(e32buf);
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_write_all_begin(MPI_File fh, MPI_Offset offset, int file_ptr_type,
+                                      const void *buf, MPI_Aint count, MPI_Datatype datatype)
+{
+    int error_code;
+    MPI_Count datatype_size;
+    ADIO_File adio_fh;
+    void *e32buf = NULL;
+    const void *xbuf = NULL;
+    void *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, __func__, error_code);
+
+    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
+        goto fn_fail;
+    }
+
+    if (adio_fh->split_coll_count) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_IO, "**iosplitcoll", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    adio_fh->split_coll_count = 1;
+
+    MPI_Type_size_x(datatype, &datatype_size);
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+    adio_fh->split_datatype = datatype;
+    ADIO_WriteStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
+                          offset, &adio_fh->split_status, &error_code);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
+
+  fn_exit:
+    if (e32buf != NULL)
+        ADIOI_Free(e32buf);
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_write_all_end(MPI_File fh, const void *buf, MPI_Status * status)
+{
+    int error_code;
+    ADIO_File adio_fh;
+
+    MPL_UNREFERENCED_ARG(buf);
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    if (!(adio_fh->split_coll_count)) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_IO, "**iosplitcollnone", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+#ifdef HAVE_STATUS_SET_BYTES
+    /* FIXME - we should really ensure that the split_datatype remains
+     * valid by incrementing the ref count in the write_allb.c routine
+     * and decrement it here after setting the bytes */
+    if (status != MPI_STATUS_IGNORE)
+        *status = adio_fh->split_status;
+#endif
+    adio_fh->split_coll_count = 0;
+
+    error_code = MPI_SUCCESS;
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_write_ordered(MPI_File fh, const void *buf, MPI_Aint count,
+                                    MPI_Datatype datatype, MPI_Status * status)
+{
+    int error_code, nprocs, myrank;
+    ADIO_Offset incr;
+    MPI_Count datatype_size;
+    int source, dest;
+    ADIO_Offset shared_fp;
+    ADIO_File adio_fh;
+    void *e32buf = NULL;
+    const void *xbuf;
+    void *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    MPI_Type_size_x(datatype, &datatype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    ADIOI_TEST_DEFERRED(adio_fh, __func__, &error_code);
+
+    MPI_Comm_size(adio_fh->comm, &nprocs);
+    MPI_Comm_rank(adio_fh->comm, &myrank);
+
+    incr = (count * datatype_size) / adio_fh->etype_size;
+    /* Use a message as a 'token' to order the operations */
+    source = myrank - 1;
+    dest = myrank + 1;
+    if (source < 0)
+        source = MPI_PROC_NULL;
+    if (dest >= nprocs)
+        dest = MPI_PROC_NULL;
+    MPI_Recv(NULL, 0, MPI_BYTE, source, 0, adio_fh->comm, MPI_STATUS_IGNORE);
+
+    ADIO_Get_shared_fp(adio_fh, incr, &shared_fp, &error_code);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_FATAL,
+                                          __func__, __LINE__, MPI_ERR_INTERN, "**iosharedfailed",
+                                          0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    MPI_Send(NULL, 0, MPI_BYTE, dest, 0, adio_fh->comm);
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+    ADIO_WriteStridedColl(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
+                          shared_fp, status, &error_code);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
+
+  fn_exit:
+    if (e32buf != NULL)
+        ADIOI_Free(e32buf);
+    /* FIXME: Check for error code from WriteStridedColl? */
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_write_ordered_begin(MPI_File fh, const void *buf, MPI_Aint count,
+                                          MPI_Datatype datatype)
+{
+    int error_code, nprocs, myrank;
+    ADIO_Offset incr;
+    MPI_Count datatype_size;
+    int source, dest;
+    ADIO_Offset shared_fp;
+    ADIO_File adio_fh;
+    void *e32buf = NULL;
+    const void *xbuf = NULL;
+    void *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+
+    if (adio_fh->split_coll_count) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_IO, "**iosplitcoll", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    adio_fh->split_coll_count = 1;
+
+    MPI_Type_size_x(datatype, &datatype_size);
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    ADIOI_TEST_DEFERRED(adio_fh, __func__, &error_code);
+
+    MPI_Comm_size(adio_fh->comm, &nprocs);
+    MPI_Comm_rank(adio_fh->comm, &myrank);
+
+    incr = (count * datatype_size) / adio_fh->etype_size;
+    /* Use a message as a 'token' to order the operations */
+    source = myrank - 1;
+    dest = myrank + 1;
+    if (source < 0)
+        source = MPI_PROC_NULL;
+    if (dest >= nprocs)
+        dest = MPI_PROC_NULL;
+    MPI_Recv(NULL, 0, MPI_BYTE, source, 0, adio_fh->comm, MPI_STATUS_IGNORE);
+
+    ADIO_Get_shared_fp(adio_fh, incr, &shared_fp, &error_code);
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_FATAL,
+                                          __func__, __LINE__, MPI_ERR_INTERN, "**iosharedfailed",
+                                          0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    MPI_Send(NULL, 0, MPI_BYTE, dest, 0, adio_fh->comm);
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+    ADIO_WriteStridedColl(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
+                          shared_fp, &adio_fh->split_status, &error_code);
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
+
+  fn_exit:
+    /* FIXME: Check for error code from WriteStridedColl? */
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_write_ordered_end(MPI_File fh, const void *buf, MPI_Status * status)
+{
+    int error_code = MPI_SUCCESS;
+    ADIO_File adio_fh;
+
+    MPL_UNREFERENCED_ARG(buf);
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+
+    if (!(adio_fh->split_coll_count)) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          __func__, __LINE__, MPI_ERR_IO, "**iosplitcollnone", 0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+#ifdef HAVE_STATUS_SET_BYTES
+    if (status != MPI_STATUS_IGNORE)
+        *status = adio_fh->split_status;
+#endif
+    adio_fh->split_coll_count = 0;
+
+
+  fn_exit:
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_File_write_shared(MPI_File fh, const void *buf, MPI_Aint count,
+                                   MPI_Datatype datatype, MPI_Status * status)
+{
+    int error_code, buftype_is_contig, filetype_is_contig;
+    ADIO_Offset bufsize;
+    MPI_Count datatype_size, incr;
+    ADIO_Offset off, shared_fp;
+    ADIO_File adio_fh;
+    void *e32buf = NULL;
+    const void *xbuf = NULL;
+    void *host_buf = NULL;
+
+    adio_fh = MPIO_File_resolve(fh);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_FILE_HANDLE(adio_fh, __func__, error_code);
+    MPIO_CHECK_COUNT(adio_fh, count, __func__, error_code);
+    MPIO_CHECK_DATATYPE(adio_fh, datatype, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    MPI_Type_size_x(datatype, &datatype_size);
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    if (count * datatype_size == 0) {
+#ifdef HAVE_STATUS_SET_BYTES
+        MPIR_Status_set_bytes(status, datatype, 0);
+#endif
+        error_code = MPI_SUCCESS;
+        goto fn_exit;
+    }
+
+    /* --BEGIN ERROR HANDLING-- */
+    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, __func__, error_code);
+    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, __func__, error_code);
+    /* --END ERROR HANDLING-- */
+
+    ADIOI_Datatype_iscontig(datatype, &buftype_is_contig);
+    ADIOI_Datatype_iscontig(adio_fh->filetype, &filetype_is_contig);
+
+    ADIOI_TEST_DEFERRED(adio_fh, __func__, &error_code);
+
+    incr = (count * datatype_size) / adio_fh->etype_size;
+
+    ADIO_Get_shared_fp(adio_fh, incr, &shared_fp, &error_code);
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_FATAL,
+                                          __func__, __LINE__, MPI_ERR_INTERN, "**iosharedfailed",
+                                          0);
+        goto fn_fail;
+    }
+    /* --END ERROR HANDLING-- */
+
+    xbuf = buf;
+    if (adio_fh->is_external32) {
+        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
+        if (error_code != MPI_SUCCESS)
+            goto fn_exit;
+
+        xbuf = e32buf;
+    } else {
+        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
+        if (host_buf != NULL) {
+            xbuf = host_buf;
+        }
+    }
+
+    if (buftype_is_contig && filetype_is_contig) {
+        /* convert bufocunt and shared_fp to bytes */
+        bufsize = datatype_size * count;
+        off = adio_fh->disp + adio_fh->etype_size * shared_fp;
+
+        /* if atomic mode requested, lock (exclusive) the region, because there
+         * could be a concurrent noncontiguous request. On NFS, locking is
+         * done in the ADIO_WriteContig. */
+
+        if ((adio_fh->atomicity) && (adio_fh->file_system != ADIO_NFS))
+            ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
+
+        ADIO_WriteContig(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
+                         off, status, &error_code);
+
+        if ((adio_fh->atomicity) && (adio_fh->file_system != ADIO_NFS))
+            ADIOI_UNLOCK(adio_fh, off, SEEK_SET, bufsize);
+    } else {
+        ADIO_WriteStrided(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
+                          shared_fp, status, &error_code);
+        /* For strided and atomic mode, locking is done in ADIO_WriteStrided */
+    }
+
+    /* --BEGIN ERROR HANDLING-- */
+    if (error_code != MPI_SUCCESS)
+        goto fn_fail;
+    /* --END ERROR HANDLING-- */
+
+    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
+
+  fn_exit:
+    if (e32buf != NULL)
+        ADIOI_Free(e32buf);
+    return error_code;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int MPIOI_Register_datarep(const char *datarep,
+                                  MPIOI_VOID_FN * read_conversion_fn,
+                                  MPIOI_VOID_FN * write_conversion_fn,
+                                  MPI_Datarep_extent_function * dtype_file_extent_fn,
+                                  void *extra_state, int is_large)
+{
+    int error_code;
+    ADIOI_Datarep *adio_datarep;
+    static char myname[] = "MPI_REGISTER_DATAREP";
+
+    ROMIO_THREAD_CS_ENTER();
+
+    /* --BEGIN ERROR HANDLING-- */
+    /* check datarep name (use strlen instead of strnlen because
+     * strnlen is not portable) */
+    if (datarep == NULL || strlen(datarep) < 1 || strlen(datarep) > MPI_MAX_DATAREP_STRING) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                          MPIR_ERR_RECOVERABLE,
+                                          myname, __LINE__, MPI_ERR_ARG, "**datarepname", 0);
+        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+        goto fn_exit;
+    }
+    /* --END ERROR HANDLING-- */
+
+    MPIR_MPIOInit(&error_code);
+    if (error_code != MPI_SUCCESS)
+        goto fn_exit;
+
+    /* --BEGIN ERROR HANDLING-- */
+    /* check datarep isn't already registered */
+    for (adio_datarep = ADIOI_Datarep_head; adio_datarep; adio_datarep = adio_datarep->next) {
+        if (!strncmp(datarep, adio_datarep->name, MPI_MAX_DATAREP_STRING)) {
+            error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                              MPIR_ERR_RECOVERABLE,
+                                              myname, __LINE__,
+                                              MPI_ERR_DUP_DATAREP,
+                                              "**datarepused", "**datarepused %s", datarep);
+            error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+            goto fn_exit;
+        }
+    }
+
+    /* Check Non-NULL Read and Write conversion function pointer */
+    /* Read and Write conversions are currently not supported.   */
+    if ((read_conversion_fn != NULL) || (write_conversion_fn != NULL)) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
+                                          myname, __LINE__,
+                                          MPI_ERR_CONVERSION, "**drconvnotsupported", 0);
+
+        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+        goto fn_exit;
+    }
+
+    /* check extent function pointer */
+    if (dtype_file_extent_fn == NULL) {
+        error_code = MPIO_Err_create_code(MPI_SUCCESS,
+                                          MPIR_ERR_RECOVERABLE,
+                                          myname, __LINE__, MPI_ERR_ARG, "**datarepextent", 0);
+        error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
+        goto fn_exit;
+    }
+    /* --END ERROR HANDLING-- */
+
+    adio_datarep = ADIOI_Malloc(sizeof(ADIOI_Datarep));
+    adio_datarep->name = ADIOI_Strdup(datarep);
+    adio_datarep->state = extra_state;
+    adio_datarep->is_large = is_large;
+    if (is_large) {
+        adio_datarep->u.large.read_conv_fn =
+            (MPI_Datarep_conversion_function_c *) read_conversion_fn;
+        adio_datarep->u.large.write_conv_fn =
+            (MPI_Datarep_conversion_function_c *) write_conversion_fn;
+    } else {
+        adio_datarep->u.small.read_conv_fn = (MPI_Datarep_conversion_function *) read_conversion_fn;
+        adio_datarep->u.small.write_conv_fn =
+            (MPI_Datarep_conversion_function *) write_conversion_fn;
+    }
+    adio_datarep->extent_fn = dtype_file_extent_fn;
+    adio_datarep->next = ADIOI_Datarep_head;
+
+    ADIOI_Datarep_head = adio_datarep;
+
+    error_code = MPI_SUCCESS;
+
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
+
+    return error_code;
+}

--- a/src/mpi/romio/mpi-io/iotest.c
+++ b/src/mpi/romio/mpi-io/iotest.c
@@ -45,13 +45,6 @@ int MPIO_Test(MPIO_Request * request, int *flag, MPI_Status * status)
 {
     int error_code;
     static char myname[] = "MPIO_TEST";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    if (*request != MPIO_REQUEST_NULL) {
-        HPMP_IO_WSTART(fl_xmpi, BLKMPIOTEST, TRDTSYSTEM, (*request)->fd);
-    }
-#endif /* MPI_hpux */
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -78,9 +71,6 @@ int MPIO_Test(MPIO_Request * request, int *flag, MPI_Status * status)
             break;
     }
 
-#ifdef MPI_hpux
-    HPMP_IO_WEND(fl_xmpi);
-#endif /* MPI_hpux */
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();

--- a/src/mpi/romio/mpi-io/iowait.c
+++ b/src/mpi/romio/mpi-io/iowait.c
@@ -45,13 +45,6 @@ int MPIO_Wait(MPIO_Request * request, MPI_Status * status)
     int error_code;
     static char myname[] = "MPIO_WAIT";
 
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    if (*request != MPIO_REQUEST_NULL) {
-        HPMP_IO_WSTART(fl_xmpi, BLKMPIOWAIT, TRDTBLOCK, (*request)->fd);
-    }
-#endif /* MPI_hpux */
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -79,9 +72,6 @@ int MPIO_Wait(MPIO_Request * request, MPI_Status * status)
             break;
     }
 
-#ifdef MPI_hpux
-    HPMP_IO_WEND(fl_xmpi);
-#endif /* MPI_hpux */
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();

--- a/src/mpi/romio/mpi-io/iread.c
+++ b/src/mpi/romio/mpi-io/iread.c
@@ -61,11 +61,6 @@ int MPI_File_iread(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI
 {
     int error_code = MPI_SUCCESS;
     static char myname[] = "MPI_FILE_IREAD";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEIREAD, TRDTSYSTEM, fh, datatype, count);
-#endif /* MPI_hpux */
 
 
     error_code = MPIOI_File_iread(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
@@ -76,9 +71,6 @@ int MPI_File_iread(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI
         error_code = MPIO_Err_return_file(fh, error_code);
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }
@@ -109,11 +101,6 @@ int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datat
 {
     int error_code = MPI_SUCCESS;
     static char myname[] = "MPI_FILE_IREAD";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEIREAD, TRDTSYSTEM, fh, datatype, count);
-#endif /* MPI_hpux */
 
 
     error_code = MPIOI_File_iread(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
@@ -124,9 +111,6 @@ int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datat
         error_code = MPIO_Err_return_file(fh, error_code);
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/iread.c
+++ b/src/mpi/romio/mpi-io/iread.c
@@ -59,20 +59,20 @@ Output Parameters:
 @*/
 int MPI_File_iread(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request * request)
 {
-    int error_code = MPI_SUCCESS;
-    static char myname[] = "MPI_FILE_IREAD";
+    int error_code;
+    ROMIO_THREAD_CS_ENTER();
 
+    error_code = MPIR_File_iread_impl(fh, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-    error_code = MPIOI_File_iread(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
-                                  buf, count, datatype, myname, request);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -99,127 +99,18 @@ Output Parameters:
 int MPI_File_iread_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype,
                      MPI_Request * request)
 {
-    int error_code = MPI_SUCCESS;
-    static char myname[] = "MPI_FILE_IREAD";
-
-
-    error_code = MPIOI_File_iread(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
-                                  buf, count, datatype, myname, request);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-
-    return error_code;
-}
-
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_iread(MPI_File fh, MPI_Offset offset, int file_ptr_type, void *buf, MPI_Aint count,
-                     MPI_Datatype datatype, char *myname, MPI_Request * request)
-{
-    int error_code, buftype_is_contig, filetype_is_contig;
-    MPI_Count datatype_size;
-    ADIO_Status status;
-    ADIO_File adio_fh;
-    ADIO_Offset off, bufsize;
-    MPI_Offset nbytes = 0;
-    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
-
+    int error_code;
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-
-    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_iread_impl(fh, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    MPI_Type_size_x(datatype, &datatype_size);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_READABLE(adio_fh, myname, error_code);
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_Datatype_iscontig(datatype, &buftype_is_contig);
-    ADIOI_Datatype_iscontig(adio_fh->filetype, &filetype_is_contig);
-
-    ADIOI_TEST_DEFERRED(adio_fh, myname, &error_code);
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        MPI_Aint e32_size = 0;
-        error_code = MPIU_datatype_full_size(datatype, &e32_size);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        e32_buf = ADIOI_Malloc(e32_size * count);
-        xbuf = e32_buf;
-    } else {
-        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-
-    if (buftype_is_contig && filetype_is_contig) {
-        /* convert count and offset to bytes */
-        bufsize = datatype_size * count;
-
-        if (file_ptr_type == ADIO_EXPLICIT_OFFSET) {
-            off = adio_fh->disp + adio_fh->etype_size * offset;
-        } else {
-            off = adio_fh->fp_ind;
-        }
-
-        if (!(adio_fh->atomicity))
-            ADIO_IreadContig(adio_fh, xbuf, count, datatype, file_ptr_type,
-                             off, request, &error_code);
-        else {
-            /* to maintain strict atomicity semantics with other concurrent
-             * operations, lock (exclusive) and call blocking routine */
-            if (ADIO_Feature(adio_fh, ADIO_LOCKS)) {
-                ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
-            }
-
-            ADIO_ReadContig(adio_fh, xbuf, count, datatype, file_ptr_type,
-                            off, &status, &error_code);
-
-            if (ADIO_Feature(adio_fh, ADIO_LOCKS)) {
-                ADIOI_UNLOCK(adio_fh, off, SEEK_SET, bufsize);
-            }
-            if (error_code == MPI_SUCCESS) {
-                nbytes = count * datatype_size;
-            }
-            MPIO_Completed_request_create(&adio_fh, nbytes, &error_code, request);
-        }
-    } else
-        ADIO_IreadStrided(adio_fh, xbuf, count, datatype, file_ptr_type,
-                          offset, request, &error_code);
-
-    if (e32_buf != NULL) {
-        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
-        ADIOI_Free(e32_buf);
-    }
-
-    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/iread_all.c
+++ b/src/mpi/romio/mpi-io/iread_all.c
@@ -63,11 +63,6 @@ int MPI_File_iread_all(MPI_File fh, void *buf, int count,
 {
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_ALL";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEREADALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_iread_all(fh, (MPI_Offset) 0,
                                       ADIO_INDIVIDUAL, buf, count, datatype, myname, request);
@@ -78,9 +73,6 @@ int MPI_File_iread_all(MPI_File fh, void *buf, int count,
     }
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }
@@ -111,11 +103,6 @@ int MPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count,
 {
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_ALL";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEREADALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_iread_all(fh, (MPI_Offset) 0,
                                       ADIO_INDIVIDUAL, buf, count, datatype, myname, request);
@@ -126,9 +113,6 @@ int MPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count,
     }
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/iread_all.c
+++ b/src/mpi/romio/mpi-io/iread_all.c
@@ -62,19 +62,19 @@ int MPI_File_iread_all(MPI_File fh, void *buf, int count,
                        MPI_Datatype datatype, MPI_Request * request)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_IREAD_ALL";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_iread_all(fh, (MPI_Offset) 0,
-                                      ADIO_INDIVIDUAL, buf, count, datatype, myname, request);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS) {
-        error_code = MPIO_Err_return_file(fh, error_code);
+    error_code = MPIR_File_iread_all_impl(fh, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
 
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -102,95 +102,17 @@ int MPI_File_iread_all_c(MPI_File fh, void *buf, MPI_Count count,
                          MPI_Datatype datatype, MPI_Request * request)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_IREAD_ALL";
-
-    error_code = MPIOI_File_iread_all(fh, (MPI_Offset) 0,
-                                      ADIO_INDIVIDUAL, buf, count, datatype, myname, request);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS) {
-        error_code = MPIO_Err_return_file(fh, error_code);
-    }
-    /* --END ERROR HANDLING-- */
-
-
-    return error_code;
-}
-
-/* Note: MPIOI_File_iread_all also used by MPI_File_iread_at_all */
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_iread_all(MPI_File fh,
-                         MPI_Offset offset,
-                         int file_ptr_type,
-                         void *buf,
-                         MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Request * request)
-{
-    int error_code;
-    MPI_Count datatype_size;
-    ADIO_File adio_fh;
-    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-
-    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_iread_all_impl(fh, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    MPI_Type_size_x(datatype, &datatype_size);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_READABLE(adio_fh, myname, error_code);
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        MPI_Aint e32_size = 0;
-        error_code = MPIU_datatype_full_size(datatype, &e32_size);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        e32_buf = ADIOI_Malloc(e32_size * count);
-        xbuf = e32_buf;
-    } else {
-        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-
-    ADIO_IreadStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
-                          offset, request, &error_code);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-    if (e32_buf != NULL) {
-        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
-        ADIOI_Free(e32_buf);
-    }
-
-    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/iread_at.c
+++ b/src/mpi/romio/mpi-io/iread_at.c
@@ -64,11 +64,6 @@ int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_AT";
 
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEIREADAT, TRDTSYSTEM, fh, datatype, count);
-#endif /* MPI_hpux */
 
 
     error_code = MPIOI_File_iread(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
@@ -79,9 +74,6 @@ int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_
         error_code = MPIO_Err_return_file(fh, error_code);
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }
@@ -114,11 +106,6 @@ int MPI_File_iread_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count cou
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_AT";
 
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEIREADAT, TRDTSYSTEM, fh, datatype, count);
-#endif /* MPI_hpux */
 
 
     error_code = MPIOI_File_iread(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
@@ -129,9 +116,6 @@ int MPI_File_iread_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count cou
         error_code = MPIO_Err_return_file(fh, error_code);
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/iread_at.c
+++ b/src/mpi/romio/mpi-io/iread_at.c
@@ -62,20 +62,19 @@ int MPI_File_iread_at(MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_
                       MPIO_Request * request)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_IREAD_AT";
+    ROMIO_THREAD_CS_ENTER();
 
+    error_code = MPIR_File_iread_at_impl(fh, offset, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-
-    error_code = MPIOI_File_iread(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
-                                  count, datatype, myname, request);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -104,18 +103,17 @@ int MPI_File_iread_at_c(MPI_File fh, MPI_Offset offset, void *buf, MPI_Count cou
                         MPI_Datatype datatype, MPIO_Request * request)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_IREAD_AT";
+    ROMIO_THREAD_CS_ENTER();
 
+    error_code = MPIR_File_iread_at_impl(fh, offset, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-
-    error_code = MPIOI_File_iread(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
-                                  count, datatype, myname, request);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/iread_atall.c
+++ b/src/mpi/romio/mpi-io/iread_atall.c
@@ -63,18 +63,19 @@ int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf,
                           int count, MPI_Datatype datatype, MPI_Request * request)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_IREAD_AT_ALL";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_iread_all(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
-                                      count, datatype, myname, request);
+    error_code = MPIR_File_iread_at_all_impl(fh, offset, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -103,16 +104,17 @@ int MPI_File_iread_at_all_c(MPI_File fh, MPI_Offset offset, void *buf,
                             MPI_Count count, MPI_Datatype datatype, MPI_Request * request)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_IREAD_AT_ALL";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_iread_all(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
-                                      count, datatype, myname, request);
+    error_code = MPIR_File_iread_at_all_impl(fh, offset, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/iread_atall.c
+++ b/src/mpi/romio/mpi-io/iread_atall.c
@@ -64,11 +64,6 @@ int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf,
 {
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_AT_ALL";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEIREADATALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_iread_all(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
                                       count, datatype, myname, request);
@@ -78,9 +73,6 @@ int MPI_File_iread_at_all(MPI_File fh, MPI_Offset offset, void *buf,
         error_code = MPIO_Err_return_file(fh, error_code);
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }
@@ -112,11 +104,6 @@ int MPI_File_iread_at_all_c(MPI_File fh, MPI_Offset offset, void *buf,
 {
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_AT_ALL";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEIREADATALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_iread_all(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
                                       count, datatype, myname, request);
@@ -126,9 +113,6 @@ int MPI_File_iread_at_all_c(MPI_File fh, MPI_Offset offset, void *buf,
         error_code = MPIO_Err_return_file(fh, error_code);
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/iread_sh.c
+++ b/src/mpi/romio/mpi-io/iread_sh.c
@@ -61,7 +61,20 @@ Output Parameters:
 int MPI_File_iread_shared(MPI_File fh, void *buf, int count,
                           MPI_Datatype datatype, MPI_Request * request)
 {
-    return MPIOI_File_iread_shared(fh, buf, count, datatype, request);
+    int error_code;
+    ROMIO_THREAD_CS_ENTER();
+
+    error_code = MPIR_File_iread_shared_impl(fh, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
+    }
+
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
+    return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -84,117 +97,18 @@ Output Parameters:
 int MPI_File_iread_shared_c(MPI_File fh, void *buf, MPI_Count count,
                             MPI_Datatype datatype, MPI_Request * request)
 {
-    return MPIOI_File_iread_shared(fh, buf, count, datatype, request);
-}
-
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_iread_shared(MPI_File fh, void *buf, MPI_Aint count,
-                            MPI_Datatype datatype, MPI_Request * request)
-{
-    int error_code, buftype_is_contig, filetype_is_contig;
-    ADIO_Offset bufsize;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_IREAD_SHARED";
-    MPI_Count datatype_size, incr;
-    MPI_Status status;
-    ADIO_Offset off, shared_fp;
-    MPI_Offset nbytes = 0;
-    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
-
+    int error_code;
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    MPI_Type_size_x(datatype, &datatype_size);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_Datatype_iscontig(datatype, &buftype_is_contig);
-    ADIOI_Datatype_iscontig(adio_fh->filetype, &filetype_is_contig);
-
-    ADIOI_TEST_DEFERRED(adio_fh, myname, &error_code);
-
-    incr = (count * datatype_size) / adio_fh->etype_size;
-    ADIO_Get_shared_fp(adio_fh, incr, &shared_fp, &error_code);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS) {
-        /* note: ADIO_Get_shared_fp should have set up error code already? */
-        MPIO_Err_return_file(adio_fh, error_code);
+    error_code = MPIR_File_iread_shared_impl(fh, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        MPI_Aint e32_size = 0;
-        error_code = MPIU_datatype_full_size(datatype, &e32_size);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        e32_buf = ADIOI_Malloc(e32_size * count);
-        xbuf = e32_buf;
-    } else {
-        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-
-    if (buftype_is_contig && filetype_is_contig) {
-        /* convert count and shared_fp to bytes */
-        bufsize = datatype_size * count;
-        off = adio_fh->disp + adio_fh->etype_size * shared_fp;
-        if (!(adio_fh->atomicity)) {
-            ADIO_IreadContig(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
-                             off, request, &error_code);
-        } else {
-            /* to maintain strict atomicity semantics with other concurrent
-             * operations, lock (exclusive) and call blocking routine */
-
-            if (adio_fh->file_system != ADIO_NFS) {
-                ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
-            }
-
-            ADIO_ReadContig(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
-                            off, &status, &error_code);
-
-            if (adio_fh->file_system != ADIO_NFS) {
-                ADIOI_UNLOCK(adio_fh, off, SEEK_SET, bufsize);
-            }
-            if (error_code == MPI_SUCCESS) {
-                nbytes = count * datatype_size;
-            }
-            MPIO_Completed_request_create(&adio_fh, nbytes, &error_code, request);
-        }
-    } else {
-        ADIO_IreadStrided(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
-                          shared_fp, request, &error_code);
-    }
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-    if (e32_buf != NULL) {
-        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
-        ADIOI_Free(e32_buf);
-    }
-
-    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/iwrite.c
+++ b/src/mpi/romio/mpi-io/iwrite.c
@@ -59,20 +59,20 @@ Output Parameters:
 int MPI_File_iwrite(MPI_File fh, ROMIO_CONST void *buf, int count,
                     MPI_Datatype datatype, MPI_Request * request)
 {
-    int error_code = MPI_SUCCESS;
-    static char myname[] = "MPI_FILE_IWRITE";
+    int error_code;
+    ROMIO_THREAD_CS_ENTER();
 
+    error_code = MPIR_File_iwrite_impl(fh, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-    error_code = MPIOI_File_iwrite(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
-                                   buf, count, datatype, myname, request);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -99,126 +99,18 @@ Output Parameters:
 int MPI_File_iwrite_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                       MPI_Datatype datatype, MPI_Request * request)
 {
-    int error_code = MPI_SUCCESS;
-    static char myname[] = "MPI_FILE_IWRITE";
-
-
-    error_code = MPIOI_File_iwrite(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
-                                   buf, count, datatype, myname, request);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-
-    return error_code;
-}
-
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_iwrite(MPI_File fh,
-                      MPI_Offset offset,
-                      int file_ptr_type,
-                      const void *buf,
-                      MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Request * request)
-{
-    int error_code, buftype_is_contig, filetype_is_contig;
-    MPI_Count datatype_size;
-    ADIO_Status status;
-    ADIO_Offset off, bufsize;
-    ADIO_File adio_fh;
-    MPI_Offset nbytes = 0;
-    void *e32buf = NULL;
-    const void *xbuf = NULL;
-    void *host_buf = NULL;
-
+    int error_code;
     ROMIO_THREAD_CS_ENTER();
-    adio_fh = MPIO_File_resolve(fh);
 
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-
-    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_iwrite_impl(fh, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    MPI_Type_size_x(datatype, &datatype_size);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_WRITABLE(adio_fh, myname, error_code);
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_Datatype_iscontig(datatype, &buftype_is_contig);
-    ADIOI_Datatype_iscontig(adio_fh->filetype, &filetype_is_contig);
-
-    ADIOI_TEST_DEFERRED(adio_fh, myname, &error_code);
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        xbuf = e32buf;
-    } else {
-        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-
-    if (buftype_is_contig && filetype_is_contig) {
-        /* convert sizes to bytes */
-        bufsize = datatype_size * count;
-        if (file_ptr_type == ADIO_EXPLICIT_OFFSET) {
-            off = adio_fh->disp + adio_fh->etype_size * offset;
-        } else {
-            off = adio_fh->fp_ind;
-        }
-
-        if (!(adio_fh->atomicity)) {
-            ADIO_IwriteContig(adio_fh, xbuf, count, datatype, file_ptr_type,
-                              off, request, &error_code);
-        } else {
-            /* to maintain strict atomicity semantics with other concurrent
-             * operations, lock (exclusive) and call blocking routine */
-            if (ADIO_Feature(adio_fh, ADIO_LOCKS)) {
-                ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
-            }
-
-            ADIO_WriteContig(adio_fh, xbuf, count, datatype, file_ptr_type, off,
-                             &status, &error_code);
-
-            if (ADIO_Feature(adio_fh, ADIO_LOCKS)) {
-                ADIOI_UNLOCK(adio_fh, off, SEEK_SET, bufsize);
-            }
-            if (error_code == MPI_SUCCESS) {
-                nbytes = count * datatype_size;
-            }
-
-            MPIO_Completed_request_create(&adio_fh, nbytes, &error_code, request);
-        }
-    } else {
-        ADIO_IwriteStrided(adio_fh, xbuf, count, datatype, file_ptr_type,
-                           offset, request, &error_code);
-    }
-
-    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
 
   fn_exit:
-    if (e32buf != NULL)
-        ADIOI_Free(e32buf);
     ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/iwrite.c
+++ b/src/mpi/romio/mpi-io/iwrite.c
@@ -61,11 +61,6 @@ int MPI_File_iwrite(MPI_File fh, ROMIO_CONST void *buf, int count,
 {
     int error_code = MPI_SUCCESS;
     static char myname[] = "MPI_FILE_IWRITE";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITE, TRDTSYSTEM, fh, datatype, count);
-#endif /* MPI_hpux */
 
 
     error_code = MPIOI_File_iwrite(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
@@ -76,9 +71,6 @@ int MPI_File_iwrite(MPI_File fh, ROMIO_CONST void *buf, int count,
         error_code = MPIO_Err_return_file(fh, error_code);
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }
@@ -109,11 +101,6 @@ int MPI_File_iwrite_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
 {
     int error_code = MPI_SUCCESS;
     static char myname[] = "MPI_FILE_IWRITE";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITE, TRDTSYSTEM, fh, datatype, count);
-#endif /* MPI_hpux */
 
 
     error_code = MPIOI_File_iwrite(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL,
@@ -124,9 +111,6 @@ int MPI_File_iwrite_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
         error_code = MPIO_Err_return_file(fh, error_code);
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/iwrite_all.c
+++ b/src/mpi/romio/mpi-io/iwrite_all.c
@@ -62,13 +62,19 @@ int MPI_File_iwrite_all(MPI_File fh, ROMIO_CONST void *buf, int count,
                         MPI_Datatype datatype, MPI_Request * request)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_IWRITE_ALL";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_iwrite_all(fh, (MPI_Offset) 0,
-                                       ADIO_INDIVIDUAL, buf, count, datatype, myname, request);
+    error_code = MPIR_File_iwrite_all_impl(fh, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -96,87 +102,17 @@ int MPI_File_iwrite_all_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                           MPI_Datatype datatype, MPI_Request * request)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_IWRITE_ALL";
-
-    error_code = MPIOI_File_iwrite_all(fh, (MPI_Offset) 0,
-                                       ADIO_INDIVIDUAL, buf, count, datatype, myname, request);
-
-
-    return error_code;
-}
-
-/* Note: MPIOI_File_iwrite_all also used by MPI_File_iwrite_at_all */
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_iwrite_all(MPI_File fh,
-                          MPI_Offset offset,
-                          int file_ptr_type,
-                          const void *buf,
-                          MPI_Aint count, MPI_Datatype datatype, char *myname,
-                          MPI_Request * request)
-{
-    int error_code;
-    MPI_Count datatype_size;
-    ADIO_File adio_fh;
-    void *e32buf = NULL;
-    const void *xbuf = NULL;
-    void *host_buf = NULL;
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-
-    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_iwrite_all_impl(fh, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    MPI_Type_size_x(datatype, &datatype_size);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_WRITABLE(adio_fh, myname, error_code);
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        xbuf = e32buf;
-    } else {
-        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-
-    ADIO_IwriteStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
-                           offset, request, &error_code);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
 
   fn_exit:
-    if (e32buf != NULL)
-        ADIOI_Free(e32buf);
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/iwrite_all.c
+++ b/src/mpi/romio/mpi-io/iwrite_all.c
@@ -63,18 +63,10 @@ int MPI_File_iwrite_all(MPI_File fh, ROMIO_CONST void *buf, int count,
 {
     int error_code;
     static char myname[] = "MPI_FILE_IWRITE_ALL";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITEALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_iwrite_all(fh, (MPI_Offset) 0,
                                        ADIO_INDIVIDUAL, buf, count, datatype, myname, request);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }
@@ -105,18 +97,10 @@ int MPI_File_iwrite_all_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
 {
     int error_code;
     static char myname[] = "MPI_FILE_IWRITE_ALL";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITEALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_iwrite_all(fh, (MPI_Offset) 0,
                                        ADIO_INDIVIDUAL, buf, count, datatype, myname, request);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/iwrite_at.c
+++ b/src/mpi/romio/mpi-io/iwrite_at.c
@@ -66,11 +66,6 @@ int MPI_File_iwrite_at(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
     ADIO_File adio_fh;
     static char myname[] = "MPI_FILE_IWRITE_AT";
 
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITEAT, TRDTSYSTEM, fh, datatype, count);
-#endif /* MPI_hpux */
 
 
     adio_fh = MPIO_File_resolve(fh);
@@ -83,10 +78,7 @@ int MPI_File_iwrite_at(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
         error_code = MPIO_Err_return_file(adio_fh, error_code);
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count)
-#endif /* MPI_hpux */
-        return error_code;
+    return error_code;
 }
 
 /* large count function */
@@ -118,11 +110,6 @@ int MPI_File_iwrite_at_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
     ADIO_File adio_fh;
     static char myname[] = "MPI_FILE_IWRITE_AT";
 
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITEAT, TRDTSYSTEM, fh, datatype, count);
-#endif /* MPI_hpux */
 
 
     adio_fh = MPIO_File_resolve(fh);
@@ -135,8 +122,5 @@ int MPI_File_iwrite_at_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
         error_code = MPIO_Err_return_file(adio_fh, error_code);
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count)
-#endif /* MPI_hpux */
-        return error_code;
+    return error_code;
 }

--- a/src/mpi/romio/mpi-io/iwrite_at.c
+++ b/src/mpi/romio/mpi-io/iwrite_at.c
@@ -63,22 +63,19 @@ int MPI_File_iwrite_at(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
                        int count, MPI_Datatype datatype, MPIO_Request * request)
 {
     int error_code;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_IWRITE_AT";
+    ROMIO_THREAD_CS_ENTER();
 
+    error_code = MPIR_File_iwrite_at_impl(fh, offset, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-
-    adio_fh = MPIO_File_resolve(fh);
-
-    error_code = MPIOI_File_iwrite(adio_fh, offset, ADIO_EXPLICIT_OFFSET, buf,
-                                   count, datatype, myname, request);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -107,20 +104,17 @@ int MPI_File_iwrite_at_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
                          MPI_Count count, MPI_Datatype datatype, MPIO_Request * request)
 {
     int error_code;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_IWRITE_AT";
+    ROMIO_THREAD_CS_ENTER();
 
+    error_code = MPIR_File_iwrite_at_impl(fh, offset, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-
-    adio_fh = MPIO_File_resolve(fh);
-
-    error_code = MPIOI_File_iwrite(adio_fh, offset, ADIO_EXPLICIT_OFFSET, buf,
-                                   count, datatype, myname, request);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/iwrite_atall.c
+++ b/src/mpi/romio/mpi-io/iwrite_atall.c
@@ -63,12 +63,19 @@ int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf
                            int count, MPI_Datatype datatype, MPI_Request * request)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_IWRITE_AT_ALL";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_iwrite_all(fh, offset, ADIO_EXPLICIT_OFFSET,
-                                       buf, count, datatype, myname, request);
+    error_code = MPIR_File_iwrite_at_all_impl(fh, offset, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
+    }
 
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -97,10 +104,17 @@ int MPI_File_iwrite_at_all_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *b
                              MPI_Count count, MPI_Datatype datatype, MPI_Request * request)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_IWRITE_AT_ALL";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_iwrite_all(fh, offset, ADIO_EXPLICIT_OFFSET,
-                                       buf, count, datatype, myname, request);
+    error_code = MPIR_File_iwrite_at_all_impl(fh, offset, buf, count, datatype, request);
+    if (error_code) {
+        goto fn_fail;
+    }
 
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/iwrite_atall.c
+++ b/src/mpi/romio/mpi-io/iwrite_atall.c
@@ -64,18 +64,10 @@ int MPI_File_iwrite_at_all(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf
 {
     int error_code;
     static char myname[] = "MPI_FILE_IWRITE_AT_ALL";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITEATALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_iwrite_all(fh, offset, ADIO_EXPLICIT_OFFSET,
                                        buf, count, datatype, myname, request);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
     return error_code;
 }
 
@@ -106,17 +98,9 @@ int MPI_File_iwrite_at_all_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *b
 {
     int error_code;
     static char myname[] = "MPI_FILE_IWRITE_AT_ALL";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEIWRITEATALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_iwrite_all(fh, offset, ADIO_EXPLICIT_OFFSET,
                                        buf, count, datatype, myname, request);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/mpioimpl.h
+++ b/src/mpi/romio/mpi-io/mpioimpl.h
@@ -88,8 +88,5 @@ void MPIR_MPIOInit(int *error_code);
 #include "mpioprof.h"
 #endif /* MPIO_BUILD_PROFILING */
 
-#ifdef MPI_hpux
-#include "mpioinst.h"
-#endif /* MPI_hpux */
 
 #endif /* MPIOIMPL_H_INCLUDED */

--- a/src/mpi/romio/mpi-io/mpioimpl.h
+++ b/src/mpi/romio/mpi-io/mpioimpl.h
@@ -88,5 +88,100 @@ void MPIR_MPIOInit(int *error_code);
 #include "mpioprof.h"
 #endif /* MPIO_BUILD_PROFILING */
 
+int MPIR_File_close_impl(MPI_File * fh);
+int MPIR_File_delete_impl(const char *filename, MPI_Info info);
+int MPIR_File_get_amode_impl(MPI_File fh, int *amode);
+int MPIR_File_get_atomicity_impl(MPI_File fh, int *flag);
+int MPIR_File_get_byte_offset_impl(MPI_File fh, MPI_Offset offset, MPI_Offset * disp);
+int MPIR_File_get_group_impl(MPI_File fh, MPI_Group * group);
+int MPIR_File_get_info_impl(MPI_File fh, MPI_Info * info_used);
+int MPIR_File_get_position_impl(MPI_File fh, MPI_Offset * offset);
+int MPIR_File_get_position_shared_impl(MPI_File fh, MPI_Offset * offset);
+int MPIR_File_get_size_impl(MPI_File fh, MPI_Offset * size);
+int MPIR_File_get_type_extent_impl(MPI_File fh, MPI_Datatype datatype, MPI_Aint * extent);
+int MPIR_File_get_view_impl(MPI_File fh, MPI_Offset * disp, MPI_Datatype * etype,
+                            MPI_Datatype * filetype, char *datarep);
+int MPIR_File_iread_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                         MPI_Request * request);
+int MPIR_File_iread_all_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                             MPI_Request * request);
+int MPIR_File_iread_at_impl(MPI_File fh, MPI_Offset offset, void *buf, MPI_Aint count,
+                            MPI_Datatype datatype, MPI_Request * request);
+int MPIR_File_iread_at_all_impl(MPI_File fh, MPI_Offset offset, void *buf, MPI_Aint count,
+                                MPI_Datatype datatype, MPI_Request * request);
+int MPIR_File_iread_shared_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                MPI_Request * request);
+int MPIR_File_iwrite_impl(MPI_File fh, const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                          MPI_Request * request);
+int MPIR_File_iwrite_all_impl(MPI_File fh, const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                              MPI_Request * request);
+int MPIR_File_iwrite_at_impl(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Aint count,
+                             MPI_Datatype datatype, MPI_Request * request);
+int MPIR_File_iwrite_at_all_impl(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Aint count,
+                                 MPI_Datatype datatype, MPI_Request * request);
+int MPIR_File_iwrite_shared_impl(MPI_File fh, const void *buf, MPI_Aint count,
+                                 MPI_Datatype datatype, MPI_Request * request);
+int MPIR_File_open_impl(MPI_Comm comm, const char *filename, int amode, MPI_Info info,
+                        MPI_File * fh);
+int MPIR_File_preallocate_impl(MPI_File fh, MPI_Offset size);
+int MPIR_File_read_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                        MPI_Status * status);
+int MPIR_File_read_all_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                            MPI_Status * status);
+int MPIR_File_read_all_begin_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype);
+int MPIR_File_read_all_end_impl(MPI_File fh, void *buf, MPI_Status * status);
+int MPIR_File_read_at_impl(MPI_File fh, MPI_Offset offset, void *buf, MPI_Aint count,
+                           MPI_Datatype datatype, MPI_Status * status);
+int MPIR_File_read_at_all_impl(MPI_File fh, MPI_Offset offset, void *buf, MPI_Aint count,
+                               MPI_Datatype datatype, MPI_Status * status);
+int MPIR_File_read_at_all_begin_impl(MPI_File fh, MPI_Offset offset, void *buf, MPI_Aint count,
+                                     MPI_Datatype datatype);
+int MPIR_File_read_at_all_end_impl(MPI_File fh, void *buf, MPI_Status * status);
+int MPIR_File_read_ordered_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                MPI_Status * status);
+int MPIR_File_read_ordered_begin_impl(MPI_File fh, void *buf, MPI_Aint count,
+                                      MPI_Datatype datatype);
+int MPIR_File_read_ordered_end_impl(MPI_File fh, void *buf, MPI_Status * status);
+int MPIR_File_read_shared_impl(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype,
+                               MPI_Status * status);
+int MPIR_File_seek_impl(MPI_File fh, MPI_Offset offset, int whence);
+int MPIR_File_seek_shared_impl(MPI_File fh, MPI_Offset offset, int whence);
+int MPIR_File_set_atomicity_impl(MPI_File fh, int flag);
+int MPIR_File_set_info_impl(MPI_File fh, MPI_Info info);
+int MPIR_File_set_size_impl(MPI_File fh, MPI_Offset size);
+int MPIR_File_set_view_impl(MPI_File fh, MPI_Offset disp, MPI_Datatype etype, MPI_Datatype filetype,
+                            const char *datarep, MPI_Info info);
+int MPIR_File_sync_impl(MPI_File fh);
+int MPIR_File_write_impl(MPI_File fh, const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                         MPI_Status * status);
+int MPIR_File_write_all_impl(MPI_File fh, const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                             MPI_Status * status);
+int MPIR_File_write_all_begin_impl(MPI_File fh, const void *buf, MPI_Aint count,
+                                   MPI_Datatype datatype);
+int MPIR_File_write_all_end_impl(MPI_File fh, const void *buf, MPI_Status * status);
+int MPIR_File_write_at_impl(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Aint count,
+                            MPI_Datatype datatype, MPI_Status * status);
+int MPIR_File_write_at_all_impl(MPI_File fh, MPI_Offset offset, const void *buf, MPI_Aint count,
+                                MPI_Datatype datatype, MPI_Status * status);
+int MPIR_File_write_at_all_begin_impl(MPI_File fh, MPI_Offset offset, const void *buf,
+                                      MPI_Aint count, MPI_Datatype datatype);
+int MPIR_File_write_at_all_end_impl(MPI_File fh, const void *buf, MPI_Status * status);
+int MPIR_File_write_ordered_impl(MPI_File fh, const void *buf, MPI_Aint count,
+                                 MPI_Datatype datatype, MPI_Status * status);
+int MPIR_File_write_ordered_begin_impl(MPI_File fh, const void *buf, MPI_Aint count,
+                                       MPI_Datatype datatype);
+int MPIR_File_write_ordered_end_impl(MPI_File fh, const void *buf, MPI_Status * status);
+int MPIR_File_write_shared_impl(MPI_File fh, const void *buf, MPI_Aint count, MPI_Datatype datatype,
+                                MPI_Status * status);
+int MPIR_Register_datarep_impl(const char *datarep,
+                               MPI_Datarep_conversion_function * read_conversion_fn,
+                               MPI_Datarep_conversion_function * write_conversion_fn,
+                               MPI_Datarep_extent_function * dtype_file_extent_fn,
+                               void *extra_state);
+int MPIR_Register_datarep_large_impl(const char *datarep,
+                                     MPI_Datarep_conversion_function_c * read_conversion_fn,
+                                     MPI_Datarep_conversion_function_c * write_conversion_fn,
+                                     MPI_Datarep_extent_function * dtype_file_extent_fn,
+                                     void *extra_state);
 
 #endif /* MPIOIMPL_H_INCLUDED */

--- a/src/mpi/romio/mpi-io/mpioimpl.h
+++ b/src/mpi/romio/mpi-io/mpioimpl.h
@@ -183,5 +183,7 @@ int MPIR_Register_datarep_large_impl(const char *datarep,
                                      MPI_Datarep_conversion_function_c * write_conversion_fn,
                                      MPI_Datarep_extent_function * dtype_file_extent_fn,
                                      void *extra_state);
+MPI_Fint MPIR_File_c2f_impl(MPI_File fh);
+MPI_File MPIR_File_f2c_impl(MPI_Fint fh);
 
 #endif /* MPIOIMPL_H_INCLUDED */

--- a/src/mpi/romio/mpi-io/open.c
+++ b/src/mpi/romio/mpi-io/open.c
@@ -60,11 +60,6 @@ int MPI_File_open(MPI_Comm comm, ROMIO_CONST char *filename, int amode,
     MPI_Comm dupcomm = MPI_COMM_NULL;
     ADIOI_Fns *fsops;
     static char myname[] = "MPI_FILE_OPEN";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_OPEN_START(fl_xmpi, comm);
-#endif /* MPI_hpux */
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -187,9 +182,6 @@ int MPI_File_open(MPI_Comm comm, ROMIO_CONST char *filename, int amode,
             MPI_Barrier(dupcomm);
         }
     }
-#ifdef MPI_hpux
-    HPMP_IO_OPEN_END(fl_xmpi, *fh, comm);
-#endif /* MPI_hpux */
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();

--- a/src/mpi/romio/mpi-io/open.c
+++ b/src/mpi/romio/mpi-io/open.c
@@ -65,7 +65,7 @@ int MPI_File_open(MPI_Comm comm, ROMIO_CONST char *filename, int amode,
 
     /* --BEGIN ERROR HANDLING-- */
     MPIO_CHECK_COMM(comm, myname, error_code);
-    MPIO_CHECK_INFO_ALL(info, error_code, comm);
+    MPIO_CHECK_INFO_ALL(info, myname, error_code, comm);
     /* --END ERROR HANDLING-- */
 
     error_code = MPI_Comm_test_inter(comm, &flag);

--- a/src/mpi/romio/mpi-io/open.c
+++ b/src/mpi/romio/mpi-io/open.c
@@ -24,9 +24,6 @@ int MPI_File_open(MPI_Comm comm, const char *filename, int amode, MPI_Info info,
 #include "mpioprof.h"
 #endif
 
-/* for user-definde reduce operator */
-#include "adio_extern.h"
-
 /* */
 #if !defined(HAVE_WEAK_SYMBOLS) && !defined(MPIO_BUILD_PROFILING)
 void *dummy_refs_MPI_File_open[] = {
@@ -34,8 +31,6 @@ void *dummy_refs_MPI_File_open[] = {
     (void *) MPIU_datatype_full_size,
 };
 #endif
-
-extern int ADIO_Init_keyval;
 
 /*@
     MPI_File_open - Opens a file
@@ -54,142 +49,20 @@ Output Parameters:
 int MPI_File_open(MPI_Comm comm, ROMIO_CONST char *filename, int amode,
                   MPI_Info info, MPI_File * fh)
 {
-    int error_code = MPI_SUCCESS, file_system, flag, tmp_amode = 0, rank;
-    int known_fstype;
-    char *tmp;
-    MPI_Comm dupcomm = MPI_COMM_NULL;
-    ADIOI_Fns *fsops;
-    static char myname[] = "MPI_FILE_OPEN";
+    int error_code = MPI_SUCCESS;
 
     ROMIO_THREAD_CS_ENTER();
 
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_COMM(comm, myname, error_code);
-    MPIO_CHECK_INFO_ALL(info, myname, error_code, comm);
-    /* --END ERROR HANDLING-- */
-
-    error_code = MPI_Comm_test_inter(comm, &flag);
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code || flag) {
-        error_code = MPIO_Err_create_code(error_code, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_COMM, "**commnotintra", 0);
-        goto fn_fail;
-    }
-
-    if (((amode & MPI_MODE_RDONLY) ? 1 : 0) + ((amode & MPI_MODE_RDWR) ? 1 : 0) +
-        ((amode & MPI_MODE_WRONLY) ? 1 : 0) != 1) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_AMODE, "**fileamodeone", 0);
-        goto fn_fail;
-    }
-
-    if ((amode & MPI_MODE_RDONLY) && ((amode & MPI_MODE_CREATE) || (amode & MPI_MODE_EXCL))) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_AMODE, "**fileamoderead", 0);
-        goto fn_fail;
-    }
-
-    if ((amode & MPI_MODE_RDWR) && (amode & MPI_MODE_SEQUENTIAL)) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_AMODE, "**fileamodeseq", 0);
-        goto fn_fail;
-    }
-
-    MPI_Comm_dup(comm, &dupcomm);
-
-/* check if ADIO has been initialized. If not, initialize it */
-    MPIR_MPIOInit(&error_code);
+    error_code = MPIR_File_open_impl(comm, filename, amode, info, fh);
     if (error_code != MPI_SUCCESS)
         goto fn_fail;
 
-/* check if amode is the same on all processes: at first glance, one might try
- * to use a built-in operator like MPI_BAND, but we need every mpi process to
- * agree the amode was not the same.  Consider process A with
- * MPI_MODE_CREATE|MPI_MODE_RDWR, and B with MPI_MODE_RDWR:  MPI_BAND yields
- * MPI_MODE_RDWR.  A determines amodes are different, but B proceeds having not
- * detected an error */
-    MPI_Allreduce(&amode, &tmp_amode, 1, MPI_INT, ADIO_same_amode, dupcomm);
-
-    if (tmp_amode == ADIO_AMODE_NOMATCH) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_NOT_SAME, "**fileamodediff", 0);
-        goto fn_fail;
-    }
-    /* --END ERROR HANDLING-- */
-
-    file_system = -1;
-
-    /* resolve file system type from file name; this is a collective call */
-    known_fstype = ADIO_ResolveFileType(dupcomm, filename, &file_system, &fsops, &error_code);
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS) {
-        /* ADIO_ResolveFileType() will print as informative a message as it
-         * possibly can or call MPIO_Err_setmsg.  We just need to propagate
-         * the error up.
-         */
-        goto fn_fail;
-    }
-    /* --END ERROR HANDLING-- */
-
-    if (known_fstype) {
-        /* filename contains a known file system type prefix, such as "ufs:".
-         * strip off prefix if there is one, but only skip prefixes
-         * if they are greater than length one to allow for windows
-         * drive specifications (e.g. c:\...)
-         */
-        tmp = strchr(filename, ':');
-        if (tmp > filename + 1) {
-            filename = tmp + 1;
-        }
-    }
-/* use default values for disp, etype, filetype */
-
-    *fh = ADIO_Open(comm, dupcomm, filename, file_system, fsops, amode, 0,
-                    MPI_BYTE, MPI_BYTE, info, ADIO_PERM_NULL, &error_code);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS) {
-        goto fn_fail;
-    }
-    /* --END ERROR HANDLING-- */
-
-    /* if MPI_MODE_SEQUENTIAL requested, file systems cannot do explicit offset
-     * or independent file pointer accesses, leaving not much else aside from
-     * shared file pointer accesses. */
-    if (!ADIO_Feature((*fh), ADIO_SHARED_FP) && (amode & MPI_MODE_SEQUENTIAL)) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__,
-                                          MPI_ERR_UNSUPPORTED_OPERATION, "**iosequnsupported", 0);
-        ADIO_Close(*fh, &error_code);
-        goto fn_fail;
-    }
-
-    /* determine name of file that will hold the shared file pointer */
-    /* can't support shared file pointers on a file system that doesn't
-     * support file locking. */
-    if ((error_code == MPI_SUCCESS) && ADIO_Feature((*fh), ADIO_SHARED_FP)) {
-        MPI_Comm_rank(dupcomm, &rank);
-        ADIOI_Shfp_fname(*fh, rank, &error_code);
-        if (error_code != MPI_SUCCESS)
-            goto fn_fail;
-
-        /* if MPI_MODE_APPEND, set the shared file pointer to end of file.
-         * indiv. file pointer already set to end of file in ADIO_Open.
-         * Here file view is just bytes. */
-        if ((*fh)->access_mode & MPI_MODE_APPEND) {
-            if (rank == (*fh)->hints->ranklist[0])      /* only one person need set the sharedfp */
-                ADIO_Set_shared_fp(*fh, (*fh)->fp_ind, &error_code);
-            MPI_Barrier(dupcomm);
-        }
-    }
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
     return error_code;
   fn_fail:
     /* --BEGIN ERROR HANDLING-- */
-    if (dupcomm != MPI_COMM_NULL)
-        MPI_Comm_free(&dupcomm);
     error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
     goto fn_exit;
     /* --END ERROR HANDLING-- */

--- a/src/mpi/romio/mpi-io/prealloc.c
+++ b/src/mpi/romio/mpi-io/prealloc.c
@@ -40,11 +40,6 @@ int MPI_File_preallocate(MPI_File fh, MPI_Offset size)
     ADIO_File adio_fh;
     static char myname[] = "MPI_FILE_PREALLOCATE";
     MPI_Offset tmp_sz, max_sz, min_sz;
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEPREALLOCATE, TRDTBLOCK, adio_fh, MPI_DATATYPE_NULL, -1);
-#endif /* MPI_hpux */
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -90,9 +85,6 @@ int MPI_File_preallocate(MPI_File fh, MPI_Offset size)
     }
     MPI_Barrier(adio_fh->comm);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, adio_fh, MPI_DATATYPE_NULL, -1);
-#endif /* MPI_hpux */
 
 
   fn_exit:

--- a/src/mpi/romio/mpi-io/rd_atallb.c
+++ b/src/mpi/romio/mpi-io/rd_atallb.c
@@ -58,12 +58,19 @@ int MPI_File_read_at_all_begin(MPI_File fh, MPI_Offset offset, void *buf,
                                int count, MPI_Datatype datatype)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_READ_AT_ALL_BEGIN";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_read_all_begin(fh, offset,
-                                           ADIO_EXPLICIT_OFFSET, buf, count, datatype, myname);
+    error_code = MPIR_File_read_at_all_begin_impl(fh, offset, buf, count, datatype);
+    if (error_code) {
+        goto fn_fail;
+    }
 
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -87,10 +94,17 @@ int MPI_File_read_at_all_begin_c(MPI_File fh, MPI_Offset offset, void *buf,
                                  MPI_Count count, MPI_Datatype datatype)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_READ_AT_ALL_BEGIN";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_read_all_begin(fh, offset,
-                                           ADIO_EXPLICIT_OFFSET, buf, count, datatype, myname);
+    error_code = MPIR_File_read_at_all_begin_impl(fh, offset, buf, count, datatype);
+    if (error_code) {
+        goto fn_fail;
+    }
 
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/rd_atalle.c
+++ b/src/mpi/romio/mpi-io/rd_atalle.c
@@ -40,10 +40,17 @@ Output Parameters:
 int MPI_File_read_at_all_end(MPI_File fh, void *buf, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_READ_AT_ALL_END";
+    ROMIO_THREAD_CS_ENTER();
 
+    error_code = MPIR_File_read_at_all_end_impl(fh, buf, status);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-    error_code = MPIOI_File_read_all_end(fh, buf, myname, status);
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/read.c
+++ b/src/mpi/romio/mpi-io/read.c
@@ -58,13 +58,19 @@ Output Parameters:
 int MPI_File_read(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_READ";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_read(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf,
-                                 count, datatype, myname, status);
+    error_code = MPIR_File_read_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -90,130 +96,17 @@ int MPI_File_read_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype dataty
                     MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_READ";
-
-    error_code = MPIOI_File_read(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf,
-                                 count, datatype, myname, status);
-
-
-    return error_code;
-}
-
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_read(MPI_File fh,
-                    MPI_Offset offset,
-                    int file_ptr_type,
-                    void *buf, MPI_Aint count, MPI_Datatype datatype, char *myname,
-                    MPI_Status * status)
-{
-    int error_code, buftype_is_contig, filetype_is_contig;
-    MPI_Count datatype_size;
-    ADIO_File adio_fh;
-    ADIO_Offset off, bufsize;
-    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-
-    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_read_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    MPI_Type_size_x(datatype, &datatype_size);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    if (count * datatype_size == 0) {
-#ifdef HAVE_STATUS_SET_BYTES
-        MPIR_Status_set_bytes(status, datatype, 0);
-#endif
-        error_code = MPI_SUCCESS;
-        goto fn_exit;
-    }
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_READABLE(adio_fh, myname, error_code);
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_Datatype_iscontig(datatype, &buftype_is_contig);
-    ADIOI_Datatype_iscontig(adio_fh->filetype, &filetype_is_contig);
-
-    ADIOI_TEST_DEFERRED(adio_fh, myname, &error_code);
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        MPI_Aint e32_size = 0;
-        error_code = MPIU_datatype_full_size(datatype, &e32_size);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        e32_buf = ADIOI_Malloc(e32_size * count);
-        xbuf = e32_buf;
-    } else {
-        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-
-    if (buftype_is_contig && filetype_is_contig) {
-        /* convert count and offset to bytes */
-        bufsize = datatype_size * count;
-        if (file_ptr_type == ADIO_EXPLICIT_OFFSET) {
-            off = adio_fh->disp + adio_fh->etype_size * offset;
-        } else {        /* ADIO_INDIVIDUAL */
-
-            off = adio_fh->fp_ind;
-        }
-
-        /* if atomic mode requested, lock (exclusive) the region, because
-         * there could be a concurrent noncontiguous request.
-         */
-        if ((adio_fh->atomicity) && ADIO_Feature(adio_fh, ADIO_LOCKS)) {
-            ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
-        }
-
-        ADIO_ReadContig(adio_fh, xbuf, count, datatype, file_ptr_type, off, status, &error_code);
-
-        if ((adio_fh->atomicity) && ADIO_Feature(adio_fh, ADIO_LOCKS)) {
-            ADIOI_UNLOCK(adio_fh, off, SEEK_SET, bufsize);
-        }
-    } else {
-        ADIO_ReadStrided(adio_fh, xbuf, count, datatype, file_ptr_type,
-                         offset, status, &error_code);
-        /* For strided and atomic mode, locking is done in ADIO_ReadStrided */
-    }
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-    if (e32_buf != NULL) {
-        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
-        ADIOI_Free(e32_buf);
-    }
-
-    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/read.c
+++ b/src/mpi/romio/mpi-io/read.c
@@ -59,18 +59,10 @@ int MPI_File_read(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_
 {
     int error_code;
     static char myname[] = "MPI_FILE_READ";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEREAD, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_read(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf,
                                  count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }
@@ -99,18 +91,10 @@ int MPI_File_read_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype dataty
 {
     int error_code;
     static char myname[] = "MPI_FILE_READ";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEREAD, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_read(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf,
                                  count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/read_all.c
+++ b/src/mpi/romio/mpi-io/read_all.c
@@ -58,13 +58,19 @@ Output Parameters:
 int MPI_File_read_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_READ_ALL";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_read_all(fh, (MPI_Offset) 0,
-                                     ADIO_INDIVIDUAL, buf, count, datatype, myname, status);
+    error_code = MPIR_File_read_all_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -90,89 +96,17 @@ int MPI_File_read_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype da
                         MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_READ_ALL";
-
-    error_code = MPIOI_File_read_all(fh, (MPI_Offset) 0,
-                                     ADIO_INDIVIDUAL, buf, count, datatype, myname, status);
-
-
-    return error_code;
-}
-
-/* Note: MPIOI_File_read_all also used by MPI_File_read_at_all */
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_read_all(MPI_File fh,
-                        MPI_Offset offset,
-                        int file_ptr_type,
-                        void *buf,
-                        MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Status * status)
-{
-    int error_code;
-    MPI_Count datatype_size;
-    ADIO_File adio_fh;
-    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-
-    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_read_all_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    MPI_Type_size_x(datatype, &datatype_size);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_READABLE(adio_fh, myname, error_code);
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        MPI_Aint e32_size = 0;
-        error_code = MPIU_datatype_full_size(datatype, &e32_size);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        e32_buf = ADIOI_Malloc(e32_size * count);
-        xbuf = e32_buf;
-    } else {
-        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-
-    ADIO_ReadStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
-                         offset, status, &error_code);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-    if (e32_buf != NULL) {
-        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
-        ADIOI_Free(e32_buf);
-    }
-
-    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/read_all.c
+++ b/src/mpi/romio/mpi-io/read_all.c
@@ -59,18 +59,10 @@ int MPI_File_read_all(MPI_File fh, void *buf, int count, MPI_Datatype datatype, 
 {
     int error_code;
     static char myname[] = "MPI_FILE_READ_ALL";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEREADALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_read_all(fh, (MPI_Offset) 0,
                                      ADIO_INDIVIDUAL, buf, count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }
@@ -99,18 +91,10 @@ int MPI_File_read_all_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype da
 {
     int error_code;
     static char myname[] = "MPI_FILE_READ_ALL";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEREADALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_read_all(fh, (MPI_Offset) 0,
                                      ADIO_INDIVIDUAL, buf, count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/read_allb.c
+++ b/src/mpi/romio/mpi-io/read_allb.c
@@ -54,12 +54,19 @@ Output Parameters:
 int MPI_File_read_all_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_READ_ALL_BEGIN";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_read_all_begin(fh, (MPI_Offset) 0,
-                                           ADIO_INDIVIDUAL, buf, count, datatype, myname);
+    error_code = MPIR_File_read_all_begin_impl(fh, buf, count, datatype);
+    if (error_code) {
+        goto fn_fail;
+    }
 
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -81,95 +88,17 @@ Output Parameters:
 int MPI_File_read_all_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_READ_ALL_BEGIN";
-
-    error_code = MPIOI_File_read_all_begin(fh, (MPI_Offset) 0,
-                                           ADIO_INDIVIDUAL, buf, count, datatype, myname);
-
-    return error_code;
-}
-
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_read_all_begin(MPI_File fh,
-                              MPI_Offset offset,
-                              int file_ptr_type,
-                              void *buf, MPI_Aint count, MPI_Datatype datatype, char *myname)
-{
-    int error_code;
-    MPI_Count datatype_size;
-    ADIO_File adio_fh;
-    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-
-    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_read_all_begin_impl(fh, buf, count, datatype);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    MPI_Type_size_x(datatype, &datatype_size);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_READABLE(adio_fh, myname, error_code);
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-
-    if (adio_fh->split_coll_count) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_IO, "**iosplitcoll", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    adio_fh->split_coll_count = 1;
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        MPI_Aint e32_size = 0;
-        error_code = MPIU_datatype_full_size(datatype, &e32_size);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        e32_buf = ADIOI_Malloc(e32_size * count);
-        xbuf = e32_buf;
-    } else {
-        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-
-    ADIO_ReadStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
-                         offset, &adio_fh->split_status, &error_code);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-    if (e32_buf != NULL) {
-        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
-        ADIOI_Free(e32_buf);
-    }
-
-    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/read_alle.c
+++ b/src/mpi/romio/mpi-io/read_alle.c
@@ -40,46 +40,17 @@ Output Parameters:
 int MPI_File_read_all_end(MPI_File fh, void *buf, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_IREAD";
-
-    error_code = MPIOI_File_read_all_end(fh, buf, myname, status);
-
-    return error_code;
-}
-
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_read_all_end(MPI_File fh, void *buf, char *myname, MPI_Status * status)
-{
-    int error_code = MPI_SUCCESS;
-    ADIO_File adio_fh;
-
-    MPL_UNREFERENCED_ARG(buf);
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-
-    if (!(adio_fh->split_coll_count)) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_IO, "**iosplitcollnone", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_read_all_end_impl(fh, buf, status);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-#ifdef HAVE_STATUS_SET_BYTES
-    if (status != MPI_STATUS_IGNORE)
-        *status = adio_fh->split_status;
-#endif
-    adio_fh->split_coll_count = 0;
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/read_at.c
+++ b/src/mpi/romio/mpi-io/read_at.c
@@ -60,14 +60,19 @@ int MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf,
                      int count, MPI_Datatype datatype, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_READ_AT";
+    ROMIO_THREAD_CS_ENTER();
 
-    /* ADIOI_File_read() defined in mpi-io/read.c */
-    error_code = MPIOI_File_read(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
-                                 count, datatype, myname, status);
+    error_code = MPIR_File_read_at_impl(fh, offset, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -93,12 +98,17 @@ int MPI_File_read_at_c(MPI_File fh, MPI_Offset offset, void *buf,
                        MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_READ_AT";
+    ROMIO_THREAD_CS_ENTER();
 
-    /* ADIOI_File_read() defined in mpi-io/read.c */
-    error_code = MPIOI_File_read(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
-                                 count, datatype, myname, status);
+    error_code = MPIR_File_read_at_impl(fh, offset, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/read_at.c
+++ b/src/mpi/romio/mpi-io/read_at.c
@@ -61,19 +61,11 @@ int MPI_File_read_at(MPI_File fh, MPI_Offset offset, void *buf,
 {
     int error_code;
     static char myname[] = "MPI_FILE_READ_AT";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEREADAT, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     /* ADIOI_File_read() defined in mpi-io/read.c */
     error_code = MPIOI_File_read(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
                                  count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }
@@ -102,19 +94,11 @@ int MPI_File_read_at_c(MPI_File fh, MPI_Offset offset, void *buf,
 {
     int error_code;
     static char myname[] = "MPI_FILE_READ_AT";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEREADAT, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     /* ADIOI_File_read() defined in mpi-io/read.c */
     error_code = MPIOI_File_read(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
                                  count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/read_atall.c
+++ b/src/mpi/romio/mpi-io/read_atall.c
@@ -61,13 +61,19 @@ int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset, void *buf,
                          int count, MPI_Datatype datatype, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_IREAD_AT";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_read_all(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
-                                     count, datatype, myname, status);
+    error_code = MPIR_File_read_at_all_impl(fh, offset, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -93,11 +99,17 @@ int MPI_File_read_at_all_c(MPI_File fh, MPI_Offset offset, void *buf,
                            MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_IREAD_AT";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_read_all(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
-                                     count, datatype, myname, status);
+    error_code = MPIR_File_read_at_all_impl(fh, offset, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/read_atall.c
+++ b/src/mpi/romio/mpi-io/read_atall.c
@@ -62,18 +62,10 @@ int MPI_File_read_at_all(MPI_File fh, MPI_Offset offset, void *buf,
 {
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_AT";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEREADATALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_read_all(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
                                      count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }
@@ -102,18 +94,10 @@ int MPI_File_read_at_all_c(MPI_File fh, MPI_Offset offset, void *buf,
 {
     int error_code;
     static char myname[] = "MPI_FILE_IREAD_AT";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEREADATALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_read_all(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
                                      count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/read_ord.c
+++ b/src/mpi/romio/mpi-io/read_ord.c
@@ -59,7 +59,20 @@ Output Parameters:
 int MPI_File_read_ordered(MPI_File fh, void *buf, int count,
                           MPI_Datatype datatype, MPI_Status * status)
 {
-    return MPIOI_File_read_ordered(fh, buf, count, datatype, status);
+    int error_code;
+    ROMIO_THREAD_CS_ENTER();
+
+    error_code = MPIR_File_read_ordered_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
+
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
+    return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -83,77 +96,18 @@ Output Parameters:
 int MPI_File_read_ordered_c(MPI_File fh, void *buf, MPI_Count count,
                             MPI_Datatype datatype, MPI_Status * status)
 {
-    return MPIOI_File_read_ordered(fh, buf, count, datatype, status);
-}
-
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_read_ordered(MPI_File fh, void *buf, MPI_Aint count,
-                            MPI_Datatype datatype, MPI_Status * status)
-{
-    int error_code, nprocs, myrank;
-    ADIO_Offset incr;
-    MPI_Count datatype_size;
-    int source, dest;
-    static char myname[] = "MPI_FILE_READ_ORDERED";
-    ADIO_Offset shared_fp = 0;
-    ADIO_File adio_fh;
-
+    int error_code;
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    MPI_Type_size_x(datatype, &datatype_size);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_TEST_DEFERRED(adio_fh, "MPI_File_read_ordered", &error_code);
-
-    MPI_Comm_size(adio_fh->comm, &nprocs);
-    MPI_Comm_rank(adio_fh->comm, &myrank);
-
-    incr = (count * datatype_size) / adio_fh->etype_size;
-
-    /* Use a message as a 'token' to order the operations */
-    source = myrank - 1;
-    dest = myrank + 1;
-    if (source < 0)
-        source = MPI_PROC_NULL;
-    if (dest >= nprocs)
-        dest = MPI_PROC_NULL;
-    MPI_Recv(NULL, 0, MPI_BYTE, source, 0, adio_fh->comm, MPI_STATUS_IGNORE);
-
-    ADIO_Get_shared_fp(adio_fh, incr, &shared_fp, &error_code);
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS) {
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_read_ordered_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    MPI_Send(NULL, 0, MPI_BYTE, dest, 0, adio_fh->comm);
-
-    ADIO_ReadStridedColl(adio_fh, buf, count, datatype, ADIO_EXPLICIT_OFFSET,
-                         shared_fp, status, &error_code);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-
-    /* FIXME: Check for error code from ReadStridedColl? */
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/read_ordb.c
+++ b/src/mpi/romio/mpi-io/read_ordb.c
@@ -53,7 +53,20 @@ Output Parameters:
 @*/
 int MPI_File_read_ordered_begin(MPI_File fh, void *buf, int count, MPI_Datatype datatype)
 {
-    return MPIOI_File_read_ordered_begin(fh, buf, count, datatype);
+    int error_code;
+    ROMIO_THREAD_CS_ENTER();
+
+    error_code = MPIR_File_read_ordered_begin_impl(fh, buf, count, datatype);
+    if (error_code) {
+        goto fn_fail;
+    }
+
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
+    return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -74,107 +87,18 @@ Output Parameters:
 @*/
 int MPI_File_read_ordered_begin_c(MPI_File fh, void *buf, MPI_Count count, MPI_Datatype datatype)
 {
-    return MPIOI_File_read_ordered_begin(fh, buf, count, datatype);
-}
-
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_read_ordered_begin(MPI_File fh, void *buf, MPI_Aint count, MPI_Datatype datatype)
-{
-    int error_code, nprocs, myrank;
-    MPI_Count datatype_size;
-    int source, dest;
-    ADIO_Offset shared_fp, incr;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_READ_ORDERED_BEGIN";
-    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
-
+    int error_code;
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-
-    if (adio_fh->split_coll_count) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_IO, "**iosplitcoll", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_read_ordered_begin_impl(fh, buf, count, datatype);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    adio_fh->split_coll_count = 1;
-
-
-    MPI_Type_size_x(datatype, &datatype_size);
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_TEST_DEFERRED(adio_fh, myname, &error_code);
-
-    MPI_Comm_size(adio_fh->comm, &nprocs);
-    MPI_Comm_rank(adio_fh->comm, &myrank);
-
-    incr = (count * datatype_size) / adio_fh->etype_size;
-    /* Use a message as a 'token' to order the operations */
-    source = myrank - 1;
-    dest = myrank + 1;
-    if (source < 0)
-        source = MPI_PROC_NULL;
-    if (dest >= nprocs)
-        dest = MPI_PROC_NULL;
-    MPI_Recv(NULL, 0, MPI_BYTE, source, 0, adio_fh->comm, MPI_STATUS_IGNORE);
-
-    ADIO_Get_shared_fp(adio_fh, incr, &shared_fp, &error_code);
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS) {
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-    /* --END ERROR HANDLING-- */
-
-    MPI_Send(NULL, 0, MPI_BYTE, dest, 0, adio_fh->comm);
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        MPI_Aint e32_size = 0;
-        error_code = MPIU_datatype_full_size(datatype, &e32_size);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        e32_buf = ADIOI_Malloc(e32_size * count);
-        xbuf = e32_buf;
-    } else {
-        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-
-
-    ADIO_ReadStridedColl(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
-                         shared_fp, &adio_fh->split_status, &error_code);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-    if (e32_buf != NULL) {
-        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
-        ADIOI_Free(e32_buf);
-    }
-
-    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/read_orde.c
+++ b/src/mpi/romio/mpi-io/read_orde.c
@@ -38,35 +38,18 @@ Output Parameters:
 @*/
 int MPI_File_read_ordered_end(MPI_File fh, void *buf, MPI_Status * status)
 {
-    int error_code = MPI_SUCCESS;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_READ_ORDERED_END";
-
-    MPL_UNREFERENCED_ARG(buf);
-
+    int error_code;
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-
-    if (!(adio_fh->split_coll_count)) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_IO, "**iosplitcollnone", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_read_ordered_end_impl(fh, buf, status);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-#ifdef HAVE_STATUS_SET_BYTES
-    if (status != MPI_STATUS_IGNORE)
-        *status = adio_fh->split_status;
-#endif
-    adio_fh->split_coll_count = 0;
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/read_sh.c
+++ b/src/mpi/romio/mpi-io/read_sh.c
@@ -59,7 +59,20 @@ Output Parameters:
 int MPI_File_read_shared(MPI_File fh, void *buf, int count,
                          MPI_Datatype datatype, MPI_Status * status)
 {
-    return MPIOI_File_read_shared(fh, buf, count, datatype, status);
+    int error_code;
+    ROMIO_THREAD_CS_ENTER();
+
+    error_code = MPIR_File_read_shared_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
+
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
+    return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -83,120 +96,18 @@ Output Parameters:
 int MPI_File_read_shared_c(MPI_File fh, void *buf, MPI_Count count,
                            MPI_Datatype datatype, MPI_Status * status)
 {
-    return MPIOI_File_read_shared(fh, buf, count, datatype, status);
-}
-
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_read_shared(MPI_File fh, void *buf, MPI_Aint count,
-                           MPI_Datatype datatype, MPI_Status * status)
-{
-    int error_code, buftype_is_contig, filetype_is_contig;
-    static char myname[] = "MPI_FILE_READ_SHARED";
-    MPI_Count datatype_size;
-    ADIO_Offset off, shared_fp, incr, bufsize;
-    ADIO_File adio_fh;
-    void *xbuf = NULL, *e32_buf = NULL, *host_buf = NULL;
-
+    int error_code;
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    MPI_Type_size_x(datatype, &datatype_size);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    if (count * datatype_size == 0) {
-#ifdef HAVE_STATUS_SET_BYTES
-        MPIR_Status_set_bytes(status, datatype, 0);
-#endif
-        error_code = MPI_SUCCESS;
-        goto fn_exit;
+    error_code = MPIR_File_read_shared_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
     }
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_READABLE(adio_fh, myname, error_code);
-    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_Datatype_iscontig(datatype, &buftype_is_contig);
-    ADIOI_Datatype_iscontig(adio_fh->filetype, &filetype_is_contig);
-
-    ADIOI_TEST_DEFERRED(adio_fh, myname, &error_code);
-
-    incr = (count * datatype_size) / adio_fh->etype_size;
-
-    ADIO_Get_shared_fp(adio_fh, incr, &shared_fp, &error_code);
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS) {
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-    /* --END ERROR HANDLING-- */
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        MPI_Aint e32_size = 0;
-        error_code = MPIU_datatype_full_size(datatype, &e32_size);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        e32_buf = ADIOI_Malloc(e32_size * count);
-        xbuf = e32_buf;
-    } else {
-        MPIO_GPU_HOST_ALLOC(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-
-    /* contiguous or strided? */
-    if (buftype_is_contig && filetype_is_contig) {
-        /* convert count and shared_fp to bytes */
-        bufsize = datatype_size * count;
-        off = adio_fh->disp + adio_fh->etype_size * shared_fp;
-
-        /* if atomic mode requested, lock (exclusive) the region, because there
-         * could be a concurrent noncontiguous request. On NFS, locking
-         * is done in the ADIO_ReadContig. */
-
-        if ((adio_fh->atomicity) && (adio_fh->file_system != ADIO_NFS))
-            ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
-
-        ADIO_ReadContig(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
-                        off, status, &error_code);
-
-        if ((adio_fh->atomicity) && (adio_fh->file_system != ADIO_NFS))
-            ADIOI_UNLOCK(adio_fh, off, SEEK_SET, bufsize);
-    } else {
-        ADIO_ReadStrided(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
-                         shared_fp, status, &error_code);
-        /* For strided and atomic mode, locking is done in ADIO_ReadStrided */
-    }
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-    if (e32_buf != NULL) {
-        error_code = MPIU_read_external32_conversion_fn(buf, datatype, count, e32_buf);
-        ADIOI_Free(e32_buf);
-    }
-
-    MPIO_GPU_SWAP_BACK(host_buf, buf, count, datatype);
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/seek.c
+++ b/src/mpi/romio/mpi-io/seek.c
@@ -42,11 +42,6 @@ int MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence)
     static char myname[] = "MPI_FILE_SEEK";
     MPI_Offset curr_offset, eof_offset;
 
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILESEEK, TRDTBLOCK, adio_fh, MPI_DATATYPE_NULL, -1);
-#endif /* MPI_hpux */
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -122,9 +117,6 @@ int MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence)
         error_code = MPIO_Err_return_file(adio_fh, error_code);
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, adio_fh, MPI_DATATYPE_NULL, -1);
-#endif /* MPI_hpux */
 
     error_code = MPI_SUCCESS;
 

--- a/src/mpi/romio/mpi-io/seek.c
+++ b/src/mpi/romio/mpi-io/seek.c
@@ -38,89 +38,17 @@ Input Parameters:
 int MPI_File_seek(MPI_File fh, MPI_Offset offset, int whence)
 {
     int error_code;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_SEEK";
-    MPI_Offset curr_offset, eof_offset;
-
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    switch (whence) {
-        case MPI_SEEK_SET:
-            /* --BEGIN ERROR HANDLING-- */
-            if (offset < 0) {
-                error_code = MPIO_Err_create_code(MPI_SUCCESS,
-                                                  MPIR_ERR_RECOVERABLE, myname,
-                                                  __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
-                error_code = MPIO_Err_return_file(adio_fh, error_code);
-                goto fn_exit;
-            }
-            /* --END ERROR HANDLING-- */
-            break;
-        case MPI_SEEK_CUR:
-            /* find offset corr. to current location of file pointer */
-            ADIOI_Get_position(adio_fh, &curr_offset);
-            offset += curr_offset;
-
-            /* --BEGIN ERROR HANDLING-- */
-            if (offset < 0) {
-                error_code = MPIO_Err_create_code(MPI_SUCCESS,
-                                                  MPIR_ERR_RECOVERABLE, myname,
-                                                  __LINE__, MPI_ERR_ARG, "**ionegoffset", 0);
-                error_code = MPIO_Err_return_file(adio_fh, error_code);
-                goto fn_exit;
-            }
-            /* --END ERROR HANDLING-- */
-
-            break;
-        case MPI_SEEK_END:
-            /* we can in many cases do seeks w/o a file actually opened, but not in
-             * the MPI_SEEK_END case */
-            ADIOI_TEST_DEFERRED(adio_fh, "MPI_File_seek", &error_code);
-
-            /* find offset corr. to end of file */
-            ADIOI_Get_eof_offset(adio_fh, &eof_offset);
-            offset += eof_offset;
-
-            /* --BEGIN ERROR HANDLING-- */
-            if (offset < 0) {
-                error_code = MPIO_Err_create_code(MPI_SUCCESS,
-                                                  MPIR_ERR_RECOVERABLE, myname,
-                                                  __LINE__, MPI_ERR_ARG, "**ionegoffset", 0);
-                error_code = MPIO_Err_return_file(adio_fh, error_code);
-                goto fn_exit;
-            }
-            /* --END ERROR HANDLING-- */
-
-            break;
-        default:
-            /* --BEGIN ERROR HANDLING-- */
-            error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                              myname, __LINE__, MPI_ERR_ARG, "**iobadwhence", 0);
-            error_code = MPIO_Err_return_file(adio_fh, error_code);
-            goto fn_exit;
-            /* --END ERROR HANDLING-- */
+    error_code = MPIR_File_seek_impl(fh, offset, whence);
+    if (error_code) {
+        goto fn_fail;
     }
-
-    ADIO_SeekIndividual(adio_fh, offset, ADIO_SEEK_SET, &error_code);
-    /* TODO: what do we do with this error? */
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-
-    error_code = MPI_SUCCESS;
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/seek_sh.c
+++ b/src/mpi/romio/mpi-io/seek_sh.c
@@ -36,133 +36,18 @@ Input Parameters:
 @*/
 int MPI_File_seek_shared(MPI_File fh, MPI_Offset offset, int whence)
 {
-    int error_code = MPI_SUCCESS, tmp_whence, myrank;
-    static char myname[] = "MPI_FILE_SEEK_SHARED";
-    MPI_Offset curr_offset, eof_offset, tmp_offset;
-    ADIO_File adio_fh;
-
+    int error_code;
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    tmp_offset = offset;
-    MPI_Bcast(&tmp_offset, 1, ADIO_OFFSET, 0, adio_fh->comm);
-    /* --BEGIN ERROR HANDLING-- */
-    if (tmp_offset != offset) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**notsame", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_seek_shared_impl(fh, offset, whence);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    tmp_whence = whence;
-    MPI_Bcast(&tmp_whence, 1, MPI_INT, 0, adio_fh->comm);
-    /* --BEGIN ERROR HANDLING-- */
-    if (tmp_whence != whence) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iobadwhence", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_TEST_DEFERRED(adio_fh, "MPI_File_seek_shared", &error_code);
-
-    MPI_Comm_rank(adio_fh->comm, &myrank);
-
-    if (!myrank) {
-        switch (whence) {
-            case MPI_SEEK_SET:
-                /* --BEGIN ERROR HANDLING-- */
-                if (offset < 0) {
-                    error_code = MPIO_Err_create_code(MPI_SUCCESS,
-                                                      MPIR_ERR_RECOVERABLE,
-                                                      myname, __LINE__,
-                                                      MPI_ERR_ARG, "**iobadoffset", 0);
-                    error_code = MPIO_Err_return_file(adio_fh, error_code);
-                    goto fn_exit;
-                }
-                /* --END ERROR HANDLING-- */
-                break;
-            case MPI_SEEK_CUR:
-                /* get current location of shared file pointer */
-                ADIO_Get_shared_fp(adio_fh, 0, &curr_offset, &error_code);
-                /* --BEGIN ERROR HANDLING-- */
-                if (error_code != MPI_SUCCESS) {
-                    error_code = MPIO_Err_create_code(MPI_SUCCESS,
-                                                      MPIR_ERR_FATAL,
-                                                      myname, __LINE__,
-                                                      MPI_ERR_INTERN, "**iosharedfailed", 0);
-                    error_code = MPIO_Err_return_file(adio_fh, error_code);
-                    goto fn_exit;
-                }
-                /* --END ERROR HANDLING-- */
-                offset += curr_offset;
-                /* --BEGIN ERROR HANDLING-- */
-                if (offset < 0) {
-                    error_code = MPIO_Err_create_code(MPI_SUCCESS,
-                                                      MPIR_ERR_RECOVERABLE,
-                                                      myname, __LINE__,
-                                                      MPI_ERR_ARG, "**ionegoffset", 0);
-                    error_code = MPIO_Err_return_file(adio_fh, error_code);
-                    goto fn_exit;
-                }
-                /* --END ERROR HANDLING-- */
-                break;
-            case MPI_SEEK_END:
-                /* find offset corr. to end of file */
-                ADIOI_Get_eof_offset(adio_fh, &eof_offset);
-                offset += eof_offset;
-                /* --BEGIN ERROR HANDLING-- */
-                if (offset < 0) {
-                    error_code = MPIO_Err_create_code(MPI_SUCCESS,
-                                                      MPIR_ERR_RECOVERABLE,
-                                                      myname, __LINE__,
-                                                      MPI_ERR_ARG, "**ionegoffset", 0);
-                    error_code = MPIO_Err_return_file(adio_fh, error_code);
-                    goto fn_exit;
-                }
-                /* --END ERROR HANDLING-- */
-                break;
-            default:
-                /* --BEGIN ERROR HANDLING-- */
-                error_code = MPIO_Err_create_code(MPI_SUCCESS,
-                                                  MPIR_ERR_RECOVERABLE,
-                                                  myname, __LINE__, MPI_ERR_ARG,
-                                                  "**iobadwhence", 0);
-                error_code = MPIO_Err_return_file(adio_fh, error_code);
-                goto fn_exit;
-                /* --END ERROR HANDLING-- */
-        }
-
-        ADIO_Set_shared_fp(adio_fh, offset, &error_code);
-        /* --BEGIN ERROR HANDLING-- */
-        if (error_code != MPI_SUCCESS) {
-            error_code = MPIO_Err_create_code(MPI_SUCCESS,
-                                              MPIR_ERR_FATAL,
-                                              myname, __LINE__,
-                                              MPI_ERR_INTERN, "**iosharedfailed", 0);
-            error_code = MPIO_Err_return_file(adio_fh, error_code);
-            goto fn_exit;
-        }
-        /* --END ERROR HANDLING-- */
-
-    }
-
-    /* FIXME: explain why the barrier is necessary */
-    MPI_Barrier(adio_fh->comm);
-
-    error_code = MPI_SUCCESS;
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/set_atom.c
+++ b/src/mpi/romio/mpi-io/set_atom.c
@@ -35,56 +35,18 @@ Input Parameters:
 @*/
 int MPI_File_set_atomicity(MPI_File fh, int flag)
 {
-    int error_code, tmp_flag;
-    static char myname[] = "MPI_FILE_SET_ATOMICITY";
-    ADIO_Fcntl_t *fcntl_struct;
-    ADIO_File adio_fh;
-
+    int error_code;
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_TEST_DEFERRED(adio_fh, myname, &error_code);
-
-    if (flag)
-        flag = 1;       /* take care of non-one values! */
-
-/* check if flag is the same on all processes */
-    tmp_flag = flag;
-    MPI_Bcast(&tmp_flag, 1, MPI_INT, 0, adio_fh->comm);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (tmp_flag != flag) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**notsame", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_set_atomicity_impl(fh, flag);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    if (adio_fh->atomicity == flag) {
-        error_code = MPI_SUCCESS;
-        goto fn_exit;
-    }
-
-
-    fcntl_struct = (ADIO_Fcntl_t *) ADIOI_Malloc(sizeof(ADIO_Fcntl_t));
-    fcntl_struct->atomicity = flag;
-    ADIO_Fcntl(adio_fh, ADIO_FCNTL_SET_ATOMICITY, fcntl_struct, &error_code);
-    /* TODO: what do we do with this error code? */
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_Free(fcntl_struct);
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/set_info.c
+++ b/src/mpi/romio/mpi-io/set_info.c
@@ -45,7 +45,7 @@ int MPI_File_set_info(MPI_File fh, MPI_Info info)
 
     /* --BEGIN ERROR HANDLING-- */
     MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_INFO_ALL(info, error_code, fh->comm);
+    MPIO_CHECK_INFO_ALL(info, myname, error_code, fh->comm);
     /* --END ERROR HANDLING-- */
 
     /* set new info */

--- a/src/mpi/romio/mpi-io/set_info.c
+++ b/src/mpi/romio/mpi-io/set_info.c
@@ -36,30 +36,17 @@ Input Parameters:
 int MPI_File_set_info(MPI_File fh, MPI_Info info)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_SET_INFO";
-    ADIO_File adio_fh;
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_INFO_ALL(info, myname, error_code, fh->comm);
-    /* --END ERROR HANDLING-- */
-
-    /* set new info */
-    ADIO_SetInfo(adio_fh, info, &error_code);
+    error_code = MPIR_File_set_info_impl(fh, info);
+    if (error_code) {
+        goto fn_fail;
+    }
 
   fn_exit:
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
   fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
     goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/set_size.c
+++ b/src/mpi/romio/mpi-io/set_size.c
@@ -36,58 +36,17 @@ Input Parameters:
 int MPI_File_set_size(MPI_File fh, MPI_Offset size)
 {
     int error_code;
-    ADIO_File adio_fh;
-    static char myname[] = "MPI_FILE_SET_SIZE";
-    MPI_Offset tmp_sz, max_sz, min_sz;
-
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-
-    if (size < 0) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iobadsize", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_set_size_impl(fh, size);
+    if (error_code) {
+        goto fn_fail;
     }
-    MPIO_CHECK_WRITABLE(fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    tmp_sz = size;
-    MPI_Allreduce(&tmp_sz, &max_sz, 1, ADIO_OFFSET, MPI_MAX, adio_fh->comm);
-    MPI_Allreduce(&tmp_sz, &min_sz, 1, ADIO_OFFSET, MPI_MIN, adio_fh->comm);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (max_sz != min_sz) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**notsame", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-    /* --END ERROR HANDLING-- */
-
-    if (!ADIO_Feature(adio_fh, ADIO_SCALABLE_RESIZE)) {
-        /* rare stupid file systems (like NFS) need to carry out resize on all
-         * processes */
-        ADIOI_TEST_DEFERRED(adio_fh, "MPI_File_set_size", &error_code);
-    }
-
-    ADIO_Resize(adio_fh, size, &error_code);
-    /* TODO: what to do with error code? */
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/set_size.c
+++ b/src/mpi/romio/mpi-io/set_size.c
@@ -40,11 +40,6 @@ int MPI_File_set_size(MPI_File fh, MPI_Offset size)
     static char myname[] = "MPI_FILE_SET_SIZE";
     MPI_Offset tmp_sz, max_sz, min_sz;
 
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILESETSIZE, TRDTBLOCK, adio_fh, MPI_DATATYPE_NULL, -1);
-#endif /* MPI_hpux */
 
     ROMIO_THREAD_CS_ENTER();
 
@@ -90,9 +85,6 @@ int MPI_File_set_size(MPI_File fh, MPI_Offset size)
         error_code = MPIO_Err_return_file(adio_fh, error_code);
     /* --END ERROR HANDLING-- */
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, adio_fh, MPI_DATATYPE_NULL, -1);
-#endif /* MPI_hpux */
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();

--- a/src/mpi/romio/mpi-io/set_view.c
+++ b/src/mpi/romio/mpi-io/set_view.c
@@ -41,145 +41,18 @@ Input Parameters:
 int MPI_File_set_view(MPI_File fh, MPI_Offset disp, MPI_Datatype etype,
                       MPI_Datatype filetype, ROMIO_CONST char *datarep, MPI_Info info)
 {
-    int error_code = MPI_SUCCESS;
-    MPI_Count filetype_size, etype_size;
-    static char myname[] = "MPI_FILE_SET_VIEW";
-    ADIO_Offset shared_fp, byte_off;
-    ADIO_File adio_fh;
-
+    int error_code;
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-
-    if ((disp < 0) && (disp != MPI_DISPLACEMENT_CURRENT)) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iobaddisp", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_set_view_impl(fh, disp, etype, filetype, datarep, info);
+    if (error_code) {
+        goto fn_fail;
     }
-
-    /* rudimentary checks for incorrect etype/filetype. */
-    if (etype == MPI_DATATYPE_NULL) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**ioetype", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-    MPIO_DATATYPE_ISCOMMITTED(etype, error_code);
-    if (error_code != MPI_SUCCESS) {
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-
-    if (filetype == MPI_DATATYPE_NULL) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iofiletype", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-    MPIO_DATATYPE_ISCOMMITTED(filetype, error_code);
-    if (error_code != MPI_SUCCESS) {
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-
-    if ((adio_fh->access_mode & MPI_MODE_SEQUENTIAL) && (disp != MPI_DISPLACEMENT_CURRENT)) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iodispifseq", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-
-    if ((disp == MPI_DISPLACEMENT_CURRENT) && !(adio_fh->access_mode & MPI_MODE_SEQUENTIAL)) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iodispifseq", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-    MPIO_CHECK_INFO_ALL(info, myname, error_code, adio_fh->comm);
-    /* --END ERROR HANDLING-- */
-
-    MPI_Type_size_x(filetype, &filetype_size);
-    MPI_Type_size_x(etype, &etype_size);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (etype_size != 0 && filetype_size % etype_size != 0) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iofiletype", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-
-    if ((datarep == NULL) || (strcmp(datarep, "native") &&
-                              strcmp(datarep, "NATIVE") &&
-                              strcmp(datarep, "external32") &&
-                              strcmp(datarep, "EXTERNAL32") &&
-                              strcmp(datarep, "internal") && strcmp(datarep, "INTERNAL"))) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__,
-                                          MPI_ERR_UNSUPPORTED_DATAREP, "**unsupporteddatarep", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-    /* --END ERROR HANDLING-- */
-
-    if (disp == MPI_DISPLACEMENT_CURRENT) {
-        MPI_Barrier(adio_fh->comm);
-        ADIO_Get_shared_fp(adio_fh, 0, &shared_fp, &error_code);
-        /* TODO: check error code */
-
-        MPI_Barrier(adio_fh->comm);
-        ADIOI_Get_byte_offset(adio_fh, shared_fp, &byte_off);
-        /* TODO: check error code */
-
-        disp = byte_off;
-    }
-
-    ADIO_Set_view(adio_fh, disp, etype, filetype, info, &error_code);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS) {
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-    /* --END ERROR HANDLING-- */
-
-    /* reset shared file pointer to zero */
-    if (ADIO_Feature(adio_fh, ADIO_SHARED_FP) && (adio_fh->shared_fp_fd != ADIO_FILE_NULL)) {
-        /* only one process needs to set it to zero, but I don't want to
-         * create the shared-file-pointer file if shared file pointers have
-         * not been used so far. Therefore, every process that has already
-         * opened the shared-file-pointer file sets the shared file pointer
-         * to zero. If the file was not opened, the value is automatically
-         * zero. Note that shared file pointer is stored as no. of etypes
-         * relative to the current view, whereas indiv. file pointer is
-         * stored in bytes. */
-
-        ADIO_Set_shared_fp(adio_fh, 0, &error_code);
-        /* --BEGIN ERROR HANDLING-- */
-        if (error_code != MPI_SUCCESS)
-            error_code = MPIO_Err_return_file(adio_fh, error_code);
-        /* --END ERROR HANDLING-- */
-    }
-
-    if (ADIO_Feature(adio_fh, ADIO_SHARED_FP)) {
-        MPI_Barrier(adio_fh->comm);     /* for above to work correctly */
-    }
-    if (strcmp(datarep, "external32") && strcmp(datarep, "EXTERNAL32"))
-        adio_fh->is_external32 = 0;
-    else
-        adio_fh->is_external32 = 1;
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
   fn_fail:
-    /* --BEGIN ERROR HANDLING-- */
     error_code = MPIO_Err_return_file(fh, error_code);
     goto fn_exit;
-    /* --END ERROR HANDLING-- */
 }

--- a/src/mpi/romio/mpi-io/set_view.c
+++ b/src/mpi/romio/mpi-io/set_view.c
@@ -99,7 +99,7 @@ int MPI_File_set_view(MPI_File fh, MPI_Offset disp, MPI_Datatype etype,
         error_code = MPIO_Err_return_file(adio_fh, error_code);
         goto fn_exit;
     }
-    MPIO_CHECK_INFO_ALL(info, error_code, adio_fh->comm);
+    MPIO_CHECK_INFO_ALL(info, myname, error_code, adio_fh->comm);
     /* --END ERROR HANDLING-- */
 
     MPI_Type_size_x(filetype, &filetype_size);

--- a/src/mpi/romio/mpi-io/wr_atallb.c
+++ b/src/mpi/romio/mpi-io/wr_atallb.c
@@ -57,12 +57,19 @@ int MPI_File_write_at_all_begin(MPI_File fh, MPI_Offset offset, ROMIO_CONST void
                                 int count, MPI_Datatype datatype)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_WRITE_AT_ALL_BEGIN";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_write_all_begin(fh, offset,
-                                            ADIO_EXPLICIT_OFFSET, buf, count, datatype, myname);
+    error_code = MPIR_File_write_at_all_begin_impl(fh, offset, buf, count, datatype);
+    if (error_code) {
+        goto fn_fail;
+    }
 
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -85,10 +92,17 @@ int MPI_File_write_at_all_begin_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST vo
                                   MPI_Count count, MPI_Datatype datatype)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_WRITE_AT_ALL_BEGIN";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_write_all_begin(fh, offset,
-                                            ADIO_EXPLICIT_OFFSET, buf, count, datatype, myname);
+    error_code = MPIR_File_write_at_all_begin_impl(fh, offset, buf, count, datatype);
+    if (error_code) {
+        goto fn_fail;
+    }
 
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/wr_atalle.c
+++ b/src/mpi/romio/mpi-io/wr_atalle.c
@@ -39,9 +39,17 @@ Output Parameters:
 int MPI_File_write_at_all_end(MPI_File fh, ROMIO_CONST void *buf, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_WRITE_AT_ALL_END";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_write_all_end(fh, buf, myname, status);
+    error_code = MPIR_File_write_at_all_end_impl(fh, buf, status);
+    if (error_code) {
+        goto fn_fail;
+    }
 
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/write.c
+++ b/src/mpi/romio/mpi-io/write.c
@@ -58,13 +58,19 @@ int MPI_File_write(MPI_File fh, ROMIO_CONST void *buf, int count,
                    MPI_Datatype datatype, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_WRITE";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_write(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf,
-                                  count, datatype, myname, status);
+    error_code = MPIR_File_write_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -89,131 +95,17 @@ int MPI_File_write_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                      MPI_Datatype datatype, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_WRITE";
-
-    error_code = MPIOI_File_write(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf,
-                                  count, datatype, myname, status);
-
-
-    return error_code;
-}
-
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_write(MPI_File fh,
-                     MPI_Offset offset,
-                     int file_ptr_type,
-                     const void *buf,
-                     MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Status * status)
-{
-    int error_code, buftype_is_contig, filetype_is_contig;
-    MPI_Count datatype_size;
-    ADIO_Offset off, bufsize;
-    ADIO_File adio_fh;
-    void *e32buf = NULL;
-    const void *xbuf = NULL;
-    void *host_buf = NULL;
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-
-    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_write_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    MPI_Type_size_x(datatype, &datatype_size);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    if (count * datatype_size == 0) {
-#ifdef HAVE_STATUS_SET_BYTES
-        MPIR_Status_set_bytes(status, datatype, 0);
-#endif
-        error_code = MPI_SUCCESS;
-        goto fn_exit;
-    }
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_WRITABLE(adio_fh, myname, error_code);
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_Datatype_iscontig(datatype, &buftype_is_contig);
-    ADIOI_Datatype_iscontig(adio_fh->filetype, &filetype_is_contig);
-
-    ADIOI_TEST_DEFERRED(adio_fh, myname, &error_code);
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        xbuf = e32buf;
-    } else {
-        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-
-    if (buftype_is_contig && filetype_is_contig) {
-        /* convert bufcount and offset to bytes */
-        bufsize = datatype_size * count;
-        if (file_ptr_type == ADIO_EXPLICIT_OFFSET) {
-            off = adio_fh->disp + adio_fh->etype_size * offset;
-        } else {        /* ADIO_INDIVIDUAL */
-
-            off = adio_fh->fp_ind;
-        }
-
-        /* if atomic mode requested, lock (exclusive) the region, because
-         * there could be a concurrent noncontiguous request. Locking doesn't
-         * work on some parallel file systems, and on NFS it is done in the
-         * ADIO_WriteContig.
-         */
-
-        if ((adio_fh->atomicity) && ADIO_Feature(adio_fh, ADIO_LOCKS)) {
-            ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
-        }
-
-        ADIO_WriteContig(adio_fh, xbuf, count, datatype, file_ptr_type, off, status, &error_code);
-
-        if ((adio_fh->atomicity) && ADIO_Feature(adio_fh, ADIO_LOCKS)) {
-            ADIOI_UNLOCK(adio_fh, off, SEEK_SET, bufsize);
-        }
-    } else {
-        /* For strided and atomic mode, locking is done in ADIO_WriteStrided */
-        ADIO_WriteStrided(adio_fh, xbuf, count, datatype, file_ptr_type,
-                          offset, status, &error_code);
-    }
-
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
 
   fn_exit:
-    if (e32buf != NULL)
-        ADIOI_Free(e32buf);
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/write.c
+++ b/src/mpi/romio/mpi-io/write.c
@@ -59,18 +59,10 @@ int MPI_File_write(MPI_File fh, ROMIO_CONST void *buf, int count,
 {
     int error_code;
     static char myname[] = "MPI_FILE_WRITE";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEWRITE, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_write(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf,
                                   count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }
@@ -98,18 +90,10 @@ int MPI_File_write_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
 {
     int error_code;
     static char myname[] = "MPI_FILE_WRITE";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEWRITE, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_write(fh, (MPI_Offset) 0, ADIO_INDIVIDUAL, buf,
                                   count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/write_all.c
+++ b/src/mpi/romio/mpi-io/write_all.c
@@ -59,13 +59,19 @@ int MPI_File_write_all(MPI_File fh, ROMIO_CONST void *buf, int count,
                        MPI_Datatype datatype, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_WRITE_ALL";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_write_all(fh, (MPI_Offset) 0,
-                                      ADIO_INDIVIDUAL, buf, count, datatype, myname, status);
+    error_code = MPIR_File_write_all_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -90,84 +96,17 @@ int MPI_File_write_all_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                          MPI_Datatype datatype, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_WRITE_ALL";
-
-    error_code = MPIOI_File_write_all(fh, (MPI_Offset) 0,
-                                      ADIO_INDIVIDUAL, buf, count, datatype, myname, status);
-
-
-    return error_code;
-}
-
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_write_all(MPI_File fh,
-                         MPI_Offset offset,
-                         int file_ptr_type,
-                         const void *buf,
-                         MPI_Aint count, MPI_Datatype datatype, char *myname, MPI_Status * status)
-{
-    int error_code;
-    MPI_Count datatype_size;
-    ADIO_File adio_fh;
-    void *e32buf = NULL;
-    const void *xbuf = NULL;
-    void *host_buf = NULL;
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-
-    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_write_all_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    MPI_Type_size_x(datatype, &datatype_size);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_WRITABLE(adio_fh, myname, error_code);
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        xbuf = e32buf;
-    } else {
-        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-    ADIO_WriteStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
-                          offset, status, &error_code);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
 
   fn_exit:
-    if (e32buf != NULL)
-        ADIOI_Free(e32buf);
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/write_all.c
+++ b/src/mpi/romio/mpi-io/write_all.c
@@ -60,18 +60,10 @@ int MPI_File_write_all(MPI_File fh, ROMIO_CONST void *buf, int count,
 {
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_ALL";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEWRITEALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_write_all(fh, (MPI_Offset) 0,
                                       ADIO_INDIVIDUAL, buf, count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }
@@ -99,18 +91,10 @@ int MPI_File_write_all_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
 {
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_ALL";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEWRITEALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_write_all(fh, (MPI_Offset) 0,
                                       ADIO_INDIVIDUAL, buf, count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/write_allb.c
+++ b/src/mpi/romio/mpi-io/write_allb.c
@@ -53,12 +53,19 @@ Input Parameters:
 int MPI_File_write_all_begin(MPI_File fh, ROMIO_CONST void *buf, int count, MPI_Datatype datatype)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_WRITE_ALL_BEGIN";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_write_all_begin(fh, (MPI_Offset) 0,
-                                            ADIO_INDIVIDUAL, buf, count, datatype, myname);
+    error_code = MPIR_File_write_all_begin_impl(fh, buf, count, datatype);
+    if (error_code) {
+        goto fn_fail;
+    }
 
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -80,92 +87,17 @@ int MPI_File_write_all_begin_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count cou
                                MPI_Datatype datatype)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_WRITE_ALL_BEGIN";
-
-    error_code = MPIOI_File_write_all_begin(fh, (MPI_Offset) 0,
-                                            ADIO_INDIVIDUAL, buf, count, datatype, myname);
-
-    return error_code;
-}
-
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_write_all_begin(MPI_File fh,
-                               MPI_Offset offset,
-                               int file_ptr_type,
-                               const void *buf, MPI_Aint count, MPI_Datatype datatype, char *myname)
-{
-    int error_code;
-    MPI_Count datatype_size;
-    ADIO_File adio_fh;
-    void *e32buf = NULL;
-    const void *xbuf = NULL;
-    void *host_buf = NULL;
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-    MPIO_CHECK_NOT_SEQUENTIAL_MODE(adio_fh, myname, error_code);
-
-    if (file_ptr_type == ADIO_EXPLICIT_OFFSET && offset < 0) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_ARG, "**iobadoffset", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_write_all_begin_impl(fh, buf, count, datatype);
+    if (error_code) {
+        goto fn_fail;
     }
-
-    if (adio_fh->split_coll_count) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_IO, "**iosplitcoll", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-    /* --END ERROR HANDLING-- */
-
-    adio_fh->split_coll_count = 1;
-
-    MPI_Type_size_x(datatype, &datatype_size);
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        xbuf = e32buf;
-    } else {
-        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-
-    adio_fh->split_datatype = datatype;
-    ADIO_WriteStridedColl(adio_fh, xbuf, count, datatype, file_ptr_type,
-                          offset, &adio_fh->split_status, &error_code);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
 
   fn_exit:
-    if (e32buf != NULL)
-        ADIOI_Free(e32buf);
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/write_alle.c
+++ b/src/mpi/romio/mpi-io/write_alle.c
@@ -39,51 +39,17 @@ Output Parameters:
 int MPI_File_write_all_end(MPI_File fh, ROMIO_CONST void *buf, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_WRITE_ALL_END";
-
-    error_code = MPIOI_File_write_all_end(fh, buf, myname, status);
-
-    return error_code;
-}
-
-/* prevent multiple definitions of this routine */
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_write_all_end(MPI_File fh, const void *buf, char *myname, MPI_Status * status)
-{
-    int error_code;
-    ADIO_File adio_fh;
-
-    MPL_UNREFERENCED_ARG(buf);
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-
-    if (!(adio_fh->split_coll_count)) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_IO, "**iosplitcollnone", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_write_all_end_impl(fh, buf, status);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-#ifdef HAVE_STATUS_SET_BYTES
-    /* FIXME - we should really ensure that the split_datatype remains
-     * valid by incrementing the ref count in the write_allb.c routine
-     * and decrement it here after setting the bytes */
-    if (status != MPI_STATUS_IGNORE)
-        *status = adio_fh->split_status;
-#endif
-    adio_fh->split_coll_count = 0;
-
-    error_code = MPI_SUCCESS;
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/write_at.c
+++ b/src/mpi/romio/mpi-io/write_at.c
@@ -62,19 +62,11 @@ int MPI_File_write_at(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
 {
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_AT";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEWRITEAT, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     /* MPIOI_File_write() defined in mpi-io/write.c */
     error_code = MPIOI_File_write(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
                                   count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }
@@ -103,19 +95,11 @@ int MPI_File_write_at_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
 {
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_AT";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEWRITEAT, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     /* MPIOI_File_write() defined in mpi-io/write.c */
     error_code = MPIOI_File_write(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
                                   count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
 
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/write_at.c
+++ b/src/mpi/romio/mpi-io/write_at.c
@@ -61,14 +61,19 @@ int MPI_File_write_at(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
                       int count, MPI_Datatype datatype, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_WRITE_AT";
+    ROMIO_THREAD_CS_ENTER();
 
-    /* MPIOI_File_write() defined in mpi-io/write.c */
-    error_code = MPIOI_File_write(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
-                                  count, datatype, myname, status);
+    error_code = MPIR_File_write_at_impl(fh, offset, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -94,12 +99,17 @@ int MPI_File_write_at_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
                         MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_WRITE_AT";
+    ROMIO_THREAD_CS_ENTER();
 
-    /* MPIOI_File_write() defined in mpi-io/write.c */
-    error_code = MPIOI_File_write(fh, offset, ADIO_EXPLICIT_OFFSET, buf,
-                                  count, datatype, myname, status);
+    error_code = MPIR_File_write_at_impl(fh, offset, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
 
-
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/write_atall.c
+++ b/src/mpi/romio/mpi-io/write_atall.c
@@ -61,12 +61,19 @@ int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
                           int count, MPI_Datatype datatype, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_WRITE_AT_ALL";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_write_all(fh, offset, ADIO_EXPLICIT_OFFSET,
-                                      buf, count, datatype, myname, status);
+    error_code = MPIR_File_write_at_all_impl(fh, offset, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
 
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -92,10 +99,17 @@ int MPI_File_write_at_all_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *bu
                             MPI_Count count, MPI_Datatype datatype, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_WRITE_AT_ALL";
+    ROMIO_THREAD_CS_ENTER();
 
-    error_code = MPIOI_File_write_all(fh, offset, ADIO_EXPLICIT_OFFSET,
-                                      buf, count, datatype, myname, status);
+    error_code = MPIR_File_write_at_all_impl(fh, offset, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
 
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/write_atall.c
+++ b/src/mpi/romio/mpi-io/write_atall.c
@@ -62,18 +62,10 @@ int MPI_File_write_at_all(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *buf,
 {
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_AT_ALL";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEWRITEATALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_write_all(fh, offset, ADIO_EXPLICIT_OFFSET,
                                       buf, count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
     return error_code;
 }
 
@@ -101,17 +93,9 @@ int MPI_File_write_at_all_c(MPI_File fh, MPI_Offset offset, ROMIO_CONST void *bu
 {
     int error_code;
     static char myname[] = "MPI_FILE_WRITE_AT_ALL";
-#ifdef MPI_hpux
-    int fl_xmpi;
-
-    HPMP_IO_START(fl_xmpi, BLKMPIFILEWRITEATALL, TRDTBLOCK, fh, datatype, count);
-#endif /* MPI_hpux */
 
     error_code = MPIOI_File_write_all(fh, offset, ADIO_EXPLICIT_OFFSET,
                                       buf, count, datatype, myname, status);
 
-#ifdef MPI_hpux
-    HPMP_IO_END(fl_xmpi, fh, datatype, count);
-#endif /* MPI_hpux */
     return error_code;
 }

--- a/src/mpi/romio/mpi-io/write_ord.c
+++ b/src/mpi/romio/mpi-io/write_ord.c
@@ -59,7 +59,20 @@ Output Parameters:
 int MPI_File_write_ordered(MPI_File fh, ROMIO_CONST void *buf, int count,
                            MPI_Datatype datatype, MPI_Status * status)
 {
-    return MPIOI_File_write_ordered(fh, buf, count, datatype, status);
+    int error_code;
+    ROMIO_THREAD_CS_ENTER();
+
+    error_code = MPIR_File_write_ordered_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
+
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
+    return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -83,100 +96,18 @@ Output Parameters:
 int MPI_File_write_ordered_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                              MPI_Datatype datatype, MPI_Status * status)
 {
-    return MPIOI_File_write_ordered(fh, buf, count, datatype, status);
-}
-
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_write_ordered(MPI_File fh, const void *buf, MPI_Aint count,
-                             MPI_Datatype datatype, MPI_Status * status)
-{
-    int error_code, nprocs, myrank;
-    ADIO_Offset incr;
-    MPI_Count datatype_size;
-    int source, dest;
-    static char myname[] = "MPI_FILE_WRITE_ORDERED";
-    ADIO_Offset shared_fp;
-    ADIO_File adio_fh;
-    void *e32buf = NULL;
-    const void *xbuf;
-    void *host_buf = NULL;
-
+    int error_code;
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    MPI_Type_size_x(datatype, &datatype_size);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_TEST_DEFERRED(adio_fh, myname, &error_code);
-
-    MPI_Comm_size(adio_fh->comm, &nprocs);
-    MPI_Comm_rank(adio_fh->comm, &myrank);
-
-    incr = (count * datatype_size) / adio_fh->etype_size;
-    /* Use a message as a 'token' to order the operations */
-    source = myrank - 1;
-    dest = myrank + 1;
-    if (source < 0)
-        source = MPI_PROC_NULL;
-    if (dest >= nprocs)
-        dest = MPI_PROC_NULL;
-    MPI_Recv(NULL, 0, MPI_BYTE, source, 0, adio_fh->comm, MPI_STATUS_IGNORE);
-
-    ADIO_Get_shared_fp(adio_fh, incr, &shared_fp, &error_code);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_FATAL,
-                                          myname, __LINE__, MPI_ERR_INTERN, "**iosharedfailed", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_write_ordered_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    MPI_Send(NULL, 0, MPI_BYTE, dest, 0, adio_fh->comm);
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        xbuf = e32buf;
-    } else {
-        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-
-    ADIO_WriteStridedColl(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
-                          shared_fp, status, &error_code);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
 
   fn_exit:
-    if (e32buf != NULL)
-        ADIOI_Free(e32buf);
     ROMIO_THREAD_CS_EXIT();
-
-    /* FIXME: Check for error code from WriteStridedColl? */
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/src/mpi/romio/mpi-io/write_ordb.c
+++ b/src/mpi/romio/mpi-io/write_ordb.c
@@ -55,7 +55,20 @@ Output Parameters:
 int MPI_File_write_ordered_begin(MPI_File fh, ROMIO_CONST void *buf, int count,
                                  MPI_Datatype datatype)
 {
-    return MPIOI_File_write_ordered_begin(fh, buf, count, datatype);
+    int error_code;
+    ROMIO_THREAD_CS_ENTER();
+
+    error_code = MPIR_File_write_ordered_begin_impl(fh, buf, count, datatype);
+    if (error_code) {
+        goto fn_fail;
+    }
+
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
+    return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -77,105 +90,21 @@ Output Parameters:
 int MPI_File_write_ordered_begin_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                                    MPI_Datatype datatype)
 {
-    return MPIOI_File_write_ordered_begin(fh, buf, count, datatype);
-}
-
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_write_ordered_begin(MPI_File fh, const void *buf, MPI_Aint count,
-                                   MPI_Datatype datatype)
-{
-    int error_code, nprocs, myrank;
-    ADIO_Offset incr;
-    MPI_Count datatype_size;
-    int source, dest;
-    static char myname[] = "MPI_FILE_WRITE_ORDERED_BEGIN";
-    ADIO_Offset shared_fp;
-    ADIO_File adio_fh;
-    void *e32buf = NULL;
-    const void *xbuf = NULL;
-    void *host_buf = NULL;
-
+    int error_code;
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-
-    if (adio_fh->split_coll_count) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_IO, "**iosplitcoll", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_write_ordered_begin_impl(fh, buf, count, datatype);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-    adio_fh->split_coll_count = 1;
-
-    MPI_Type_size_x(datatype, &datatype_size);
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_TEST_DEFERRED(adio_fh, myname, &error_code);
-
-    MPI_Comm_size(adio_fh->comm, &nprocs);
-    MPI_Comm_rank(adio_fh->comm, &myrank);
-
-    incr = (count * datatype_size) / adio_fh->etype_size;
-    /* Use a message as a 'token' to order the operations */
-    source = myrank - 1;
-    dest = myrank + 1;
-    if (source < 0)
-        source = MPI_PROC_NULL;
-    if (dest >= nprocs)
-        dest = MPI_PROC_NULL;
-    MPI_Recv(NULL, 0, MPI_BYTE, source, 0, adio_fh->comm, MPI_STATUS_IGNORE);
-
-    ADIO_Get_shared_fp(adio_fh, incr, &shared_fp, &error_code);
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_FATAL,
-                                          myname, __LINE__, MPI_ERR_INTERN, "**iosharedfailed", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-    /* --END ERROR HANDLING-- */
-
-    MPI_Send(NULL, 0, MPI_BYTE, dest, 0, adio_fh->comm);
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        xbuf = e32buf;
-    } else {
-        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-
-    ADIO_WriteStridedColl(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
-                          shared_fp, &adio_fh->split_status, &error_code);
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-
-    /* FIXME: Check for error code from WriteStridedColl? */
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
+
+#ifdef MPIO_BUILD_PROFILING
 #endif

--- a/src/mpi/romio/mpi-io/write_orde.c
+++ b/src/mpi/romio/mpi-io/write_orde.c
@@ -39,34 +39,17 @@ Output Parameters:
 int MPI_File_write_ordered_end(MPI_File fh, ROMIO_CONST void *buf, MPI_Status * status)
 {
     int error_code;
-    static char myname[] = "MPI_FILE_WRITE_ORDERED_END";
-    ADIO_File adio_fh;
-
-    MPL_UNREFERENCED_ARG(buf);
-
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-
-    if (!(adio_fh->split_coll_count)) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
-                                          myname, __LINE__, MPI_ERR_IO, "**iosplitcollnone", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
+    error_code = MPIR_File_write_ordered_end_impl(fh, buf, status);
+    if (error_code) {
+        goto fn_fail;
     }
-    /* --END ERROR HANDLING-- */
-
-#ifdef HAVE_STATUS_SET_BYTES
-    if (status != MPI_STATUS_IGNORE)
-        *status = adio_fh->split_status;
-#endif
-    adio_fh->split_coll_count = 0;
-
 
   fn_exit:
     ROMIO_THREAD_CS_EXIT();
-    return MPI_SUCCESS;
+    return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }

--- a/src/mpi/romio/mpi-io/write_sh.c
+++ b/src/mpi/romio/mpi-io/write_sh.c
@@ -59,7 +59,20 @@ Output Parameters:
 int MPI_File_write_shared(MPI_File fh, ROMIO_CONST void *buf, int count,
                           MPI_Datatype datatype, MPI_Status * status)
 {
-    return MPIOI_File_write_shared(fh, buf, count, datatype, status);
+    int error_code;
+    ROMIO_THREAD_CS_ENTER();
+
+    error_code = MPIR_File_write_shared_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
+    }
+
+  fn_exit:
+    ROMIO_THREAD_CS_EXIT();
+    return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
 
 /* large count function */
@@ -83,117 +96,18 @@ Output Parameters:
 int MPI_File_write_shared_c(MPI_File fh, ROMIO_CONST void *buf, MPI_Count count,
                             MPI_Datatype datatype, MPI_Status * status)
 {
-    return MPIOI_File_write_shared(fh, buf, count, datatype, status);
-}
-
-#ifdef MPIO_BUILD_PROFILING
-int MPIOI_File_write_shared(MPI_File fh, const void *buf, MPI_Aint count,
-                            MPI_Datatype datatype, MPI_Status * status)
-{
-    int error_code, buftype_is_contig, filetype_is_contig;
-    ADIO_Offset bufsize;
-    static char myname[] = "MPI_FILE_READ_SHARED";
-    MPI_Count datatype_size, incr;
-    ADIO_Offset off, shared_fp;
-    ADIO_File adio_fh;
-    void *e32buf = NULL;
-    const void *xbuf = NULL;
-    void *host_buf = NULL;
-
+    int error_code;
     ROMIO_THREAD_CS_ENTER();
 
-    adio_fh = MPIO_File_resolve(fh);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_FILE_HANDLE(adio_fh, myname, error_code);
-    MPIO_CHECK_COUNT(adio_fh, count, myname, error_code);
-    MPIO_CHECK_DATATYPE(adio_fh, datatype, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    MPI_Type_size_x(datatype, &datatype_size);
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_COUNT_SIZE(adio_fh, count, datatype_size, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    if (count * datatype_size == 0) {
-#ifdef HAVE_STATUS_SET_BYTES
-        MPIR_Status_set_bytes(status, datatype, 0);
-#endif
-        error_code = MPI_SUCCESS;
-        goto fn_exit;
+    error_code = MPIR_File_write_shared_impl(fh, buf, count, datatype, status);
+    if (error_code) {
+        goto fn_fail;
     }
-
-    /* --BEGIN ERROR HANDLING-- */
-    MPIO_CHECK_INTEGRAL_ETYPE(adio_fh, count, datatype_size, myname, error_code);
-    MPIO_CHECK_FS_SUPPORTS_SHARED(adio_fh, myname, error_code);
-    /* --END ERROR HANDLING-- */
-
-    ADIOI_Datatype_iscontig(datatype, &buftype_is_contig);
-    ADIOI_Datatype_iscontig(adio_fh->filetype, &filetype_is_contig);
-
-    ADIOI_TEST_DEFERRED(adio_fh, myname, &error_code);
-
-    incr = (count * datatype_size) / adio_fh->etype_size;
-
-    ADIO_Get_shared_fp(adio_fh, incr, &shared_fp, &error_code);
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS) {
-        error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_FATAL,
-                                          myname, __LINE__, MPI_ERR_INTERN, "**iosharedfailed", 0);
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-        goto fn_exit;
-    }
-    /* --END ERROR HANDLING-- */
-
-    xbuf = buf;
-    if (adio_fh->is_external32) {
-        error_code = MPIU_external32_buffer_setup(buf, count, datatype, &e32buf);
-        if (error_code != MPI_SUCCESS)
-            goto fn_exit;
-
-        xbuf = e32buf;
-    } else {
-        MPIO_GPU_HOST_SWAP(host_buf, buf, count, datatype);
-        if (host_buf != NULL) {
-            xbuf = host_buf;
-        }
-    }
-
-    if (buftype_is_contig && filetype_is_contig) {
-        /* convert bufocunt and shared_fp to bytes */
-        bufsize = datatype_size * count;
-        off = adio_fh->disp + adio_fh->etype_size * shared_fp;
-
-        /* if atomic mode requested, lock (exclusive) the region, because there
-         * could be a concurrent noncontiguous request. On NFS, locking is
-         * done in the ADIO_WriteContig. */
-
-        if ((adio_fh->atomicity) && (adio_fh->file_system != ADIO_NFS))
-            ADIOI_WRITE_LOCK(adio_fh, off, SEEK_SET, bufsize);
-
-        ADIO_WriteContig(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
-                         off, status, &error_code);
-
-        if ((adio_fh->atomicity) && (adio_fh->file_system != ADIO_NFS))
-            ADIOI_UNLOCK(adio_fh, off, SEEK_SET, bufsize);
-    } else {
-        ADIO_WriteStrided(adio_fh, xbuf, count, datatype, ADIO_EXPLICIT_OFFSET,
-                          shared_fp, status, &error_code);
-        /* For strided and atomic mode, locking is done in ADIO_WriteStrided */
-    }
-
-    /* --BEGIN ERROR HANDLING-- */
-    if (error_code != MPI_SUCCESS)
-        error_code = MPIO_Err_return_file(adio_fh, error_code);
-    /* --END ERROR HANDLING-- */
-
-    MPIO_GPU_HOST_FREE(host_buf, count, datatype);
 
   fn_exit:
-    if (e32buf != NULL)
-        ADIOI_Free(e32buf);
     ROMIO_THREAD_CS_EXIT();
     return error_code;
+  fn_fail:
+    error_code = MPIO_Err_return_file(fh, error_code);
+    goto fn_exit;
 }
-#endif

--- a/test/mpi/io/resized.c
+++ b/test/mpi/io/resized.c
@@ -51,7 +51,18 @@ int main(int argc, char **argv)
         strcpy(filename, *argv);
     }
 
-    MPI_File_delete(filename, MPI_INFO_NULL);
+    /* delete the file in case it exists. If it exists, it should return MPI_ERR_NO_SUCH_FILE */
+    mpi_errno = MPI_File_delete(filename, MPI_INFO_NULL);
+    if (mpi_errno != MPI_SUCCESS) {
+        int error_class = 0;
+        MPI_Error_class(mpi_errno, &error_class);
+        if (error_class != MPI_ERR_NO_SUCH_FILE) {
+            printf
+                ("MPI_File_delete returned error code %x, error class %x, expect error class MPI_ERR_NO_SUCH_FILE\n",
+                 mpi_errno, error_class);
+            errs++;
+        }
+    }
 
     /* create a resized type comprising an integer with an lb at sizeof(int) and extent = 3*sizeof(int) */
     lb = sizeof(int);


### PR DESCRIPTION

## Pull Request Description
This PR is a split from https://github.com/pmodels/mpich/pull/7228. It should not change any of the ROMIO behaviors.

Refactor to split interface and implementation. This prepares for
binding generations.

The binding layer, e.g. open.c, close.c, etc. will be replaced by python
generation when ROMIO is building `FROM_MPICH`.


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
