### PR TITLE
api: add handle to/from int conversion APIs

### DIFF
--- a/maint/gen_abi.py
+++ b/maint/gen_abi.py
@@ -56,6 +56,8 @@ def dump_mpi_abi_internal_h(mpi_abi_internal_h):
                 if T == "MPI_Datatype":
                     idx = int(val, 0) & G.datatype_mask
                     G.abi_datatypes[idx] = name
+                    if re.match(r'MPI_LOGICAL\d+', name):
+                        G.abi_datatypes[idx] = "MPI_DATATYPE_NULL"
                 elif T == "MPI_Op":
                     idx = int(val, 0) & G.op_mask
                     G.abi_ops[idx] = name

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -2052,8 +2052,7 @@ def dump_body_of_routine(func):
                 for l in func['code-large_count']:
                     G.out.append(l)
             else:
-                for l in func['body']:
-                    G.out.append(l)
+                dump_function_direct(func)
         elif 'impl' in func:
             if RE.match(r'mpid', func['impl'], re.IGNORECASE):
                 dump_body_impl(func, "mpid")
@@ -2123,7 +2122,10 @@ def dump_function_replace(func, repl_call):
     G.out.append("return mpi_errno;")
 
 def dump_function_direct(func):
-    for l in func['body']:
+    body = func['body']
+    if '_is_abi' in func and 'code-is_abi' in func:
+        body = func['code-is_abi']
+    for l in body:
         G.out.append(l)
 
 # -- fn_fail ----

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -781,7 +781,7 @@ def process_func_parameters(func):
                 pass
             else:
                 validation_list.append({'kind': "ARGNULL", 'name': name})
-        elif RE.match(r'(ERROR_CLASS|ERROR_CODE|FILE|ATTRIBUTE_VAL|EXTRA_STATE|LOGICAL|MATH)', kind):
+        elif RE.match(r'(ERROR_CLASS|ERROR_CODE|FILE|ATTRIBUTE_VAL|EXTRA_STATE|LOGICAL|MATH|ASYNC_THING|INTEGER)', kind):
             # no validation for these kinds
             pass
         elif RE.match(r'F90_(COMM|ERRHANDLER|FILE|GROUP|INFO|MESSAGE|OP|REQUEST|SESSION|DATATYPE|WIN)', kind):

--- a/maint/local_python/binding_f08.py
+++ b/maint/local_python/binding_f08.py
@@ -1338,7 +1338,7 @@ def check_func_directives(func):
         func['_skip_fortran'] = 1
     elif RE.match(r'mpi_attr_', func['name'], re.IGNORECASE):
         func['_skip_fortran'] = 1
-    elif RE.match(r'mpi_\w+_(f|f08|c)2(f|f08|c)$', func['name'], re.IGNORECASE):
+    elif RE.match(r'mpi_\w+_((f|f08|c)2(f|f08|c)|fromint|toint)$', func['name'], re.IGNORECASE):
         # implemented in mpi_f08_types.f90
         func['_skip_fortran'] = 1
     elif RE.match(r'mpi_.*_function$', func['name'], re.IGNORECASE):

--- a/maint/local_python/binding_f77.py
+++ b/maint/local_python/binding_f77.py
@@ -1270,7 +1270,7 @@ def check_func_directives(func):
         func['_skip_fortran'] = 1
     elif RE.match(r'mpix_(grequest_|type_iov|async_|(comm|file|win|session)_create_errhandler_x|op_create_x)', func['name'], re.IGNORECASE):
         func['_skip_fortran'] = 1
-    elif RE.match(r'mpi_\w+_(f|f08|c)2(f|f08|c)$', func['name'], re.IGNORECASE):
+    elif RE.match(r'mpi_\w+_((f|f08|c)2(f|f08|c)|fromint|toint)$', func['name'], re.IGNORECASE):
         # implemented in mpi_f08_types.f90
         func['_skip_fortran'] = 1
     elif RE.match(r'mpi_.*_function$', func['name'], re.IGNORECASE):

--- a/maint/local_python/binding_f90.py
+++ b/maint/local_python/binding_f90.py
@@ -224,7 +224,7 @@ def check_func_directives(func):
         func['_skip_fortran'] = 1
     elif RE.match(r'mpi_pcontrol', func['name'], re.IGNORECASE):
         func['_skip_fortran'] = 1
-    elif RE.match(r'mpi_\w+_(f|f08|c)2(f|f08|c)$', func['name'], re.IGNORECASE):
+    elif RE.match(r'mpi_\w+_((f|f08|c)2(f|f08|c)|fromint|toint)$', func['name'], re.IGNORECASE):
         # implemented in mpi_f08_types.f90
         func['_skip_fortran'] = 1
 

--- a/maint/local_python/mpi_api.py
+++ b/maint/local_python/mpi_api.py
@@ -156,6 +156,9 @@ def load_mpi_api(api_txt, gen_in_dir=""):
                     stage = "code-"+RE.m.group(1)
                     if stage not in cur_func:
                         cur_func[stage] = []
+                    # abi specific functions always require direct body routines for both
+                    if RE.m.group(1) == "is_abi" and 'body' not in cur_func:
+                        print("WARNING: code-is_abi provided but missing non-abi body code")
                     # "error_check" may include list of parameters checked
                     # "handle_ptr" may include list of parameters converted
                     cur_func[stage + "-tail"] = RE.m.group(2).replace(' ','').split(',')

--- a/src/binding/abi/mpi_abi.h
+++ b/src/binding/abi/mpi_abi.h
@@ -592,6 +592,7 @@ extern MPI_F08_status* MPI_F08_STATUSES_IGNORE;
 /* MPI functions */
 int MPI_Abi_get_info(MPI_Info *info);
 int MPI_Abi_get_version(int *abi_major, int *abi_minor);
+int MPI_Abi_is_supported(int *flag);
 int MPI_Abort(MPI_Comm comm, int errorcode);
 int MPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
 int MPI_Accumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
@@ -1290,6 +1291,7 @@ int MPI_T_source_get_timestamp(int source_index, MPI_Count *timestamp);
 /* PMPI functions */
 int PMPI_Abi_get_info(MPI_Info *info);
 int PMPI_Abi_get_version(int *abi_major, int *abi_minor);
+int PMPI_Abi_is_supported(int *flag);
 int PMPI_Abort(MPI_Comm comm, int errorcode);
 int PMPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
 int PMPI_Accumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);

--- a/src/binding/abi/mpi_abi.h
+++ b/src/binding/abi/mpi_abi.h
@@ -159,21 +159,21 @@ typedef struct MPI_ABI_Datatype* MPI_Datatype;
 #define MPI_UINT32_T                   ((MPI_Datatype)0x00000251)
 #define MPI_INT64_T                    ((MPI_Datatype)0x00000258)
 #define MPI_UINT64_T                   ((MPI_Datatype)0x00000259)
-#define MPIX_LOGICAL1                  ((MPI_Datatype)0x000002c0)
+#define MPI_LOGICAL1                   ((MPI_Datatype)0x000002c0)
 #define MPI_INTEGER1                   ((MPI_Datatype)0x000002c1)
 #define MPI_CHARACTER                  ((MPI_Datatype)0x000002c3)
-#define MPIX_LOGICAL2                  ((MPI_Datatype)0x000002c8)
+#define MPI_LOGICAL2                   ((MPI_Datatype)0x000002c8)
 #define MPI_INTEGER2                   ((MPI_Datatype)0x000002c9)
 #define MPI_REAL2                      ((MPI_Datatype)0x000002ca)
-#define MPIX_LOGICAL4                  ((MPI_Datatype)0x000002d0)
+#define MPI_LOGICAL4                   ((MPI_Datatype)0x000002d0)
 #define MPI_INTEGER4                   ((MPI_Datatype)0x000002d1)
 #define MPI_REAL4                      ((MPI_Datatype)0x000002d2)
 #define MPI_COMPLEX4                   ((MPI_Datatype)0x000002d3)
-#define MPIX_LOGICAL8                  ((MPI_Datatype)0x000002d8)
+#define MPI_LOGICAL8                   ((MPI_Datatype)0x000002d8)
 #define MPI_INTEGER8                   ((MPI_Datatype)0x000002d9)
 #define MPI_REAL8                      ((MPI_Datatype)0x000002da)
 #define MPI_COMPLEX8                   ((MPI_Datatype)0x000002db)
-#define MPIX_LOGICAL16                 ((MPI_Datatype)0x000002e0)
+#define MPI_LOGICAL16                  ((MPI_Datatype)0x000002e0)
 #define MPI_INTEGER16                  ((MPI_Datatype)0x000002e1)
 #define MPI_REAL16                     ((MPI_Datatype)0x000002e2)
 #define MPI_COMPLEX16                  ((MPI_Datatype)0x000002e3)
@@ -590,6 +590,8 @@ extern MPI_F08_status* MPI_F08_STATUS_IGNORE;
 extern MPI_F08_status* MPI_F08_STATUSES_IGNORE;
 
 /* MPI functions */
+int MPI_Abi_get_info(MPI_Info *info);
+int MPI_Abi_get_version(int *abi_major, int *abi_minor);
 int MPI_Abort(MPI_Comm comm, int errorcode);
 int MPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
 int MPI_Accumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
@@ -1180,6 +1182,29 @@ MPI_Aint MPI_Aint_diff(MPI_Aint addr1, MPI_Aint addr2);
 double MPI_Wtick(void);
 double MPI_Wtime(void);
 
+MPI_Comm MPI_Comm_fromint(int comm);
+int MPI_Comm_toint(MPI_Comm comm);
+MPI_Errhandler MPI_Errhandler_fromint(int errhandler);
+int MPI_Errhandler_toint(MPI_Errhandler errhandler);
+MPI_File MPI_File_fromint(int file);
+int MPI_File_toint(MPI_File file);
+MPI_Group MPI_Group_fromint(int group);
+int MPI_Group_toint(MPI_Group group);
+MPI_Info MPI_Info_fromint(int info);
+int MPI_Info_toint(MPI_Info info);
+MPI_Message MPI_Message_fromint(int message);
+int MPI_Message_toint(MPI_Message message);
+MPI_Op MPI_Op_fromint(int op);
+int MPI_Op_toint(MPI_Op op);
+MPI_Request MPI_Request_fromint(int request);
+int MPI_Request_toint(MPI_Request request);
+MPI_Session MPI_Session_fromint(int session);
+int MPI_Session_toint(MPI_Session session);
+MPI_Datatype MPI_Type_fromint(int datatype);
+int MPI_Type_toint(MPI_Datatype datatype);
+MPI_Win MPI_Win_fromint(int win);
+int MPI_Win_toint(MPI_Win win);
+
 int MPI_Status_c2f(const MPI_Status *c_status, MPI_Fint *f_status);
 int MPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status);
 int MPI_Status_c2f08(const MPI_Status *c_status, MPI_F08_status *f08_status);
@@ -1190,8 +1215,6 @@ MPI_Fint MPI_Comm_c2f(MPI_Comm comm);
 MPI_Comm MPI_Comm_f2c(MPI_Fint comm);
 MPI_Fint MPI_Errhandler_c2f(MPI_Errhandler errhandler);
 MPI_Errhandler MPI_Errhandler_f2c(MPI_Fint errhandler);
-MPI_Fint MPI_Type_c2f(MPI_Datatype datatype);
-MPI_Datatype MPI_Type_f2c(MPI_Fint datatype);
 MPI_Fint MPI_File_c2f(MPI_File file);
 MPI_File MPI_File_f2c(MPI_Fint file);
 MPI_Fint MPI_Group_c2f(MPI_Group group);
@@ -1206,6 +1229,8 @@ MPI_Fint MPI_Request_c2f(MPI_Request request);
 MPI_Request MPI_Request_f2c(MPI_Fint request);
 MPI_Fint MPI_Session_c2f(MPI_Session session);
 MPI_Session MPI_Session_f2c(MPI_Fint session);
+MPI_Fint MPI_Type_c2f(MPI_Datatype datatype);
+MPI_Datatype MPI_Type_f2c(MPI_Fint datatype);
 MPI_Fint MPI_Win_c2f(MPI_Win win);
 MPI_Win MPI_Win_f2c(MPI_Fint win);
 
@@ -1263,6 +1288,8 @@ int MPI_T_source_get_num(int *num_sources);
 int MPI_T_source_get_timestamp(int source_index, MPI_Count *timestamp);
 
 /* PMPI functions */
+int PMPI_Abi_get_info(MPI_Info *info);
+int PMPI_Abi_get_version(int *abi_major, int *abi_minor);
 int PMPI_Abort(MPI_Comm comm, int errorcode);
 int PMPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
 int PMPI_Accumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
@@ -1852,6 +1879,29 @@ MPI_Aint PMPI_Aint_diff(MPI_Aint addr1, MPI_Aint addr2);
 double PMPI_Wtick(void);
 double PMPI_Wtime(void);
 
+MPI_Comm PMPI_Comm_fromint(int comm);
+int PMPI_Comm_toint(MPI_Comm comm);
+MPI_Errhandler PMPI_Errhandler_fromint(int errhandler);
+int PMPI_Errhandler_toint(MPI_Errhandler errhandler);
+MPI_File PMPI_File_fromint(int file);
+int PMPI_File_toint(MPI_File file);
+MPI_Group PMPI_Group_fromint(int group);
+int PMPI_Group_toint(MPI_Group group);
+MPI_Info PMPI_Info_fromint(int info);
+int PMPI_Info_toint(MPI_Info info);
+MPI_Message PMPI_Message_fromint(int message);
+int PMPI_Message_toint(MPI_Message message);
+MPI_Op PMPI_Op_fromint(int op);
+int PMPI_Op_toint(MPI_Op op);
+MPI_Request PMPI_Request_fromint(int request);
+int PMPI_Request_toint(MPI_Request request);
+MPI_Session PMPI_Session_fromint(int session);
+int PMPI_Session_toint(MPI_Session session);
+MPI_Datatype PMPI_Type_fromint(int datatype);
+int PMPI_Type_toint(MPI_Datatype datatype);
+MPI_Win PMPI_Win_fromint(int win);
+int PMPI_Win_toint(MPI_Win win);
+
 int PMPI_Status_c2f(const MPI_Status *c_status, MPI_Fint *f_status);
 int PMPI_Status_f2c(const MPI_Fint *f_status, MPI_Status *c_status);
 int PMPI_Status_c2f08(const MPI_Status *c_status, MPI_F08_status *f08_status);
@@ -1862,8 +1912,6 @@ MPI_Fint PMPI_Comm_c2f(MPI_Comm comm);
 MPI_Comm PMPI_Comm_f2c(MPI_Fint comm);
 MPI_Fint PMPI_Errhandler_c2f(MPI_Errhandler errhandler);
 MPI_Errhandler PMPI_Errhandler_f2c(MPI_Fint errhandler);
-MPI_Fint PMPI_Type_c2f(MPI_Datatype datatype);
-MPI_Datatype PMPI_Type_f2c(MPI_Fint datatype);
 MPI_Fint PMPI_File_c2f(MPI_File file);
 MPI_File PMPI_File_f2c(MPI_Fint file);
 MPI_Fint PMPI_Group_c2f(MPI_Group group);
@@ -1878,6 +1926,8 @@ MPI_Fint PMPI_Request_c2f(MPI_Request request);
 MPI_Request PMPI_Request_f2c(MPI_Fint request);
 MPI_Fint PMPI_Session_c2f(MPI_Session session);
 MPI_Session PMPI_Session_f2c(MPI_Fint session);
+MPI_Fint PMPI_Type_c2f(MPI_Datatype datatype);
+MPI_Datatype PMPI_Type_f2c(MPI_Fint datatype);
 MPI_Fint PMPI_Win_c2f(MPI_Win win);
 MPI_Win PMPI_Win_f2c(MPI_Fint win);
 

--- a/src/binding/abi/mpi_abi_util.h
+++ b/src/binding/abi/mpi_abi_util.h
@@ -326,12 +326,18 @@ static inline ABI_Win ABI_Win_from_mpi(MPI_Win in)
 
 static inline MPI_File ABI_File_to_mpi(ABI_File in)
 {
+    if (in == ABI_FILE_NULL) {
+        return MPI_FILE_NULL;
+    }
     /* Both MPI_File in mpich and ABI_File are pointers */
     return (MPI_File) in;
 }
 
 static inline ABI_File ABI_File_from_mpi(MPI_File in)
 {
+    if (in == MPI_FILE_NULL) {
+        return ABI_FILE_NULL;
+    }
     /* Both MPI_File in mpich and ABI_File are pointers */
     return (ABI_File) in;
 }

--- a/src/binding/c/abi_api.txt
+++ b/src/binding/c/abi_api.txt
@@ -1,0 +1,203 @@
+# vim: set ft=c:
+
+MPI_Comm_toint:
+    .return: INTEGER
+    comm: COMMUNICATOR
+    .desc: converts MPI_Comm to an integer handle
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (int) comm;
+}
+
+MPI_Comm_fromint:
+    .return: COMMUNICATOR
+    comm: INTEGER
+    .desc: converts an integer handle to MPI_Comm
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (MPI_Comm) comm;
+}
+
+MPI_Errhandler_toint:
+    .return: INTEGER
+    errhandler: ERRHANDLER
+    .desc: converts MPI_Errhandler to an integer handle
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (int) errhandler;
+}
+
+MPI_Errhandler_fromint:
+    .return: ERRHANDLER
+    errhandler: INTEGER
+    .desc: converts an integer handle to MPI_Errhandler
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (MPI_Errhandler) errhandler;
+}
+
+# MPI_File_fromint and MPI_File_toint are defined in io_api.txt
+
+MPI_Group_toint:
+    .return: INTEGER
+    group: GROUP
+    .desc: converts MPI_Group to an integer handle
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (int) group;
+}
+
+MPI_Group_fromint:
+    .return: GROUP
+    group: INTEGER
+    .desc: converts an integer handle to MPI_Group
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (MPI_Group) group;
+}
+
+MPI_Info_toint:
+    .return: INTEGER
+    info: INFO
+    .desc: converts MPI_Info to an integer handle
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (int) info;
+}
+
+MPI_Info_fromint:
+    .return: INFO
+    info: INTEGER
+    .desc: converts an integer handle to MPI_Info
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (MPI_Info) info;
+}
+
+MPI_Message_toint:
+    .return: INTEGER
+    message: MESSAGE
+    .desc: converts MPI_Message to an integer handle
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (int) message;
+}
+
+MPI_Message_fromint:
+    .return: MESSAGE
+    message: INTEGER
+    .desc: converts an integer handle to MPI_Message
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (MPI_Message) message;
+}
+
+MPI_Op_toint:
+    .return: INTEGER
+    op: OPERATION
+    .desc: converts MPI_Op to an integer handle
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (int) op;
+}
+
+MPI_Op_fromint:
+    .return: OPERATION
+    op: INTEGER
+    .desc: converts an integer handle to MPI_Op
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (MPI_Op) op;
+}
+
+MPI_Request_toint:
+    .return: INTEGER
+    request: REQUEST
+    .desc: converts MPI_Request to an integer handle
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (int) request;
+}
+
+MPI_Request_fromint:
+    .return: REQUEST
+    request: INTEGER
+    .desc: converts an integer handle to MPI_Request
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (MPI_Request) request;
+}
+
+MPI_Session_toint:
+    .request: INTEGER
+    session: SESSION
+    .desc: converts MPI_Session to an integer handle
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (int) session;
+}
+
+MPI_Session_fromint:
+    .return: SESSION
+    session: INTEGER
+    .desc: converts an integer handle to MPI_Session
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (MPI_Session) session;
+}
+
+MPI_Type_toint:
+    .return: INTEGER
+    datatype: DATATYPE
+    .desc: converts MPI_Type to an integer handle
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (int) datatype;
+}
+
+MPI_Type_fromint:
+    .return: DATATYPE
+    datatype: INTEGER
+    .desc: converts an integer handle to MPI_Type
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (MPI_Datatype) datatype;
+}
+
+MPI_Win_toint:
+    .return: INTEGER
+    win: WINDOW
+    .desc: converts MPI_Win to an integer handle
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (int) win;
+}
+
+MPI_Win_fromint:
+    .return: WINDOW
+    win: INTEGER
+    .desc: converts an integer handle to MPI_Win
+    .impl: direct
+    .skip: Fortran, Errors
+{
+    return (MPI_Win) win;
+}

--- a/src/binding/c/abi_api.txt
+++ b/src/binding/c/abi_api.txt
@@ -22,7 +22,57 @@ MPI_Abi_get_info:
     return MPI_SUCCESS;
 }
 { -- is_abi --
+    int mpi_errno = MPI_SUCCESS;
     *info = MPI_INFO_NULL;
+
+    MPIR_Info *info_ptr;
+    mpi_errno = MPIR_Info_alloc(&info_ptr);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPI_Aint size;
+    char str[10];
+#define PUSH_TYPE_INFO(type, keyname) \
+    do { \
+        MPIR_Type_size_impl(type, &size); \
+        snprintf(str, 10, "%d", (int) size); \
+        MPIR_Info_push(info_ptr, keyname, str); \
+    } while (0)
+    PUSH_TYPE_INFO(MPI_AINT, "mpi_aint_size");
+    PUSH_TYPE_INFO(MPI_COUNT, "mpi_count_size");
+    PUSH_TYPE_INFO(MPI_OFFSET, "mpi_offset_size");
+    PUSH_TYPE_INFO(MPI_INTEGER, "mpi_integer_size");
+    PUSH_TYPE_INFO(MPI_REAL, "mpi_real_size");
+    PUSH_TYPE_INFO(MPI_DOUBLE_PRECISION, "mpi_double_precision_size");
+#undef PUSH_TYPE_INFO
+#define PUSH_TYPE_INFO(type, keyname) \
+    do { \
+        MPIR_Type_size_impl(type, &size); \
+        snprintf(str, 10, "%d", (size > 0) ? 1 : 0); \
+        MPIR_Info_push(info_ptr, keyname, str); \
+    } while (0)
+    PUSH_TYPE_INFO(MPI_INTEGER1, "mpi_integer1_supported");
+    PUSH_TYPE_INFO(MPI_INTEGER2, "mpi_integer2_supported");
+    PUSH_TYPE_INFO(MPI_INTEGER4, "mpi_integer4_supported");
+    PUSH_TYPE_INFO(MPI_INTEGER8, "mpi_integer8_supported");
+    PUSH_TYPE_INFO(MPI_INTEGER16, "mpi_integer16_supported");
+    PUSH_TYPE_INFO(MPI_LOGICAL1, "mpi_logical1_supported");
+    PUSH_TYPE_INFO(MPI_LOGICAL2, "mpi_logical2_supported");
+    PUSH_TYPE_INFO(MPI_LOGICAL4, "mpi_logical4_supported");
+    PUSH_TYPE_INFO(MPI_LOGICAL8, "mpi_logical8_supported");
+    PUSH_TYPE_INFO(MPI_LOGICAL16, "mpi_logical16_supported");
+    PUSH_TYPE_INFO(MPI_REAL2, "mpi_real2_supported");
+    PUSH_TYPE_INFO(MPI_REAL4, "mpi_real4_supported");
+    PUSH_TYPE_INFO(MPI_REAL8, "mpi_real8_supported");
+    PUSH_TYPE_INFO(MPI_REAL16, "mpi_real16_supported");
+    PUSH_TYPE_INFO(MPI_COMPLEX4, "mpi_complex4_supported");
+    PUSH_TYPE_INFO(MPI_COMPLEX8, "mpi_complex8_supported");
+    PUSH_TYPE_INFO(MPI_COMPLEX16, "mpi_complex16_supported");
+    PUSH_TYPE_INFO(MPI_COMPLEX32, "mpi_complex32_supported");
+    PUSH_TYPE_INFO(MPI_DOUBLE_COMPLEX, "mpi_double_complex_supported");
+#undef PUSH_TYPE_INFO
+    *info = info_ptr->handle;
+
+  fn_fail:
     return MPI_SUCCESS;
 }
 

--- a/src/binding/c/abi_api.txt
+++ b/src/binding/c/abi_api.txt
@@ -1,5 +1,48 @@
 # vim: set ft=c:
 
+MPI_Abi_is_supported:
+    flag: LOGICAL, direction=out, [true if the standard ABI is supported, false otherwise]
+    .desc: Return whether the standard ABI is supported
+    .impl: direct
+{
+    *flag = 0;
+    return MPI_SUCCESS;
+}
+{ -- is_abi --
+    *flag = 1;
+    return MPI_SUCCESS;
+}
+
+MPI_Abi_get_info:
+    info: INFO, direction=out, [info object]
+    .desc: Return an info object that provides information related to the ABI
+    .impl: direct
+{
+    *info = MPI_INFO_NULL;
+    return MPI_SUCCESS;
+}
+{ -- is_abi --
+    *info = MPI_INFO_NULL;
+    return MPI_SUCCESS;
+}
+
+MPI_Abi_get_version:
+    abi_major: VERSION, direction=out, [version number]
+    abi_minor: VERSION, direction=out, [subversion number]
+    .desc: Return the standard ABI version
+    .impl: direct
+{
+    *abi_major = -1;
+    *abi_minor = -1;
+    return MPI_SUCCESS;
+}
+{ -- is_abi --
+    *abi_major = 1;
+    *abi_minor = 0;
+    return MPI_SUCCESS;
+}
+
+
 MPI_Comm_toint:
     .return: INTEGER
     comm: COMMUNICATOR

--- a/src/binding/c/abi_api.txt
+++ b/src/binding/c/abi_api.txt
@@ -55,11 +55,13 @@ MPI_Abi_get_info:
     PUSH_TYPE_INFO(MPI_INTEGER4, "mpi_integer4_supported");
     PUSH_TYPE_INFO(MPI_INTEGER8, "mpi_integer8_supported");
     PUSH_TYPE_INFO(MPI_INTEGER16, "mpi_integer16_supported");
+    /*
     PUSH_TYPE_INFO(MPI_LOGICAL1, "mpi_logical1_supported");
     PUSH_TYPE_INFO(MPI_LOGICAL2, "mpi_logical2_supported");
     PUSH_TYPE_INFO(MPI_LOGICAL4, "mpi_logical4_supported");
     PUSH_TYPE_INFO(MPI_LOGICAL8, "mpi_logical8_supported");
     PUSH_TYPE_INFO(MPI_LOGICAL16, "mpi_logical16_supported");
+    */
     PUSH_TYPE_INFO(MPI_REAL2, "mpi_real2_supported");
     PUSH_TYPE_INFO(MPI_REAL4, "mpi_real4_supported");
     PUSH_TYPE_INFO(MPI_REAL8, "mpi_real8_supported");

--- a/src/binding/c/io_api.txt
+++ b/src/binding/c/io_api.txt
@@ -1,15 +1,5 @@
 # vim: set ft=c:
 
-MPI_File_open:
-    .desc: Opens a file
-    .skip: validate-amode
-
-MPI_File_close:
-    .desc: Closes a file
-
-MPI_File_delete:
-    .desc: Deletes a file
-
 MPI_File_c2f:
     .desc: Translates a C file handle to a Fortran file handle
     .impl: direct
@@ -31,6 +21,42 @@ MPI_File_f2c:
     return MPIR_File_f2c_impl(file);
 #endif
 }
+
+MPI_File_toint:
+    .return: INTEGER
+    file: FILE, [file handle]
+    .desc: converts a MPI_File to an integer handle
+    .impl: direct
+{
+#ifndef HAVE_ROMIO
+    return 0;
+#else
+    return (int) MPIR_File_c2f_impl(file);
+#endif
+}
+
+MPI_File_fromint:
+    .return: FILE
+    file: INTEGER
+    .desc: converts an integer handle to MPI_File
+    .impl: direct
+{
+#ifndef HAVE_ROMIO
+    return 0;
+#else
+    return MPIR_File_f2c_impl(file);
+#endif
+}
+
+MPI_File_open:
+    .desc: Opens a file
+    .skip: validate-amode
+
+MPI_File_close:
+    .desc: Closes a file
+
+MPI_File_delete:
+    .desc: Deletes a file
 
 MPI_File_sync:
     .desc: Causes all previous writes to be transferred

--- a/src/binding/custom_mapping.txt
+++ b/src/binding/custom_mapping.txt
@@ -7,6 +7,7 @@ LIS_KIND_MAP:
     STREAM: handle
     IOVEC: None
     ASYNC_THING: None
+    INTEGER: integer
 
 SMALL_F90_KIND_MAP:
     GPU_TYPE: INTEGER
@@ -42,6 +43,7 @@ SMALL_C_KIND_MAP:
     STREAM: MPIX_Stream
     IOVEC: MPIX_Iov
     ASYNC_THING: MPIX_Async_thing
+    INTEGER: int
 
 BIG_C_KIND_MAP:
     GPU_TYPE: int
@@ -49,3 +51,4 @@ BIG_C_KIND_MAP:
     STREAM: MPIX_Stream
     IOVEC: MPIX_Iov
     ASYNC_THING: MPIX_Async_thing
+    INTEGER: int


### PR DESCRIPTION
## Pull Request Description
Add routines to support conversion of MPI handles to/from C `int`. These APIs are proposed in MPI 4.2 as C-only APIs to support binding implementations.

 ## TODO
* [ ] Before merging we should consider prefix these routines with `MPIX_` due to its unofficial status.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
