### PR TITLE
romio: redefine MPI_DISPLACEMENT_CURRENT

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -1106,7 +1106,7 @@ def dump_abi_wrappers(func, is_large):
         G.out.append("int ret = " + static_call + ";")
         for l in post_filters:
             G.out.append(l)
-        if re.match(r'MPI_(Init|Init_thread|Session_init)$', func_name, re.IGNORECASE):
+        if re.match(r'MPI_(Init|Init_thread|Session_init)|MPI_T_init_thread$', func_name, re.IGNORECASE):
             G.out.append("ABI_init_builtins();")
         G.out.append("return ret;")
     G.out.append("DEDENT")

--- a/src/binding/abi/mpi_abi.h
+++ b/src/binding/abi/mpi_abi.h
@@ -425,7 +425,7 @@ enum {
 };
 
 /* File Operation Constants */
-#define MPI_DISPLACEMENT_CURRENT       ((MPI_Offset)-54278278)
+#define MPI_DISPLACEMENT_CURRENT       ((MPI_Offset)-1)
 
 /* Predefined Attribute Keys */
 enum {

--- a/src/binding/abi/mpi_abi_util.h
+++ b/src/binding/abi/mpi_abi_util.h
@@ -137,6 +137,7 @@ static inline ABI_Datatype ABI_Datatype_from_mpi(MPI_Datatype in)
                 return (ABI_Datatype) ((intptr_t) ABI_DATATYPE_NULL + i);
             }
         }
+        MPIR_Assert(0);
     }
     MPIR_Datatype *ptr;
     MPIR_Datatype_get_ptr(in, ptr);


### PR DESCRIPTION
## Pull Request Description

It is quite odd to have `-54278278` for `MPI_DISPLACEMENT_CURRENT` let users and developers wonder its reasons. In fact, I believe this is used as a sentinel dummy argument and an arbitary value should work.

The value `-1` is as arbitrary as `-54278278` and people won't wonder.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
