### PR TITLE
ch3: use group to build communicator vc tables 

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -296,6 +296,15 @@ void MPIR_stream_comm_free(MPIR_Comm * comm_ptr);
 int MPIR_Comm_copy_stream(MPIR_Comm * oldcomm, MPIR_Comm * newcomm);
 int MPIR_get_local_gpu_stream(MPIR_Comm * comm_ptr, MPL_gpu_stream_t * gpu_stream);
 
+MPL_STATIC_INLINE_PREFIX MPIR_Lpid MPIR_comm_rank_to_lpid(MPIR_Comm * comm_ptr, int rank)
+{
+    if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
+        return MPIR_Group_rank_to_lpid(comm_ptr->local_group, rank);
+    } else {
+        return MPIR_Group_rank_to_lpid(comm_ptr->remote_group, rank);
+    }
+}
+
 MPL_STATIC_INLINE_PREFIX MPIR_Stream *MPIR_stream_comm_get_local_stream(MPIR_Comm * comm_ptr)
 {
     if (comm_ptr->stream_comm_type == MPIR_STREAM_COMM_SINGLE) {

--- a/src/include/mpir_group.h
+++ b/src/include/mpir_group.h
@@ -81,6 +81,14 @@ int MPIR_find_world(const char *namespace);
  */
 typedef int64_t MPIR_Lpid;
 
+#define MPIR_LPID_WORLD_INDEX(lpid) ((lpid) >> 32)
+#define MPIR_LPID_WORLD_RANK(lpid)  ((lpid) & 0xffffffff)
+#define MPIR_LPID_FROM(world_idx, world_rank) (((uint64_t)(world_idx) << 32) | (world_rank))
+/* A dynamic mask is used for temporary lpid during establishing dynamic connections.
+ *     dynamic_lpid = MPIR_LPID_DYNAMIC_MASK | index_to_dynamic_av_table
+ */
+#define MPIR_LPID_DYNAMIC_MASK ((MPIR_Lpid)0x1 << 63)
+
 struct MPIR_Pmap {
     int size;                   /* same as group->size, duplicate here so Pmap is logically complete */
     bool use_map;

--- a/src/include/mpir_group.h
+++ b/src/include/mpir_group.h
@@ -142,12 +142,26 @@ int MPIR_Group_create_map(int size, int rank, MPIR_Session * session_ptr, MPIR_L
 int MPIR_Group_create_stride(int size, int rank, MPIR_Session * session_ptr,
                              MPIR_Lpid offset, MPIR_Lpid stride, MPIR_Lpid blocksize,
                              MPIR_Group ** new_group_ptr);
-MPIR_Lpid MPIR_Group_rank_to_lpid(MPIR_Group * group, int rank);
 int MPIR_Group_lpid_to_rank(MPIR_Group * group, MPIR_Lpid lpid);
 
 int MPIR_Group_check_subset(MPIR_Group * group_ptr, MPIR_Comm * comm_ptr);
 void MPIR_Group_set_session_ptr(MPIR_Group * group_ptr, MPIR_Session * session_out);
 int MPIR_Group_init(void);
 void MPIR_Group_finalize(void);
+
+MPL_STATIC_INLINE_PREFIX MPIR_Lpid MPIR_Group_rank_to_lpid(MPIR_Group * group, int rank)
+{
+    if (rank < 0 || rank >= group->pmap.size) {
+        return MPI_UNDEFINED;
+    }
+
+    if (group->pmap.use_map) {
+        return group->pmap.u.map[rank];
+    } else {
+        MPIR_Lpid i_blk = rank / group->pmap.u.stride.blocksize;
+        MPIR_Lpid r_blk = rank % group->pmap.u.stride.blocksize;
+        return group->pmap.u.stride.offset + i_blk * group->pmap.u.stride.stride + r_blk;
+    }
+}
 
 #endif /* MPIR_GROUP_H_INCLUDED */

--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -407,31 +407,6 @@ int MPIR_Comm_create_inter(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Co
     mpi_errno = MPII_Comm_create_calculate_mapping(group_ptr, comm_ptr, &mapping, &mapping_comm);
     MPIR_ERR_CHECK(mpi_errno);
 
-    *newcomm_ptr = NULL;
-
-    if (group_ptr->rank != MPI_UNDEFINED) {
-        /* Get the new communicator structure and context id */
-        mpi_errno = MPIR_Comm_create(newcomm_ptr);
-        if (mpi_errno)
-            goto fn_fail;
-
-        (*newcomm_ptr)->recvcontext_id = new_context_id;
-        (*newcomm_ptr)->rank = group_ptr->rank;
-        (*newcomm_ptr)->comm_kind = comm_ptr->comm_kind;
-        /* Since the group has been provided, let the new communicator know
-         * about the group */
-        (*newcomm_ptr)->local_comm = 0;
-        (*newcomm_ptr)->local_group = group_ptr;
-        MPIR_Group_add_ref(group_ptr);
-
-        (*newcomm_ptr)->local_size = group_ptr->size;
-        (*newcomm_ptr)->remote_group = 0;
-
-        (*newcomm_ptr)->is_low_group = comm_ptr->is_low_group;
-
-        MPIR_Comm_set_session_ptr(*newcomm_ptr, session_ptr);
-    }
-
     /* There is an additional step.  We must communicate the
      * information on the local context id and the group members,
      * given by the ranks so that the remote process can construct the
@@ -454,9 +429,6 @@ int MPIR_Comm_create_inter(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Co
                                   rinfo, 2, MPIR_INT_INTERNAL, 0, 0, comm_ptr, MPI_STATUS_IGNORE,
                                   MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
-        if (*newcomm_ptr != NULL) {
-            (*newcomm_ptr)->context_id = rinfo[0];
-        }
         remote_size = rinfo[1];
 
         MPIR_CHKLMEM_MALLOC(remote_mapping, remote_size * sizeof(int));
@@ -478,9 +450,7 @@ int MPIR_Comm_create_inter(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Co
         /* Broadcast to the other members of the local group */
         mpi_errno = MPIR_Bcast(rinfo, 2, MPIR_INT_INTERNAL, 0, comm_ptr->local_comm, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
-        if (*newcomm_ptr != NULL) {
-            (*newcomm_ptr)->context_id = rinfo[0];
-        }
+
         remote_size = rinfo[1];
         MPIR_CHKLMEM_MALLOC(remote_mapping, remote_size * sizeof(int));
         mpi_errno = MPIR_Bcast(remote_mapping, remote_size, MPIR_INT_INTERNAL, 0,
@@ -489,9 +459,45 @@ int MPIR_Comm_create_inter(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Co
     }
 
     MPIR_Assert(remote_size >= 0);
+    if (group_ptr->rank == MPI_UNDEFINED || remote_size <= 0) {
+        /* If we are not part of the group, or -
+         * It's possible that no members of the other side of comm were
+         * members of the group that they passed, which we only know after
+         * receiving/bcasting the remote_size above.  We must return
+         * MPI_COMM_NULL in this case.
+         */
+        MPIR_Free_contextid(new_context_id);
+        *newcomm_ptr = NULL;
+        goto fn_exit;
+    }
+
+    /* FIXME: the branch was kept to minimize line changes. Remove the if-check. */
+    if (group_ptr->rank != MPI_UNDEFINED) {
+        /* Get the new communicator structure and context id */
+        mpi_errno = MPIR_Comm_create(newcomm_ptr);
+        if (mpi_errno)
+            goto fn_fail;
+
+        (*newcomm_ptr)->context_id = rinfo[0];
+        (*newcomm_ptr)->remote_size = rinfo[1];
+        (*newcomm_ptr)->recvcontext_id = new_context_id;
+        (*newcomm_ptr)->rank = group_ptr->rank;
+        (*newcomm_ptr)->comm_kind = comm_ptr->comm_kind;
+        /* Since the group has been provided, let the new communicator know
+         * about the group */
+        (*newcomm_ptr)->local_comm = 0;
+        (*newcomm_ptr)->local_group = group_ptr;
+        MPIR_Group_add_ref(group_ptr);
+
+        (*newcomm_ptr)->local_size = group_ptr->size;
+        (*newcomm_ptr)->remote_group = 0;
+
+        (*newcomm_ptr)->is_low_group = comm_ptr->is_low_group;
+
+        MPIR_Comm_set_session_ptr(*newcomm_ptr, session_ptr);
+    }
 
     if (group_ptr->rank != MPI_UNDEFINED) {
-        (*newcomm_ptr)->remote_size = remote_size;
         /* Now, everyone has the remote_mapping, and can apply that to
          * the network address mapping. */
 
@@ -521,23 +527,6 @@ int MPIR_Comm_create_inter(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Co
         (*newcomm_ptr)->tainted = comm_ptr->tainted;
         mpi_errno = MPIR_Comm_commit(*newcomm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
-
-        if (remote_size <= 0) {
-            /* It's possible that no members of the other side of comm were
-             * members of the group that they passed, which we only know after
-             * receiving/bcasting the remote_size above.  We must return
-             * MPI_COMM_NULL in this case, but we can't free the newcomm_ptr
-             * immediately after the communication above because
-             * MPIR_Comm_release won't work correctly with a half-constructed
-             * comm. */
-            mpi_errno = MPIR_Comm_release(*newcomm_ptr);
-            MPIR_ERR_CHECK(mpi_errno);
-            *newcomm_ptr = NULL;
-        }
-    } else {
-        /* This process is not in the group */
-        MPIR_Free_contextid(new_context_id);
-        *newcomm_ptr = NULL;
     }
 
   fn_exit:

--- a/src/mpi/group/grouputil.c
+++ b/src/mpi/group/grouputil.c
@@ -117,6 +117,9 @@ int MPIR_Group_release(MPIR_Group * group_ptr)
             /* Release session */
             MPIR_Session_release(group_ptr->session_ptr);
         }
+#ifdef MPID_DEV_GROUP_DECL
+        mpi_errno = MPID_Group_free_hook(group_ptr);
+#endif
         MPIR_Handle_obj_free(&MPIR_Group_mem, group_ptr);
     }
 
@@ -150,6 +153,9 @@ int MPIR_Group_create(int nproc, MPIR_Group ** new_group_ptr)
     (*new_group_ptr)->session_ptr = NULL;
     memset(&(*new_group_ptr)->pmap, 0, sizeof(struct MPIR_Pmap));
     (*new_group_ptr)->pmap.size = nproc;
+#ifdef MPID_DEV_GROUP_DECL
+    mpi_errno = MPID_Group_init_hook(*new_group_ptr);
+#endif
 
     return mpi_errno;
 }
@@ -182,6 +188,9 @@ int MPIR_Group_dup(MPIR_Group * old_group, MPIR_Session * session_ptr, MPIR_Grou
     }
 
     *new_group_ptr = new_group;
+#ifdef MPID_DEV_GROUP_DECL
+    mpi_errno = MPID_Group_init_hook(*new_group_ptr);
+#endif
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/group/grouputil.c
+++ b/src/mpi/group/grouputil.c
@@ -204,6 +204,8 @@ int MPIR_Group_create_map(int size, int rank, MPIR_Session * session_ptr, MPIR_L
          * for others it is implied */
         MPL_free(map);
         *new_group_ptr = MPIR_Group_empty;
+        MPIR_Group_add_ref(*new_group_ptr);
+        goto fn_exit;
     } else {
         MPIR_Group *newgrp;
         mpi_errno = MPIR_Group_create(size, &newgrp);

--- a/src/mpi/group/grouputil.c
+++ b/src/mpi/group/grouputil.c
@@ -270,16 +270,10 @@ int MPIR_Group_create_stride(int size, int rank, MPIR_Session * session_ptr,
 }
 
 static int pmap_lpid_to_rank(struct MPIR_Pmap *pmap, MPIR_Lpid lpid);
-static MPIR_Lpid pmap_rank_to_lpid(struct MPIR_Pmap *pmap, int rank);
 
 int MPIR_Group_lpid_to_rank(MPIR_Group * group, MPIR_Lpid lpid)
 {
     return pmap_lpid_to_rank(&group->pmap, lpid);
-}
-
-MPIR_Lpid MPIR_Group_rank_to_lpid(MPIR_Group * group, int rank)
-{
-    return pmap_rank_to_lpid(&group->pmap, rank);
 }
 
 #ifdef HAVE_ERROR_CHECKING
@@ -518,21 +512,6 @@ static bool check_map_is_strided(int size, MPIR_Lpid * map,
             *blocksize_out = blocksize;
             return true;
         }
-    }
-}
-
-static MPIR_Lpid pmap_rank_to_lpid(struct MPIR_Pmap *pmap, int rank)
-{
-    if (rank < 0 || rank >= pmap->size) {
-        return MPI_UNDEFINED;
-    }
-
-    if (pmap->use_map) {
-        return pmap->u.map[rank];
-    } else {
-        MPIR_Lpid i_blk = rank / pmap->u.stride.blocksize;
-        MPIR_Lpid r_blk = rank % pmap->u.stride.blocksize;
-        return pmap->u.stride.offset + i_blk * pmap->u.stride.stride + r_blk;
     }
 }
 

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -490,7 +490,7 @@ typedef int (*MPIDI_PG_Destroy_fn_t)(MPIDI_PG_t * pg);
 
 int MPIDI_VCRT_Create(int size, struct MPIDI_VCRT **vcrt_ptr);
 int MPIDI_VCRT_Add_ref(struct MPIDI_VCRT *vcrt);
-int MPIDI_VCRT_Release(struct MPIDI_VCRT *vcrt, int isDisconnect);
+int MPIDI_VCRT_Release(struct MPIDI_VCRT *vcrt);
 int MPIDI_VCR_Dup(MPIDI_VCR orig_vcr, MPIDI_VCR * new_vcr);
 
 int MPIDI_PG_Init(MPIDI_PG_Compare_ids_fn_t, MPIDI_PG_Destroy_fn_t);

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -1134,7 +1134,7 @@ int MPIDI_CH3I_Get_accumulate(const void *origin_addr, MPI_Aint origin_count,
   MPIDI_CH3_Progress_signal_completion - Inform the progress engine that a 
   pending request has completed.
 
-  IMPLEMENTORS:
+  IMPLEMENTERS:
   In a single-threaded environment, this routine can be implemented by
   incrementing a request completion counter.  In a
   multi-threaded environment, the request completion counter must be atomically
@@ -1235,10 +1235,10 @@ int MPIDI_CH3I_VC_post_sockconnect(MPIDI_VC_t * );
  all processes in comm*/
 int MPID_PG_BCast( MPIR_Comm *peercomm_p, MPIR_Comm *comm_p, int root );
 
-/* Channel defintitions */
+/* Channel definititions */
 /*@
-  MPIDI_CH3_iStartMsg - A non-blocking request to send a CH3 packet.  A r
-  equest object is allocated only if the send could not be completed 
+  MPIDI_CH3_iStartMsg - A non-blocking request to send a CH3 packet.  A
+  request object is allocated only if the send could not be completed 
   immediately.
 
   Input Parameters:
@@ -1288,7 +1288,7 @@ int MPIDI_CH3_iStartMsg(MPIDI_VC_t * vc, void * pkt, intptr_t pkt_sz,
   packet structure and the vector may be allocated on
   the stack.
 
-  IMPLEMENTORS:
+  IMPLEMENTERS:
   If the send can not be completed immediately, the CH3 packet structure and 
   the vector must be stored internally until the
   request is complete.
@@ -1352,7 +1352,7 @@ int MPIDI_CH3_iSend(MPIDI_VC_t * vc, MPIR_Request * sreq, void * pkt,
   packet structure and the vector may be allocated on
   the stack.
 
-  IMPLEMENTORS:
+  IMPLEMENTERS:
   If the send can not be completed immediately, the packet structure and the 
   vector must be stored internally until the request is
   complete.

--- a/src/mpid/ch3/include/mpidpost.h
+++ b/src/mpid/ch3/include/mpidpost.h
@@ -45,7 +45,7 @@
       }
 .ve
 
-  IMPLEMENTORS:
+  IMPLEMENTERS:
   A multi-threaded implementation might save the current value of a request 
   completion counter in the state.
 @*/
@@ -66,7 +66,7 @@ void MPIDI_CH3_Progress_start(MPID_Progress_state * state);
   NOTE:
   MPIDI_CH3_Progress_start/end() need to be called.
   
-  IMPLEMENTORS:
+  IMPLEMENTERS:
   A multi-threaded implementation would return immediately if the a request 
   had been completed between the call to
   MPIDI_CH3_Progress_start() and MPIDI_CH3_Progress_wait().  This could be 
@@ -110,7 +110,7 @@ int MPIDI_CH3_Progress_test(void);
   Return value:
   An mpi error code.
   
-  IMPLEMENTORS:
+  IMPLEMENTERS:
   This routine is similar to MPIDI_CH3_Progress_test but may not be as 
   thorough in its attempt to satisfy all outstanding
   communication.

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -195,6 +195,11 @@ typedef struct MPIDI_CH3I_comm
 }
 MPIDI_CH3I_comm_t;
 
+/* add vcrt to MPIR_Group so we can inherit it whenever possible */
+#define MPID_DEV_GROUP_DECL  struct MPIDI_VCRT *ch3_vcrt;
+int MPID_Group_init_hook(MPIR_Group * group_ptr);
+int MPID_Group_free_hook(MPIR_Group * group_ptr);
+
 #define MPID_DEV_COMM_DECL MPIDI_CH3I_comm_t dev;
 
 #ifndef DEFINED_REQ

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -182,10 +182,6 @@ typedef struct MPIDI_CH3I_comm
                              * waiting for a revoke message before we can release
                              * the context id */
 
-    int is_disconnected;    /* set to TRUE if this communicator was
-                             * disconnected as a part of
-                             * MPI_COMM_DISCONNECT; FALSE otherwise. */
-
     struct MPIDI_VCRT *vcrt;          /* virtual connection reference table */
     struct MPIDI_VCRT *local_vcrt;    /* local virtual connection reference table */
 

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -480,7 +480,7 @@ typedef struct MPIDI_Request {
      *   4. The callback function can complete other requests, thus
      *      calling those requests' callback functions.  However, the
      *      recursion depth of request completion function is limited.
-     *      If we ever need deeper recurisve calls, we need to change
+     *      If we ever need deeper recursive calls, we need to change
      *      to an iterative design instead of a recursive design for
      *      request completion.
      *

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -581,3 +581,22 @@ void MPIDI_CH3I_Comm_find(int context_id, MPIR_Comm **comm)
 
     MPIR_FUNC_EXIT;
 }
+
+int MPID_Group_init_hook(MPIR_Group * group_ptr)
+{
+    group_ptr->ch3_vcrt = NULL;
+    return MPI_SUCCESS;
+}
+
+int MPID_Group_free_hook(MPIR_Group * group_ptr)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    if (group_ptr->ch3_vcrt) {
+        /* FIXME: setting TRUE so vc entries may get released.
+         *        Is there a case we don't want that?
+         */
+        mpi_errno = MPIDI_VCRT_Release(group_ptr->ch3_vcrt, TRUE);
+    }
+    return mpi_errno;
+}

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -172,11 +172,6 @@ int MPIDI_CH3I_Comm_commit_pre_hook(MPIR_Comm *comm)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    /* initialize the is_disconnected variable to FALSE.  this will be
-     * set to TRUE if the communicator is freed by an
-     * MPI_COMM_DISCONNECT call. */
-    comm->dev.is_disconnected = 0;
-
     if (comm == MPIR_Process.comm_world) {
         comm->rank        = MPIR_Process.rank;
         comm->remote_size = MPIR_Process.size;
@@ -288,11 +283,11 @@ int MPIDI_CH3I_Comm_destroy_hook(MPIR_Comm *comm)
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    mpi_errno = MPIDI_VCRT_Release(comm->dev.vcrt, comm->dev.is_disconnected);
+    mpi_errno = MPIDI_VCRT_Release(comm->dev.vcrt);
     MPIR_ERR_CHECK(mpi_errno);
 
     if (comm->comm_kind == MPIR_COMM_KIND__INTERCOMM) {
-        mpi_errno = MPIDI_VCRT_Release(comm->dev.local_vcrt, comm->dev.is_disconnected);
+        mpi_errno = MPIDI_VCRT_Release(comm->dev.local_vcrt);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -522,10 +517,7 @@ int MPID_Group_free_hook(MPIR_Group * group_ptr)
     int mpi_errno = MPI_SUCCESS;
 
     if (group_ptr->ch3_vcrt) {
-        /* FIXME: setting TRUE so vc entries may get released.
-         *        Is there a case we don't want that?
-         */
-        mpi_errno = MPIDI_VCRT_Release(group_ptr->ch3_vcrt, TRUE);
+        mpi_errno = MPIDI_VCRT_Release(group_ptr->ch3_vcrt);
     }
     return mpi_errno;
 }

--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -487,11 +487,9 @@ static int MPIDI_CH3I_Initialize_tmp_comm(MPIR_Comm **comm_pptr,
 					  MPIDI_VC_t *vc_ptr, int is_low_group, int context_id_offset)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Comm *tmp_comm, *commself_ptr;
+    MPIR_Comm *tmp_comm;
 
     MPIR_FUNC_ENTER;
-
-    MPIR_Comm_get_ptr( MPI_COMM_SELF, commself_ptr );
 
     /* WDG-old code allocated a context id that was then discarded */
     mpi_errno = MPIR_Comm_create(&tmp_comm);
@@ -524,11 +522,6 @@ static int MPIDI_CH3I_Initialize_tmp_comm(MPIR_Comm **comm_pptr,
     /* No pg structure needed since vc has already been set up 
        (connection has been established). */
 
-    /* Point local vcrt at those of commself_ptr */
-    /* FIXME: Explain why */
-    tmp_comm->dev.local_vcrt = commself_ptr->dev.vcrt;
-    MPIDI_VCRT_Add_ref(commself_ptr->dev.vcrt);
-
     /* No pg needed since connection has already been formed. 
        FIXME - ensure that the comm_release code does not try to
        free an unallocated pg */
@@ -542,27 +535,28 @@ static int MPIDI_CH3I_Initialize_tmp_comm(MPIR_Comm **comm_pptr,
     /* FIXME: Why do we do a dup here? */
     MPIDI_VCR_Dup(vc_ptr, &tmp_comm->dev.vcrt->vcr_table[0]);
 
-    MPIR_Coll_comm_init(tmp_comm);
-
-    MPIR_Lpid local_lpid = tmp_comm->dev.local_vcrt->vcr_table[0]->lpid;
-    MPIR_Lpid remote_lpid = tmp_comm->dev.vcrt->vcr_table[0]->lpid;
-    mpi_errno = MPIR_Group_create_stride(1, 0, commself_ptr->session_ptr, local_lpid, 1, 1,
-                                         &tmp_comm->local_group);
-    mpi_errno = MPIR_Group_create_stride(1, 0, commself_ptr->session_ptr, remote_lpid, 1, 1,
-                                         &tmp_comm->remote_group);
-
-    /* Even though this is a tmp comm and we don't call
-       MPI_Comm_commit, we still need to call the creation hook
-       because the destruction hook will be called in comm_release */
-    mpi_errno = MPID_Comm_commit_pre_hook(tmp_comm);
-    MPIR_ERR_CHECK(mpi_errno);
-    
     *comm_pptr = tmp_comm;
 
 fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
 fn_fail:
+    goto fn_exit;
+}
+
+static int MPIDI_CH3I_Release_tmp_comm(MPIR_Comm *tmp_comm)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIDI_VCRT_Release(tmp_comm->dev.vcrt, FALSE);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPIR_Free_contextid(tmp_comm->recvcontext_id);
+    MPIR_Handle_obj_free(&MPIR_Comm_mem, tmp_comm);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
     goto fn_exit;
 }
 
@@ -746,7 +740,7 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
         MPIR_ERR_CHECK(mpi_errno);
 
         /* All communication with remote root done. Release the communicator. */
-        MPIR_Comm_release(tmp_comm);
+        MPIDI_CH3I_Release_tmp_comm(tmp_comm);
     }
 
     /*printf("connect:barrier\n");fflush(stdout);*/
@@ -1268,7 +1262,7 @@ int MPIDI_Comm_accept(const char *port_name, MPIR_Info *info, int root,
         MPIR_ERR_CHECK(mpi_errno);
 
         /* All communication with remote root done. Release the communicator. */
-        MPIR_Comm_release(tmp_comm);
+        MPIDI_CH3I_Release_tmp_comm(tmp_comm);
     }
 
     MPL_DBG_MSG(MPIDI_CH3_DBG_CONNECT,VERBOSE,"Barrier");

--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -1326,20 +1326,6 @@ static int SetupNewIntercomm( MPIR_Comm *comm_ptr, int remote_comm_size,
     intercomm->comm_kind    = MPIR_COMM_KIND__INTERCOMM;
     intercomm->local_comm   = NULL;
 
-    /* Point local vcrt at those of incoming intracommunicator */
-    intercomm->dev.local_vcrt = comm_ptr->dev.vcrt;
-    MPIDI_VCRT_Add_ref(comm_ptr->dev.vcrt);
-
-    /* Set up VC reference table */
-    mpi_errno = MPIDI_VCRT_Create(intercomm->remote_size, &intercomm->dev.vcrt);
-    if (mpi_errno != MPI_SUCCESS) {
-	MPIR_ERR_SETANDJUMP(mpi_errno,MPI_ERR_OTHER, "**init_vcrt");
-    }
-    for (i=0; i < intercomm->remote_size; i++) {
-	MPIDI_PG_Dup_vcr(remote_pg[remote_translation[i].pg_index], 
-			 remote_translation[i].pg_rank, &intercomm->dev.vcrt->vcr_table[i]);
-    }
-
     intercomm->local_group  = comm_ptr->local_group;
     MPIR_Group_add_ref(comm_ptr->local_group);
 

--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -548,7 +548,7 @@ static int MPIDI_CH3I_Release_tmp_comm(MPIR_Comm *tmp_comm)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    mpi_errno = MPIDI_VCRT_Release(tmp_comm->dev.vcrt, FALSE);
+    mpi_errno = MPIDI_VCRT_Release(tmp_comm->dev.vcrt);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIR_Free_contextid(tmp_comm->recvcontext_id);

--- a/src/mpid/ch3/src/mpid_comm_disconnect.c
+++ b/src/mpid/ch3/src/mpid_comm_disconnect.c
@@ -27,10 +27,6 @@ int MPID_Comm_disconnect(MPIR_Comm *comm_ptr)
         MPIR_ERR_SETANDJUMP(mpi_errno,MPIX_ERR_REVOKED,"**revoked");
     }
 
-    /* it's more than a comm_release, but ok for now */
-    /* FIXME: Describe what more might be required */
-    /* MPIU_PG_Printall( stdout ); */
-    comm_ptr->dev.is_disconnected = 1;
     mpi_errno = MPIR_Comm_release(comm_ptr);
     MPIR_ERR_CHECK(mpi_errno);
     /* If any of the VCs were released by this Comm_release, wait

--- a/src/mpid/ch3/src/mpid_vc.c
+++ b/src/mpid/ch3/src/mpid_vc.c
@@ -623,64 +623,8 @@ int MPID_Create_intercomm_from_lpids( MPIR_Comm *newcomm_ptr,
 			    int size, const MPIR_Lpid lpids[] )
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_Comm *commworld_ptr;
-    int i;
-    MPIDI_PG_iterator iter;
 
-    commworld_ptr = MPIR_Process.comm_world;
-    /* Setup the communicator's vc table: remote group */
-    MPIDI_VCRT_Create( size, &newcomm_ptr->dev.vcrt );
-    for (i=0; i<size; i++) {
-	MPIDI_VC_t *vc = 0;
-
-	/* For rank i in the new communicator, find the corresponding
-	   virtual connection.  For lpids less than the size of comm_world,
-	   we can just take the corresponding entry from comm_world.
-	   Otherwise, we need to search through the process groups.
-	*/
-	/* printf( "[%d] Remote rank %d has lpid %d\n", 
-	   MPIR_Process.comm_world->rank, i, lpids[i] ); */
-	if (lpids[i] < commworld_ptr->remote_size) {
-	    vc = commworld_ptr->dev.vcrt->vcr_table[lpids[i]];
-	}
-	else {
-	    /* We must find the corresponding vcr for a given lpid */	
-	    /* For now, this means iterating through the process groups */
-	    MPIDI_PG_t *pg = 0;
-	    int j;
-
-	    MPIDI_PG_Get_iterator(&iter);
-	    /* Skip comm_world */
-	    MPIDI_PG_Get_next( &iter, &pg );
-	    do {
-		MPIDI_PG_Get_next( &iter, &pg );
-                MPIR_ERR_CHKINTERNAL(!pg, mpi_errno, "no pg");
-		/* FIXME: a quick check on the min/max values of the lpid
-		   for this process group could help speed this search */
-		for (j=0; j<pg->size; j++) {
-		    /*printf( "Checking lpid %d against %d in pg %s\n",
-			    lpids[i], pg->vct[j].lpid, (char *)pg->id );
-			    fflush(stdout); */
-		    if (pg->vct[j].lpid == lpids[i]) {
-			vc = &pg->vct[j];
-			/*printf( "found vc %x for lpid = %d in another pg\n", 
-			  (int)vc, lpids[i] );*/
-			break;
-		    }
-		}
-	    } while (!vc);
-	}
-
-	/* printf( "about to dup vc %x for lpid = %d in another pg\n", 
-	   (int)vc, lpids[i] ); */
-	/* Note that his will increment the ref count for the associate
-	   PG if necessary.  */
-	MPIDI_VCR_Dup( vc, &newcomm_ptr->dev.vcrt->vcr_table[i] );
-    }
-fn_exit:
     return mpi_errno;
-fn_fail:
-    goto fn_exit;
 }
 
 /* The following is a temporary hook to ensure that all processes in 

--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -44,6 +44,12 @@ int MPIDI_PG_Init(MPIDI_PG_Compare_ids_fn_t compare_ids_fn,
     MPIDI_PG_Compare_ids_fn = compare_ids_fn;
     MPIDI_PG_Destroy_fn     = destroy_fn;
 
+    /* initialize the device fields in builtin groups */
+#ifdef MPID_DEV_GROUP_DECL
+    for (int i = 0; i < MPIR_GROUP_N_BUILTIN; i++) {
+        MPID_Group_init_hook(MPIR_Group_builtin + i);
+    }
+#endif
     return mpi_errno;
 }
 
@@ -63,6 +69,13 @@ int MPIDI_PG_Finalize(void)
     if (MPIR_CVAR_CH3_PG_VERBOSE) {
 	MPIU_PG_Printall( stdout );
     }
+
+    /* release the vcrt in builtin groups, since they don't really get freed */
+#ifdef MPID_DEV_GROUP_DECL
+    for (int i = 0; i < MPIR_GROUP_N_BUILTIN; i++) {
+        MPID_Group_free_hook(MPIR_Group_builtin + i);
+    }
+#endif
 
     /* Free the storage associated with the process groups */
     pg = MPIDI_PG_list;

--- a/src/mpid/ch4/src/ch4_proc.h
+++ b/src/mpid/ch4/src/ch4_proc.h
@@ -9,7 +9,7 @@
 #include "ch4_types.h"
 
 /* There are 3 terms referencing processes:
- * upid, or "unversal process id", is netmod layer address (addrname)
+ * upid, or "universal process id", is netmod layer address (addrname)
  * lpid, or "local process id", is av entry index in an ch4-layer table
  * gpid, or "global process id", is av table index plus av entry index
  *
@@ -262,7 +262,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_rank_is_local(int rank, MPIR_Comm * comm)
 
 #ifdef MPIDI_CH4_DIRECT_NETMOD
     /* Ask the netmod for locality information. If it decided not to build it,
-     * it will call back up to the MPIDIU function to get the infomration. */
+     * it will call back up to the MPIDIU function to get the information. */
     ret = MPIDI_NM_rank_is_local(rank, comm);
 #else
     ret = MPIDIU_av_is_local(MPIDIU_comm_rank_to_av(comm, rank));

--- a/test/mpi/include/multi_tests.c
+++ b/test/mpi/include/multi_tests.c
@@ -204,7 +204,7 @@ static void cleanup_cvars(void)
 {
     for (int i = 0; i < num_cvars; i++) {
         if (cvar_list[i].num_enums > 0) {
-            for (int j = 0; j < num_cvars; j++) {
+            for (int j = 0; j < cvar_list[i].num_enums; j++) {
                 free(cvar_list[i].enum_list[j]);
             }
         }

--- a/test/mpi/runtests
+++ b/test/mpi/runtests
@@ -765,6 +765,22 @@ sub run_mpitests {
             }
         }
         close($in);
+        {
+            my @inline;
+            while (<$out>) {
+                print "        $_" if $g_opt{verbose};
+                push @inline, $_;
+            }
+            if (@inline) {
+                my $runtime = 0;
+                my $test_opt = {name=>"run_mpitests", np=>$np, dir=>".", args=>[], envs=>[] };
+                RunPreMsg($test_opt);
+                print "run_mpitests: stray output in finalize\n";
+                show_failed_test_detail($test_opt, \@inline);
+                RunTestFailed($test_opt, join('', @inline), $runtime);
+                RunPostMsg($test_opt);
+            }
+        }
         close($out);
         waitpid($pid, 0); # TODO: check $?
         if ($flag_aborted) {


### PR DESCRIPTION
## Pull Request Description
Based on #7235, #7237

Now the `local_group` and `remote_group` in `MPIR_Comm` can fully replace the functions of mapper, refactor ch3 to use group instead of mapper in `MPIDI_CH3I_Comm_commit_pre_hook`.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
