### PR TITLE
mpi.h: Move stdint header inclusion outside of extern C block

### DIFF
--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -77,6 +77,24 @@
 #define MPICH_CALC_VERSION(MAJOR, MINOR, REVISION, TYPE, PATCH) \
     (((MAJOR) * 10000000) + ((MINOR) * 100000) + ((REVISION) * 1000) + ((TYPE) * 100) + (PATCH))
 
+#if !defined(INT8_C)
+/* stdint.h was not included, see if we can get it */
+#  if defined(__cplusplus)
+#    if __cplusplus >= 201103
+#      include <cstdint>
+#    endif
+#  endif
+#endif
+
+#if !defined(INT8_C)
+/* stdint.h was not included, see if we can get it */
+#  if defined(__STDC_VERSION__)
+#    if __STDC_VERSION__ >= 199901
+#      include <stdint.h>
+#    endif
+#  endif
+#endif
+
 /* Keep C++ compilers from getting confused */
 #if defined(__cplusplus)
 extern "C" {
@@ -103,24 +121,6 @@ extern "C" {
 #  define MPICH_ATTR_TYPE_TAG(type)
 #  define MPICH_ATTR_TYPE_TAG_LAYOUT_COMPATIBLE(type)
 #  define MPICH_ATTR_TYPE_TAG_MUST_BE_NULL()
-#endif
-
-#if !defined(INT8_C)
-/* stdint.h was not included, see if we can get it */
-#  if defined(__cplusplus)
-#    if __cplusplus >= 201103
-#      include <cstdint>
-#    endif
-#  endif
-#endif
-
-#if !defined(INT8_C)
-/* stdint.h was not included, see if we can get it */
-#  if defined(__STDC_VERSION__)
-#    if __STDC_VERSION__ >= 199901
-#      include <stdint.h>
-#    endif
-#  endif
 #endif
 
 #if defined(INT8_C)


### PR DESCRIPTION
## Pull Request Description

In C++ mode we try to include <cstdint> so we can annotate fixed-width integer types, but doing so within an extern C block can cause an error. Move these header includes outside of extern C to avoid the issue. Observed on macOS with Xcode 16.2 and CXXFLAGS=-std=gnu++20:

```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__assertion_handler:29:1: error: templates must have C++ linkage
   29 | template <class T>
      | ^~~~~~~~~~~~~~~~~~
./src/include/mpi.h:60:1: note: extern "C" language linkage specification begins here
   60 | extern "C" {
      | ^
1 error generated.
```

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
