### PR TITLE
mpir_mem: simplify MPIR_CHKLMEM_ macros

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,10 @@
 ===============================================================================
+                               Changes in 5.0
+===============================================================================
+# MPIR_CHKLMEM_ and MPIR_CHKPMEM_ macros are simplified, removing non-essential
+  argument such as type case and custom error messages.
+
+===============================================================================
                                Changes in 4.3
 ===============================================================================
 # Support MPI memory allocation kinds side document.

--- a/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
+++ b/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
@@ -331,7 +331,7 @@ int MPII_Recexchalgo_reverse_digits_step2(int rank, int comm_size, int k)
     int pofk = 1, log_pofk = 0;
     int *digit, *digit_reverse;
     int mpi_errno ATTRIBUTE((unused)) = MPI_SUCCESS;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -350,10 +350,8 @@ int MPII_Recexchalgo_reverse_digits_step2(int rank, int comm_size, int k)
     step2rank = MPII_Recexchalgo_origrank_to_step2rank(rank, rem, T, k);
 
     /* calculate the digits in base k representation of step2rank */
-    MPIR_CHKLMEM_MALLOC(digit, int *, sizeof(int) * log_pofk,
-                        mpi_errno, "digit buffer", MPL_MEM_COLL);
-    MPIR_CHKLMEM_MALLOC(digit_reverse, int *, sizeof(int) * log_pofk,
-                        mpi_errno, "digit_reverse buffer", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(digit, sizeof(int) * log_pofk);
+    MPIR_CHKLMEM_MALLOC(digit_reverse, sizeof(int) * log_pofk);
     for (i = 0; i < log_pofk; i++)
         digit[i] = 0;
 

--- a/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
+++ b/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
@@ -22,7 +22,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
     void *tmp_buf = NULL;
     MPIR_Comm *newcomm_ptr = NULL;
 
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     local_size = comm_ptr->local_size;
     remote_size = comm_ptr->remote_size;
@@ -32,8 +32,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
         /* In each group, rank 0 allocates temp. buffer for local
          * gather */
         MPIR_Datatype_get_size_macro(sendtype, sendtype_sz);
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, sendcount * sendtype_sz * local_size, mpi_errno,
-                            "tmp_buf", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(tmp_buf, sendcount * sendtype_sz * local_size);
     } else {
         /* silence -Wmaybe-uninitialized due to MPIR_{Gather,Bcast} calls by non-zero ranks */
         sendtype_sz = 0;

--- a/src/mpi/coll/allgather/allgather_intra_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_brucks.c
@@ -28,7 +28,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
     void *tmp_buf = NULL;
     int dst;
 
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     if (((sendcount == 0) && (sendbuf != MPI_IN_PLACE)) || (recvcount == 0))
         goto fn_exit;
@@ -39,8 +39,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
     MPIR_Datatype_get_size_macro(recvtype, recvtype_sz);
 
     /* allocate a temporary buffer of the same size as recvbuf. */
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, recvcount * comm_size * recvtype_sz, mpi_errno,
-                        "tmp_buf", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf, recvcount * comm_size * recvtype_sz);
 
     /* copy local data to the top of tmp_buf */
     if (sendbuf != MPI_IN_PLACE) {

--- a/src/mpi/coll/allgather/allgather_intra_k_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_k_brucks.c
@@ -47,9 +47,8 @@ MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
 
     int delta = 1;
     void *tmp_recvbuf = NULL;
-    MPIR_CHKLMEM_DECL(2);
-    MPIR_CHKLMEM_MALLOC(reqs, MPIR_Request **, (2 * (k - 1) * sizeof(MPIR_Request *)), mpi_errno,
-                        "reqs", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_DECL();
+    MPIR_CHKLMEM_MALLOC(reqs, (2 * (k - 1) * sizeof(MPIR_Request *)));
 
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST,
                                              "Allgather_brucks_radix_k algorithm: num_ranks: %d, k: %d",

--- a/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
@@ -32,7 +32,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
     int pof2, src, dst, rem;
     MPI_Aint curr_cnt, send_cnt, recv_cnt, total_count;
     void *tmp_buf;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
@@ -48,8 +48,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
     /* allocate a temporary buffer that can hold all the data */
     MPIR_Datatype_get_size_macro(recvtype, recvtype_sz);
 
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, total_count * recvtype_sz, mpi_errno, "tmp_buf",
-                        MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf, total_count * recvtype_sz);
 
     /* copy local data to the top of tmp_buf */
     if (sendbuf != MPI_IN_PLACE) {

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -36,7 +36,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
     void *tmp_buf;
     int mask, dst_tree_root, my_tree_root, nprocs_completed, k, tmp_mask, tree_root;
     MPI_Aint position, send_offset, recv_offset, offset;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -58,8 +58,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
     MPIR_Datatype_get_size_macro(recvtype, recvtype_sz);
 
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *,
-                        total_count * recvtype_sz, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf, total_count * recvtype_sz);
 
     /* copy local data into right location in tmp_buf */
     position = 0;

--- a/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
+++ b/src/mpi/coll/allreduce/allreduce_inter_reduce_exchange_bcast.c
@@ -17,17 +17,16 @@ int MPIR_Allreduce_inter_reduce_exchange_bcast(const void *sendbuf, void *recvbu
                                                MPI_Datatype datatype, MPI_Op op,
                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
-    int mpi_errno;
+    int mpi_errno = MPI_SUCCESS;
     MPI_Aint true_extent, true_lb, extent;
     void *tmp_buf = NULL;
     MPIR_Comm *newcomm_ptr = NULL;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     if (comm_ptr->rank == 0) {
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         MPIR_Datatype_get_extent_macro(datatype, extent);
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)), mpi_errno,
-                            "temporary buffer", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(tmp_buf, count * (MPL_MAX(extent, true_extent)));
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *) ((char *) tmp_buf - true_lb);
     }

--- a/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
@@ -32,7 +32,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
     MPIR_Request **send_reqs = NULL, **recv_reqs = NULL;
     int num_sreq = 0, num_rreq = 0, total_phases = 0;
     void *tmp_recvbuf = NULL;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_Assert(k > 1);
 
@@ -123,10 +123,8 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
     /* Main recursive exchange step */
     if (in_step2) {
         MPI_Aint *cnts = NULL, *displs = NULL;
-        MPIR_CHKLMEM_MALLOC(cnts, MPI_Aint *, sizeof(MPI_Aint) * nranks, mpi_errno, "cnts",
-                            MPL_MEM_COLL);
-        MPIR_CHKLMEM_MALLOC(displs, MPI_Aint *, sizeof(MPI_Aint) * nranks, mpi_errno, "displs",
-                            MPL_MEM_COLL);
+        MPIR_CHKLMEM_MALLOC(cnts, sizeof(MPI_Aint) * nranks);
+        MPIR_CHKLMEM_MALLOC(displs, sizeof(MPI_Aint) * nranks);
         idx = 0;
         rem = nranks - p_of_k;
 

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
@@ -24,7 +24,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
                                             MPI_Datatype datatype,
                                             MPI_Op op, MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
     int mask, dst, is_commutative, pof2, newrank, rem, newdst;
@@ -39,8 +39,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)), mpi_errno,
-                        "temporary buffer", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf, count * (MPL_MAX(extent, true_extent)));
 
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *) ((char *) tmp_buf - true_lb);

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_multiplying.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_multiplying.c
@@ -43,14 +43,13 @@ int MPIR_Allreduce_intra_recursive_multiplying(const void *sendbuf,
         pofk *= k;
     }
 
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
     void *tmp_buf;
 
     /*Allocate for nb requests */
     MPIR_Request **reqs;
     int num_reqs = 0;
-    MPIR_CHKLMEM_MALLOC(reqs, MPIR_Request **, (2 * (k - 1) * sizeof(MPIR_Request *)), mpi_errno,
-                        "reqs", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(reqs, (2 * (k - 1) * sizeof(MPIR_Request *)));
 
     /* need to allocate temporary buffer to store incoming data */
     MPI_Aint true_extent, true_lb, extent;
@@ -65,8 +64,7 @@ int MPIR_Allreduce_intra_recursive_multiplying(const void *sendbuf,
         }
     }
 
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, (k - 1) * single_size, mpi_errno,
-                        "temporary buffer", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf, (k - 1) * single_size);
 
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *) ((char *) tmp_buf - true_lb);

--- a/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
@@ -45,7 +45,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
                                                   MPI_Op op,
                                                   MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
     int comm_size, rank;
     int mpi_errno = MPI_SUCCESS;
     int mask, dst, pof2, newrank, rem, newdst, i, send_idx, recv_idx, last_idx;
@@ -59,8 +59,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)), mpi_errno,
-                        "temporary buffer", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf, count * (MPL_MAX(extent, true_extent)));
 
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *) ((char *) tmp_buf - true_lb);
@@ -126,10 +125,8 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
 
     if (newrank != -1) {
         MPI_Aint *cnts, *disps;
-        MPIR_CHKLMEM_MALLOC(cnts, MPI_Aint *, pof2 * sizeof(MPI_Aint), mpi_errno, "counts",
-                            MPL_MEM_BUFFER);
-        MPIR_CHKLMEM_MALLOC(disps, MPI_Aint *, pof2 * sizeof(MPI_Aint), mpi_errno, "displacements",
-                            MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(cnts, pof2 * sizeof(MPI_Aint));
+        MPIR_CHKLMEM_MALLOC(disps, pof2 * sizeof(MPI_Aint));
 
         for (i = 0; i < pof2; i++)
             cnts[i] = count / pof2;

--- a/src/mpi/coll/allreduce/allreduce_intra_tree.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_tree.c
@@ -46,7 +46,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
     extent = MPL_MAX(extent, true_extent);
     is_commutative = MPIR_Op_is_commutative(op);
 
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     /* copy local data into recvbuf */
     if (sendbuf != MPI_IN_PLACE) {
@@ -110,8 +110,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
     is_tree_leaf = (num_children == 0) ? 1 : 0;
 
     if (!is_tree_leaf) {
-        MPIR_CHKLMEM_MALLOC(child_buffer, void **, sizeof(void *) * num_children, mpi_errno,
-                            "child_buffer", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(child_buffer, sizeof(void *) * num_children);
         child_buffer[0] = MPL_malloc(extent * count, MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP(!child_buffer[0], mpi_errno, MPI_ERR_OTHER, "**nomem");
 
@@ -130,9 +129,8 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
     }
     reduce_buffer = recvbuf;
 
-    MPIR_CHKLMEM_MALLOC(reqs, MPIR_Request **,
-                        (num_children * num_chunks + num_chunks + 10) * sizeof(MPIR_Request *),
-                        mpi_errno, "reqs", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(reqs,
+                        (num_children * num_chunks + num_chunks + 10) * sizeof(MPIR_Request *));
 
     for (j = 0; j < num_chunks; j++) {
         MPI_Aint msgsize = (j == 0) ? chunk_size_floor : chunk_size_ceil;

--- a/src/mpi/coll/allreduce_group/allreduce_group.c
+++ b/src/mpi/coll/allreduce_group/allreduce_group.c
@@ -27,7 +27,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
     void *tmp_buf;
     int group_rank, group_size;
     int cdst, csrc;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     group_rank = group_ptr->rank;
     group_size = group_ptr->size;
@@ -39,8 +39,7 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)), mpi_errno,
-                        "temporary buffer", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf, count * (MPL_MAX(extent, true_extent)));
 
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *) ((char *) tmp_buf - true_lb);
@@ -150,10 +149,8 @@ int MPII_Allreduce_group_intra(void *sendbuf, void *recvbuf, MPI_Aint count,
              * the buffer */
 
             MPI_Aint *cnts, *disps;
-            MPIR_CHKLMEM_MALLOC(cnts, MPI_Aint *, pof2 * sizeof(MPI_Aint), mpi_errno, "counts",
-                                MPL_MEM_BUFFER);
-            MPIR_CHKLMEM_MALLOC(disps, MPI_Aint *, pof2 * sizeof(MPI_Aint), mpi_errno,
-                                "displacements", MPL_MEM_BUFFER);
+            MPIR_CHKLMEM_MALLOC(cnts, pof2 * sizeof(MPI_Aint));
+            MPIR_CHKLMEM_MALLOC(disps, pof2 * sizeof(MPI_Aint));
 
             for (i = 0; i < (pof2 - 1); i++)
                 cnts[i] = count / pof2;

--- a/src/mpi/coll/alltoall/alltoall_intra_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_brucks.c
@@ -34,7 +34,7 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
     MPI_Datatype newtype = MPI_DATATYPE_NULL;
     MPI_Aint newtype_sz;
     void *tmp_buf;
-    MPIR_CHKLMEM_DECL(6);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
@@ -49,7 +49,7 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
     /* allocate temporary buffer */
     MPIR_Datatype_get_size_macro(recvtype, recvtype_sz);
     pack_size = recvcount * comm_size * recvtype_sz;
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, pack_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf, pack_size);
 
     /* Do Phase 1 of the algorithim. Shift the data blocks on process i
      * upwards by a distance of i blocks. Store the result in recvbuf. */
@@ -74,8 +74,7 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
      * communication */
 
     MPI_Aint *displs;
-    MPIR_CHKLMEM_MALLOC(displs, MPI_Aint *, comm_size * sizeof(MPI_Aint), mpi_errno, "displs",
-                        MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(displs, comm_size * sizeof(MPI_Aint));
 
     pof2 = 1;
     while (pof2 < comm_size) {

--- a/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
@@ -127,10 +127,9 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
     MPIR_Request **reqs;
     int num_reqs = 0;
 
-    MPIR_CHKLMEM_DECL(4);
+    MPIR_CHKLMEM_DECL();
 
-    MPIR_CHKLMEM_MALLOC(reqs, MPIR_Request **, (2 * (k - 1) * sizeof(MPIR_Request *)), mpi_errno,
-                        "reqs", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(reqs, (2 * (k - 1) * sizeof(MPIR_Request *)));
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
 
@@ -182,8 +181,7 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
     }
 #endif
     /* temporary buffer used for rotation, so used as sendbuf when inplace is true */
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, recvcnt * size * r_extent, mpi_errno, "tmp_buf",
-                        MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(tmp_buf, recvcnt * size * r_extent);
 
     if (is_inplace) {
         mpi_errno =
@@ -214,10 +212,8 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
     /* Step 2: Allocate buffer space for packing/receiving data for every phase */
     delta = 1;
 
-    MPIR_CHKLMEM_MALLOC(tmp_sbuf, void **, sizeof(void *) * (k - 1), mpi_errno, "tmp_sbuf",
-                        MPL_MEM_COLL);
-    MPIR_CHKLMEM_MALLOC(tmp_rbuf, void **, sizeof(void *) * (k - 1), mpi_errno, "tmp_rbuf",
-                        MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(tmp_sbuf, sizeof(void *) * (k - 1));
+    MPIR_CHKLMEM_MALLOC(tmp_rbuf, sizeof(void *) * (k - 1));
 
     for (j = 0; j < k - 1; j++) {
         tmp_sbuf[j] = (void *) MPL_malloc(r_extent * recvcnt * p_of_k, MPL_MEM_COLL);

--- a/src/mpi/coll/alltoall/alltoall_intra_scattered.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_scattered.c
@@ -40,7 +40,7 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
     int mpi_errno = MPI_SUCCESS, dst, rank;
     MPIR_Request **reqarray;
     MPI_Status *starray;
-    MPIR_CHKLMEM_DECL(6);
+    MPIR_CHKLMEM_DECL();
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -58,11 +58,9 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
     if (bblock == 0)
         bblock = comm_size;
 
-    MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request **, 2 * bblock * sizeof(MPIR_Request *), mpi_errno,
-                        "reqarray", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(reqarray, 2 * bblock * sizeof(MPIR_Request *));
 
-    MPIR_CHKLMEM_MALLOC(starray, MPI_Status *, 2 * bblock * sizeof(MPI_Status), mpi_errno,
-                        "starray", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(starray, 2 * bblock * sizeof(MPI_Status));
 
     for (ii = 0; ii < comm_size; ii += bblock) {
         ss = comm_size - ii < bblock ? comm_size - ii : bblock;

--- a/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
@@ -35,7 +35,7 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
     int dst, rank, req_cnt;
     int ii, ss, bblock;
 
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
@@ -52,10 +52,8 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
 
     MPIR_Datatype_get_extent_macro(sendtype, send_extent);
 
-    MPIR_CHKLMEM_MALLOC(starray, MPI_Status *, 2 * bblock * sizeof(MPI_Status), mpi_errno,
-                        "starray", MPL_MEM_BUFFER);
-    MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request **, 2 * bblock * sizeof(MPIR_Request *), mpi_errno,
-                        "reqarray", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(starray, 2 * bblock * sizeof(MPI_Status));
+    MPIR_CHKLMEM_MALLOC(reqarray, 2 * bblock * sizeof(MPIR_Request *));
 
     /* post only bblock isends/irecvs at a time as suggested by Tony Ladd */
     for (ii = 0; ii < comm_size; ii += bblock) {

--- a/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
@@ -33,7 +33,7 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
     int outstanding_requests;
     int ii, ss, bblock;
     MPI_Aint type_size;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
@@ -50,10 +50,8 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
     if (bblock == 0)
         bblock = comm_size;
 
-    MPIR_CHKLMEM_MALLOC(starray, MPI_Status *, 2 * bblock * sizeof(MPI_Status), mpi_errno,
-                        "starray", MPL_MEM_BUFFER);
-    MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request **, 2 * bblock * sizeof(MPIR_Request *), mpi_errno,
-                        "reqarray", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(starray, 2 * bblock * sizeof(MPI_Status));
+    MPIR_CHKLMEM_MALLOC(reqarray, 2 * bblock * sizeof(MPIR_Request *));
 
     /* post only bblock isends/irecvs at a time as suggested by Tony Ladd */
     for (ii = 0; ii < comm_size; ii += bblock) {

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -30,7 +30,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
     int is_contig;
     MPI_Aint type_size;
     void *tmp_buf = NULL;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
@@ -47,7 +47,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
         goto fn_exit;   /* nothing to do */
 
     if (!is_contig) {
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(tmp_buf, nbytes);
 
         /* TODO: Pipeline the packing and communication */
         if (rank == root) {

--- a/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
@@ -29,7 +29,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
     MPIR_Request **reqs = NULL;
     MPI_Status *statuses = NULL;
     MPIR_Treealgo_tree_t my_tree;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -55,7 +55,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         sendbuf = (char *) buffer + true_lb;
     } else {
-        MPIR_CHKLMEM_MALLOC(sendbuf, void *, nbytes, mpi_errno, "sendbuf", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(sendbuf, nbytes);
         if (rank == root) {
             mpi_errno = MPIR_Typerep_pack(buffer, count, datatype, 0, sendbuf, nbytes,
                                           &actual_packed_unpacked_bytes, MPIR_TYPEREP_FLAG_NONE);
@@ -95,12 +95,10 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
     }
 
     if (is_nb) {
-        MPIR_CHKLMEM_MALLOC(reqs, MPIR_Request **,
-                            sizeof(MPIR_Request *) * (num_children * num_chunks + num_chunks),
-                            mpi_errno, "request array", MPL_MEM_COLL);
-        MPIR_CHKLMEM_MALLOC(statuses, MPI_Status *,
-                            sizeof(MPI_Status) * (num_children * num_chunks + num_chunks),
-                            mpi_errno, "status array", MPL_MEM_COLL);
+        MPIR_CHKLMEM_MALLOC(reqs,
+                            sizeof(MPIR_Request *) * (num_children * num_chunks + num_chunks));
+        MPIR_CHKLMEM_MALLOC(statuses,
+                            sizeof(MPI_Status) * (num_children * num_chunks + num_chunks));
     }
 
     if (tree_type != MPIR_TREE_TYPE_KARY && my_tree.parent != -1)

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -41,7 +41,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
     MPI_Aint type_size, nbytes;
     int relative_dst, dst_tree_root, my_tree_root;
     int tree_root, nprocs_completed;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
     MPI_Aint true_extent, true_lb;
     void *tmp_buf;
 
@@ -67,7 +67,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
 
         tmp_buf = MPIR_get_contig_ptr(buffer, true_lb);
     } else {
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(tmp_buf, nbytes);
 
         if (rank == root) {
             mpi_errno = MPIR_Localcopy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE);

--- a/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
@@ -36,7 +36,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
     MPI_Aint recvd_size, curr_size = 0;
     MPI_Status status;
     MPI_Aint true_extent, true_lb;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -59,7 +59,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
 
         tmp_buf = MPIR_get_contig_ptr(buffer, true_lb);
     } else {
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, nbytes, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(tmp_buf, nbytes);
 
         if (rank == root) {
             mpi_errno = MPIR_Localcopy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE);

--- a/src/mpi/coll/bcast/bcast_intra_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_tree.c
@@ -27,7 +27,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
     MPI_Datatype dtype;
 
     MPIR_Treealgo_tree_t my_tree;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -52,7 +52,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
     dtype = datatype;
 
     if (!is_contig) {
-        MPIR_CHKLMEM_MALLOC(send_buf, void *, nbytes, mpi_errno, "send_buf", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(send_buf, nbytes);
 
         /* TODO: Pipeline the packing and communication */
         if (rank == root) {
@@ -120,10 +120,8 @@ int MPIR_Bcast_intra_tree(void *buffer,
     }
 
     if (is_nb) {
-        MPIR_CHKLMEM_MALLOC(reqs, MPIR_Request **, sizeof(MPIR_Request *) * num_children,
-                            mpi_errno, "request array", MPL_MEM_COLL);
-        MPIR_CHKLMEM_MALLOC(statuses, MPI_Status *, sizeof(MPI_Status) * num_children,
-                            mpi_errno, "status array", MPL_MEM_COLL);
+        MPIR_CHKLMEM_MALLOC(reqs, sizeof(MPIR_Request *) * num_children);
+        MPIR_CHKLMEM_MALLOC(statuses, sizeof(MPI_Status) * num_children);
     }
 
     if ((parent != -1 && tree_type != MPIR_TREE_TYPE_KARY)

--- a/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
@@ -56,7 +56,7 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
     int mask, dst, is_commutative, flag;
     MPI_Aint true_extent, true_lb, extent;
     void *partial_scan, *tmp_buf;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
@@ -67,14 +67,12 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    MPIR_CHKLMEM_MALLOC(partial_scan, void *, (count * (MPL_MAX(true_extent, extent))), mpi_errno,
-                        "partial_scan", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(partial_scan, count * (MPL_MAX(true_extent, extent)));
     /* adjust for potential negative lower bound in datatype */
     partial_scan = (void *) ((char *) partial_scan - true_lb);
 
     /* need to allocate temporary buffer to store incoming data */
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, (count * (MPL_MAX(true_extent, extent))), mpi_errno,
-                        "tmp_buf", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf, count * (MPL_MAX(true_extent, extent)));
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *) ((char *) tmp_buf - true_lb);
 

--- a/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
+++ b/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
@@ -21,7 +21,7 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sen
     int rank, local_size, remote_size, mpi_errno = MPI_SUCCESS;
     MPI_Status status;
     MPIR_Comm *newcomm_ptr = NULL;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     if (root == MPI_PROC_NULL) {
         /* local processes other than root do nothing */
@@ -48,9 +48,7 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sen
 
         if (rank == 0) {
             MPIR_Datatype_get_size_macro(sendtype, sendtype_sz);
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void *,
-                                sendcount * local_size * sendtype_sz, mpi_errno,
-                                "tmp_buf", MPL_MEM_BUFFER);
+            MPIR_CHKLMEM_MALLOC(tmp_buf, sendcount * local_size * sendtype_sz);
         } else {
             /* silence -Wmaybe-uninitialized due to MPIR_Gather by non-zero ranks */
             sendtype_sz = 0;

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -54,7 +54,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
     MPI_Aint extent = 0;        /* Datatype extent */
     MPI_Datatype types[2], tmp_type;
     int copy_offset = 0, copy_blks = 0;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
 
     MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
@@ -98,7 +98,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
         tmp_buf_size = 0;
 
     if (tmp_buf_size) {
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(tmp_buf, tmp_buf_size);
     }
 
     if (rank == root) {

--- a/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
@@ -30,7 +30,7 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
     int i, reqs;
     MPIR_Request **reqarray;
     MPI_Status *starray;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
@@ -42,10 +42,8 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
 
         MPIR_Datatype_get_extent_macro(recvtype, extent);
 
-        MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request **, comm_size * sizeof(MPIR_Request *),
-                            mpi_errno, "reqarray", MPL_MEM_BUFFER);
-        MPIR_CHKLMEM_MALLOC(starray, MPI_Status *, comm_size * sizeof(MPI_Status), mpi_errno,
-                            "starray", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(reqarray, comm_size * sizeof(MPIR_Request *));
+        MPIR_CHKLMEM_MALLOC(starray, comm_size * sizeof(MPI_Status));
 
         reqs = 0;
         for (i = 0; i < comm_size; i++) {

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -307,7 +307,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
     void *tmpbuf = NULL;
     MPI_Aint tmpbuf_size = 0;
     MPI_Aint actual_pack_bytes = 0;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -321,8 +321,7 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
 
     if (count > 0 && dest != MPI_PROC_NULL) {
         MPIR_Pack_size(count, datatype, &tmpbuf_size);
-        MPIR_CHKLMEM_MALLOC(tmpbuf, void *, tmpbuf_size, mpi_errno, "temporary send buffer",
-                            MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(tmpbuf, tmpbuf_size);
 
         mpi_errno =
             MPIR_Typerep_pack(buf, count, datatype, 0, tmpbuf, tmpbuf_size, &actual_pack_bytes,
@@ -465,7 +464,7 @@ int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status * statuses)
     int i;
     MPI_Status status_static_array[MPIC_REQUEST_PTR_ARRAY_SIZE];
     MPI_Status *status_array = statuses;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -475,8 +474,7 @@ int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status * statuses)
 
     if (numreq > MPIC_REQUEST_PTR_ARRAY_SIZE) {
         if (statuses == MPI_STATUSES_IGNORE) {
-            MPIR_CHKLMEM_MALLOC(status_array, MPI_Status *, numreq * sizeof(MPI_Status), mpi_errno,
-                                "status objects", MPL_MEM_BUFFER);
+            MPIR_CHKLMEM_MALLOC(status_array, numreq * sizeof(MPI_Status));
         }
     }
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks.c
@@ -34,7 +34,7 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
     int i_recv = 0;
     int *recv_id = NULL;
     void *tmp_recvbuf = NULL;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
@@ -66,8 +66,7 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
     if (MPL_ipow(k, nphases) == size)
         p_of_k = 1;
 
-    MPIR_CHKLMEM_MALLOC(recv_id, int *, sizeof(int) * nphases * (k - 1),
-                        mpi_errno, "recv_id buffer", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(recv_id, sizeof(int) * nphases * (k - 1));
 
     if (rank == 0)
         tmp_recvbuf = recvbuf;

--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch.c
@@ -249,7 +249,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, MPI_Aint sendco
     int *recv_id;
     int tag;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -272,8 +272,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, MPI_Aint sendco
                                    &step2_nbrs, &step2_nphases, &p_of_k, &T);
     is_instep2 = (step1_sendto == -1);  /* whether this rank participates in Step 2 */
     log_pofk = step2_nphases;
-    MPIR_CHKLMEM_MALLOC(recv_id, int *, sizeof(int) * ((step2_nphases * (k - 1)) + 1),
-                        mpi_errno, "recv_id buffer", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(recv_id, sizeof(int) * ((step2_nphases * (k - 1)) + 1));
 
     if (!is_inplace && is_instep2) {
         /* copy the data to recvbuf but only if you are a rank participating in Step 2 */

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks.c
@@ -48,7 +48,7 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
     int *recv_id = NULL;
     MPI_Aint *recv_index = NULL;
     int *scount_lookup = NULL;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
     void *tmp_recvbuf = NULL;
     int **s_counts = NULL;
     int **r_counts = NULL;
@@ -96,14 +96,11 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
         p_of_k = 1;
 
     /* if nphases=0 then no recv_id needed */
-    MPIR_CHKLMEM_MALLOC(recv_id, int *, sizeof(int) * nphases * (k - 1), mpi_errno, "recv_id",
-                        MPL_MEM_COLL);
-    MPIR_CHKLMEM_MALLOC(scount_lookup, int *, sizeof(int) * nphases, mpi_errno, "scount_lookup",
-                        MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(recv_id, sizeof(int) * nphases * (k - 1));
+    MPIR_CHKLMEM_MALLOC(scount_lookup, sizeof(int) * nphases);
 
     /* To store the index to receive in various phases and steps within */
-    MPIR_CHKLMEM_MALLOC(recv_index, MPI_Aint *, sizeof(MPI_Aint) * nphases * (k - 1), mpi_errno,
-                        "recv_index", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(recv_index, sizeof(MPI_Aint) * nphases * (k - 1));
 
     for (i = 0; i < size; i++)
         total_recvcount += recvcounts[i];

--- a/src/mpi/coll/iallreduce/iallreduce_intra_sched_reduce_scatter_allgather.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_sched_reduce_scatter_allgather.c
@@ -16,7 +16,7 @@ int MPIR_Iallreduce_intra_sched_reduce_scatter_allgather(const void *sendbuf, vo
     int i, send_idx, recv_idx, last_idx, mask, newdst, dst;
     MPI_Aint true_lb, true_extent, extent;
     void *tmp_buf = NULL;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
 #ifdef HAVE_ERROR_CHECKING
     /* we only support builtin datatypes for now, breaking up user types to do
@@ -92,10 +92,8 @@ int MPIR_Iallreduce_intra_sched_reduce_scatter_allgather(const void *sendbuf, vo
          * "2*pof2"-sized memory allocation */
 
         MPI_Aint *cnts, *disps;
-        MPIR_CHKLMEM_MALLOC(cnts, MPI_Aint *, pof2 * sizeof(MPI_Aint), mpi_errno, "counts",
-                            MPL_MEM_BUFFER);
-        MPIR_CHKLMEM_MALLOC(disps, MPI_Aint *, pof2 * sizeof(MPI_Aint), mpi_errno, "displacements",
-                            MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(cnts, pof2 * sizeof(MPI_Aint));
+        MPIR_CHKLMEM_MALLOC(disps, pof2 * sizeof(MPI_Aint));
 
         MPIR_Assert(count >= pof2);     /* the cnts calculations assume this */
         for (i = 0; i < (pof2 - 1); i++)

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv.c
@@ -40,7 +40,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     int allgather_algo_type = MPIR_IALLGATHER_RECEXCH_TYPE_DISTANCE_HALVING;
     int redscat_algo_type = IREDUCE_SCATTER_RECEXCH_TYPE_DISTANCE_HALVING;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -96,10 +96,8 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST, "Start Step2"));
 
     if (in_step2) {
-        MPIR_CHKLMEM_MALLOC(cnts, MPI_Aint *, sizeof(MPI_Aint) * nranks, mpi_errno, "cnts",
-                            MPL_MEM_COLL);
-        MPIR_CHKLMEM_MALLOC(displs, MPI_Aint *, sizeof(MPI_Aint) * nranks, mpi_errno, "displs",
-                            MPL_MEM_COLL);
+        MPIR_CHKLMEM_MALLOC(cnts, sizeof(MPI_Aint) * nranks);
+        MPIR_CHKLMEM_MALLOC(displs, sizeof(MPI_Aint) * nranks);
         int idx = 0;
         rem = nranks - p_of_k;
 

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_ring.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_ring.c
@@ -27,7 +27,7 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
     MPIR_FUNC_ENTER;
-    MPIR_CHKLMEM_DECL(4);
+    MPIR_CHKLMEM_DECL();
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
     nranks = MPIR_Comm_size(comm);
@@ -37,10 +37,8 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
     MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);
     extent = MPL_MAX(extent, true_extent);
 
-    MPIR_CHKLMEM_MALLOC(cnts, MPI_Aint *, nranks * sizeof(MPI_Aint), mpi_errno, "cnts",
-                        MPL_MEM_COLL);
-    MPIR_CHKLMEM_MALLOC(displs, MPI_Aint *, nranks * sizeof(MPI_Aint), mpi_errno, "displs",
-                        MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(cnts, nranks * sizeof(MPI_Aint));
+    MPIR_CHKLMEM_MALLOC(displs, nranks * sizeof(MPI_Aint));
 
     for (i = 0; i < nranks; i++)
         cnts[i] = 0;
@@ -71,7 +69,7 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
 
     /* Phase 2: Ring based send recv reduce scatter */
     /* Need only 2 spaces for current and previous reduce_id(s) */
-    MPIR_CHKLMEM_MALLOC(reduce_id, int *, 2 * sizeof(int), mpi_errno, "reduce_id", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(reduce_id, 2 * sizeof(int));
     tmpbuf = MPIR_TSP_sched_malloc(count * extent, sched);
 
     src = (nranks + rank - 1) % nranks;
@@ -104,7 +102,7 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
                                  datatype, dst, tag, comm, sched, nvtcs, &vtcs, &vtx_id);
         MPIR_ERR_CHECK(mpi_errno);
     }
-    MPIR_CHKLMEM_MALLOC(reduce_id, int *, 2 * sizeof(int), mpi_errno, "reduce_id", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(reduce_id, 2 * sizeof(int));
 
     mpi_errno = MPIR_TSP_sched_fence(sched);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree.c
@@ -33,7 +33,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
     int tag, vtx_id;
     int root = 0;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -98,13 +98,10 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
     }
 
     /* initialize arrays to store graph vertex indices */
-    MPIR_CHKLMEM_MALLOC(vtcs, int *, sizeof(int) * (num_children + 1),
-                        mpi_errno, "vtcs buffer", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(vtcs, sizeof(int) * (num_children + 1));
     if (num_children > 0) {
-        MPIR_CHKLMEM_MALLOC(reduce_id, int *, sizeof(int) * num_children,
-                            mpi_errno, "reduce_id buffer", MPL_MEM_COLL);
-        MPIR_CHKLMEM_MALLOC(recv_id, int *, sizeof(int) * num_children,
-                            mpi_errno, "recv_id buffer", MPL_MEM_COLL);
+        MPIR_CHKLMEM_MALLOC(reduce_id, sizeof(int) * num_children);
+        MPIR_CHKLMEM_MALLOC(recv_id, sizeof(int) * num_children);
     }
 
     /* do pipelined allreduce */

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_brucks.c
@@ -31,7 +31,7 @@ int MPIR_Ialltoall_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
     int pof2, dst, src;
     int count, block;
     MPI_Datatype newtype;
-    MPIR_CHKLMEM_DECL(1);       /* displs */
+    MPIR_CHKLMEM_DECL();        /* displs */
 
 #ifdef HAVE_ERROR_CHECKING
     MPIR_Assert(sendbuf != MPI_IN_PLACE);       /* we do not handle in-place */
@@ -74,8 +74,7 @@ int MPIR_Ialltoall_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
      * communication */
 
     MPI_Aint *displs;
-    MPIR_CHKLMEM_MALLOC(displs, MPI_Aint *, comm_size * sizeof(MPI_Aint), mpi_errno, "displs",
-                        MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(displs, comm_size * sizeof(MPI_Aint));
 
     pof2 = 1;
     while (pof2 < comm_size) {

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks.c
@@ -140,7 +140,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
     int tag;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
-    MPIR_CHKLMEM_DECL(6);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -149,13 +149,10 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPIR_CHKLMEM_MALLOC(pack_invtcs, int *, sizeof(int) * k, mpi_errno, "pack_invtcs",
-                        MPL_MEM_COLL);
-    MPIR_CHKLMEM_MALLOC(recv_invtcs, int *, sizeof(int) * k, mpi_errno, "recv_invtcs",
-                        MPL_MEM_COLL);
-    MPIR_CHKLMEM_MALLOC(unpack_invtcs, int *, sizeof(int) * k, mpi_errno, "unpack_invtcs",
-                        MPL_MEM_COLL);
-    MPIR_CHKLMEM_MALLOC(invtcs, int *, sizeof(int) * 6 * k, mpi_errno, "invtcs", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(pack_invtcs, sizeof(int) * k);
+    MPIR_CHKLMEM_MALLOC(recv_invtcs, sizeof(int) * k);
+    MPIR_CHKLMEM_MALLOC(unpack_invtcs, sizeof(int) * k);
+    MPIR_CHKLMEM_MALLOC(invtcs, sizeof(int) * 6 * k);
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
 
@@ -224,10 +221,8 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
 
     /* Step 2: Allocate buffer space for packing/receiving data for every phase */
     delta = 1;
-    MPIR_CHKLMEM_MALLOC(tmp_sbuf, void ***, sizeof(void **) * nphases, mpi_errno, "tmp_sbuf",
-                        MPL_MEM_COLL);
-    MPIR_CHKLMEM_MALLOC(tmp_rbuf, void ***, sizeof(void **) * nphases, mpi_errno, "tmp_rbuf",
-                        MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(tmp_sbuf, sizeof(void **) * nphases);
+    MPIR_CHKLMEM_MALLOC(tmp_rbuf, sizeof(void **) * nphases);
 
     for (i = 0; i < nphases; i++) {
         tmp_sbuf[i] = (void **) MPL_malloc(sizeof(void *) * (k - 1), MPL_MEM_COLL);

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered.c
@@ -21,7 +21,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Ain
     int tag;
     int *vtcs, *recv_id, *send_id;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_Assert(!(sendbuf == MPI_IN_PLACE));
 
@@ -42,9 +42,9 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Ain
         bblock = size;
 
     /* vtcs is twice the batch size to store both send and recv ids */
-    MPIR_CHKLMEM_MALLOC(vtcs, int *, 2 * batch_size * sizeof(int), mpi_errno, "vtcs", MPL_MEM_COLL);
-    MPIR_CHKLMEM_MALLOC(recv_id, int *, bblock * sizeof(int), mpi_errno, "recv_id", MPL_MEM_COLL);
-    MPIR_CHKLMEM_MALLOC(send_id, int *, bblock * sizeof(int), mpi_errno, "send_id", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(vtcs, 2 * batch_size * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(recv_id, bblock * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(send_id, bblock * sizeof(int));
 
     /* Get datatype info of sendtype and recvtype */
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);

--- a/src/mpi/coll/ibarrier/ibarrier_intra_tsp_dissem.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_tsp_dissem.c
@@ -15,7 +15,7 @@ int MPIR_TSP_Ibarrier_sched_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_
     int nphases = 0;
     int tag, vtx_id;
     int *recv_ids = NULL;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -35,7 +35,7 @@ int MPIR_TSP_Ibarrier_sched_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                     (MPL_DBG_FDEST, "dissem barrier - number of phases = %d\n", nphases));
 
-    MPIR_CHKLMEM_MALLOC(recv_ids, int *, sizeof(int) * nphases * (k - 1), mpi_errno, "recv_ids", MPL_MEM_COLL); /* to store size of subtree of each child */
+    MPIR_CHKLMEM_MALLOC(recv_ids, sizeof(int) * nphases * (k - 1));
     shift = 1;
     for (i = 0; i < nphases; i++) {
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
@@ -28,7 +28,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
     int num_children, *child_subtree_size = NULL;
     int num_send_dependencies;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
@@ -53,8 +53,8 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
     extent = MPL_MAX(extent, true_extent);
 
     nbytes = type_size * count;
-    MPIR_CHKLMEM_MALLOC(cnts, MPI_Aint *, sizeof(MPI_Aint) * size, mpi_errno, "cnts", MPL_MEM_COLL);    /* to store counts of each rank */
-    MPIR_CHKLMEM_MALLOC(displs, MPI_Aint *, sizeof(MPI_Aint) * size, mpi_errno, "displs", MPL_MEM_COLL);        /* to store displs of each rank */
+    MPIR_CHKLMEM_MALLOC(cnts, sizeof(MPI_Aint) * size);
+    MPIR_CHKLMEM_MALLOC(displs, sizeof(MPI_Aint) * size);
 
     total_count = 0;
     for (i = 0; i < size; i++)
@@ -95,7 +95,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
     MPIR_ERR_CHECK(mpi_errno);
     num_children = my_tree.num_children;
 
-    MPIR_CHKLMEM_MALLOC(child_subtree_size, int *, sizeof(int) * num_children, mpi_errno, "child_subtree_size buffer", MPL_MEM_COLL);   /* to store size of subtree of each child */
+    MPIR_CHKLMEM_MALLOC(child_subtree_size, sizeof(int) * num_children);
     /* calculate size of subtree of each child */
 
     /* get tree information of the parent */

--- a/src/mpi/coll/igather/igather_tsp_tree.c
+++ b/src/mpi/coll/igather/igather_tsp_tree.c
@@ -27,7 +27,7 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     int num_dependencies;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPI_Aint *child_data_offset;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -66,8 +66,8 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     recvtype_extent = MPL_MAX(recvtype_extent, recvtype_true_extent);
 
     num_children = my_tree.num_children;
-    MPIR_CHKLMEM_MALLOC(child_subtree_size, int *, sizeof(int) * num_children, mpi_errno, "child_subtree_size buffer", MPL_MEM_COLL);   /* to store size of subtree of each child */
-    MPIR_CHKLMEM_MALLOC(child_data_offset, MPI_Aint *, sizeof(MPI_Aint) * num_children, mpi_errno, "child_data_offset buffer", MPL_MEM_COLL);   /* to store the offset of the data to be sent to each child  */
+    MPIR_CHKLMEM_MALLOC(child_subtree_size, sizeof(int) * num_children);
+    MPIR_CHKLMEM_MALLOC(child_data_offset, sizeof(MPI_Aint) * num_children);
 
     /* calculate size of subtree of each child */
 
@@ -130,8 +130,7 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
         tmp_buf = (void *) sendbuf;
     }
 
-    MPIR_CHKLMEM_MALLOC(recv_id, int *, sizeof(int) * num_children,
-                        mpi_errno, "recv_id buffer", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(recv_id, sizeof(int) * num_children);
     /* Leaf nodes send to parent */
     if (num_children == 0) {
         mpi_errno =

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_allcomm_sched_linear.c
@@ -22,14 +22,14 @@ int MPIR_Ineighbor_allgather_allcomm_sched_linear(const void *sendbuf, MPI_Aint 
     int k, l;
     int *srcs, *dsts;
     MPI_Aint recvtype_extent;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
-    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(srcs, indegree * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(dsts, outdegree * sizeof(int));
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);

--- a/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_allgather/ineighbor_allgather_tsp_linear.c
@@ -23,14 +23,14 @@ int MPIR_TSP_Ineighbor_allgather_sched_allcomm_linear(const void *sendbuf, MPI_A
 
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
-    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(srcs, indegree * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(dsts, outdegree * sizeof(int));
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_allcomm_sched_linear.c
@@ -23,14 +23,14 @@ int MPIR_Ineighbor_allgatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint
     int k, l;
     int *srcs, *dsts;
     MPI_Aint recvtype_extent;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
-    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(srcs, indegree * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(dsts, outdegree * sizeof(int));
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);

--- a/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_allgatherv/ineighbor_allgatherv_tsp_linear.c
@@ -22,7 +22,7 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_
     int tag, vtx_id;
     MPI_Aint recvtype_extent;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -30,8 +30,8 @@ int MPIR_TSP_Ineighbor_allgatherv_sched_allcomm_linear(const void *sendbuf, MPI_
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
-    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(srcs, indegree * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(dsts, outdegree * sizeof(int));
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_allcomm_sched_linear.c
@@ -22,15 +22,15 @@ int MPIR_Ineighbor_alltoall_allcomm_sched_linear(const void *sendbuf, MPI_Aint s
     int k, l;
     int *srcs, *dsts;
     MPI_Aint sendtype_extent, recvtype_extent;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
-    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(srcs, indegree * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(dsts, outdegree * sizeof(int));
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);

--- a/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoall/ineighbor_alltoall_tsp_linear.c
@@ -23,15 +23,15 @@ int MPIR_TSP_Ineighbor_alltoall_sched_allcomm_linear(const void *sendbuf, MPI_Ai
 
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
-    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(srcs, indegree * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(dsts, outdegree * sizeof(int));
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_allcomm_sched_linear.c
@@ -23,15 +23,15 @@ int MPIR_Ineighbor_alltoallv_allcomm_sched_linear(const void *sendbuf, const MPI
     int k, l;
     int *srcs, *dsts;
     MPI_Aint sendtype_extent, recvtype_extent;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
-    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(srcs, indegree * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(dsts, outdegree * sizeof(int));
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);

--- a/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallv/ineighbor_alltoallv_tsp_linear.c
@@ -27,15 +27,15 @@ int MPIR_TSP_Ineighbor_alltoallv_sched_allcomm_linear(const void *sendbuf,
 
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
-    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(srcs, indegree * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(dsts, outdegree * sizeof(int));
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_sched_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_allcomm_sched_linear.c
@@ -24,12 +24,12 @@ int MPIR_Ineighbor_alltoallw_allcomm_sched_linear(const void *sendbuf, const MPI
     int indegree, outdegree, weighted;
     int k, l;
     int *srcs, *dsts;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
-    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(srcs, indegree * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(dsts, outdegree * sizeof(int));
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);

--- a/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear.c
+++ b/src/mpi/coll/ineighbor_alltoallw/ineighbor_alltoallw_tsp_linear.c
@@ -26,12 +26,12 @@ int MPIR_TSP_Ineighbor_alltoallw_sched_allcomm_linear(const void *sendbuf,
 
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     mpi_errno = MPIR_Topo_canon_nhb_count(comm_ptr, &indegree, &outdegree, &weighted);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_CHKLMEM_MALLOC(srcs, int *, indegree * sizeof(int), mpi_errno, "srcs", MPL_MEM_COMM);
-    MPIR_CHKLMEM_MALLOC(dsts, int *, outdegree * sizeof(int), mpi_errno, "dsts", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(srcs, indegree * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(dsts, outdegree * sizeof(int));
     mpi_errno = MPIR_Topo_canon_nhb(comm_ptr,
                                     indegree, srcs, MPI_UNWEIGHTED,
                                     outdegree, dsts, MPI_UNWEIGHTED);

--- a/src/mpi/coll/ireduce/ireduce_intra_sched_reduce_scatter_gather.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_sched_reduce_scatter_gather.c
@@ -42,7 +42,7 @@ int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *re
     int newroot, newdst_tree_root, newroot_tree_root;
     void *tmp_buf = NULL;
     MPI_Aint true_lb, true_extent, extent;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -139,10 +139,8 @@ int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *re
      * because if root is one of the excluded processes, we will
      * need them on the root later on below. */
     MPI_Aint *cnts, *disps;
-    MPIR_CHKLMEM_MALLOC(cnts, MPI_Aint *, pof2 * sizeof(MPI_Aint), mpi_errno, "counts",
-                        MPL_MEM_BUFFER);
-    MPIR_CHKLMEM_MALLOC(disps, MPI_Aint *, pof2 * sizeof(MPI_Aint), mpi_errno, "displacements",
-                        MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(cnts, pof2 * sizeof(MPI_Aint));
+    MPIR_CHKLMEM_MALLOC(disps, pof2 * sizeof(MPI_Aint));
 
     last_idx = send_idx = 0;    /* suppress spurious compiler warnings */
 

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree.c
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree.c
@@ -38,7 +38,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
     int nvtcs;
     int tag;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -174,13 +174,10 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
     MPIR_ERR_CHECK(mpi_errno);
 
     /* initialize arrays to store graph vertex indices */
-    MPIR_CHKLMEM_MALLOC(vtcs, int *, sizeof(int) * (num_children + 1),
-                        mpi_errno, "vtcs buffer", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(vtcs, sizeof(int) * (num_children + 1));
     if (num_children > 0) {
-        MPIR_CHKLMEM_MALLOC(reduce_id, int *, sizeof(int) * num_children,
-                            mpi_errno, "reduce_id buffer", MPL_MEM_COLL);
-        MPIR_CHKLMEM_MALLOC(recv_id, int *, sizeof(int) * num_children,
-                            mpi_errno, "recv_id buffer", MPL_MEM_COLL);
+        MPIR_CHKLMEM_MALLOC(reduce_id, sizeof(int) * num_children);
+        MPIR_CHKLMEM_MALLOC(recv_id, sizeof(int) * num_children);
     }
 
     /* do pipelined reduce */

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
@@ -151,7 +151,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
     MPI_Aint *displs;
     int tag, vtx_id;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -177,8 +177,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
         return mpi_errno;
     }
 
-    MPIR_CHKLMEM_MALLOC(displs, MPI_Aint *, nranks * sizeof(MPI_Aint),
-                        mpi_errno, "displs buffer", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(displs, nranks * sizeof(MPI_Aint));
     displs[0] = 0;
     for (i = 1; i < nranks; i++) {
         displs[i] = displs[i - 1] + recvcounts[i - 1];

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree.c
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree.c
@@ -32,7 +32,7 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     int tag;
     int num_send_dependencies;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     size = MPIR_Comm_size(comm);
     rank = MPIR_Comm_rank(comm);
@@ -68,8 +68,8 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     recvtype_extent = MPL_MAX(recvtype_extent, recvtype_true_extent);
 
     num_children = my_tree.num_children;
-    MPIR_CHKLMEM_MALLOC(child_subtree_size, int *, sizeof(int) * num_children, mpi_errno, "child_subtree_size buffer", MPL_MEM_COLL);   /* to store size of subtree of each child */
-    MPIR_CHKLMEM_MALLOC(child_data_offset, MPI_Aint *, sizeof(MPI_Aint) * num_children, mpi_errno, "child_data_offset buffer", MPL_MEM_COLL);   /* to store the offset of the data to be sent to each child  */
+    MPIR_CHKLMEM_MALLOC(child_subtree_size, sizeof(int) * num_children);
+    MPIR_CHKLMEM_MALLOC(child_data_offset, sizeof(MPI_Aint) * num_children);
 
     /* calculate size of subtree of each child */
 

--- a/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
+++ b/src/mpi/coll/reduce/reduce_inter_local_reduce_remote_send.c
@@ -21,12 +21,13 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
                                                int root,
                                                MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
-    int rank, mpi_errno;
+    int mpi_errno = MPI_SUCCESS;
+    int rank;
     MPI_Status status;
     MPI_Aint true_extent, true_lb, extent;
     void *tmp_buf = NULL;
     MPIR_Comm *newcomm_ptr = NULL;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     if (root == MPI_PROC_NULL) {
         /* local processes other than root do nothing */
@@ -48,8 +49,7 @@ int MPIR_Reduce_inter_local_reduce_remote_send(const void *sendbuf,
             MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
             MPIR_Datatype_get_extent_macro(datatype, extent);
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)), mpi_errno,
-                                "temporary buffer", MPL_MEM_BUFFER);
+            MPIR_CHKLMEM_MALLOC(tmp_buf, count * (MPL_MAX(extent, true_extent)));
             /* adjust for potential negative lower bound in datatype */
             tmp_buf = (void *) ((char *) tmp_buf - true_lb);
         }

--- a/src/mpi/coll/reduce/reduce_intra_binomial.c
+++ b/src/mpi/coll/reduce/reduce_intra_binomial.c
@@ -21,7 +21,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
     int mask, relrank, source, lroot;
     MPI_Aint true_lb, true_extent, extent;
     void *tmp_buf;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
@@ -32,17 +32,14 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
 
     is_commutative = MPIR_Op_is_commutative(op);
 
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)),
-                        mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf, count * (MPL_MAX(extent, true_extent)));
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *) ((char *) tmp_buf - true_lb);
 
     /* If I'm not the root, then my recvbuf may not be valid, therefore
      * I have to allocate a temporary one */
     if (rank != root) {
-        MPIR_CHKLMEM_MALLOC(recvbuf, void *,
-                            count * (MPL_MAX(extent, true_extent)),
-                            mpi_errno, "receive buffer", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(recvbuf, count * (MPL_MAX(extent, true_extent)));
         recvbuf = (void *) ((char *) recvbuf - true_lb);
     }
 

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -47,7 +47,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
     MPI_Aint true_lb, true_extent, extent;
     void *tmp_buf;
 
-    MPIR_CHKLMEM_DECL(4);
+    MPIR_CHKLMEM_DECL();
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -57,17 +57,14 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)),
-                        mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf, count * (MPL_MAX(extent, true_extent)));
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *) ((char *) tmp_buf - true_lb);
 
     /* If I'm not the root, then my recvbuf may not be valid, therefore
      * I have to allocate a temporary one */
     if (rank != root) {
-        MPIR_CHKLMEM_MALLOC(recvbuf, void *,
-                            count * (MPL_MAX(extent, true_extent)),
-                            mpi_errno, "receive buffer", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(recvbuf, count * (MPL_MAX(extent, true_extent)));
         recvbuf = (void *) ((char *) recvbuf - true_lb);
     }
 
@@ -136,10 +133,8 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
      * because if root is one of the excluded processes, we will
      * need them on the root later on below. */
     MPI_Aint *cnts, *disps;
-    MPIR_CHKLMEM_MALLOC(cnts, MPI_Aint *, pof2 * sizeof(MPI_Aint), mpi_errno, "counts",
-                        MPL_MEM_BUFFER);
-    MPIR_CHKLMEM_MALLOC(disps, MPI_Aint *, pof2 * sizeof(MPI_Aint), mpi_errno, "displacements",
-                        MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(cnts, pof2 * sizeof(MPI_Aint));
+    MPIR_CHKLMEM_MALLOC(disps, pof2 * sizeof(MPI_Aint));
 
     if (newrank != -1) {
         for (i = 0; i < pof2; i++)

--- a/src/mpi/coll/reduce/reduce_intra_smp.c
+++ b/src/mpi/coll/reduce/reduce_intra_smp.c
@@ -12,7 +12,7 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
     int mpi_errno = MPI_SUCCESS;
     void *tmp_buf = NULL;
     MPI_Aint true_lb, true_extent, extent;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
 #ifdef HAVE_ERROR_CHECKING
     {
@@ -28,8 +28,7 @@ int MPIR_Reduce_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         MPIR_Datatype_get_extent_macro(datatype, extent);
 
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)),
-                            mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(tmp_buf, count * (MPL_MAX(extent, true_extent)));
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *) ((char *) tmp_buf - true_lb);
     }

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_inter_remote_reduce_local_scatter.c
@@ -18,12 +18,13 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
                                                           MPIR_Comm * comm_ptr,
                                                           MPIR_Errflag_t errflag)
 {
-    int rank, mpi_errno, root, local_size, total_count, i;
+    int mpi_errno = MPI_SUCCESS;
+    int rank, root, local_size, total_count, i;
     MPI_Aint true_extent, true_lb = 0, extent;
     void *tmp_buf = NULL;
     MPI_Aint *disps = NULL;
     MPIR_Comm *newcomm_ptr = NULL;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     rank = comm_ptr->rank;
     local_size = comm_ptr->local_size;
@@ -36,8 +37,7 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
         /* In each group, rank 0 allocates a temp. buffer for the
          * reduce */
 
-        MPIR_CHKLMEM_MALLOC(disps, MPI_Aint *, local_size * sizeof(MPI_Aint), mpi_errno, "disps",
-                            MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(disps, local_size * sizeof(MPI_Aint));
 
         total_count = 0;
         for (i = 0; i < local_size; i++) {
@@ -48,8 +48,7 @@ int MPIR_Reduce_scatter_inter_remote_reduce_local_scatter(const void *sendbuf, v
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         MPIR_Datatype_get_extent_macro(datatype, extent);
 
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, total_count * (MPL_MAX(extent, true_extent)),
-                            mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(tmp_buf, total_count * (MPL_MAX(extent, true_extent)));
 
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *) ((char *) tmp_buf - true_lb);

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
@@ -35,7 +35,7 @@ int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
     void *tmp_buf0;
     void *tmp_buf1;
     void *result_ptr;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
@@ -56,10 +56,8 @@ int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
     block_size = recvcounts[0];
     total_count = block_size * comm_size;
 
-    MPIR_CHKLMEM_MALLOC(tmp_buf0, void *, true_extent * total_count, mpi_errno, "tmp_buf0",
-                        MPL_MEM_BUFFER);
-    MPIR_CHKLMEM_MALLOC(tmp_buf1, void *, true_extent * total_count, mpi_errno, "tmp_buf1",
-                        MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf0, true_extent * total_count);
+    MPIR_CHKLMEM_MALLOC(tmp_buf1, true_extent * total_count);
     /* adjust for potential negative lower bound in datatype */
     tmp_buf0 = (void *) ((char *) tmp_buf0 - true_lb);
     tmp_buf1 = (void *) ((char *) tmp_buf1 - true_lb);

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
@@ -23,7 +23,7 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
     void *tmp_recvbuf;
     int mpi_errno = MPI_SUCCESS;
     int src, dst;
-    MPIR_CHKLMEM_DECL(5);
+    MPIR_CHKLMEM_DECL();
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -40,8 +40,7 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
     }
 #endif /* HAVE_ERROR_CHECKING */
 
-    MPIR_CHKLMEM_MALLOC(disps, MPI_Aint *, comm_size * sizeof(MPI_Aint), mpi_errno, "disps",
-                        MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(disps, comm_size * sizeof(MPI_Aint));
 
     MPI_Aint total_count;
     total_count = 0;
@@ -65,8 +64,7 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
     }
 
     /* allocate temporary buffer to store incoming data */
-    MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, recvcounts[rank] * (MPL_MAX(true_extent, extent)) + 1,
-                        mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_recvbuf, recvcounts[rank] * (MPL_MAX(true_extent, extent)) + 1);
     /* adjust for potential negative lower bound in datatype */
     tmp_recvbuf = (void *) ((char *) tmp_recvbuf - true_lb);
 

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
@@ -32,7 +32,7 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
     int pof2, received;
     MPI_Datatype sendtype, recvtype;
     int nprocs_completed, tmp_mask, tree_root, is_commutative;
-    MPIR_CHKLMEM_DECL(5);
+    MPIR_CHKLMEM_DECL();
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -42,7 +42,7 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
 
     is_commutative = MPIR_Op_is_commutative(op);
 
-    MPIR_CHKLMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(disps, comm_size * sizeof(int));
 
     total_count = 0;
     for (i = 0; i < comm_size; i++) {
@@ -61,15 +61,13 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
     }
 
     /* need to allocate temporary buffer to receive incoming data */
-    MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, total_count * (MPL_MAX(true_extent, extent)),
-                        mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_recvbuf, total_count * (MPL_MAX(true_extent, extent)));
     /* adjust for potential negative lower bound in datatype */
     tmp_recvbuf = (void *) ((char *) tmp_recvbuf - true_lb);
 
     /* need to allocate another temporary buffer to accumulate
      * results */
-    MPIR_CHKLMEM_MALLOC(tmp_results, void *, total_count * (MPL_MAX(true_extent, extent)),
-                        mpi_errno, "tmp_results", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_results, total_count * (MPL_MAX(true_extent, extent)));
     /* adjust for potential negative lower bound in datatype */
     tmp_results = (void *) ((char *) tmp_results - true_lb);
 

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -48,7 +48,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
     int mask;
     int rem, newdst, send_idx, recv_idx, last_idx, send_cnt, recv_cnt;
     int pof2, old_i, newrank;
-    MPIR_CHKLMEM_DECL(5);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
@@ -63,7 +63,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
-    MPIR_CHKLMEM_MALLOC(disps, int *, comm_size * sizeof(int), mpi_errno, "disps", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(disps, comm_size * sizeof(int));
 
     total_count = 0;
     for (i = 0; i < comm_size; i++) {
@@ -78,15 +78,13 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
     /* commutative and short. use recursive halving algorithm */
 
     /* allocate temp. buffer to receive incoming data */
-    MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, total_count * (MPL_MAX(true_extent, extent)),
-                        mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_recvbuf, total_count * (MPL_MAX(true_extent, extent)));
     /* adjust for potential negative lower bound in datatype */
     tmp_recvbuf = (void *) ((char *) tmp_recvbuf - true_lb);
 
     /* need to allocate another temporary buffer to accumulate
      * results because recvbuf may not be big enough */
-    MPIR_CHKLMEM_MALLOC(tmp_results, void *, total_count * (MPL_MAX(true_extent, extent)),
-                        mpi_errno, "tmp_results", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_results, total_count * (MPL_MAX(true_extent, extent)));
     /* adjust for potential negative lower bound in datatype */
     tmp_results = (void *) ((char *) tmp_results - true_lb);
 
@@ -144,10 +142,8 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
          * have their result calculated by the process to their
          * right (rank+1). */
         MPI_Aint *newcnts, *newdisps;
-        MPIR_CHKLMEM_MALLOC(newcnts, MPI_Aint *, pof2 * sizeof(MPI_Aint), mpi_errno, "newcnts",
-                            MPL_MEM_BUFFER);
-        MPIR_CHKLMEM_MALLOC(newdisps, MPI_Aint *, pof2 * sizeof(MPI_Aint), mpi_errno, "newdisps",
-                            MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(newcnts, pof2 * sizeof(MPI_Aint));
+        MPIR_CHKLMEM_MALLOC(newdisps, pof2 * sizeof(MPI_Aint));
 
         for (i = 0; i < pof2; i++) {
             /* what does i map to in the old ranking? */

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_inter_remote_reduce_local_scatter.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_inter_remote_reduce_local_scatter.c
@@ -20,11 +20,12 @@ int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *send
                                                                 MPIR_Comm * comm_ptr,
                                                                 MPIR_Errflag_t errflag)
 {
-    int rank, mpi_errno, root, local_size;
+    int mpi_errno = MPI_SUCCESS;
+    int rank, root, local_size;
     MPI_Aint true_extent, true_lb = 0, extent;
     void *tmp_buf = NULL;
     MPIR_Comm *newcomm_ptr = NULL;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     rank = comm_ptr->rank;
     local_size = comm_ptr->local_size;
@@ -38,8 +39,7 @@ int MPIR_Reduce_scatter_block_inter_remote_reduce_local_scatter(const void *send
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         MPIR_Datatype_get_extent_macro(datatype, extent);
 
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, total_count * (MPL_MAX(extent, true_extent)),
-                            mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(tmp_buf, total_count * (MPL_MAX(extent, true_extent)));
 
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *) ((char *) tmp_buf - true_lb);

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
@@ -37,7 +37,7 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
     void *tmp_buf0;
     void *tmp_buf1;
     void *result_ptr;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
@@ -54,10 +54,8 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
     block_size = recvcount;
     total_count = block_size * comm_size;
 
-    MPIR_CHKLMEM_MALLOC(tmp_buf0, void *, true_extent * total_count, mpi_errno, "tmp_buf0",
-                        MPL_MEM_BUFFER);
-    MPIR_CHKLMEM_MALLOC(tmp_buf1, void *, true_extent * total_count, mpi_errno, "tmp_buf1",
-                        MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf0, true_extent * total_count);
+    MPIR_CHKLMEM_MALLOC(tmp_buf1, true_extent * total_count);
     /* adjust for potential negative lower bound in datatype */
     tmp_buf0 = (void *) ((char *) tmp_buf0 - true_lb);
     tmp_buf1 = (void *) ((char *) tmp_buf1 - true_lb);

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
@@ -32,7 +32,7 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
     void *tmp_recvbuf;
     int mpi_errno = MPI_SUCCESS;
     int src, dst;
-    MPIR_CHKLMEM_DECL(5);
+    MPIR_CHKLMEM_DECL();
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -49,8 +49,7 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
 #endif /* HAVE_ERROR_CHECKING */
 
     MPI_Aint *disps;
-    MPIR_CHKLMEM_MALLOC(disps, MPI_Aint *, comm_size * sizeof(MPI_Aint), mpi_errno, "disps",
-                        MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(disps, comm_size * sizeof(MPI_Aint));
 
     for (i = 0; i < comm_size; i++) {
         disps[i] = i * recvcount;
@@ -67,8 +66,7 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
     }
 
     /* allocate temporary buffer to store incoming data */
-    MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, recvcount * (MPL_MAX(true_extent, extent)) + 1,
-                        mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_recvbuf, recvcount * (MPL_MAX(true_extent, extent)) + 1);
     /* adjust for potential negative lower bound in datatype */
     tmp_recvbuf = (void *) ((char *) tmp_recvbuf - true_lb);
 

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
@@ -36,7 +36,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
     int received;
     MPI_Datatype sendtype, recvtype;
     int nprocs_completed, tmp_mask, tree_root, is_commutative;
-    MPIR_CHKLMEM_DECL(5);
+    MPIR_CHKLMEM_DECL();
 
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
@@ -47,8 +47,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
     is_commutative = MPIR_Op_is_commutative(op);
 
     MPI_Aint *disps;
-    MPIR_CHKLMEM_MALLOC(disps, MPI_Aint *, comm_size * sizeof(MPI_Aint), mpi_errno, "disps",
-                        MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(disps, comm_size * sizeof(MPI_Aint));
 
     MPI_Aint total_count;
     total_count = comm_size * recvcount;
@@ -57,15 +56,13 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
     }
 
     /* need to allocate temporary buffer to receive incoming data */
-    MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, total_count * (MPL_MAX(true_extent, extent)),
-                        mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_recvbuf, total_count * (MPL_MAX(true_extent, extent)));
     /* adjust for potential negative lower bound in datatype */
     tmp_recvbuf = (void *) ((char *) tmp_recvbuf - true_lb);
 
     /* need to allocate another temporary buffer to accumulate
      * results */
-    MPIR_CHKLMEM_MALLOC(tmp_results, void *, total_count * (MPL_MAX(true_extent, extent)),
-                        mpi_errno, "tmp_results", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_results, total_count * (MPL_MAX(true_extent, extent)));
     /* adjust for potential negative lower bound in datatype */
     tmp_results = (void *) ((char *) tmp_results - true_lb);
 

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -50,7 +50,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
     int mask;
     int rem, newdst, send_idx, recv_idx, last_idx;
     int pof2, old_i, newrank;
-    MPIR_CHKLMEM_DECL(5);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
@@ -66,8 +66,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
     MPI_Aint *disps;
-    MPIR_CHKLMEM_MALLOC(disps, MPI_Aint *, comm_size * sizeof(MPI_Aint), mpi_errno, "disps",
-                        MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(disps, comm_size * sizeof(MPI_Aint));
 
     MPI_Aint total_count;
     total_count = comm_size * recvcount;
@@ -78,15 +77,13 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
     /* commutative and short. use recursive halving algorithm */
 
     /* allocate temp. buffer to receive incoming data */
-    MPIR_CHKLMEM_MALLOC(tmp_recvbuf, void *, total_count * (MPL_MAX(true_extent, extent)),
-                        mpi_errno, "tmp_recvbuf", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_recvbuf, total_count * (MPL_MAX(true_extent, extent)));
     /* adjust for potential negative lower bound in datatype */
     tmp_recvbuf = (void *) ((char *) tmp_recvbuf - true_lb);
 
     /* need to allocate another temporary buffer to accumulate
      * results because recvbuf may not be big enough */
-    MPIR_CHKLMEM_MALLOC(tmp_results, void *, total_count * (MPL_MAX(true_extent, extent)),
-                        mpi_errno, "tmp_results", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_results, total_count * (MPL_MAX(true_extent, extent)));
     /* adjust for potential negative lower bound in datatype */
     tmp_results = (void *) ((char *) tmp_results - true_lb);
 
@@ -145,10 +142,8 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
          * have their result calculated by the process to their
          * right (rank+1). */
         MPI_Aint *newcnts, *newdisps;
-        MPIR_CHKLMEM_MALLOC(newcnts, MPI_Aint *, pof2 * sizeof(MPI_Aint), mpi_errno, "newcnts",
-                            MPL_MEM_BUFFER);
-        MPIR_CHKLMEM_MALLOC(newdisps, MPI_Aint *, pof2 * sizeof(MPI_Aint), mpi_errno, "newdisps",
-                            MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(newcnts, pof2 * sizeof(MPI_Aint));
+        MPIR_CHKLMEM_MALLOC(newdisps, pof2 * sizeof(MPI_Aint));
 
         for (i = 0; i < pof2; i++) {
             /* what does i map to in the old ranking? */

--- a/src/mpi/coll/scan/scan_intra_recursive_doubling.c
+++ b/src/mpi/coll/scan/scan_intra_recursive_doubling.c
@@ -52,7 +52,7 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
     int mask, dst, is_commutative;
     MPI_Aint true_extent, true_lb, extent;
     void *partial_scan, *tmp_buf;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
@@ -62,15 +62,13 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
-    MPIR_CHKLMEM_MALLOC(partial_scan, void *, count * (MPL_MAX(extent, true_extent)), mpi_errno,
-                        "partial_scan", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(partial_scan, count * (MPL_MAX(extent, true_extent)));
 
     /* adjust for potential negative lower bound in datatype */
     partial_scan = (void *) ((char *) partial_scan - true_lb);
 
     /* need to allocate temporary buffer to store incoming data */
-    MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)), mpi_errno,
-                        "tmp_buf", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf, count * (MPL_MAX(extent, true_extent)));
 
     /* adjust for potential negative lower bound in datatype */
     tmp_buf = (void *) ((char *) tmp_buf - true_lb);

--- a/src/mpi/coll/scan/scan_intra_smp.c
+++ b/src/mpi/coll/scan/scan_intra_smp.c
@@ -11,7 +11,7 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
                         MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
     int rank = comm_ptr->rank;
     MPI_Status status;
     void *tempbuf = NULL, *localfulldata = NULL, *prefulldata = NULL;
@@ -23,19 +23,16 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    MPIR_CHKLMEM_MALLOC(tempbuf, void *, count * (MPL_MAX(extent, true_extent)),
-                        mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tempbuf, count * (MPL_MAX(extent, true_extent)));
     tempbuf = (void *) ((char *) tempbuf - true_lb);
 
     /* Create prefulldata and localfulldata on local roots of all nodes */
     if (comm_ptr->node_roots_comm != NULL) {
-        MPIR_CHKLMEM_MALLOC(prefulldata, void *, count * (MPL_MAX(extent, true_extent)),
-                            mpi_errno, "prefulldata for scan", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(prefulldata, count * (MPL_MAX(extent, true_extent)));
         prefulldata = (void *) ((char *) prefulldata - true_lb);
 
         if (comm_ptr->node_comm != NULL) {
-            MPIR_CHKLMEM_MALLOC(localfulldata, void *, count * (MPL_MAX(extent, true_extent)),
-                                mpi_errno, "localfulldata for scan", MPL_MEM_BUFFER);
+            MPIR_CHKLMEM_MALLOC(localfulldata, count * (MPL_MAX(extent, true_extent)));
             localfulldata = (void *) ((char *) localfulldata - true_lb);
         }
     }

--- a/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
@@ -22,7 +22,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
     int rank, local_size, remote_size, mpi_errno = MPI_SUCCESS;
     MPI_Status status;
     MPIR_Comm *newcomm_ptr = NULL;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     if (root == MPI_PROC_NULL) {
         /* local processes other than root do nothing */
@@ -49,9 +49,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
 
         if (rank == 0) {
             MPIR_Datatype_get_size_macro(recvtype, recvtype_sz);
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void *,
-                                recvcount * local_size * recvtype_sz, mpi_errno,
-                                "tmp_buf", MPL_MEM_BUFFER);
+            MPIR_CHKLMEM_MALLOC(tmp_buf, recvcount * local_size * recvtype_sz);
 
             mpi_errno = MPIC_Recv(tmp_buf, recvcount * local_size * recvtype_sz, MPI_BYTE,
                                   root, MPIR_SCATTER_TAG, comm_ptr, &status);

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -39,7 +39,7 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
     MPI_Aint tmp_buf_size = 0;
     void *tmp_buf = NULL;
     int mpi_errno = MPI_SUCCESS;
-    MPIR_CHKLMEM_DECL(4);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
@@ -68,7 +68,7 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
      * receive data of max size (nbytes*comm_size)/2 */
     if (relative_rank && !(relative_rank % 2)) {
         tmp_buf_size = (nbytes * comm_size) / 2;
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(tmp_buf, tmp_buf_size);
     }
 
     /* if the root is not rank 0, we reorder the sendbuf in order of
@@ -78,8 +78,7 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
     if (rank == root) {
         if (root != 0) {
             tmp_buf_size = nbytes * comm_size;
-            MPIR_CHKLMEM_MALLOC(tmp_buf, void *, tmp_buf_size, mpi_errno, "tmp_buf",
-                                MPL_MEM_BUFFER);
+            MPIR_CHKLMEM_MALLOC(tmp_buf, tmp_buf_size);
 
             if (recvbuf != MPI_IN_PLACE)
                 mpi_errno = MPIR_Localcopy(((char *) sendbuf + extent * sendcount * rank),

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -27,7 +27,7 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcount
     int i, reqs;
     MPIR_Request **reqarray;
     MPI_Status *starray;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
@@ -39,10 +39,8 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcount
 
         MPIR_Datatype_get_extent_macro(sendtype, extent);
 
-        MPIR_CHKLMEM_MALLOC(reqarray, MPIR_Request **, comm_size * sizeof(MPIR_Request *),
-                            mpi_errno, "reqarray", MPL_MEM_BUFFER);
-        MPIR_CHKLMEM_MALLOC(starray, MPI_Status *, comm_size * sizeof(MPI_Status), mpi_errno,
-                            "starray", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(reqarray, comm_size * sizeof(MPIR_Request *));
+        MPIR_CHKLMEM_MALLOC(starray, comm_size * sizeof(MPI_Status));
 
         reqs = 0;
         for (i = 0; i < comm_size; i++) {

--- a/src/mpi/coll/transports/gentran/tsp_gentran.c
+++ b/src/mpi/coll/transports/gentran/tsp_gentran.c
@@ -427,15 +427,14 @@ int MPIR_TSP_sched_sink(MPIR_TSP_sched_t s, int *vtx_id)
     int *in_vtcs;
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     /* assign a new vertex */
     *vtx_id = MPII_Genutil_vtx_create(sched, &vtxp);
 
     vtxp->vtx_kind = MPII_GENUTIL_VTX_KIND__SINK;
 
-    MPIR_CHKLMEM_MALLOC(in_vtcs, int *, sizeof(int) * (*vtx_id),
-                        mpi_errno, "in_vtcs buffer", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(in_vtcs, sizeof(int) * (*vtx_id));
     /* record incoming vertices */
     sched_fence = ut_type_array(&sched->vtcs, vtx_t *) + *vtx_id - 1;
     MPIR_ERR_CHKANDJUMP(sched_fence == NULL, mpi_errno, MPI_ERR_OTHER, "**nofence");

--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -192,7 +192,7 @@ int MPII_Comm_create_calculate_mapping(MPIR_Group * group_ptr,
     int i, j;
     int n;
     int *mapping = 0;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -200,7 +200,7 @@ int MPII_Comm_create_calculate_mapping(MPIR_Group * group_ptr,
     *mapping_comm = comm_ptr;
 
     n = group_ptr->size;
-    MPIR_CHKPMEM_MALLOC(mapping, int *, n * sizeof(int), mpi_errno, "mapping", MPL_MEM_ADDRESS);
+    MPIR_CHKPMEM_MALLOC(mapping, n * sizeof(int), MPL_MEM_COMM);
 
     /* Make sure that the processes for this group are contained within
      * the input communicator.  Also identify the mapping from the ranks of
@@ -275,7 +275,6 @@ int MPII_Comm_create_calculate_mapping(MPIR_Group * group_ptr,
     *mapping_out = mapping;
     MPL_VG_CHECK_MEM_IS_DEFINED(*mapping_out, n * sizeof(**mapping_out));
 
-    MPIR_CHKPMEM_COMMIT();
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -406,7 +406,7 @@ int MPIR_Comm_create_inter(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Co
     MPIR_Comm *mapping_comm = NULL;
     int remote_size = -1;
     int rinfo[2];
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -479,9 +479,7 @@ int MPIR_Comm_create_inter(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Co
         }
         remote_size = rinfo[1];
 
-        MPIR_CHKLMEM_MALLOC(remote_mapping, int *,
-                            remote_size * sizeof(int),
-                            mpi_errno, "remote_mapping", MPL_MEM_ADDRESS);
+        MPIR_CHKLMEM_MALLOC(remote_mapping, remote_size * sizeof(int));
 
         /* Populate and exchange the ranks */
         mpi_errno = MPIC_Sendrecv(mapping, group_ptr->size, MPI_INT, 0, 0,
@@ -504,9 +502,7 @@ int MPIR_Comm_create_inter(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Co
             (*newcomm_ptr)->context_id = rinfo[0];
         }
         remote_size = rinfo[1];
-        MPIR_CHKLMEM_MALLOC(remote_mapping, int *,
-                            remote_size * sizeof(int),
-                            mpi_errno, "remote_mapping", MPL_MEM_ADDRESS);
+        MPIR_CHKLMEM_MALLOC(remote_mapping, remote_size * sizeof(int));
         mpi_errno = MPIR_Bcast(remote_mapping, remote_size, MPI_INT, 0,
                                comm_ptr->local_comm, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/comm/comm_split.c
+++ b/src/mpi/comm/comm_split.c
@@ -90,15 +90,14 @@ int MPIR_Comm_split_impl(MPIR_Comm * comm_ptr, int color, int key, MPIR_Comm ** 
     int in_newcomm;             /* TRUE iff *newcomm should be populated */
     int new_context_id, remote_context_id;
     MPIR_Comm_map_t *mapper;
-    MPIR_CHKLMEM_DECL(4);
+    MPIR_CHKLMEM_DECL();
 
     rank = comm_ptr->rank;
     size = comm_ptr->local_size;
     remote_size = comm_ptr->remote_size;
 
     /* Step 1: Find out what color and keys all of the processes have */
-    MPIR_CHKLMEM_MALLOC(table, splittype *, size * sizeof(splittype), mpi_errno,
-                        "table", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(table, size * sizeof(splittype));
     table[rank].color = color;
     table[rank].key = key;
 
@@ -150,9 +149,7 @@ int MPIR_Comm_split_impl(MPIR_Comm * comm_ptr, int color, int key, MPIR_Comm ** 
          * local group - perform an (intercommunicator) all gather
          * of the color and rank information for the remote group.
          */
-        MPIR_CHKLMEM_MALLOC(remotetable, splittype *,
-                            remote_size * sizeof(splittype), mpi_errno,
-                            "remotetable", MPL_MEM_COMM);
+        MPIR_CHKLMEM_MALLOC(remotetable, remote_size * sizeof(splittype));
         /* This is an intercommunicator allgather */
 
         /* We must use a local splittype because we've already modified the
@@ -257,8 +254,7 @@ int MPIR_Comm_split_impl(MPIR_Comm * comm_ptr, int color, int key, MPIR_Comm ** 
          * extract the table into a smaller array and sort that.
          * Also, store in the "color" entry the rank in the input communicator
          * of the entry. */
-        MPIR_CHKLMEM_MALLOC(keytable, sorttype *, new_size * sizeof(sorttype),
-                            mpi_errno, "keytable", MPL_MEM_COMM);
+        MPIR_CHKLMEM_MALLOC(keytable, new_size * sizeof(sorttype));
         for (i = 0; i < new_size; i++) {
             keytable[i].key = table[first_entry].key;
             keytable[i].color = first_entry;
@@ -270,9 +266,7 @@ int MPIR_Comm_split_impl(MPIR_Comm * comm_ptr, int color, int key, MPIR_Comm ** 
         MPIU_Sort_inttable(keytable, new_size);
 
         if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) {
-            MPIR_CHKLMEM_MALLOC(remotekeytable, sorttype *,
-                                new_remote_size * sizeof(sorttype),
-                                mpi_errno, "remote keytable", MPL_MEM_COMM);
+            MPIR_CHKLMEM_MALLOC(remotekeytable, new_remote_size * sizeof(sorttype));
             for (i = 0; i < new_remote_size; i++) {
                 remotekeytable[i].key = remotetable[first_remote_entry].key;
                 remotekeytable[i].color = first_remote_entry;

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -430,12 +430,11 @@ int MPIR_Comm_map_irregular(MPIR_Comm * newcomm, MPIR_Comm * src_comm,
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Comm_map_t *mapper;
-    MPIR_CHKPMEM_DECL(3);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKPMEM_MALLOC(mapper, MPIR_Comm_map_t *, sizeof(MPIR_Comm_map_t), mpi_errno, "mapper",
-                        MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(mapper, sizeof(MPIR_Comm_map_t), MPL_MEM_COMM);
 
     mapper->type = MPIR_COMM_MAP_TYPE__IRREGULAR;
     mapper->src_comm = src_comm;
@@ -446,9 +445,7 @@ int MPIR_Comm_map_irregular(MPIR_Comm * newcomm, MPIR_Comm * src_comm,
         mapper->src_mapping = src_mapping;
         mapper->free_mapping = 0;
     } else {
-        MPIR_CHKPMEM_MALLOC(mapper->src_mapping, int *,
-                            src_mapping_size * sizeof(int), mpi_errno, "mapper mapping",
-                            MPL_MEM_COMM);
+        MPIR_CHKPMEM_MALLOC(mapper->src_mapping, src_mapping_size * sizeof(int), MPL_MEM_COMM);
         mapper->free_mapping = 1;
     }
 
@@ -460,7 +457,6 @@ int MPIR_Comm_map_irregular(MPIR_Comm * newcomm, MPIR_Comm * src_comm,
         *map = mapper;
 
   fn_exit:
-    MPIR_CHKPMEM_COMMIT();
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:
@@ -472,12 +468,11 @@ int MPIR_Comm_map_dup(MPIR_Comm * newcomm, MPIR_Comm * src_comm, MPIR_Comm_map_d
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Comm_map_t *mapper;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKPMEM_MALLOC(mapper, MPIR_Comm_map_t *, sizeof(MPIR_Comm_map_t), mpi_errno, "mapper",
-                        MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(mapper, sizeof(MPIR_Comm_map_t), MPL_MEM_COMM);
 
     mapper->type = MPIR_COMM_MAP_TYPE__DUP;
     mapper->src_comm = src_comm;
@@ -488,7 +483,6 @@ int MPIR_Comm_map_dup(MPIR_Comm * newcomm, MPIR_Comm * src_comm, MPIR_Comm_map_d
     LL_APPEND(newcomm->mapper_head, newcomm->mapper_tail, mapper);
 
   fn_exit:
-    MPIR_CHKPMEM_COMMIT();
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:
@@ -1326,7 +1320,7 @@ int MPII_Comm_is_node_balanced(MPIR_Comm * comm, int *num_nodes, bool * node_bal
     int *ranks_per_node;
     *num_nodes = 0;
 
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     if (!MPIR_Comm_is_parent_comm(comm)) {
         *node_balanced = false;
@@ -1342,8 +1336,7 @@ int MPII_Comm_is_node_balanced(MPIR_Comm * comm, int *num_nodes, bool * node_bal
     /* number of nodes is max_node_id + 1 */
     (*num_nodes)++;
 
-    MPIR_CHKPMEM_CALLOC(ranks_per_node, int *,
-                        *num_nodes * sizeof(int), mpi_errno, "ranks per node", MPL_MEM_OTHER);
+    MPIR_CHKPMEM_CALLOC(ranks_per_node, *num_nodes * sizeof(int), MPL_MEM_OTHER);
 
     for (i = 0; i < comm->local_size; i++) {
         ranks_per_node[comm->internode_table[i]]++;

--- a/src/mpi/comm/contextid.c
+++ b/src/mpi/comm/contextid.c
@@ -890,10 +890,9 @@ static int sched_get_cid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newcomm,
 {
     int mpi_errno = MPI_SUCCESS;
     struct gcn_state *st = NULL;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
-    MPIR_CHKPMEM_MALLOC(st, struct gcn_state *, sizeof(struct gcn_state), mpi_errno, "gcn_state",
-                        MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(st, sizeof(struct gcn_state), MPL_MEM_COMM);
     st->ctx0 = ctx0;
     st->ctx1 = ctx1;
     if (gcn_cid_kind == MPIR_COMM_KIND__INTRACOMM) {
@@ -921,7 +920,6 @@ static int sched_get_cid_nonblock(MPIR_Comm * comm_ptr, MPIR_Comm * newcomm,
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_SCHED_BARRIER(s);
 
-    MPIR_CHKPMEM_COMMIT();
   fn_exit:
     return mpi_errno;
     /* --BEGIN ERROR HANDLING-- */

--- a/src/mpi/datatype/type_create.c
+++ b/src/mpi/datatype/type_create.c
@@ -518,13 +518,12 @@ int MPIR_Type_create_indexed_block_impl(int count,
     MPIR_Datatype *new_dtp;
     MPI_Aint *p_disp;
     int *ints;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     if (sizeof(MPI_Aint) == sizeof(int)) {
         p_disp = (MPI_Aint *) array_of_displacements;
     } else {
-        MPIR_CHKLMEM_MALLOC_ORJUMP(p_disp, MPI_Aint *, count * sizeof(MPI_Aint), mpi_errno,
-                                   "aint displacement array", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(p_disp, count * sizeof(MPI_Aint));
         for (int i = 0; i < count; i++) {
             p_disp[i] = array_of_displacements[i];
         }
@@ -533,8 +532,7 @@ int MPIR_Type_create_indexed_block_impl(int count,
                                        oldtype, &new_handle);
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (count + 2) * sizeof(int), mpi_errno,
-                               "content description", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(ints, (count + 2) * sizeof(int));
 
     ints[0] = count;
     ints[1] = blocklength;
@@ -564,14 +562,13 @@ int MPIR_Type_create_indexed_block_large_impl(MPI_Aint count, MPI_Aint blockleng
     MPI_Datatype new_handle;
     MPIR_Datatype *new_dtp;
     MPI_Aint *counts;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     mpi_errno = MPIR_Type_blockindexed(count, blocklength, array_of_displacements, 0,   /* dispinbytes */
                                        oldtype, &new_handle);
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPIR_CHKLMEM_MALLOC_ORJUMP(counts, MPI_Aint *, (count + 2) * sizeof(MPI_Aint), mpi_errno,
-                               "content description", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(counts, (count + 2) * sizeof(MPI_Aint));
 
     counts[0] = count;
     counts[1] = blocklength;
@@ -631,14 +628,13 @@ int MPIR_Type_create_hindexed_block_large_impl(MPI_Aint count, MPI_Aint blocklen
     MPI_Datatype new_handle;
     MPIR_Datatype *new_dtp;
     MPI_Aint *counts;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     mpi_errno = MPIR_Type_blockindexed(count, blocklength, array_of_displacements,
                                        1, oldtype, &new_handle);
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPIR_CHKLMEM_MALLOC_ORJUMP(counts, MPI_Aint *, (count + 2) * sizeof(MPI_Aint), mpi_errno,
-                               "content description", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(counts, (count + 2) * sizeof(MPI_Aint));
     counts[0] = count;
     counts[1] = blocklength;
     for (MPI_Aint i = 0; i < count; i++)
@@ -667,16 +663,14 @@ int MPIR_Type_indexed_impl(int count, const int *array_of_blocklengths,
     MPIR_Datatype *new_dtp;
     MPI_Aint *p_blkl, *p_disp;
     int *ints;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     if (sizeof(MPI_Aint) == sizeof(int)) {
         p_blkl = (MPI_Aint *) array_of_blocklengths;
         p_disp = (MPI_Aint *) array_of_displacements;
     } else {
-        MPIR_CHKLMEM_MALLOC_ORJUMP(p_blkl, MPI_Aint *, count * sizeof(MPI_Aint), mpi_errno,
-                                   "aint blocklengths array", MPL_MEM_BUFFER);
-        MPIR_CHKLMEM_MALLOC_ORJUMP(p_disp, MPI_Aint *, count * sizeof(MPI_Aint), mpi_errno,
-                                   "aint displacements array", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(p_blkl, count * sizeof(MPI_Aint));
+        MPIR_CHKLMEM_MALLOC(p_disp, count * sizeof(MPI_Aint));
         for (int i = 0; i < count; i++) {
             p_blkl[i] = array_of_blocklengths[i];
             p_disp[i] = array_of_displacements[i];
@@ -689,8 +683,7 @@ int MPIR_Type_indexed_impl(int count, const int *array_of_blocklengths,
     /* copy all integer values into a temporary buffer; this
      * includes the count, the blocklengths, and the displacements.
      */
-    MPIR_CHKLMEM_MALLOC(ints, int *, (2 * count + 1) * sizeof(int), mpi_errno,
-                        "contents integer array", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(ints, (2 * count + 1) * sizeof(int));
 
     ints[0] = count;
 
@@ -723,7 +716,7 @@ int MPIR_Type_indexed_large_impl(MPI_Aint count,
     MPI_Datatype new_handle;
     MPIR_Datatype *new_dtp;
     MPI_Aint *counts;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     mpi_errno = MPIR_Type_indexed(count, array_of_blocklengths, array_of_displacements, 0,      /* displacements not in bytes */
                                   oldtype, &new_handle);
@@ -732,8 +725,7 @@ int MPIR_Type_indexed_large_impl(MPI_Aint count,
     /* copy all integer values into a temporary buffer; this
      * includes the count, the blocklengths, and the displacements.
      */
-    MPIR_CHKLMEM_MALLOC(counts, MPI_Aint *, (2 * count + 1) * sizeof(MPI_Aint), mpi_errno,
-                        "contents counts array", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(counts, (2 * count + 1) * sizeof(MPI_Aint));
 
     counts[0] = count;
 
@@ -766,13 +758,12 @@ int MPIR_Type_create_hindexed_impl(int count, const int array_of_blocklengths[],
     MPIR_Datatype *new_dtp;
     MPI_Aint *p_blkl;
     int *ints;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     if (sizeof(MPI_Aint) == sizeof(int)) {
         p_blkl = (MPI_Aint *) array_of_blocklengths;
     } else {
-        MPIR_CHKLMEM_MALLOC_ORJUMP(p_blkl, MPI_Aint *, count * sizeof(MPI_Aint), mpi_errno,
-                                   "aint blocklengths array", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(p_blkl, count * sizeof(MPI_Aint));
         for (int i = 0; i < count; i++) {
             p_blkl[i] = array_of_blocklengths[i];
         }
@@ -780,8 +771,7 @@ int MPIR_Type_create_hindexed_impl(int count, const int array_of_blocklengths[],
     mpi_errno = MPIR_Type_indexed(count, p_blkl, array_of_displacements, 1,     /* displacements in bytes */
                                   oldtype, &new_handle);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (count + 1) * sizeof(int), mpi_errno,
-                               "content description", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(ints, (count + 1) * sizeof(int));
     ints[0] = count;
 
     for (int i = 0; i < count; i++) {
@@ -810,13 +800,12 @@ int MPIR_Type_create_hindexed_large_impl(MPI_Aint count,
     MPI_Datatype new_handle;
     MPIR_Datatype *new_dtp;
     MPI_Aint *counts;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     mpi_errno = MPIR_Type_indexed(count, array_of_blocklengths, array_of_displacements, 1,      /* displacements in bytes */
                                   oldtype, &new_handle);
     MPIR_ERR_CHECK(mpi_errno);
-    MPIR_CHKLMEM_MALLOC_ORJUMP(counts, MPI_Aint *, (count * 2 + 1) * sizeof(MPI_Aint), mpi_errno,
-                               "content description", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(counts, (count * 2 + 1) * sizeof(MPI_Aint));
     counts[0] = count;
 
     for (MPI_Aint i = 0; i < count; i++) {
@@ -847,15 +836,14 @@ int MPIR_Type_create_struct_large_impl(MPI_Aint count,
     MPI_Datatype new_handle;
     MPIR_Datatype *new_dtp;
     MPI_Aint *counts;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     mpi_errno = MPIR_Type_struct(count, array_of_blocklengths,
                                  array_of_displacements, array_of_types, &new_handle);
     MPIR_ERR_CHECK(mpi_errno);
 
 
-    MPIR_CHKLMEM_MALLOC(counts, MPI_Aint *, (count * 2 + 1) * sizeof(MPI_Aint), mpi_errno,
-                        "contents counts array", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(counts, (count * 2 + 1) * sizeof(MPI_Aint));
 
     counts[0] = count;
     for (MPI_Aint i = 0; i < count; i++) {
@@ -890,13 +878,12 @@ int MPIR_Type_create_struct_impl(int count, const int *array_of_blocklengths,
     MPIR_Datatype *new_dtp;
     MPI_Aint *p_blkl;
     int *ints;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     if (sizeof(MPI_Aint) == sizeof(int)) {
         p_blkl = (MPI_Aint *) array_of_blocklengths;
     } else {
-        MPIR_CHKLMEM_MALLOC_ORJUMP(p_blkl, MPI_Aint *, count * sizeof(MPI_Aint), mpi_errno,
-                                   "aint blocklengths array", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(p_blkl, count * sizeof(MPI_Aint));
         for (int i = 0; i < count; i++) {
             p_blkl[i] = array_of_blocklengths[i];
         }
@@ -906,8 +893,7 @@ int MPIR_Type_create_struct_impl(int count, const int *array_of_blocklengths,
     MPIR_ERR_CHECK(mpi_errno);
 
 
-    MPIR_CHKLMEM_MALLOC(ints, int *, (count + 1) * sizeof(int), mpi_errno, "contents integer array",
-                        MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(ints, (count + 1) * sizeof(int));
 
     ints[0] = count;
     for (int i = 0; i < count; i++) {

--- a/src/mpi/datatype/type_create_darray.c
+++ b/src/mpi/datatype/type_create_darray.c
@@ -287,11 +287,10 @@ static int MPIR_Type_create_darray(int size, int rank, int ndims,
     MPI_Aint *st_offsets, orig_extent, disps[3];
     MPI_Datatype type_old, type_new = MPI_DATATYPE_NULL, tmp_type;
 
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     /* calculate position in Cartesian grid as MPI would (row-major ordering) */
-    MPIR_CHKLMEM_MALLOC_ORJUMP(coords, int *, ndims * sizeof(int), mpi_errno,
-                               "position is Cartesian grid", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(coords, ndims * sizeof(int));
 
     MPIR_Datatype_get_extent_macro(oldtype, orig_extent);
     procs = size;
@@ -302,8 +301,7 @@ static int MPIR_Type_create_darray(int size, int rank, int ndims,
         tmp_rank = tmp_rank % procs;
     }
 
-    MPIR_CHKLMEM_MALLOC_ORJUMP(st_offsets, MPI_Aint *, ndims * sizeof(MPI_Aint), mpi_errno,
-                               "st_offsets", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(st_offsets, ndims * sizeof(MPI_Aint));
 
     type_old = oldtype;
 
@@ -451,10 +449,9 @@ int MPIR_Type_create_darray_impl(int size, int rank, int ndims,
 
     MPI_Aint *real_array_of_gsizes;
     int *ints;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
-    MPIR_CHKLMEM_MALLOC_ORJUMP(real_array_of_gsizes, MPI_Aint *, ndims * sizeof(MPI_Aint),
-                               mpi_errno, "real_array_of_gsizes", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(real_array_of_gsizes, ndims * sizeof(MPI_Aint));
     for (int i = 0; i < ndims; i++) {
         real_array_of_gsizes[i] = array_of_gsizes[i];
     }
@@ -469,8 +466,7 @@ int MPIR_Type_create_darray_impl(int size, int rank, int ndims,
      */
 
     /* Save contents */
-    MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (4 * ndims + 4) * sizeof(int), mpi_errno,
-                               "content description", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(ints, (4 * ndims + 4) * sizeof(int));
 
     ints[0] = size;
     ints[1] = rank;
@@ -514,17 +510,15 @@ int MPIR_Type_create_darray_large_impl(int size, int rank, int ndims,
 
     int *ints;
     MPI_Aint *counts;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     mpi_errno = MPIR_Type_create_darray(size, rank, ndims, array_of_gsizes, array_of_distribs,
                                         array_of_dargs, array_of_psizes, order, oldtype, newtype);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Save contents */
-    MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (3 * ndims + 4) * sizeof(int), mpi_errno,
-                               "content ints array", MPL_MEM_BUFFER);
-    MPIR_CHKLMEM_MALLOC_ORJUMP(counts, MPI_Aint *, ndims * sizeof(MPI_Aint), mpi_errno,
-                               "content counts array", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(ints, (3 * ndims + 4) * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(counts, ndims * sizeof(MPI_Aint));
 
     ints[0] = size;
     ints[1] = rank;

--- a/src/mpi/datatype/type_create_subarray.c
+++ b/src/mpi/datatype/type_create_subarray.c
@@ -122,14 +122,11 @@ int MPIR_Type_create_subarray_impl(int ndims, const int array_of_sizes[],
 
     MPI_Aint *p_sizes, *p_subsizes, *p_starts;
     int *ints;
-    MPIR_CHKLMEM_DECL(4);
+    MPIR_CHKLMEM_DECL();
 
-    MPIR_CHKLMEM_MALLOC_ORJUMP(p_sizes, MPI_Aint *, ndims * sizeof(MPI_Aint), mpi_errno,
-                               "real array_of_sizes", MPL_MEM_BUFFER);
-    MPIR_CHKLMEM_MALLOC_ORJUMP(p_subsizes, MPI_Aint *, ndims * sizeof(MPI_Aint), mpi_errno,
-                               "real array_of_subsizes", MPL_MEM_BUFFER);
-    MPIR_CHKLMEM_MALLOC_ORJUMP(p_starts, MPI_Aint *, ndims * sizeof(MPI_Aint), mpi_errno,
-                               "real array_of_starts", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(p_sizes, ndims * sizeof(MPI_Aint));
+    MPIR_CHKLMEM_MALLOC(p_subsizes, ndims * sizeof(MPI_Aint));
+    MPIR_CHKLMEM_MALLOC(p_starts, ndims * sizeof(MPI_Aint));
     for (int i = 0; i < ndims; i++) {
         p_sizes[i] = array_of_sizes[i];
         p_subsizes[i] = array_of_subsizes[i];
@@ -141,8 +138,7 @@ int MPIR_Type_create_subarray_impl(int ndims, const int array_of_sizes[],
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Save contents */
-    MPIR_CHKLMEM_MALLOC_ORJUMP(ints, int *, (3 * ndims + 2) * sizeof(int), mpi_errno,
-                               "content description", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(ints, (3 * ndims + 2) * sizeof(int));
 
     ints[0] = ndims;
     for (int i = 0; i < ndims; i++) {
@@ -177,15 +173,14 @@ int MPIR_Type_create_subarray_large_impl(int ndims, const MPI_Aint array_of_size
     int mpi_errno = MPI_SUCCESS;
 
     MPI_Aint *counts;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     mpi_errno = MPIR_Type_create_subarray(ndims, array_of_sizes, array_of_subsizes, array_of_starts,
                                           order, oldtype, newtype);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Save contents */
-    MPIR_CHKLMEM_MALLOC_ORJUMP(counts, MPI_Aint *, (3 * ndims) * sizeof(MPI_Aint), mpi_errno,
-                               "content description", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(counts, (3 * ndims) * sizeof(MPI_Aint));
 
     int ints[2];
     ints[0] = ndims;

--- a/src/mpi/group/grouputil.c
+++ b/src/mpi/group/grouputil.c
@@ -359,12 +359,11 @@ int MPIR_Group_check_subset(MPIR_Group * group_ptr, MPIR_Comm * comm_ptr)
     MPII_Group_pmap_t *vmap = 0;
     int vsize = comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM ? comm_ptr->local_size :
         comm_ptr->remote_size;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_Assert(group_ptr != NULL);
 
-    MPIR_CHKLMEM_MALLOC(vmap, MPII_Group_pmap_t *,
-                        vsize * sizeof(MPII_Group_pmap_t), mpi_errno, "", MPL_MEM_GROUP);
+    MPIR_CHKLMEM_MALLOC(vmap, vsize * sizeof(MPII_Group_pmap_t));
     /* Initialize the vmap */
     for (i = 0; i < vsize; i++) {
         MPID_Comm_get_lpid(comm_ptr, i, &vmap[i].lpid, FALSE);

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -63,7 +63,7 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
     MPI_Aint sendsize, recvsize, sdata_sz, rdata_sz, copy_sz;
     char *buf = NULL;
     MPL_pointer_attr_t send_attr, recv_attr;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -160,7 +160,7 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
         } else if (MPL_gpu_attr_is_strict_dev(&send_attr) || MPL_gpu_attr_is_strict_dev(&recv_attr)) {
             MPL_gpu_malloc_host((void **) &buf, COPY_BUFFER_SZ);
         } else {
-            MPIR_CHKLMEM_MALLOC(buf, char *, COPY_BUFFER_SZ, mpi_errno, "buf", MPL_MEM_BUFFER);
+            MPIR_CHKLMEM_MALLOC(buf, COPY_BUFFER_SZ);
         }
 
         sfirst = sendoffset;

--- a/src/mpi/pt2pt/sendrecv.c
+++ b/src/mpi/pt2pt/sendrecv.c
@@ -96,15 +96,14 @@ int MPIR_Sendrecv_replace_impl(void *buf, MPI_Aint count, MPI_Datatype datatype,
     void *tmpbuf = NULL;
     MPI_Aint tmpbuf_size = 0;
     MPI_Aint actual_pack_bytes = 0;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
     if (count > 0 && dest != MPI_PROC_NULL) {
         MPIR_Pack_size(count, datatype, &tmpbuf_size);
 
-        MPIR_CHKLMEM_MALLOC_ORJUMP(tmpbuf, void *, tmpbuf_size, mpi_errno,
-                                   "temporary send buffer", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(tmpbuf, tmpbuf_size);
 
         mpi_errno =
             MPIR_Typerep_pack(buf, count, datatype, 0, tmpbuf, tmpbuf_size, &actual_pack_bytes,

--- a/src/mpi/request/mpir_greq.c
+++ b/src/mpi/request/mpir_greq.c
@@ -56,7 +56,7 @@ int MPIR_Grequest_start_impl(MPI_Grequest_query_function * query_fn,
                              void *extra_state, MPIR_Request ** request_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     /* MT FIXME this routine is not thread-safe in the non-global case */
 
@@ -68,8 +68,8 @@ int MPIR_Grequest_start_impl(MPI_Grequest_query_function * query_fn,
     (*request_ptr)->cc_ptr = &(*request_ptr)->cc;
     MPIR_cc_set((*request_ptr)->cc_ptr, 1);
     (*request_ptr)->comm = NULL;
-    MPIR_CHKPMEM_MALLOC((*request_ptr)->u.ureq.greq_fns, struct MPIR_Grequest_fns *,
-                        sizeof(struct MPIR_Grequest_fns), mpi_errno, "greq_fns", MPL_MEM_GREQ);
+    MPIR_CHKPMEM_MALLOC((*request_ptr)->u.ureq.greq_fns, sizeof(struct MPIR_Grequest_fns),
+                        MPL_MEM_GREQ);
     (*request_ptr)->u.ureq.greq_fns->U.C.cancel_fn = cancel_fn;
     (*request_ptr)->u.ureq.greq_fns->U.C.free_fn = free_fn;
     (*request_ptr)->u.ureq.greq_fns->U.C.query_fn = query_fn;
@@ -83,7 +83,6 @@ int MPIR_Grequest_start_impl(MPI_Grequest_query_function * query_fn,
      * we test or wait on it. */
     MPIR_Request_add_ref((*request_ptr));
 
-    MPIR_CHKPMEM_COMMIT();
   fn_exit:
     return mpi_errno;
   fn_fail:

--- a/src/mpi/spawn/spawn_impl.c
+++ b/src/mpi/spawn/spawn_impl.c
@@ -128,14 +128,12 @@ int MPIR_Comm_join_impl(int fd, MPIR_Comm ** p_intercomm_ptr)
     int mpi_errno = MPI_SUCCESS;
     MPIR_Comm *intercomm_ptr;
     char *local_port, *remote_port;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKLMEM_MALLOC(local_port, char *, PORT_SIZE, mpi_errno, "local port name",
-                        MPL_MEM_DYNAMIC);
-    MPIR_CHKLMEM_MALLOC(remote_port, char *, PORT_SIZE, mpi_errno, "remote port name",
-                        MPL_MEM_DYNAMIC);
+    MPIR_CHKLMEM_MALLOC(local_port, PORT_SIZE);
+    MPIR_CHKLMEM_MALLOC(remote_port, PORT_SIZE);
 
     MPL_VG_MEM_INIT(local_port, PORT_SIZE * sizeof(char));
 

--- a/src/mpi/topo/dims_create.c
+++ b/src/mpi/topo/dims_create.c
@@ -224,7 +224,8 @@ static int ndivisors_from_factor(int nf, const Factors * factors)
 
 static int factor_to_divisors(int nf, Factors * factors, int ndiv, int divs[])
 {
-    int i, powers[MAX_FACTORS], curbase[MAX_FACTORS], nd, idx, val, mpi_errno;
+    int mpi_errno = MPI_SUCCESS;
+    int i, powers[MAX_FACTORS], curbase[MAX_FACTORS], nd, idx, val;
 
     MPIR_T_PVAR_TIMER_START(DIMS, dims_getdivs);
     for (i = 0; i < nf; i++) {
@@ -262,11 +263,11 @@ static int factor_to_divisors(int nf, Factors * factors, int ndiv, int divs[])
      */
     if (nf > 1) {
         int gap, j, j1, j2, k, j1max, j2max;
-        MPIR_CHKLMEM_DECL(1);
+        MPIR_CHKLMEM_DECL();
         int *divs2;
         int *restrict d1, *restrict d2;
 
-        MPIR_CHKLMEM_MALLOC(divs2, int *, nd * sizeof(int), mpi_errno, "divs2", MPL_MEM_COMM);
+        MPIR_CHKLMEM_MALLOC(divs2, nd * sizeof(int));
 
         MPIR_T_PVAR_TIMER_START(DIMS, dims_sort);
         /* handling the first set of pairs separately saved about 20%;
@@ -393,9 +394,9 @@ static int optbalance(int n, int idx, int nd, int ndivs, const int divs[],
             MPL_msg_printf("%d%c", trydims[i], (i + 1 < nd) ? 'x' : '\n');
     }
     if (idx > 1) {
-        MPIR_CHKLMEM_DECL(1);
+        MPIR_CHKLMEM_DECL();
         int *newdivs;
-        MPIR_CHKLMEM_MALLOC(newdivs, int *, ndivs * sizeof(int), mpi_errno, "divs", MPL_MEM_COMM);
+        MPIR_CHKLMEM_MALLOC(newdivs, ndivs * sizeof(int));
 
         /* At least 3 divisors to set (0...idx).  We try all choices
          * recursively, but stop looking when we can easily tell that
@@ -551,14 +552,15 @@ static int optbalance(int n, int idx, int nd, int ndivs, const int divs[],
 
 int MPIR_Dims_create_impl(int nnodes, int ndims, int dims[])
 {
+    int mpi_errno = MPI_SUCCESS;
     Factors f[MAX_FACTORS];
     int nf, nprimes = 0, i, j, k, val, nextidx;
     int ndivs, curbal;
     int trydims[MAX_DIMS];
-    int dims_needed, dims_product, mpi_errno;
+    int dims_needed, dims_product;
     int chosen[MAX_DIMS], foundDecomp;
     int *divs;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     /* Initialize pvars and cvars if this is the first call */
     if (MPIR_DIMS_initPCVars) {
@@ -751,8 +753,7 @@ int MPIR_Dims_create_impl(int nnodes, int ndims, int dims[])
      * have already trimmed off some large factors */
     /* First, find all of the divisors given by the remaining factors */
     ndivs = ndivisors_from_factor(nf, (const Factors *) f);
-    MPIR_CHKLMEM_MALLOC(divs, int *, ((unsigned int) ndivs) * sizeof(int), mpi_errno, "divs",
-                        MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(divs, ((unsigned int) ndivs) * sizeof(int));
     ndivs = factor_to_divisors(nf, f, ndivs, divs);
     if (MPIR_CVAR_DIMS_VERBOSE) {
         for (i = 0; i < ndivs; i++) {

--- a/src/mpi/topo/dist_graph_create.c
+++ b/src/mpi/topo/dist_graph_create.c
@@ -24,7 +24,7 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
 
     int comm_size = comm_ptr->local_size;
     MPIR_CHKLMEM_DECL();
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     /* following the spirit of the old topo interface, attributes do not
      * propagate to the new communicator (see MPI-2.1 pp. 243 line 11) */
@@ -159,8 +159,7 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
 
     /* Create the topology structure */
     MPIR_Topology *topo_ptr = NULL;
-    MPIR_CHKPMEM_MALLOC(topo_ptr, MPIR_Topology *, sizeof(MPIR_Topology), mpi_errno, "topo_ptr",
-                        MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(topo_ptr, sizeof(MPIR_Topology), MPL_MEM_COMM);
     topo_ptr->kind = MPI_DIST_GRAPH;
     dist_graph_ptr = &topo_ptr->topo.dist_graph;
     dist_graph_ptr->indegree = 0;
@@ -300,7 +299,7 @@ int MPIR_Dist_graph_create_adjacent_impl(MPIR_Comm * comm_ptr,
                                          MPIR_Comm ** comm_dist_graph_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_CHKPMEM_DECL(5);
+    MPIR_CHKPMEM_DECL();
 
     /* Implementation based on Torsten Hoefler's reference implementation
      * attached to MPI-2.2 ticket #33. */
@@ -312,8 +311,7 @@ int MPIR_Dist_graph_create_adjacent_impl(MPIR_Comm * comm_ptr,
 
     /* Create the topology structure */
     MPIR_Topology *topo_ptr;
-    MPIR_CHKPMEM_MALLOC(topo_ptr, MPIR_Topology *, sizeof(MPIR_Topology), mpi_errno, "topo_ptr",
-                        MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(topo_ptr, sizeof(MPIR_Topology), MPL_MEM_COMM);
     topo_ptr->kind = MPI_DIST_GRAPH;
     MPII_Dist_graph_topology *dist_graph_ptr = &topo_ptr->topo.dist_graph;
     dist_graph_ptr->indegree = indegree;
@@ -325,23 +323,19 @@ int MPIR_Dist_graph_create_adjacent_impl(MPIR_Comm * comm_ptr,
     dist_graph_ptr->is_weighted = (sourceweights != MPI_UNWEIGHTED);
 
     if (indegree > 0) {
-        MPIR_CHKPMEM_MALLOC(dist_graph_ptr->in, int *, indegree * sizeof(int), mpi_errno,
-                            "dist_graph_ptr->in", MPL_MEM_COMM);
+        MPIR_CHKPMEM_MALLOC(dist_graph_ptr->in, indegree * sizeof(int), MPL_MEM_COMM);
         MPIR_Memcpy(dist_graph_ptr->in, sources, indegree * sizeof(int));
         if (dist_graph_ptr->is_weighted) {
-            MPIR_CHKPMEM_MALLOC(dist_graph_ptr->in_weights, int *, indegree * sizeof(int),
-                                mpi_errno, "dist_graph_ptr->in_weights", MPL_MEM_COMM);
+            MPIR_CHKPMEM_MALLOC(dist_graph_ptr->in_weights, indegree * sizeof(int), MPL_MEM_COMM);
             MPIR_Memcpy(dist_graph_ptr->in_weights, sourceweights, indegree * sizeof(int));
         }
     }
 
     if (outdegree > 0) {
-        MPIR_CHKPMEM_MALLOC(dist_graph_ptr->out, int *, outdegree * sizeof(int), mpi_errno,
-                            "dist_graph_ptr->out", MPL_MEM_COMM);
+        MPIR_CHKPMEM_MALLOC(dist_graph_ptr->out, outdegree * sizeof(int), MPL_MEM_COMM);
         MPIR_Memcpy(dist_graph_ptr->out, destinations, outdegree * sizeof(int));
         if (dist_graph_ptr->is_weighted) {
-            MPIR_CHKPMEM_MALLOC(dist_graph_ptr->out_weights, int *, outdegree * sizeof(int),
-                                mpi_errno, "dist_graph_ptr->out_weights", MPL_MEM_COMM);
+            MPIR_CHKPMEM_MALLOC(dist_graph_ptr->out_weights, outdegree * sizeof(int), MPL_MEM_COMM);
             MPIR_Memcpy(dist_graph_ptr->out_weights, destweights, outdegree * sizeof(int));
         }
     }

--- a/src/mpi/topo/dist_graph_create.c
+++ b/src/mpi/topo/dist_graph_create.c
@@ -23,7 +23,7 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
     int *buf = NULL;
 
     int comm_size = comm_ptr->local_size;
-    MPIR_CHKLMEM_DECL(8);
+    MPIR_CHKLMEM_DECL();
     MPIR_CHKPMEM_DECL(1);
 
     /* following the spirit of the old topo interface, attributes do not
@@ -39,16 +39,12 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
      * rout is an array of comm_size containing pointers to arrays of
      * rout_sizes[x].  rout[x] is the locally known number of edges out of this
      * process to rank x. */
-    MPIR_CHKLMEM_MALLOC(rout, int **, comm_size * sizeof(int *), mpi_errno, "rout", MPL_MEM_COMM);
-    MPIR_CHKLMEM_MALLOC(rin, int **, comm_size * sizeof(int *), mpi_errno, "rin", MPL_MEM_COMM);
-    MPIR_CHKLMEM_MALLOC(rin_sizes, int *, comm_size * sizeof(int), mpi_errno, "rin_sizes",
-                        MPL_MEM_COMM);
-    MPIR_CHKLMEM_MALLOC(rout_sizes, int *, comm_size * sizeof(int), mpi_errno, "rout_sizes",
-                        MPL_MEM_COMM);
-    MPIR_CHKLMEM_MALLOC(rin_idx, int *, comm_size * sizeof(int), mpi_errno, "rin_idx",
-                        MPL_MEM_COMM);
-    MPIR_CHKLMEM_MALLOC(rout_idx, int *, comm_size * sizeof(int), mpi_errno, "rout_idx",
-                        MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(rout, comm_size * sizeof(int *));
+    MPIR_CHKLMEM_MALLOC(rin, comm_size * sizeof(int *));
+    MPIR_CHKLMEM_MALLOC(rin_sizes, comm_size * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(rout_sizes, comm_size * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(rin_idx, comm_size * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(rout_idx, comm_size * sizeof(int));
 
     memset(rout, 0, comm_size * sizeof(int *));
     memset(rin, 0, comm_size * sizeof(int *));
@@ -123,8 +119,7 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
     }
 
     int *rs;
-    MPIR_CHKLMEM_MALLOC(rs, int *, 2 * comm_size * sizeof(int), mpi_errno, "red-scat source buffer",
-                        MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(rs, 2 * comm_size * sizeof(int));
     for (int i = 0; i < comm_size; ++i) {
         rs[2 * i] = (rin_sizes[i] ? 1 : 0);
         rs[2 * i + 1] = (rout_sizes[i] ? 1 : 0);
@@ -143,8 +138,7 @@ int MPIR_Dist_graph_create_impl(MPIR_Comm * comm_ptr,
     /* must be 2*comm_size requests because we will possibly send inbound and
      * outbound edges to everyone in our communicator */
     MPIR_Request **reqs;
-    MPIR_CHKLMEM_MALLOC(reqs, MPIR_Request **, 2 * comm_size * sizeof(MPIR_Request *), mpi_errno,
-                        "temp request array", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(reqs, 2 * comm_size * sizeof(MPIR_Request *));
     for (int i = 0; i < comm_size; ++i) {
         if (rin_sizes[i]) {
             /* send edges where i is a destination to process i */

--- a/src/mpi/topo/topo_impl.c
+++ b/src/mpi/topo/topo_impl.c
@@ -30,7 +30,7 @@ int MPIR_Cart_create_impl(MPIR_Comm * comm_ptr, int ndims, const int dims[],
     int i, newsize, rank, nranks;
     MPIR_Comm *newcomm_ptr = NULL;
     MPIR_Topology *cart_ptr = NULL;
-    MPIR_CHKPMEM_DECL(4);
+    MPIR_CHKPMEM_DECL();
 
     /* Check for invalid arguments */
     newsize = 1;
@@ -56,8 +56,7 @@ int MPIR_Cart_create_impl(MPIR_Comm * comm_ptr, int ndims, const int dims[],
             MPIR_ERR_CHECK(mpi_errno);
 
             /* Create the topology structure */
-            MPIR_CHKPMEM_MALLOC(cart_ptr, MPIR_Topology *, sizeof(MPIR_Topology),
-                                mpi_errno, "cart_ptr", MPL_MEM_COMM);
+            MPIR_CHKPMEM_MALLOC(cart_ptr, sizeof(MPIR_Topology), MPL_MEM_COMM);
 
             cart_ptr->kind = MPI_CART;
             cart_ptr->topo.cart.nnodes = 1;
@@ -66,12 +65,9 @@ int MPIR_Cart_create_impl(MPIR_Comm * comm_ptr, int ndims, const int dims[],
             /* make mallocs of size 1 int so that they get freed as part of the
              * normal free mechanism */
 
-            MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.dims, int *, sizeof(int),
-                                mpi_errno, "cart.dims", MPL_MEM_COMM);
-            MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.periodic, int *, sizeof(int),
-                                mpi_errno, "cart.periodic", MPL_MEM_COMM);
-            MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.position, int *, sizeof(int),
-                                mpi_errno, "cart.position", MPL_MEM_COMM);
+            MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.dims, sizeof(int), MPL_MEM_COMM);
+            MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.periodic, sizeof(int), MPL_MEM_COMM);
+            MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.position, sizeof(int), MPL_MEM_COMM);
         } else {
             *comm_cart_ptr = NULL;
             goto fn_exit;
@@ -110,18 +106,14 @@ int MPIR_Cart_create_impl(MPIR_Comm * comm_ptr, int ndims, const int dims[],
         }
 
         /* Create the topololgy structure */
-        MPIR_CHKPMEM_MALLOC(cart_ptr, MPIR_Topology *, sizeof(MPIR_Topology),
-                            mpi_errno, "cart_ptr", MPL_MEM_COMM);
+        MPIR_CHKPMEM_MALLOC(cart_ptr, sizeof(MPIR_Topology), MPL_MEM_COMM);
 
         cart_ptr->kind = MPI_CART;
         cart_ptr->topo.cart.nnodes = newsize;
         cart_ptr->topo.cart.ndims = ndims;
-        MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.dims, int *, ndims * sizeof(int),
-                            mpi_errno, "cart.dims", MPL_MEM_COMM);
-        MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.periodic, int *, ndims * sizeof(int),
-                            mpi_errno, "cart.periodic", MPL_MEM_COMM);
-        MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.position, int *, ndims * sizeof(int),
-                            mpi_errno, "cart.position", MPL_MEM_COMM);
+        MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.dims, ndims * sizeof(int), MPL_MEM_COMM);
+        MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.periodic, ndims * sizeof(int), MPL_MEM_COMM);
+        MPIR_CHKPMEM_MALLOC(cart_ptr->topo.cart.position, ndims * sizeof(int), MPL_MEM_COMM);
         nranks = newsize;
         for (i = 0; i < ndims; i++) {
             cart_ptr->topo.cart.dims[i] = dims[i];
@@ -304,7 +296,7 @@ int MPIR_Cart_sub_impl(MPIR_Comm * comm_ptr, const int remain_dims[], MPIR_Comm 
     MPIR_Comm *newcomm_ptr;
     MPIR_Topology *topo_ptr, *toponew_ptr;
     int ndims, key, color, ndims_in_subcomm, nnodes_in_subcomm, i, j, rank;
-    MPIR_CHKPMEM_DECL(4);
+    MPIR_CHKPMEM_DECL();
 
     /* Check that the communicator already has a Cartesian topology */
     topo_ptr = MPIR_Topology_get(comm_ptr);
@@ -356,22 +348,18 @@ int MPIR_Cart_sub_impl(MPIR_Comm * comm_ptr, const int remain_dims[], MPIR_Comm 
         *p_newcomm_ptr = newcomm_ptr;
 
         /* Save the topology of this new communicator */
-        MPIR_CHKPMEM_MALLOC(toponew_ptr, MPIR_Topology *, sizeof(MPIR_Topology),
-                            mpi_errno, "toponew_ptr", MPL_MEM_COMM);
+        MPIR_CHKPMEM_MALLOC(toponew_ptr, sizeof(MPIR_Topology), MPL_MEM_COMM);
 
         toponew_ptr->kind = MPI_CART;
         toponew_ptr->topo.cart.ndims = ndims_in_subcomm;
         toponew_ptr->topo.cart.nnodes = nnodes_in_subcomm;
         if (ndims_in_subcomm) {
-            MPIR_CHKPMEM_MALLOC(toponew_ptr->topo.cart.dims, int *,
-                                ndims_in_subcomm * sizeof(int), mpi_errno, "cart.dims",
-                                MPL_MEM_COMM);
-            MPIR_CHKPMEM_MALLOC(toponew_ptr->topo.cart.periodic, int *,
-                                ndims_in_subcomm * sizeof(int), mpi_errno, "cart.periodic",
-                                MPL_MEM_COMM);
-            MPIR_CHKPMEM_MALLOC(toponew_ptr->topo.cart.position, int *,
-                                ndims_in_subcomm * sizeof(int), mpi_errno, "cart.position",
-                                MPL_MEM_COMM);
+            MPIR_CHKPMEM_MALLOC(toponew_ptr->topo.cart.dims,
+                                ndims_in_subcomm * sizeof(int), MPL_MEM_COMM);
+            MPIR_CHKPMEM_MALLOC(toponew_ptr->topo.cart.periodic,
+                                ndims_in_subcomm * sizeof(int), MPL_MEM_COMM);
+            MPIR_CHKPMEM_MALLOC(toponew_ptr->topo.cart.position,
+                                ndims_in_subcomm * sizeof(int), MPL_MEM_COMM);
         } else {
             toponew_ptr->topo.cart.dims = 0;
             toponew_ptr->topo.cart.periodic = 0;
@@ -488,7 +476,7 @@ int MPIR_Graph_create_impl(MPIR_Comm * comm_ptr, int nnodes,
     int i, nedges;
     MPIR_Comm *newcomm_ptr = NULL;
     MPIR_Topology *graph_ptr = NULL;
-    MPIR_CHKPMEM_DECL(3);
+    MPIR_CHKPMEM_DECL();
 
     /* Create a new communicator */
     if (reorder) {
@@ -520,16 +508,13 @@ int MPIR_Graph_create_impl(MPIR_Comm * comm_ptr, int nnodes,
     }
 
     nedges = indx[nnodes - 1];
-    MPIR_CHKPMEM_MALLOC(graph_ptr, MPIR_Topology *, sizeof(MPIR_Topology),
-                        mpi_errno, "graph_ptr", MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(graph_ptr, sizeof(MPIR_Topology), MPL_MEM_COMM);
 
     graph_ptr->kind = MPI_GRAPH;
     graph_ptr->topo.graph.nnodes = nnodes;
     graph_ptr->topo.graph.nedges = nedges;
-    MPIR_CHKPMEM_MALLOC(graph_ptr->topo.graph.index, int *,
-                        nnodes * sizeof(int), mpi_errno, "graph.index", MPL_MEM_COMM);
-    MPIR_CHKPMEM_MALLOC(graph_ptr->topo.graph.edges, int *,
-                        nedges * sizeof(int), mpi_errno, "graph.edges", MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(graph_ptr->topo.graph.index, nnodes * sizeof(int), MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(graph_ptr->topo.graph.edges, nedges * sizeof(int), MPL_MEM_COMM);
     for (i = 0; i < nnodes; i++)
         graph_ptr->topo.graph.index[i] = indx[i];
     for (i = 0; i < nedges; i++)

--- a/src/mpi/topo/topoutil.c
+++ b/src/mpi/topo/topoutil.c
@@ -128,14 +128,13 @@ static int MPIR_Topology_copy_internal(void *attr_in, void *attr_out, int *flag)
 {
     MPIR_Topology *old_topology = (MPIR_Topology *) attr_in;
     MPIR_Topology *copy_topology = NULL;
-    MPIR_CHKPMEM_DECL(5);
+    MPIR_CHKPMEM_DECL();
     int mpi_errno = 0;
 
     *flag = 0;
     *(void **) attr_out = NULL;
 
-    MPIR_CHKPMEM_MALLOC(copy_topology, MPIR_Topology *, sizeof(MPIR_Topology), mpi_errno,
-                        "copy_topology", MPL_MEM_OTHER);
+    MPIR_CHKPMEM_MALLOC(copy_topology, sizeof(MPIR_Topology), MPL_MEM_COMM);
 
     MPL_VG_MEM_INIT(copy_topology, sizeof(MPIR_Topology));
 
@@ -186,7 +185,6 @@ static int MPIR_Topology_copy_internal(void *attr_in, void *attr_out, int *flag)
 
     *(void **) attr_out = (void *) copy_topology;
     *flag = 1;
-    MPIR_CHKPMEM_COMMIT();
   fn_exit:
     /* Return mpi_errno in case one of the copy array functions failed */
     return mpi_errno;

--- a/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
+++ b/src/mpid/ch3/channels/nemesis/include/mpidi_ch3_impl.h
@@ -209,11 +209,10 @@ static inline int MPIDI_CH3I_SHM_Wins_append(MPIDI_SHM_Wins_list_t * list, MPIR_
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_SHM_Win_t *tmp_ptr;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     /* FIXME: We should use a pool allocator here */
-    MPIR_CHKPMEM_MALLOC(tmp_ptr, MPIDI_SHM_Win_t *, sizeof(MPIDI_SHM_Win_t),
-                        mpi_errno, "SHM window entry", MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC(tmp_ptr, sizeof(MPIDI_SHM_Win_t), MPL_MEM_SHM);
 
     tmp_ptr->next = NULL;
     tmp_ptr->win = win;

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
@@ -548,7 +548,7 @@ static int recv_id_or_tmpvc_info(sockconn_t * const sc, int *got_sc_eof)
 #endif
 
     MPIR_CHKPMEM_DECL(1);
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -575,8 +575,7 @@ static int recv_id_or_tmpvc_info(sockconn_t * const sc, int *got_sc_eof)
         iov[0].iov_len = sizeof(sc->pg_rank);
         pg_id_len = hdr.datalen - sizeof(MPIDI_nem_tcp_idinfo_t);
         if (pg_id_len != 0) {
-            MPIR_CHKLMEM_MALLOC(pg_id, char *, pg_id_len, mpi_errno, "sockconn pg_id",
-                                MPL_MEM_OTHER);
+            MPIR_CHKLMEM_MALLOC(pg_id, pg_id_len);
             iov[1].iov_base = (void *) pg_id;
             iov[1].iov_len = pg_id_len;
             ++iov_cnt;
@@ -777,7 +776,7 @@ int MPID_nem_tcp_connect(struct MPIDI_VC *const vc)
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
 #endif
 
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -832,7 +831,7 @@ int MPID_nem_tcp_connect(struct MPIDI_VC *const vc)
 
             val_max_sz = MPIR_pmi_max_val_size();
 
-            MPIR_CHKLMEM_MALLOC(bc, char *, val_max_sz, mpi_errno, "bc", MPL_MEM_OTHER);
+            MPIR_CHKLMEM_MALLOC(bc, val_max_sz);
 
             sc->is_tmpvc = FALSE;
 

--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/tcp_send.c
@@ -23,8 +23,7 @@ static struct {
 #define ALLOC_Q_ELEMENT(e) do {                                                                                                         \
         if (S_EMPTY (free_buffers))                                                                                                     \
         {                                                                                                                               \
-            MPIR_CHKPMEM_MALLOC (*(e), MPID_nem_tcp_send_q_element_t *, sizeof(MPID_nem_tcp_send_q_element_t),      \
-                                 mpi_errno, "send queue element", MPL_MEM_BUFFER);                                                      \
+            MPIR_CHKPMEM_MALLOC (*(e), sizeof(MPID_nem_tcp_send_q_element_t), MPL_MEM_BUFFER); \
         }                                                                                                                               \
         else                                                                                                                            \
         {                                                                                                                               \
@@ -40,15 +39,13 @@ int MPID_nem_tcp_send_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
-    MPIR_CHKPMEM_DECL(NUM_PREALLOC_SENDQ);
+    MPIR_CHKPMEM_DECL();
 
     /* preallocate sendq elements */
     for (i = 0; i < NUM_PREALLOC_SENDQ; ++i) {
         MPID_nem_tcp_send_q_element_t *e;
 
-        MPIR_CHKPMEM_MALLOC(e, MPID_nem_tcp_send_q_element_t *,
-                            sizeof(MPID_nem_tcp_send_q_element_t), mpi_errno, "send queue element",
-                            MPL_MEM_BUFFER);
+        MPIR_CHKPMEM_MALLOC(e, sizeof(MPID_nem_tcp_send_q_element_t), MPL_MEM_BUFFER);
         S_PUSH(&free_buffers, e);
     }
 

--- a/src/mpid/ch3/channels/nemesis/src/ch3_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_init.c
@@ -203,13 +203,13 @@ int MPIDI_CH3_Connect_to_root (const char *port_name, MPIDI_VC_t **new_vc)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_VC_t * vc;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
     *new_vc = NULL; /* so that the err handling knows to cleanup */
 
-    MPIR_CHKPMEM_MALLOC (vc, MPIDI_VC_t *, sizeof(MPIDI_VC_t), mpi_errno, "vc", MPL_MEM_ADDRESS);
+    MPIR_CHKPMEM_MALLOC(vc, sizeof(MPIDI_VC_t), MPL_MEM_ADDRESS);
     /* FIXME - where does this vc get freed?
        ANSWER (goodell@) - ch3u_port.c FreeNewVC
                            (but the VC_Destroy is in this file) */
@@ -288,10 +288,10 @@ int MPID_nem_register_initcomp_cb(int (* callback)(void))
 {
     int mpi_errno = MPI_SUCCESS;
     initcomp_cb_t *ep;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
-    MPIR_CHKPMEM_MALLOC(ep, initcomp_cb_t *, sizeof(*ep), mpi_errno, "initcomp callback element", MPL_MEM_OTHER);
+    MPIR_CHKPMEM_MALLOC(ep, sizeof(*ep), MPL_MEM_OTHER);
 
     ep->callback = callback;
     INITCOMP_S_PUSH(ep);

--- a/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_progress.c
@@ -893,7 +893,7 @@ static int shm_connection_terminated(MPIDI_VC_t * vc)
 int MPIDI_CH3_Connection_terminate(MPIDI_VC_t * vc)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -938,7 +938,7 @@ int MPIDI_CH3_Connection_terminate(MPIDI_VC_t * vc)
                    have completed.  */
                 vc_term_element_t *ep;
                 MPL_DBG_MSG(MPIDI_CH3_DBG_DISCONNECT, TYPICAL, "Shm send queue not empty, waiting to terminate");
-                MPIR_CHKPMEM_MALLOC(ep, vc_term_element_t *, sizeof(vc_term_element_t), mpi_errno, "vc_term_element", MPL_MEM_ADDRESS);
+                MPIR_CHKPMEM_MALLOC(ep, sizeof(vc_term_element_t), MPL_MEM_ADDRESS);
                 ep->vc = vc;
                 ep->req = MPIDI_CH3I_shm_sendq.tail;
                 MPIR_Request_add_ref(ep->req); /* make sure this doesn't get released before we can check it */
@@ -1024,9 +1024,9 @@ int MPIDI_CH3I_Register_anysource_notification(void (*enqueue_fn)(MPIR_Request *
 {
     int mpi_errno = MPI_SUCCESS;
     qn_ent_t *ent;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
-    MPIR_CHKPMEM_MALLOC(ent, qn_ent_t *, sizeof(qn_ent_t), mpi_errno, "queue entry", MPL_MEM_BUFFER);
+    MPIR_CHKPMEM_MALLOC(ent, sizeof(qn_ent_t), MPL_MEM_BUFFER);
 
     ent->enqueue_fn = enqueue_fn;
     ent->dequeue_fn = dequeue_fn;

--- a/src/mpid/ch3/channels/nemesis/src/ch3_win_fns.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_win_fns.c
@@ -249,7 +249,7 @@ static int MPIDI_CH3I_Win_detect_shm(MPIR_Win ** win_ptr)
     int i, node_size;
     MPI_Aint *base_shm_offs;
 
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
     MPIR_CHKLMEM_DECL();
     MPIR_FUNC_ENTER;
 
@@ -271,8 +271,7 @@ static int MPIDI_CH3I_Win_detect_shm(MPIR_Win ** win_ptr)
         goto fn_exit;
 
     (*win_ptr)->shm_allocated = TRUE;
-    MPIR_CHKPMEM_MALLOC((*win_ptr)->shm_base_addrs, void **,
-                        node_size * sizeof(void *), mpi_errno, "(*win_ptr)->shm_base_addrs", MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC((*win_ptr)->shm_base_addrs, node_size * sizeof(void *), MPL_MEM_SHM);
 
     /* Compute the base address of shm buffer on each process.
      * shm_base_addrs[i] = my_shm_base_addr + off[i] */
@@ -427,7 +426,7 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
     MPIR_Comm *node_comm_ptr;
     MPI_Aint *node_sizes;
     int noncontig = FALSE;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
     MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
@@ -464,8 +463,7 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
     MPIR_T_PVAR_TIMER_START(RMA, rma_wincreate_allgather);
     /* allocate memory for the base addresses, disp_units, and
      * completion counters of all processes */
-    MPIR_CHKPMEM_MALLOC((*win_ptr)->shm_base_addrs, void **,
-                        node_size * sizeof(void *), mpi_errno, "(*win_ptr)->shm_base_addrs", MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC((*win_ptr)->shm_base_addrs, node_size * sizeof(void *), MPL_MEM_SHM);
 
     /* get the sizes of the windows and window objectsof
      * all processes.  allocate temp. buffer for communication */

--- a/src/mpid/ch3/channels/nemesis/src/ch3_win_fns.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_win_fns.c
@@ -129,7 +129,7 @@ static int MPIDI_CH3I_SHM_Wins_match(MPIR_Win ** win_ptr, MPIR_Win ** matched_wi
 
     MPIDI_SHM_Win_t *elem = shm_wins_list;
 
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
     MPIR_FUNC_ENTER;
 
     *matched_win = NULL;
@@ -141,9 +141,8 @@ static int MPIDI_CH3I_SHM_Wins_match(MPIR_Win ** win_ptr, MPIR_Win ** matched_wi
 
     comm_size = (*win_ptr)->comm_ptr->local_size;
 
-    MPIR_CHKLMEM_MALLOC(node_ranks, int *, node_size * sizeof(int), mpi_errno, "node_ranks", MPL_MEM_RMA);
-    MPIR_CHKLMEM_MALLOC(node_ranks_in_shm_node, int *, node_size * sizeof(int),
-                        mpi_errno, "node_ranks_in_shm_comm", MPL_MEM_RMA);
+    MPIR_CHKLMEM_MALLOC(node_ranks, node_size * sizeof(int));
+    MPIR_CHKLMEM_MALLOC(node_ranks_in_shm_node, node_size * sizeof(int));
 
     for (i = 0; i < node_size; i++) {
         node_ranks[i] = i;
@@ -251,7 +250,7 @@ static int MPIDI_CH3I_Win_detect_shm(MPIR_Win ** win_ptr)
     MPI_Aint *base_shm_offs;
 
     MPIR_CHKPMEM_DECL(1);
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
     MPIR_FUNC_ENTER;
 
     if ((*win_ptr)->comm_ptr->node_comm == NULL) {
@@ -260,8 +259,7 @@ static int MPIDI_CH3I_Win_detect_shm(MPIR_Win ** win_ptr)
 
     node_size = (*win_ptr)->comm_ptr->node_comm->local_size;
 
-    MPIR_CHKLMEM_MALLOC(base_shm_offs, MPI_Aint *, node_size * sizeof(MPI_Aint),
-                        mpi_errno, "base_shm_offs", MPL_MEM_RMA);
+    MPIR_CHKLMEM_MALLOC(base_shm_offs, node_size * sizeof(MPI_Aint));
 
     /* Return the first matched shared window.
      * It is noted that the shared windows including all local processes are
@@ -308,7 +306,7 @@ static int MPIDI_CH3I_Win_gather_info(void *base, MPI_Aint size, int disp_unit, 
     int i, k;
     int mpi_errno = MPI_SUCCESS;
     int mpl_err = 0;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -382,8 +380,7 @@ static int MPIDI_CH3I_Win_gather_info(void *base, MPI_Aint size, int disp_unit, 
 
     (*win_ptr)->basic_info_table = (MPIDI_Win_basic_info_t *) ((*win_ptr)->info_shm_base_addr);
 
-    MPIR_CHKLMEM_MALLOC(tmp_buf, MPI_Aint *, 4 * comm_size * sizeof(MPI_Aint),
-                        mpi_errno, "tmp_buf", MPL_MEM_RMA);
+    MPIR_CHKLMEM_MALLOC(tmp_buf, 4 * comm_size * sizeof(MPI_Aint));
 
     tmp_buf[4 * comm_rank] = MPIR_Ptr_to_aint(base);
     tmp_buf[4 * comm_rank + 1] = size;
@@ -431,7 +428,7 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
     MPI_Aint *node_sizes;
     int noncontig = FALSE;
     MPIR_CHKPMEM_DECL(1);
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -472,8 +469,7 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
 
     /* get the sizes of the windows and window objectsof
      * all processes.  allocate temp. buffer for communication */
-    MPIR_CHKLMEM_MALLOC(node_sizes, MPI_Aint *, node_size * sizeof(MPI_Aint), mpi_errno,
-                        "node_sizes", MPL_MEM_RMA);
+    MPIR_CHKLMEM_MALLOC(node_sizes, node_size * sizeof(MPI_Aint));
 
     node_sizes[node_rank] = (MPI_Aint) size;
 

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_init.c
@@ -122,7 +122,7 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
     char strerrbuf[MPIR_STRERROR_BUF_SIZE];
 #endif
 
-    MPIR_CHKPMEM_DECL(8);
+    MPIR_CHKPMEM_DECL();
 
     /* TODO add compile-time asserts (rather than run-time) and convert most of these */
 
@@ -158,7 +158,7 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
     MPIR_ERR_CHECK(mpi_errno);
 
 #ifdef MEM_REGION_IN_HEAP
-    MPIR_CHKPMEM_MALLOC (MPID_nem_mem_region_ptr, MPID_nem_mem_region_t *, sizeof(MPID_nem_mem_region_t), mpi_errno, "mem_region", MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC (MPID_nem_mem_region_ptr, sizeof(MPID_nem_mem_region_t), MPL_MEM_SHM);
 #endif /* MEM_REGION_IN_HEAP */
 
     MPID_nem_mem_region.rank           = pg_rank;
@@ -166,10 +166,10 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
     MPID_nem_mem_region.num_procs      = num_procs;
     MPID_nem_mem_region.local_procs    = local_procs;
     MPID_nem_mem_region.local_rank     = local_rank;
-    MPIR_CHKPMEM_MALLOC (MPID_nem_mem_region.local_ranks, int *, num_procs * sizeof(int), mpi_errno, "mem_region local ranks", MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC (MPID_nem_mem_region.local_ranks, num_procs * sizeof(int), MPL_MEM_SHM);
     MPID_nem_mem_region.ext_procs      = num_procs - num_local ;
     if (MPID_nem_mem_region.ext_procs > 0)
-        MPIR_CHKPMEM_MALLOC (MPID_nem_mem_region.ext_ranks, int *, MPID_nem_mem_region.ext_procs * sizeof(int), mpi_errno, "mem_region ext ranks", MPL_MEM_SHM);
+        MPIR_CHKPMEM_MALLOC (MPID_nem_mem_region.ext_ranks, MPID_nem_mem_region.ext_procs * sizeof(int), MPL_MEM_SHM);
     MPID_nem_mem_region.next           = NULL;
 
     for (idx = 0 ; idx < num_procs; idx++)
@@ -276,8 +276,8 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
     MPID_nem_mem_region.Elements = (void *) ((char *) cells_p + local_rank * MPID_NEM_NUM_CELLS * MPID_NEM_CELL_LEN);
 
     /* Tables of pointers to shared memory Qs */
-    MPIR_CHKPMEM_MALLOC(MPID_nem_mem_region.FreeQ, MPID_nem_queue_ptr_t *, num_procs * sizeof(MPID_nem_queue_ptr_t), mpi_errno, "FreeQ", MPL_MEM_SHM);
-    MPIR_CHKPMEM_MALLOC(MPID_nem_mem_region.RecvQ, MPID_nem_queue_ptr_t *, num_procs * sizeof(MPID_nem_queue_ptr_t), mpi_errno, "RecvQ", MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC(MPID_nem_mem_region.FreeQ, num_procs * sizeof(MPID_nem_queue_ptr_t), MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC(MPID_nem_mem_region.RecvQ, num_procs * sizeof(MPID_nem_queue_ptr_t), MPL_MEM_SHM);
 
     /* Init table entry for our Qs */
     MPID_nem_mem_region.FreeQ[pg_rank] = &free_queues_p[local_rank];
@@ -350,8 +350,8 @@ MPID_nem_init(int pg_rank, MPIDI_PG_t *pg_p, int has_parent ATTRIBUTE((unused)))
 
     
     /* Allocate table of pointers to fastboxes */
-    MPIR_CHKPMEM_MALLOC(MPID_nem_mem_region.mailboxes.in,  MPID_nem_fastbox_t **, num_local * sizeof(MPID_nem_fastbox_t *), mpi_errno, "fastboxes", MPL_MEM_SHM);
-    MPIR_CHKPMEM_MALLOC(MPID_nem_mem_region.mailboxes.out, MPID_nem_fastbox_t **, num_local * sizeof(MPID_nem_fastbox_t *), mpi_errno, "fastboxes", MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC(MPID_nem_mem_region.mailboxes.in, num_local * sizeof(MPID_nem_fastbox_t *), MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC(MPID_nem_mem_region.mailboxes.out, num_local * sizeof(MPID_nem_fastbox_t *), MPL_MEM_SHM);
 
     MPIR_Assert(num_local > 0);
 
@@ -438,7 +438,7 @@ MPID_nem_vc_init (MPIDI_VC_t *vc)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_CH3I_VC *vc_ch = &vc->ch;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
     
@@ -454,7 +454,7 @@ MPID_nem_vc_init (MPIDI_VC_t *vc)
     vc_ch->ckpt_restart_vc    = NULL;
 #endif
     vc_ch->pending_pkt_len    = 0;
-    MPIR_CHKPMEM_MALLOC (vc_ch->pending_pkt, MPIDI_CH3_Pkt_t *, sizeof (MPIDI_CH3_Pkt_t), mpi_errno, "pending_pkt", MPL_MEM_BUFFER);
+    MPIR_CHKPMEM_MALLOC (vc_ch->pending_pkt, sizeof (MPIDI_CH3_Pkt_t), MPL_MEM_BUFFER);
 
     /* We do different things for vcs in the COMM_WORLD pg vs other pgs
        COMM_WORLD vcs may use shared memory, and already have queues allocated
@@ -656,12 +656,12 @@ static int get_local_procs(MPIDI_PG_t *pg, int our_pg_rank, int *num_local_p,
     int i;
     int num_local = 0;
     int our_node_id;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_Assert(our_pg_rank < pg->size);
     our_node_id = pg->vct[our_pg_rank].node_id;
 
-    MPIR_CHKPMEM_MALLOC(procs, int *, pg->size * sizeof(int), mpi_errno, "local process index array", MPL_MEM_ADDRESS);
+    MPIR_CHKPMEM_MALLOC(procs, pg->size * sizeof(int), MPL_MEM_ADDRESS);
 
     for (i = 0; i < pg->size; ++i) {
         if (our_node_id == pg->vct[i].node_id) {

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt.c
@@ -165,7 +165,7 @@ static int pkt_RTS_handler(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *data, int
     int found;
     MPID_nem_pkt_lmt_rts_t * const rts_pkt = (MPID_nem_pkt_lmt_rts_t *)pkt;
     intptr_t data_len;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -197,7 +197,7 @@ static int pkt_RTS_handler(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *data, int
     {
         /* set for the cookie to be received into the tmp_cookie in the request */
         MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"haven't received entire cookie");
-        MPIR_CHKPMEM_MALLOC(rreq->ch.lmt_tmp_cookie.iov_base, char *, rts_pkt->cookie_len, mpi_errno, "tmp cookie buf", MPL_MEM_BUFFER);
+        MPIR_CHKPMEM_MALLOC(rreq->ch.lmt_tmp_cookie.iov_base, rts_pkt->cookie_len, MPL_MEM_BUFFER);
         rreq->ch.lmt_tmp_cookie.iov_len = rts_pkt->cookie_len;
 
         rreq->dev.iov[0] = rreq->ch.lmt_tmp_cookie;
@@ -233,7 +233,7 @@ static int pkt_RTS_handler(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *data, int
         {
             /* receive cookie into tmp_cookie in the request */
             MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"received entire cookie");
-            MPIR_CHKPMEM_MALLOC(rreq->ch.lmt_tmp_cookie.iov_base, char *, rts_pkt->cookie_len, mpi_errno, "tmp cookie buf", MPL_MEM_BUFFER);
+            MPIR_CHKPMEM_MALLOC(rreq->ch.lmt_tmp_cookie.iov_base, rts_pkt->cookie_len, MPL_MEM_BUFFER);
             rreq->ch.lmt_tmp_cookie.iov_len = rts_pkt->cookie_len;
         
             MPIR_Memcpy(rreq->ch.lmt_tmp_cookie.iov_base, data, rts_pkt->cookie_len);
@@ -276,7 +276,7 @@ static int pkt_CTS_handler(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *data, int
     MPIR_Request *rts_sreq;
     intptr_t data_len;
     int mpi_errno = MPI_SUCCESS;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -322,7 +322,7 @@ static int pkt_CTS_handler(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *data, int
             /* create a recv req and set up to receive the cookie into the sreq's tmp_cookie */
             MPIR_Request *rreq;
 
-            MPIR_CHKPMEM_MALLOC(sreq->ch.lmt_tmp_cookie.iov_base, char *, cts_pkt->cookie_len, mpi_errno, "tmp cookie buf", MPL_MEM_BUFFER);
+            MPIR_CHKPMEM_MALLOC(sreq->ch.lmt_tmp_cookie.iov_base, cts_pkt->cookie_len, MPL_MEM_BUFFER);
             sreq->ch.lmt_tmp_cookie.iov_len = cts_pkt->cookie_len;
 
             MPIDI_Request_create_rreq(rreq, mpi_errno, goto fn_fail);
@@ -399,7 +399,7 @@ static int pkt_COOKIE_handler(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *data, 
     MPID_nem_pkt_lmt_cookie_t * const cookie_pkt = (MPID_nem_pkt_lmt_cookie_t *)pkt;
     MPIR_Request *req;
     intptr_t data_len;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -437,7 +437,7 @@ static int pkt_COOKIE_handler(MPIDI_VC_t *vc, MPIDI_CH3_Pkt_t *pkt, void *data, 
             MPIR_Request *rreq;
 
             MPIDI_Request_create_rreq(rreq, mpi_errno, goto fn_fail);
-            MPIR_CHKPMEM_MALLOC(rreq->ch.lmt_tmp_cookie.iov_base, char *, cookie_pkt->cookie_len, mpi_errno, "tmp cookie buf", MPL_MEM_BUFFER);
+            MPIR_CHKPMEM_MALLOC(rreq->ch.lmt_tmp_cookie.iov_base, cookie_pkt->cookie_len, MPL_MEM_BUFFER);
             /* FIXME:  where does this request get freed? */
             rreq->ch.lmt_tmp_cookie.iov_len = cookie_pkt->cookie_len;
 

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_shm.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_lmt_shm.c
@@ -154,7 +154,7 @@ int MPID_nem_lmt_shm_start_recv(MPIDI_VC_t *vc, MPIR_Request *req, struct iovec 
 {
     int mpi_errno = MPI_SUCCESS;
     int done = FALSE;
-    MPIR_CHKPMEM_DECL(2);
+    MPIR_CHKPMEM_DECL();
     MPID_nem_lmt_shm_wait_element_t *e;
     int queue_initially_empty;
     MPIDI_CH3I_VC *vc_ch = &vc->ch;
@@ -187,7 +187,7 @@ int MPID_nem_lmt_shm_start_recv(MPIDI_VC_t *vc, MPIR_Request *req, struct iovec 
 
     queue_initially_empty = LMT_SHM_Q_EMPTY(vc_ch->lmt_queue) && vc_ch->lmt_active_lmt == NULL;
 
-    MPIR_CHKPMEM_MALLOC (e, MPID_nem_lmt_shm_wait_element_t *, sizeof (MPID_nem_lmt_shm_wait_element_t), mpi_errno, "lmt wait queue element", MPL_MEM_BUFFER);
+    MPIR_CHKPMEM_MALLOC (e, sizeof (MPID_nem_lmt_shm_wait_element_t), MPL_MEM_BUFFER);
     e->progress = lmt_shm_recv_progress;
     e->req = req;
     LMT_SHM_Q_ENQUEUE(&vc_ch->lmt_queue, e); /* MT: not thread safe */
@@ -206,7 +206,7 @@ int MPID_nem_lmt_shm_start_recv(MPIDI_VC_t *vc, MPIR_Request *req, struct iovec 
 
         MPL_DBG_MSG(MPIDI_CH3_DBG_CHANNEL, VERBOSE, "lmt recv not finished:  enqueue");
 
-        MPIR_CHKPMEM_MALLOC (pe, lmt_shm_prog_element_t *, sizeof (lmt_shm_prog_element_t), mpi_errno, "lmt progress queue element", MPL_MEM_BUFFER);
+        MPIR_CHKPMEM_MALLOC (pe, sizeof (lmt_shm_prog_element_t), MPL_MEM_BUFFER);
         pe->vc = vc;
         LMT_SHM_L_ADD(pe);
         MPID_nem_local_lmt_pending = TRUE;
@@ -232,7 +232,7 @@ int MPID_nem_lmt_shm_start_send(MPIDI_VC_t *vc, MPIR_Request *req, struct iovec 
     int queue_initially_empty;
     MPID_nem_lmt_shm_wait_element_t *e;
     MPIDI_CH3I_VC *vc_ch = &vc->ch;
-    MPIR_CHKPMEM_DECL(3);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -274,7 +274,7 @@ int MPID_nem_lmt_shm_start_send(MPIDI_VC_t *vc, MPIR_Request *req, struct iovec 
 
     queue_initially_empty = LMT_SHM_Q_EMPTY(vc_ch->lmt_queue) && vc_ch->lmt_active_lmt == NULL;
 
-    MPIR_CHKPMEM_MALLOC (e, MPID_nem_lmt_shm_wait_element_t *, sizeof (MPID_nem_lmt_shm_wait_element_t), mpi_errno, "lmt wait queue element", MPL_MEM_BUFFER);
+    MPIR_CHKPMEM_MALLOC (e, sizeof (MPID_nem_lmt_shm_wait_element_t), MPL_MEM_BUFFER);
     e->progress = lmt_shm_send_progress;
     e->req = req;
     LMT_SHM_Q_ENQUEUE(&vc_ch->lmt_queue, e); /* MT: not thread safe */
@@ -291,7 +291,7 @@ int MPID_nem_lmt_shm_start_send(MPIDI_VC_t *vc, MPIR_Request *req, struct iovec 
         /* lmt send didn't finish, enqueue it to be completed later */
         lmt_shm_prog_element_t *pe;
 
-        MPIR_CHKPMEM_MALLOC (pe, lmt_shm_prog_element_t *, sizeof (lmt_shm_prog_element_t), mpi_errno, "lmt progress queue element", MPL_MEM_BUFFER);
+        MPIR_CHKPMEM_MALLOC (pe, sizeof (lmt_shm_prog_element_t), MPL_MEM_BUFFER);
         pe->vc = vc;
         LMT_SHM_L_ADD(pe);
         MPID_nem_local_lmt_pending = TRUE;

--- a/src/mpid/ch3/channels/nemesis/src/mpid_nem_mpich.c
+++ b/src/mpid/ch3/channels/nemesis/src/mpid_nem_mpich.c
@@ -27,13 +27,13 @@ MPID_nem_mpich_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
-    MPIR_CHKPMEM_DECL (2);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
     MPID_nem_prefetched_cell = NULL;
 
-    MPIR_CHKPMEM_MALLOC (MPID_nem_recv_seqno, unsigned short *, sizeof(*MPID_nem_recv_seqno) * MPID_nem_mem_region.num_procs, mpi_errno, "recv seqno", MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC (MPID_nem_recv_seqno, sizeof(*MPID_nem_recv_seqno) * MPID_nem_mem_region.num_procs, MPL_MEM_SHM);
 
     for (i = 0; i < MPID_nem_mem_region.num_procs; ++i)
     {
@@ -41,7 +41,7 @@ MPID_nem_mpich_init(void)
     }
 
     /* set up fbox queue */
-    MPIR_CHKPMEM_MALLOC (MPID_nem_fboxq_elem_list, MPID_nem_fboxq_elem_t *, MPID_nem_mem_region.num_local * sizeof(MPID_nem_fboxq_elem_t), mpi_errno, "fastbox element list", MPL_MEM_SHM);
+    MPIR_CHKPMEM_MALLOC (MPID_nem_fboxq_elem_list, MPID_nem_mem_region.num_local * sizeof(MPID_nem_fboxq_elem_t), MPL_MEM_SHM);
 
     for (i = 0; i < MPID_nem_mem_region.num_local; ++i)
     {

--- a/src/mpid/ch3/include/mpidrma.h
+++ b/src/mpid/ch3/include/mpidrma.h
@@ -1048,12 +1048,11 @@ static inline int fill_ranks_in_win_grp(MPIR_Win * win_ptr, MPIR_Group * group_p
     int mpi_errno = MPI_SUCCESS;
     int i, *ranks_in_grp;
     MPIR_Group *win_grp_ptr;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKLMEM_MALLOC(ranks_in_grp, int *, group_ptr->size * sizeof(int),
-                        mpi_errno, "ranks_in_grp", MPL_MEM_RMA);
+    MPIR_CHKLMEM_MALLOC(ranks_in_grp, group_ptr->size * sizeof(int));
     for (i = 0; i < group_ptr->size; i++)
         ranks_in_grp[i] = i;
 

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -53,7 +53,7 @@ int MPIDI_CH3I_Comm_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
 #if defined HAVE_HCOLL && MPID_CH3I_CH_HCOLL_BCOL
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 #endif
 
     MPIR_FUNC_ENTER;
@@ -83,7 +83,7 @@ int MPIDI_CH3I_Comm_init(void)
             char *envstr;
             int size = strlen("HCOLL_BCOL=") + strlen(MPID_CH3I_CH_HCOLL_BCOL) + 1;
 
-            MPIR_CHKLMEM_MALLOC(envstr, char *, size, mpi_errno, "**malloc", MPL_MEM_COMM);
+            MPIR_CHKLMEM_MALLOC(envstr, size);
             snprintf(envstr, size, "HCOLL_BCOL=%s", MPID_CH3I_CH_HCOLL_BCOL);
 
             r = MPL_putenv(envstr);

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -387,11 +387,11 @@ int MPIDI_CH3U_Comm_register_create_hook(int (*hook_fn)(struct MPIR_Comm *, void
 {
     int mpi_errno = MPI_SUCCESS;
     hook_elt *elt;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKPMEM_MALLOC(elt, hook_elt *, sizeof(hook_elt), mpi_errno, "hook_elt", MPL_MEM_OTHER);
+    MPIR_CHKPMEM_MALLOC(elt, sizeof(hook_elt), MPL_MEM_OTHER);
 
     elt->hook_fn = hook_fn;
     elt->param = param;
@@ -411,11 +411,11 @@ int MPIDI_CH3U_Comm_register_destroy_hook(int (*hook_fn)(struct MPIR_Comm *, voi
 {
     int mpi_errno = MPI_SUCCESS;
     hook_elt *elt;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKPMEM_MALLOC(elt, hook_elt *, sizeof(hook_elt), mpi_errno, "hook_elt", MPL_MEM_OTHER);
+    MPIR_CHKPMEM_MALLOC(elt, sizeof(hook_elt), MPL_MEM_OTHER);
 
     elt->hook_fn = hook_fn;
     elt->param = param;

--- a/src/mpid/ch3/src/ch3u_handle_recv_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_recv_req.c
@@ -235,7 +235,7 @@ int MPIDI_CH3_ReqHandler_GaccumRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
     int is_empty_origin = FALSE;
     MPI_Aint extent, type_size;
     MPI_Aint stream_data_len, total_len;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -289,8 +289,7 @@ int MPIDI_CH3_ReqHandler_GaccumRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq
     MPIR_Object_set_ref(resp_req, 1);
     MPIDI_Request_set_type(resp_req, MPIDI_REQUEST_TYPE_GET_ACCUM_RESP);
 
-    MPIR_CHKPMEM_MALLOC(resp_req->dev.user_buf, void *, stream_data_len,
-                        mpi_errno, "GACC resp. buffer", MPL_MEM_BUFFER);
+    MPIR_CHKPMEM_MALLOC(resp_req->dev.user_buf, stream_data_len, MPL_MEM_BUFFER);
 
     /* NOTE: 'copy data + ACC' needs to be atomic */
 
@@ -386,7 +385,7 @@ int MPIDI_CH3_ReqHandler_FOPRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
     MPIDI_CH3_Pkt_fop_resp_t *fop_resp_pkt = &upkt.fop_resp;
     int is_contig;
     int is_empty_origin = FALSE;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -413,7 +412,7 @@ int MPIDI_CH3_ReqHandler_FOPRecvComplete(MPIDI_VC_t * vc, MPIR_Request * rreq, i
     resp_req->dev.target_win_handle = rreq->dev.target_win_handle;
     resp_req->dev.pkt_flags = rreq->dev.pkt_flags;
 
-    MPIR_CHKPMEM_MALLOC(resp_req->dev.user_buf, void *, type_size, mpi_errno, "FOP resp. buffer", MPL_MEM_BUFFER);
+    MPIR_CHKPMEM_MALLOC(resp_req->dev.user_buf, type_size, MPL_MEM_BUFFER);
 
     /* here we increment the Active Target counter to guarantee the GET-like
      * operation are completed when counter reaches zero. */

--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -814,7 +814,7 @@ static int ExtractLocalPGInfo( MPIR_Comm *comm_p,
 {
     pg_node        *pg_list = 0, *pg_iter, *pg_trailer;
     int            i, cur_index = 0, local_comm_size, mpi_errno = 0;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -830,8 +830,7 @@ static int ExtractLocalPGInfo( MPIR_Comm *comm_p,
        group id, size and all its KVS values */
     
     cur_index = 0;
-    MPIR_CHKPMEM_MALLOC(pg_list,pg_node*,sizeof(pg_node),mpi_errno,
-			"pg_list", MPL_MEM_ADDRESS);
+    MPIR_CHKPMEM_MALLOC(pg_list, sizeof(pg_node), MPL_MEM_ADDRESS);
     
     pg_list->pg_id = MPL_strdup(comm_p->dev.vcrt->vcr_table[0]->pg->id);
     pg_list->index = cur_index++;
@@ -1694,9 +1693,8 @@ static int MPIDI_CH3I_Port_connreq_create(MPIDI_VC_t * vc, MPIDI_CH3I_Port_connr
     int mpi_errno = MPI_SUCCESS;
     MPIDI_CH3I_Port_connreq_t *connreq = NULL;
 
-    MPIR_CHKPMEM_DECL(1);
-    MPIR_CHKPMEM_MALLOC(connreq, MPIDI_CH3I_Port_connreq_t *, sizeof(MPIDI_CH3I_Port_connreq_t),
-                        mpi_errno, "comm_conn", MPL_MEM_DYNAMIC);
+    MPIR_CHKPMEM_DECL();
+    MPIR_CHKPMEM_MALLOC(connreq, sizeof(MPIDI_CH3I_Port_connreq_t), MPL_MEM_DYNAMIC);
 
     connreq->vc = vc;
     MPIDI_CH3I_PORT_CONNREQ_SET_STAT(connreq, INITED);
@@ -1755,9 +1753,8 @@ int MPIDI_CH3I_Port_init(int port_name_tag)
 
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKPMEM_DECL(1);
-    MPIR_CHKPMEM_MALLOC(port, MPIDI_CH3I_Port_t *, sizeof(MPIDI_CH3I_Port_t),
-                        mpi_errno, "comm_port", MPL_MEM_DYNAMIC);
+    MPIR_CHKPMEM_DECL();
+    MPIR_CHKPMEM_MALLOC(port, sizeof(MPIDI_CH3I_Port_t), MPL_MEM_DYNAMIC);
 
     port->port_name_tag = port_name_tag;
     port->accept_connreq_q.head = port->accept_connreq_q.tail = 0;

--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -586,7 +586,7 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
     pg_node *pg_list = NULL;
     MPIDI_PG_t **remote_pg = NULL;
     int recvcontext_id = MPIR_INVALID_CONTEXT_ID;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -621,9 +621,7 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
 
 	/* Make an array to translate local ranks to process group index 
 	   and rank */
-	MPIR_CHKLMEM_MALLOC(local_translation,pg_translation*,
-			    local_comm_size*sizeof(pg_translation),
-			    mpi_errno,"local_translation", MPL_MEM_DYNAMIC);
+	MPIR_CHKLMEM_MALLOC(local_translation, local_comm_size*sizeof(pg_translation));
 
 	/* Make a list of the local communicator's process groups and encode 
 	   them in strings to be sent to the other side.
@@ -667,12 +665,8 @@ int MPIDI_Comm_connect(const char *port_name, MPIR_Info *info, int root,
     remote_comm_size = recv_ints[1];
     context_id	     = recv_ints[2];
 
-    MPIR_CHKLMEM_MALLOC(remote_pg,MPIDI_PG_t**,
-			n_remote_pgs * sizeof(MPIDI_PG_t*),
-			mpi_errno,"remote_pg", MPL_MEM_DYNAMIC);
-    MPIR_CHKLMEM_MALLOC(remote_translation,pg_translation*,
-			remote_comm_size * sizeof(pg_translation),
-			mpi_errno,"remote_translation", MPL_MEM_DYNAMIC);
+    MPIR_CHKLMEM_MALLOC(remote_pg, n_remote_pgs * sizeof(MPIDI_PG_t*));
+    MPIR_CHKLMEM_MALLOC(remote_translation, remote_comm_size * sizeof(pg_translation));
     MPL_DBG_MSG(MPIDI_CH3_DBG_CONNECT,VERBOSE,"allocated remote process groups");
 
     /* Exchange the process groups and their corresponding KVSes */
@@ -982,14 +976,12 @@ int MPID_PG_BCast( MPIR_Comm *peercomm_p, MPIR_Comm *comm_p, int root )
     pg_translation *local_translation = 0;
     pg_node *pg_list, *pg_next, *pg_head = 0;
     int rank, i, peer_comm_size;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     peer_comm_size = comm_p->local_size;
     rank            = comm_p->rank;
 
-    MPIR_CHKLMEM_MALLOC(local_translation,pg_translation*,
-			peer_comm_size*sizeof(pg_translation),
-			mpi_errno,"local_translation", MPL_MEM_DYNAMIC);
+    MPIR_CHKLMEM_MALLOC(local_translation, peer_comm_size*sizeof(pg_translation));
     
     if (rank == root) {
 	/* Get the process groups known to the *peercomm* */
@@ -1135,7 +1127,7 @@ int MPIDI_Comm_accept(const char *port_name, MPIR_Info *info, int root,
     pg_translation *local_translation = NULL, *remote_translation = NULL;
     pg_node *pg_list = NULL;
     MPIDI_PG_t **remote_pg = NULL;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -1161,9 +1153,7 @@ int MPIDI_Comm_accept(const char *port_name, MPIR_Info *info, int root,
 
 	/* Make an array to translate local ranks to process group index and 
 	   rank */
-	MPIR_CHKLMEM_MALLOC(local_translation,pg_translation*,
-			    local_comm_size*sizeof(pg_translation),
-			    mpi_errno,"local_translation", MPL_MEM_DYNAMIC);
+	MPIR_CHKLMEM_MALLOC(local_translation, local_comm_size*sizeof(pg_translation));
 
 	/* Make a list of the local communicator's process groups and encode 
 	   them in strings to be sent to the other side.
@@ -1196,12 +1186,8 @@ int MPIDI_Comm_accept(const char *port_name, MPIR_Info *info, int root,
     n_remote_pgs     = recv_ints[0];
     remote_comm_size = recv_ints[1];
     context_id       = recv_ints[2];
-    MPIR_CHKLMEM_MALLOC(remote_pg,MPIDI_PG_t**,
-			n_remote_pgs * sizeof(MPIDI_PG_t*),
-			mpi_errno,"remote_pg", MPL_MEM_DYNAMIC);
-    MPIR_CHKLMEM_MALLOC(remote_translation,pg_translation*,
-			remote_comm_size * sizeof(pg_translation),
-			mpi_errno, "remote_translation", MPL_MEM_DYNAMIC);
+    MPIR_CHKLMEM_MALLOC(remote_pg, n_remote_pgs * sizeof(MPIDI_PG_t*));
+    MPIR_CHKLMEM_MALLOC(remote_translation, remote_comm_size * sizeof(pg_translation));
     MPL_DBG_MSG_FMT(MPIDI_CH3_DBG_OTHER,TERSE,(MPL_DBG_FDEST,"[%d]accept:remote process groups: %d\nremote comm size: %d\n", rank, n_remote_pgs, remote_comm_size));
 
     /* Exchange the process groups and their corresponding KVSes */

--- a/src/mpid/ch3/src/ch3u_rma_sync.c
+++ b/src/mpid/ch3/src/ch3u_rma_sync.c
@@ -459,7 +459,7 @@ int MPID_Win_fence(int assert, MPIR_Win * win_ptr)
     int scalable_fence_enabled = 0;
     int *rma_target_marks = NULL;
     int mpi_errno = MPI_SUCCESS;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -523,8 +523,7 @@ int MPID_Win_fence(int assert, MPIR_Win * win_ptr)
 
     /* Perform basic algorithm by calling reduce-scatter */
     if (!scalable_fence_enabled) {
-      MPIR_CHKLMEM_MALLOC(rma_target_marks, int *, comm_size * sizeof(int),
-                            mpi_errno, "rma_target_marks", MPL_MEM_RMA);
+      MPIR_CHKLMEM_MALLOC(rma_target_marks, comm_size * sizeof(int));
         for (i = 0; i < comm_size; i++)
             rma_target_marks[i] = 0;
 
@@ -656,7 +655,7 @@ int MPID_Win_post(MPIR_Group * post_grp_ptr, int assert, MPIR_Win * win_ptr)
 {
     int *post_ranks_in_win_grp;
     int mpi_errno = MPI_SUCCESS;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -690,15 +689,12 @@ int MPID_Win_post(MPIR_Group * post_grp_ptr, int assert, MPIR_Win * win_ptr)
         win_comm_ptr = win_ptr->comm_ptr;
         rank = win_ptr->comm_ptr->rank;
 
-        MPIR_CHKLMEM_MALLOC(post_ranks_in_win_grp, int *,
-                            post_grp_size * sizeof(int), mpi_errno, "post_ranks_in_win_grp", MPL_MEM_RMA);
+        MPIR_CHKLMEM_MALLOC(post_ranks_in_win_grp, post_grp_size * sizeof(int));
         mpi_errno = fill_ranks_in_win_grp(win_ptr, post_grp_ptr, post_ranks_in_win_grp);
         MPIR_ERR_CHECK(mpi_errno);
 
-        MPIR_CHKLMEM_MALLOC(req, MPIR_Request **, post_grp_size * sizeof(MPIR_Request *),
-                            mpi_errno, "req", MPL_MEM_RMA);
-        MPIR_CHKLMEM_MALLOC(status, MPI_Status *, post_grp_size * sizeof(MPI_Status),
-                            mpi_errno, "status", MPL_MEM_RMA);
+        MPIR_CHKLMEM_MALLOC(req, post_grp_size * sizeof(MPIR_Request *));
+        MPIR_CHKLMEM_MALLOC(status, post_grp_size * sizeof(MPI_Status));
 
         /* Send a 0-byte message to the source processes */
         for (i = 0; i < post_grp_size; i++) {
@@ -774,7 +770,7 @@ static int start_req_complete(MPIR_Request * req)
 int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
     MPIR_CHKPMEM_DECL(1);
 
     MPIR_FUNC_ENTER;
@@ -811,11 +807,8 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
         /* post IRECVs */
         if (win_ptr->shm_allocated == TRUE) {
             int node_comm_size = comm_ptr->node_comm->local_size;
-            MPIR_CHKLMEM_MALLOC(intra_start_req, MPIR_Request **,
-                                node_comm_size * sizeof(MPIR_Request *), mpi_errno, "intra_start_req", MPL_MEM_RMA);
-            MPIR_CHKLMEM_MALLOC(intra_start_status, MPI_Status *,
-                                node_comm_size * sizeof(MPI_Status),
-                                mpi_errno, "intra_start_status", MPL_MEM_RMA);
+            MPIR_CHKLMEM_MALLOC(intra_start_req, node_comm_size * sizeof(MPIR_Request *));
+            MPIR_CHKLMEM_MALLOC(intra_start_status, node_comm_size * sizeof(MPI_Status));
         }
 
         intra_cnt = 0;

--- a/src/mpid/ch3/src/ch3u_rma_sync.c
+++ b/src/mpid/ch3/src/ch3u_rma_sync.c
@@ -771,7 +771,7 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_CHKLMEM_DECL();
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -787,9 +787,8 @@ int MPID_Win_start(MPIR_Group * group_ptr, int assert, MPIR_Win * win_ptr)
 
     win_ptr->start_grp_size = group_ptr->size;
 
-    MPIR_CHKPMEM_MALLOC(win_ptr->start_ranks_in_win_grp, int *,
+    MPIR_CHKPMEM_MALLOC(win_ptr->start_ranks_in_win_grp,
                         win_ptr->start_grp_size * sizeof(int),
-                        mpi_errno, "win_ptr->start_ranks_in_win_grp",
                         MPL_MEM_RMA);
 
     mpi_errno = fill_ranks_in_win_grp(win_ptr, group_ptr, win_ptr->start_ranks_in_win_grp);

--- a/src/mpid/ch3/src/ch3u_win_fns.c
+++ b/src/mpid/ch3/src/ch3u_win_fns.c
@@ -34,7 +34,7 @@ int MPIDI_CH3U_Win_gather_info(void *base, MPI_Aint size, int disp_unit,
     int mpi_errno = MPI_SUCCESS, i, k, comm_size, rank;
     MPI_Aint *tmp_buf;
     MPIR_CHKPMEM_DECL(1);
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -51,8 +51,7 @@ int MPIDI_CH3U_Win_gather_info(void *base, MPI_Aint size, int disp_unit,
 
     /* get the addresses of the windows, window objects, and completion
      * counters of all processes.  allocate temp. buffer for communication */
-    MPIR_CHKLMEM_MALLOC(tmp_buf, MPI_Aint *, 4 * comm_size * sizeof(MPI_Aint),
-                        mpi_errno, "tmp_buf", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tmp_buf, 4 * comm_size * sizeof(MPI_Aint));
 
     /* FIXME: If we wanted to validate the transfer as within range at the
      * origin, we'd also need the window size. */

--- a/src/mpid/ch3/src/ch3u_win_fns.c
+++ b/src/mpid/ch3/src/ch3u_win_fns.c
@@ -33,7 +33,7 @@ int MPIDI_CH3U_Win_gather_info(void *base, MPI_Aint size, int disp_unit,
 {
     int mpi_errno = MPI_SUCCESS, i, k, comm_size, rank;
     MPI_Aint *tmp_buf;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
     MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
@@ -44,9 +44,8 @@ int MPIDI_CH3U_Win_gather_info(void *base, MPI_Aint size, int disp_unit,
     MPIR_T_PVAR_TIMER_START(RMA, rma_wincreate_allgather);
     /* allocate memory for the base addresses, disp_units, and
      * completion counters of all processes */
-    MPIR_CHKPMEM_MALLOC((*win_ptr)->basic_info_table, MPIDI_Win_basic_info_t *,
+    MPIR_CHKPMEM_MALLOC((*win_ptr)->basic_info_table,
                         comm_size * sizeof(MPIDI_Win_basic_info_t),
-                        mpi_errno, "(*win_ptr)->basic_info_table",
                         MPL_MEM_RMA);
 
     /* get the addresses of the windows, window objects, and completion
@@ -219,12 +218,12 @@ int MPIDI_CH3U_Win_allocate_no_shm(MPI_Aint size, int disp_unit, MPIR_Info * inf
 {
     void **base_pp = (void **) baseptr;
     int mpi_errno = MPI_SUCCESS;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
     if (size > 0) {
-        MPIR_CHKPMEM_MALLOC(*base_pp, void *, size, mpi_errno, "(*win_ptr)->base", MPL_MEM_RMA);
+        MPIR_CHKPMEM_MALLOC(*base_pp, size, MPL_MEM_RMA);
         MPL_VG_MEM_INIT(*base_pp, size);
     }
     else if (size == 0) {

--- a/src/mpid/ch3/src/mpid_rma.c
+++ b/src/mpid/ch3/src/mpid_rma.c
@@ -202,7 +202,7 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
     int i;
     MPIR_Comm *win_comm_ptr;
     int win_target_pool_size;
-    MPIR_CHKPMEM_DECL(5);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -278,9 +278,9 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
     mpi_errno = MPID_Win_set_info((*win_ptr), info);
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPIR_CHKPMEM_MALLOC((*win_ptr)->op_pool_start, MPIDI_RMA_Op_t *,
-                        sizeof(MPIDI_RMA_Op_t) * MPIR_CVAR_CH3_RMA_OP_WIN_POOL_SIZE, mpi_errno,
-                        "RMA op pool", MPL_MEM_RMA);
+    MPIR_CHKPMEM_MALLOC((*win_ptr)->op_pool_start,
+                        sizeof(MPIDI_RMA_Op_t) * MPIR_CVAR_CH3_RMA_OP_WIN_POOL_SIZE,
+                        MPL_MEM_RMA);
     (*win_ptr)->op_pool_head = NULL;
     for (i = 0; i < MPIR_CVAR_CH3_RMA_OP_WIN_POOL_SIZE; i++) {
         (*win_ptr)->op_pool_start[i].pool_type = MPIDI_RMA_POOL_WIN;
@@ -289,9 +289,9 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
 
     win_target_pool_size =
         MPL_MIN(MPIR_CVAR_CH3_RMA_TARGET_WIN_POOL_SIZE, MPIR_Comm_size(win_comm_ptr));
-    MPIR_CHKPMEM_MALLOC((*win_ptr)->target_pool_start, MPIDI_RMA_Target_t *,
-                        sizeof(MPIDI_RMA_Target_t) * win_target_pool_size, mpi_errno,
-                        "RMA target pool", MPL_MEM_RMA);
+    MPIR_CHKPMEM_MALLOC((*win_ptr)->target_pool_start,
+                        sizeof(MPIDI_RMA_Target_t) * win_target_pool_size,
+                        MPL_MEM_RMA);
     (*win_ptr)->target_pool_head = NULL;
     for (i = 0; i < win_target_pool_size; i++) {
         (*win_ptr)->target_pool_start[i].pool_type = MPIDI_RMA_POOL_WIN;
@@ -299,18 +299,16 @@ static int win_init(MPI_Aint size, int disp_unit, int create_flavor, int model, 
     }
 
     (*win_ptr)->num_slots = MPL_MIN(MPIR_CVAR_CH3_RMA_SLOTS_SIZE, MPIR_Comm_size(win_comm_ptr));
-    MPIR_CHKPMEM_MALLOC((*win_ptr)->slots, MPIDI_RMA_Slot_t *,
-                        sizeof(MPIDI_RMA_Slot_t) * (*win_ptr)->num_slots, mpi_errno, "RMA slots",
+    MPIR_CHKPMEM_MALLOC((*win_ptr)->slots,
+                        sizeof(MPIDI_RMA_Slot_t) * (*win_ptr)->num_slots,
                         MPL_MEM_RMA);
     for (i = 0; i < (*win_ptr)->num_slots; i++) {
         (*win_ptr)->slots[i].target_list_head = NULL;
     }
 
     MPIR_CHKPMEM_MALLOC((*win_ptr)->target_lock_entry_pool_start,
-                        MPIDI_RMA_Target_lock_entry_t *,
-                        sizeof(MPIDI_RMA_Target_lock_entry_t) *
-                        MPIR_CVAR_CH3_RMA_TARGET_LOCK_ENTRY_WIN_POOL_SIZE, mpi_errno,
-                        "RMA lock entry pool", MPL_MEM_RMA);
+                        sizeof(MPIDI_RMA_Target_lock_entry_t) * MPIR_CVAR_CH3_RMA_TARGET_LOCK_ENTRY_WIN_POOL_SIZE,
+                        MPL_MEM_RMA);
     (*win_ptr)->target_lock_entry_pool_head = NULL;
     for (i = 0; i < MPIR_CVAR_CH3_RMA_TARGET_LOCK_ENTRY_WIN_POOL_SIZE; i++) {
         DL_APPEND((*win_ptr)->target_lock_entry_pool_head,

--- a/src/mpid/ch3/src/mpid_vc.c
+++ b/src/mpid/ch3/src/mpid_vc.c
@@ -58,11 +58,11 @@ int MPIDI_VCRT_Create(int size, struct MPIDI_VCRT **vcrt_ptr)
 {
     MPIDI_VCRT_t * vcrt;
     int mpi_errno = MPI_SUCCESS;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKPMEM_MALLOC(vcrt, MPIDI_VCRT_t *, sizeof(MPIDI_VCRT_t) + (size - 1) * sizeof(MPIDI_VC_t *),	mpi_errno, "**nomem", MPL_MEM_ADDRESS);
+    MPIR_CHKPMEM_MALLOC(vcrt, sizeof(MPIDI_VCRT_t) + (size - 1) * sizeof(MPIDI_VC_t *), MPL_MEM_ADDRESS);
     vcrt->handle = HANDLE_SET_KIND(0, HANDLE_KIND_INVALID);
     MPIR_Object_set_ref(vcrt, 1);
     vcrt->size = size;

--- a/src/mpid/ch3/src/mpid_vc.c
+++ b/src/mpid/ch3/src/mpid_vc.c
@@ -402,7 +402,7 @@ static int check_disjoint_lpids(uint64_t lpids1[], int n1, uint64_t lpids2[], in
     int mpi_errno = MPI_SUCCESS;
     uint32_t lpidmaskPrealloc[N_STATIC_LPID32];
     uint32_t *lpidmask;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     /* Find the max lpid */
     for (i=0; i<n1; i++) {
@@ -417,8 +417,7 @@ static int check_disjoint_lpids(uint64_t lpids1[], int n1, uint64_t lpids2[], in
     mask_size = (maxlpid / 32) + 1;
 
     if (mask_size > N_STATIC_LPID32) {
-        MPIR_CHKLMEM_MALLOC(lpidmask,uint32_t*,mask_size*sizeof(uint32_t),
-                            mpi_errno,"lpidmask", MPL_MEM_DYNAMIC);
+        MPIR_CHKLMEM_MALLOC(lpidmask, mask_size*sizeof(uint32_t));
     }
     else {
         lpidmask = lpidmaskPrealloc;
@@ -471,7 +470,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
     MPIDI_Gpid *local_gpids=NULL, *remote_gpids=NULL;
     int comm_info[2];
     int cts_tag;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     cts_tag = 0 | MPIR_TAG_COLL_BIT;
 
@@ -499,10 +498,10 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
                                        *remote_size ));
         /* With this information, we can now send and receive the
            global process ids from the peer. */
-        MPIR_CHKLMEM_MALLOC(remote_gpids,MPIDI_Gpid*,(*remote_size)*sizeof(MPIDI_Gpid), mpi_errno,"remote_gpids", MPL_MEM_DYNAMIC);
+        MPIR_CHKLMEM_MALLOC(remote_gpids, (*remote_size)*sizeof(MPIDI_Gpid));
         *remote_lpids = (uint64_t*) MPL_malloc((*remote_size)*sizeof(uint64_t), MPL_MEM_ADDRESS);
-        MPIR_CHKLMEM_MALLOC(local_gpids,MPIDI_Gpid*,local_size*sizeof(MPIDI_Gpid), mpi_errno,"local_gpids", MPL_MEM_DYNAMIC);
-        MPIR_CHKLMEM_MALLOC(local_lpids,uint64_t*,local_size*sizeof(uint64_t), mpi_errno,"local_lpids", MPL_MEM_DYNAMIC);
+        MPIR_CHKLMEM_MALLOC(local_gpids, local_size*sizeof(MPIDI_Gpid));
+        MPIR_CHKLMEM_MALLOC(local_lpids, local_size*sizeof(uint64_t));
 
         mpi_errno = MPIDI_GPID_GetAllInComm( local_comm_ptr, local_size, local_gpids, &singlePG );
         MPIR_ERR_CHECK(mpi_errno);
@@ -569,7 +568,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
         mpi_errno = MPIR_Bcast( comm_info, 2, MPI_INT, local_leader, local_comm_ptr, MPIR_ERR_NONE );
         MPIR_ERR_CHECK(mpi_errno);
         *remote_size = comm_info[0];
-        MPIR_CHKLMEM_MALLOC(remote_gpids,MPIDI_Gpid*,(*remote_size)*sizeof(MPIDI_Gpid), mpi_errno,"remote_gpids", MPL_MEM_DYNAMIC);
+        MPIR_CHKLMEM_MALLOC(remote_gpids, (*remote_size)*sizeof(MPIDI_Gpid));
         *remote_lpids = (uint64_t*) MPL_malloc((*remote_size)*sizeof(uint64_t), MPL_MEM_ADDRESS);
         mpi_errno = MPIR_Bcast( remote_gpids, (*remote_size)*sizeof(MPIDI_Gpid), MPI_BYTE, local_leader,
                                      local_comm_ptr, MPIR_ERR_NONE );

--- a/src/mpid/ch3/src/mpidi_pg.c
+++ b/src/mpid/ch3/src/mpidi_pg.c
@@ -132,13 +132,12 @@ int MPIDI_PG_Create(int vct_sz, void * pg_id, MPIDI_PG_t ** pg_ptr)
     MPIDI_PG_t * pg = NULL, *pgnext;
     int p;
     int mpi_errno = MPI_SUCCESS;
-    MPIR_CHKPMEM_DECL(2);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
     
-    MPIR_CHKPMEM_MALLOC(pg,MPIDI_PG_t*,sizeof(MPIDI_PG_t),mpi_errno,"pg", MPL_MEM_GROUP);
-    MPIR_CHKPMEM_MALLOC(pg->vct,MPIDI_VC_t *,sizeof(MPIDI_VC_t)*vct_sz,
-			mpi_errno,"pg->vct", MPL_MEM_GROUP);
+    MPIR_CHKPMEM_MALLOC(pg, sizeof(MPIDI_PG_t), MPL_MEM_GROUP);
+    MPIR_CHKPMEM_MALLOC(pg->vct, sizeof(MPIDI_VC_t)*vct_sz, MPL_MEM_GROUP);
 
     if (MPIR_CVAR_CH3_PG_VERBOSE) {
 	fprintf( stdout, "Creating a process group of size %d\n", vct_sz );
@@ -708,11 +707,11 @@ static int connToString( char **buf_p, int *slen, MPIDI_PG_t *pg )
     int mpi_errno = MPI_SUCCESS;
     char *str = NULL, *pg_id;
     int  i, len=0;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
     MPIDI_ConnInfo *connInfo = (MPIDI_ConnInfo *)pg->connData;
 
     /* Create this from the string array */
-    MPIR_CHKPMEM_MALLOC(str, char *, connInfo->toStringLen, mpi_errno, "str", MPL_MEM_STRINGS);
+    MPIR_CHKPMEM_MALLOC(str, connInfo->toStringLen, MPL_MEM_STRINGS);
 
 #if defined(MPICH_DEBUG_MEMINIT)
     memset(str, 0, connInfo->toStringLen);

--- a/src/mpid/ch3/src/mpidi_rma.c
+++ b/src/mpid/ch3/src/mpidi_rma.c
@@ -85,22 +85,22 @@ int MPIDI_RMA_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
     int i;
-    MPIR_CHKPMEM_DECL(3);
+    MPIR_CHKPMEM_DECL();
 
 
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKPMEM_MALLOC(global_rma_op_pool_start, MPIDI_RMA_Op_t *,
+    MPIR_CHKPMEM_MALLOC(global_rma_op_pool_start,
                         sizeof(MPIDI_RMA_Op_t) * MPIR_CVAR_CH3_RMA_OP_GLOBAL_POOL_SIZE,
-                        mpi_errno, "RMA op pool", MPL_MEM_RMA);
+                        MPL_MEM_RMA);
     for (i = 0; i < MPIR_CVAR_CH3_RMA_OP_GLOBAL_POOL_SIZE; i++) {
         global_rma_op_pool_start[i].pool_type = MPIDI_RMA_POOL_GLOBAL;
         DL_APPEND(global_rma_op_pool_head, &(global_rma_op_pool_start[i]));
     }
 
-    MPIR_CHKPMEM_MALLOC(global_rma_target_pool_start, MPIDI_RMA_Target_t *,
+    MPIR_CHKPMEM_MALLOC(global_rma_target_pool_start,
                         sizeof(MPIDI_RMA_Target_t) * MPIR_CVAR_CH3_RMA_TARGET_GLOBAL_POOL_SIZE,
-                        mpi_errno, "RMA target pool", MPL_MEM_RMA);
+                        MPL_MEM_RMA);
     for (i = 0; i < MPIR_CVAR_CH3_RMA_TARGET_GLOBAL_POOL_SIZE; i++) {
         global_rma_target_pool_start[i].pool_type = MPIDI_RMA_POOL_GLOBAL;
         DL_APPEND(global_rma_target_pool_head, &(global_rma_target_pool_start[i]));

--- a/src/mpid/ch3/util/sock/ch3u_connect_sock.c
+++ b/src/mpid/ch3/util/sock/ch3u_connect_sock.c
@@ -143,12 +143,11 @@ int MPIDI_CH3I_Connection_alloc(MPIDI_CH3I_Connection_t ** connp)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_CH3I_Connection_t * conn = NULL;
-    MPIR_CHKPMEM_DECL(2);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKPMEM_MALLOC(conn,MPIDI_CH3I_Connection_t*,
-			sizeof(MPIDI_CH3I_Connection_t),mpi_errno,"conn", MPL_MEM_DYNAMIC);
+    MPIR_CHKPMEM_MALLOC(conn, sizeof(MPIDI_CH3I_Connection_t), MPL_MEM_DYNAMIC);
     conn->pg_id = NULL;
 
     *connp = conn;
@@ -171,7 +170,7 @@ int MPIDI_CH3I_Connect_to_root_sock(const char * port_name,
     int mpi_errno = MPI_SUCCESS;
     MPIDI_VC_t * vc;
     MPIDI_CH3I_VC *vcch;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
     char host_description[MAX_HOST_DESCRIPTION_LEN];
     int port, port_name_tag;
     MPL_sockaddr_t ifaddr;
@@ -182,7 +181,7 @@ int MPIDI_CH3I_Connect_to_root_sock(const char * port_name,
 
     /* First, create a new vc (we may use this to pass to a generic
        connection routine) */
-    MPIR_CHKPMEM_MALLOC(vc,MPIDI_VC_t *,sizeof(MPIDI_VC_t),mpi_errno,"vc", MPL_MEM_DYNAMIC);
+    MPIR_CHKPMEM_MALLOC(vc, sizeof(MPIDI_VC_t), MPL_MEM_DYNAMIC);
     /* FIXME - where does this vc get freed? */
 
     *new_vc = vc;

--- a/src/mpid/ch4/netmod/ofi/init_addrxchg.c
+++ b/src/mpid/ch4/netmod/ofi/init_addrxchg.c
@@ -213,7 +213,7 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
     MPIR_Comm *comm = MPIR_Process.comm_world;
     int size = MPIR_Process.size;
     int rank = MPIR_Process.rank;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     int max_vcis;
     int *all_num_vcis;
@@ -223,8 +223,7 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
     all_num_vcis = NULL;
 #else
     /* Allgather num_vcis */
-    MPIR_CHKLMEM_MALLOC(all_num_vcis, void *, sizeof(int) * size,
-                        mpi_errno, "all_num_vcis", MPL_MEM_ADDRESS);
+    MPIR_CHKLMEM_MALLOC(all_num_vcis, sizeof(int) * size);
     mpi_errno = MPIR_Allgather_fallback(&MPIDI_OFI_global.num_vcis, 1, MPI_INT,
                                         all_num_vcis, 1, MPI_INT, comm, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
@@ -249,7 +248,7 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
     int name_len = MPIDI_OFI_global.addrnamelen;
     int my_len = max_vcis * num_nics * name_len;
     char *all_names;
-    MPIR_CHKLMEM_MALLOC(all_names, char *, size * my_len, mpi_errno, "all_names", MPL_MEM_ADDRESS);
+    MPIR_CHKLMEM_MALLOC(all_names, size * my_len);
     char *my_names = all_names + rank * my_len;
 
     /* put in my addrnames */
@@ -284,8 +283,7 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
 
     int *is_node_roots = NULL;
     if (MPIR_CVAR_CH4_ROOTS_ONLY_PMI) {
-        MPIR_CHKLMEM_MALLOC(is_node_roots, int *, size * sizeof(int),
-                            mpi_errno, "is_node_roots", MPL_MEM_ADDRESS);
+        MPIR_CHKLMEM_MALLOC(is_node_roots, size * sizeof(int));
         for (int r = 0; r < size; r++) {
             is_node_roots[r] = 0;
         }

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -573,7 +573,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_inject(int rank,
     int nic = 0;
     int ctx_idx = MPIDI_OFI_get_ctx_index(vci_src, nic);
     fi_addr_t dst_addr = MPIDI_OFI_comm_to_phys(comm, rank, nic, vci_dst);
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -595,7 +595,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_inject(int rank,
     }
 
     buff_len = sizeof(msg_hdr) + am_hdr_sz;
-    MPIR_CHKLMEM_MALLOC(buff, char *, buff_len, mpi_errno, "buff", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(buff, buff_len);
     memcpy(buff, &msg_hdr, sizeof(msg_hdr));
     memcpy(buff + sizeof(msg_hdr), am_hdr, am_hdr_sz);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_nic.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.c
@@ -256,7 +256,7 @@ static int setup_multi_nic(int nic_count)
     int num_parents = 0;
     int local_rank = MPIR_Process.local_rank;
     MPIDI_OFI_nic_info_t *nics = MPIDI_OFI_global.nic_info;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
     bool pref_nic_set = false;
 
     MPIDI_OFI_global.num_nics = nic_count;
@@ -364,8 +364,7 @@ static int setup_multi_nic(int nic_count)
         /* When using this CVAR, the rank can only use 1 NIC. We do not reset num_close_nics again
          * in case a NIC is down and it needs to use another NIC. */
         MPIDI_OFI_nic_info_t *tmp_nic;
-        MPIR_CHKLMEM_MALLOC(tmp_nic, MPIDI_OFI_nic_info_t *, sizeof(MPIDI_OFI_nic_info_t),
-                            mpi_errno, "temporary nic info", MPL_MEM_ADDRESS);
+        MPIR_CHKLMEM_MALLOC(tmp_nic, sizeof(MPIDI_OFI_nic_info_t));
         int idx_to = 0;
         int idx_from = MPIR_CVAR_CH4_OFI_PREF_NIC;
         memcpy(tmp_nic, &nics[idx_from], sizeof(MPIDI_OFI_nic_info_t));
@@ -390,9 +389,7 @@ static int setup_multi_nic(int nic_count)
 
         if (old_idx != 0) {
             MPIDI_OFI_nic_info_t *old_nics;
-            MPIR_CHKLMEM_MALLOC(old_nics, MPIDI_OFI_nic_info_t *, sizeof(MPIDI_OFI_nic_info_t) *
-                                MPIDI_OFI_global.num_nics, mpi_errno, "temporary nic info",
-                                MPL_MEM_ADDRESS);
+            MPIR_CHKLMEM_MALLOC(old_nics, sizeof(MPIDI_OFI_nic_info_t) * MPIDI_OFI_global.num_nics);
             memcpy(old_nics, nics, sizeof(MPIDI_OFI_nic_info_t) * MPIDI_OFI_global.num_nics);
 
             /* Rotate the preferred NIC for each process starting at old_idx. */

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -234,12 +234,10 @@ int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, int **local_upid_size, char **lo
     int nic = 0;
     int ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
 
-    MPIR_CHKPMEM_DECL(2);
+    MPIR_CHKPMEM_DECL();
 
-    MPIR_CHKPMEM_MALLOC((*local_upid_size), int *, comm->local_size * sizeof(int),
-                        mpi_errno, "local_upid_size", MPL_MEM_ADDRESS);
-    MPIR_CHKPMEM_MALLOC(temp_buf, char *, comm->local_size * MPIDI_OFI_global.addrnamelen,
-                        mpi_errno, "temp_buf", MPL_MEM_BUFFER);
+    MPIR_CHKPMEM_MALLOC((*local_upid_size), comm->local_size * sizeof(int), MPL_MEM_ADDRESS);
+    MPIR_CHKPMEM_MALLOC(temp_buf, comm->local_size * MPIDI_OFI_global.addrnamelen, MPL_MEM_BUFFER);
 
     int buf_size = 0;
     int idx = 0;
@@ -273,7 +271,6 @@ int MPIDI_OFI_get_local_upids(MPIR_Comm * comm, int **local_upid_size, char **lo
 
     *local_upids = temp_buf;
 
-    MPIR_CHKPMEM_COMMIT();
   fn_exit:
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -147,12 +147,10 @@ int MPIDI_OFI_upids_to_gpids(int size, int *remote_upid_size, char *remote_upids
     int nic = 0;
     int ctx_idx = MPIDI_OFI_get_ctx_index(0, nic);
 
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
-    MPIR_CHKLMEM_MALLOC(new_avt_procs, int *, sizeof(int) * size, mpi_errno, "new_avt_procs",
-                        MPL_MEM_ADDRESS);
-    MPIR_CHKLMEM_MALLOC(new_upids, char **, sizeof(char *) * size, mpi_errno, "new_upids",
-                        MPL_MEM_ADDRESS);
+    MPIR_CHKLMEM_MALLOC(new_avt_procs, sizeof(int) * size);
+    MPIR_CHKLMEM_MALLOC(new_upids, sizeof(char *) * size);
 
     n_avts = MPIDIU_get_n_avts();
 

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -869,7 +869,7 @@ int MPIDI_OFI_mpi_win_create_dynamic_hook(MPIR_Win * win)
     MPIR_FUNC_ENTER;
     win_init_am(win);
 
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     /* This hook is called by CH4 generic call after CH4 initialization */
     if (MPIDI_OFI_ENABLE_RMA) {
@@ -889,9 +889,8 @@ int MPIDI_OFI_mpi_win_create_dynamic_hook(MPIR_Win * win)
                                 "**mpl_gavl_create");
 
             /* Initialize AVL trees for remote registered regions */
-            MPIR_CHKPMEM_MALLOC(MPIDI_OFI_WIN(win).dwin_target_mrs, MPL_gavl_tree_t *,
-                                sizeof(MPL_gavl_tree_t) * win->comm_ptr->local_size, mpi_errno,
-                                "AVL tree for remote dynamic win memory regions", MPL_MEM_RMA);
+            MPIR_CHKPMEM_MALLOC(MPIDI_OFI_WIN(win).dwin_target_mrs,
+                                sizeof(MPL_gavl_tree_t) * win->comm_ptr->local_size, MPL_MEM_RMA);
             int i;
             for (i = 0; i < win->comm_ptr->local_size; i++) {
                 mpl_err = MPL_gavl_tree_create(dwin_free_target_mr,
@@ -905,8 +904,6 @@ int MPIDI_OFI_mpi_win_create_dynamic_hook(MPIR_Win * win)
             MPIDI_WIN(win, winattr) |= MPIDI_WINATTR_NM_DYNAMIC_MR;
         }
     }
-
-    MPIR_CHKPMEM_COMMIT();
 
   fn_exit:
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -936,7 +936,7 @@ int MPIDI_OFI_mpi_win_attach_hook(MPIR_Win * win, void *base, MPI_Aint size)
 
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     if (!MPIDI_OFI_ENABLE_RMA || MPIDI_OFI_WIN(win).mr || !MPIDIG_WIN(win, info_args).coll_attach)
         goto fn_exit;
@@ -982,10 +982,7 @@ int MPIDI_OFI_mpi_win_attach_hook(MPIR_Win * win, void *base, MPI_Aint size)
                                    (uintptr_t) size, (const void *) mr);
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**mpl_gavl_insert");
 
-    MPIR_CHKLMEM_MALLOC(target_mrs, dwin_target_mr_t *,
-                        sizeof(dwin_target_mr_t) * comm_ptr->local_size,
-                        mpi_errno, "temp buffer for dynamic win remote memory regions",
-                        MPL_MEM_RMA);
+    MPIR_CHKLMEM_MALLOC(target_mrs, sizeof(dwin_target_mr_t) * comm_ptr->local_size);
 
     /* Exchange remote MR across all processes because "coll_attach" info ensures
      * that all processes collectively call attach. */
@@ -1031,7 +1028,7 @@ int MPIDI_OFI_mpi_win_detach_hook(MPIR_Win * win, const void *base)
     const void **target_bases;
     int mpl_err = MPL_SUCCESS, i;
 
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     if (!MPIDI_OFI_ENABLE_RMA || MPIDI_OFI_WIN(win).mr || !MPIDIG_WIN(win, info_args).coll_attach)
         goto fn_exit;
@@ -1043,10 +1040,7 @@ int MPIDI_OFI_mpi_win_detach_hook(MPIR_Win * win, const void *base)
                         "**mpl_gavl_delete_start_addr");
 
     /* Notify remote processes to delete their local cached MR key */
-    MPIR_CHKLMEM_MALLOC(target_bases, const void **,
-                        sizeof(const void *) * comm_ptr->local_size,
-                        mpi_errno, "temp buffer for dynamic win remote memory regions",
-                        MPL_MEM_RMA);
+    MPIR_CHKLMEM_MALLOC(target_bases, sizeof(const void *) * comm_ptr->local_size);
 
     /* Exchange remote MR across all processes because "coll_attach" info ensures
      * that all processes collectively call detach. */

--- a/src/mpid/ch4/netmod/ucx/ucx_spawn.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_spawn.c
@@ -125,11 +125,9 @@ int MPIDI_UCX_get_local_upids(MPIR_Comm * comm, int **local_upid_size, char **lo
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIR_CHKPMEM_DECL(2);
-    MPIR_CHKPMEM_MALLOC((*local_upid_size), int *, comm->local_size * sizeof(int),
-                        mpi_errno, "local_upid_size", MPL_MEM_ADDRESS);
-    MPIR_CHKPMEM_MALLOC((*local_upids), char *, comm->local_size * MPID_MAX_BC_SIZE,
-                        mpi_errno, "temp_buf", MPL_MEM_BUFFER);
+    MPIR_CHKPMEM_DECL();
+    MPIR_CHKPMEM_MALLOC((*local_upid_size), comm->local_size * sizeof(int), MPL_MEM_ADDRESS);
+    MPIR_CHKPMEM_MALLOC((*local_upids), comm->local_size * MPID_MAX_BC_SIZE, MPL_MEM_BUFFER);
 
     int offset = 0;
     for (int i = 0; i < comm->local_size; i++) {
@@ -139,7 +137,6 @@ int MPIDI_UCX_get_local_upids(MPIR_Comm * comm, int **local_upid_size, char **lo
         offset += t->upid_len;
     }
 
-    MPIR_CHKPMEM_COMMIT();
   fn_exit:
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/netmod/ucx/ucx_spawn.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_spawn.c
@@ -156,12 +156,10 @@ int MPIDI_UCX_upids_to_gpids(int size, int *remote_upid_size, char *remote_upids
     int *new_avt_procs;
     char **new_upids;
     int vci = 0;
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
-    MPIR_CHKLMEM_MALLOC(new_avt_procs, int *, sizeof(int) * size, mpi_errno, "new_avt_procs",
-                        MPL_MEM_ADDRESS);
-    MPIR_CHKLMEM_MALLOC(new_upids, char **, sizeof(char *) * size, mpi_errno, "new_upids",
-                        MPL_MEM_ADDRESS);
+    MPIR_CHKLMEM_MALLOC(new_avt_procs, sizeof(int) * size);
+    MPIR_CHKLMEM_MALLOC(new_upids, sizeof(char *) * size);
 
     char *curr_upid = remote_upids;
     for (int i = 0; i < size; i++) {

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -42,7 +42,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_lmt(const void *buf, MPI_Aint count
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq = NULL;
     MPIDI_IPC_rts_t am_hdr;
-    MPIR_CHKLMEM_DECL(1);       /* we may need allocate hdr for non-contig case */
+    MPIR_CHKLMEM_DECL();        /* we may need allocate hdr for non-contig case */
 
     int flags = syncflag ? MPIDIG_AM_SEND_FLAGS_SYNC : MPIDIG_AM_SEND_FLAGS_NONE;
     MPIR_FUNC_ENTER;
@@ -120,7 +120,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_lmt(const void *buf, MPI_Aint count
         am_hdr.ipc_hdr.count = count;
 
         hdr_sz = sizeof(am_hdr) + flattened_sz;
-        MPIR_CHKLMEM_MALLOC(hdr, void *, hdr_sz, mpi_errno, "hdr", MPL_MEM_OTHER);
+        MPIR_CHKLMEM_MALLOC(hdr, hdr_sz);
         memcpy(hdr, &am_hdr, sizeof(am_hdr));
         memcpy((char *) hdr + sizeof(am_hdr), flattened_dt, flattened_sz);
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_win.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_win.c
@@ -69,7 +69,7 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
 
     MPIR_FUNC_ENTER;
     MPIR_CHKPMEM_DECL(2);
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     /* Skip IPC initialization if no local process */
     if (!shm_comm_ptr)
@@ -124,9 +124,7 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
                         mpi_errno, "shared table", MPL_MEM_RMA);
     shared_table = MPIDIG_WIN(win, shared_table);
 
-    MPIR_CHKLMEM_MALLOC(ipc_shared_table, win_shared_info_t *,
-                        sizeof(win_shared_info_t) * shm_comm_ptr->local_size,
-                        mpi_errno, "IPC temporary shared table", MPL_MEM_RMA);
+    MPIR_CHKLMEM_MALLOC(ipc_shared_table, sizeof(win_shared_info_t) * shm_comm_ptr->local_size);
 
     memset(&ipc_shared_table[shm_comm_ptr->rank], 0, sizeof(win_shared_info_t));
     ipc_shared_table[shm_comm_ptr->rank].size = win->size;
@@ -176,8 +174,7 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
     }
 
     /* Attach remote memory regions based on its IPC type */
-    MPIR_CHKLMEM_MALLOC(ranks_in_shm_grp, int *, shm_comm_ptr->local_size * sizeof(int) * 2,
-                        mpi_errno, "ranks in shm group", MPL_MEM_RMA);
+    MPIR_CHKLMEM_MALLOC(ranks_in_shm_grp, shm_comm_ptr->local_size * sizeof(int) * 2);
     mpi_errno = get_node_ranks(shm_comm_ptr, ranks_in_shm_grp,
                                &ranks_in_shm_grp[shm_comm_ptr->local_size]);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/shm/ipc/src/ipc_win.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_win.c
@@ -68,7 +68,7 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
     MPIDI_IPCI_ipc_attr_t ipc_attr;
 
     MPIR_FUNC_ENTER;
-    MPIR_CHKPMEM_DECL(2);
+    MPIR_CHKPMEM_DECL();
     MPIR_CHKLMEM_DECL();
 
     /* Skip IPC initialization if no local process */
@@ -119,9 +119,8 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
      * initializes shared table for win_allocate and win_allocate_shared because
      * their shm region are ensured by POSIX. The other window types can only
      * optionally initialize it in shmmod .*/
-    MPIR_CHKPMEM_CALLOC(MPIDIG_WIN(win, shared_table), MPIDIG_win_shared_info_t *,
-                        sizeof(MPIDIG_win_shared_info_t) * shm_comm_ptr->local_size,
-                        mpi_errno, "shared table", MPL_MEM_RMA);
+    MPIR_CHKPMEM_CALLOC(MPIDIG_WIN(win, shared_table),
+                        sizeof(MPIDIG_win_shared_info_t) * shm_comm_ptr->local_size, MPL_MEM_RMA);
     shared_table = MPIDIG_WIN(win, shared_table);
 
     MPIR_CHKLMEM_MALLOC(ipc_shared_table, sizeof(win_shared_info_t) * shm_comm_ptr->local_size);

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
@@ -26,7 +26,7 @@ int MPIDI_XPMEM_init_world(void)
     }
 
     MPIR_FUNC_ENTER;
-    MPIR_CHKPMEM_DECL(3);
+    MPIR_CHKPMEM_DECL();
 
 #ifdef MPL_USE_DBG_LOGGING
     MPIDI_XPMEMI_DBG_GENERAL = MPL_dbg_class_alloc("SHM_IPC_XPMEM", "shm_ipc_xpmem");

--- a/src/mpid/ch4/shm/posix/posix_coll_gpu_ipc.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_gpu_ipc.h
@@ -201,7 +201,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoall_gpu_ipc_read(const void *s
                                                                    MPIR_Errflag_t errflag)
 {
     MPIR_FUNC_ENTER;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     int mpi_errno = MPI_SUCCESS;
 
@@ -231,8 +231,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoall_gpu_ipc_read(const void *s
 
     /* map ipc_handles to remote_bufs */
     void **remote_bufs = NULL;
-    MPIR_CHKLMEM_MALLOC(remote_bufs, void **, sizeof(void *) * comm_size, mpi_errno, "Remote bufs",
-                        MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(remote_bufs, sizeof(void *) * comm_size);
     for (int i = 0; i < comm_size; i++) {
         if (i != my_rank) {
             int remote_dev =
@@ -246,8 +245,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_alltoall_gpu_ipc_read(const void *s
     }
     /* use imemcpy to copy the data concurrently */
     MPL_gpu_request *reqs = NULL;
-    MPIR_CHKLMEM_MALLOC(reqs, MPL_gpu_request *, sizeof(MPL_gpu_request) * comm_size, mpi_errno,
-                        "Memcpy requests", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(reqs, sizeof(MPL_gpu_request) * comm_size);
     for (int i = 0; i < comm_size; i++) {
         int target = (my_rank + 1 + i) % comm_size;
         char *temp_recv = (char *) recv_mem_addr + target * data_sz;
@@ -295,7 +293,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgather_gpu_ipc_read(const void *
                                                                     MPIR_Errflag_t errflag)
 {
     MPIR_FUNC_ENTER;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     int mpi_errno = MPI_SUCCESS;
 
@@ -325,8 +323,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgather_gpu_ipc_read(const void *
 
     /* map ipc_handles to remote_bufs */
     void **remote_bufs = NULL;
-    MPIR_CHKLMEM_MALLOC(remote_bufs, void **, sizeof(void *) * comm_size, mpi_errno, "Remote bufs",
-                        MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(remote_bufs, sizeof(void *) * comm_size);
     for (int i = 0; i < comm_size; i++) {
         if (i != my_rank) {
             int remote_dev =
@@ -340,8 +337,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgather_gpu_ipc_read(const void *
     }
     /* use imemcpy to copy the data concurrently */
     MPL_gpu_request *reqs = NULL;
-    MPIR_CHKLMEM_MALLOC(reqs, MPL_gpu_request *, sizeof(MPL_gpu_request) * comm_size, mpi_errno,
-                        "Memcpy requests", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(reqs, sizeof(MPL_gpu_request) * comm_size);
     for (int i = 0; i < comm_size; i++) {
         int target = (my_rank + 1 + i) % comm_size;
         char *temp_recv = (char *) recv_mem_addr + target * data_sz;
@@ -390,7 +386,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgatherv_gpu_ipc_read(const void 
                                                                      MPIR_Errflag_t errflag)
 {
     MPIR_FUNC_ENTER;
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     int mpi_errno = MPI_SUCCESS;
 
@@ -421,8 +417,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgatherv_gpu_ipc_read(const void 
 
     /* map ipc_handles to remote_bufs */
     void **remote_bufs = NULL;
-    MPIR_CHKLMEM_MALLOC(remote_bufs, void **, sizeof(void *) * comm_size, mpi_errno, "Remote bufs",
-                        MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(remote_bufs, sizeof(void *) * comm_size);
     for (int i = 0; i < comm_size; i++) {
         if (i != my_rank) {
             int remote_dev =
@@ -436,8 +431,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_allgatherv_gpu_ipc_read(const void 
     }
     /* use imemcpy to copy the data concurrently */
     MPL_gpu_request *reqs = NULL;
-    MPIR_CHKLMEM_MALLOC(reqs, MPL_gpu_request *, sizeof(MPL_gpu_request) * comm_size, mpi_errno,
-                        "Memcpy requests", MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(reqs, sizeof(MPL_gpu_request) * comm_size);
     MPI_Aint recvtype_extent;
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
     for (int i = 0; i < comm_size; i++) {

--- a/src/mpid/ch4/shm/posix/release_gather/nb_bcast_release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_bcast_release_gather.h
@@ -354,7 +354,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_nb_release_gather_ibcast_impl(void *loc
     void *ori_local_buf = local_buf;
     MPI_Datatype ori_datatype = datatype;
 
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
     /* Register the vertices */
     root_datacopy_type_id =
         MPIR_TSP_sched_new_type(sched, MPIDI_POSIX_NB_RG_root_datacopy_issue,
@@ -401,8 +401,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_nb_release_gather_ibcast_impl(void *loc
     MPIR_Algo_calculate_pipeline_chunk_info(MPIDI_POSIX_RELEASE_GATHER_BCAST_CELLSIZE, 1,
                                             nbytes, &num_chunks, &chunk_count_floor,
                                             &chunk_count_ceil);
-    MPIR_CHKLMEM_MALLOC(sixth_vtx_id, int *, num_chunks * sizeof(int), mpi_errno, "sixth_vtx_ids",
-                        MPL_MEM_COLL);
+    MPIR_CHKLMEM_MALLOC(sixth_vtx_id, num_chunks * sizeof(int));
 
     /* Do pipelined release-gather */
     /* A schedule gets created in the form of a forest, where each tree has 6 vertices (to perform

--- a/src/mpid/ch4/shm/src/topotree.c
+++ b/src/mpid/ch4/shm/src/topotree.c
@@ -366,7 +366,7 @@ int MPIDI_SHM_gen_tree(int k_val, int *shared_region, int *max_entries_per_level
     const int package_tree_sz = num_packages > num_ranks ? num_packages : num_ranks;
     int *package_leaders = NULL;
 
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
 
     mpi_errno = MPIDI_SHM_topotree_allocate(&tree, num_ranks, k_val);
     MPIR_ERR_CHECK(mpi_errno);
@@ -374,8 +374,7 @@ int MPIDI_SHM_gen_tree(int k_val, int *shared_region, int *max_entries_per_level
     mpi_errno = MPIDI_SHM_topotree_allocate(&package_tree, package_tree_sz, k_val);
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPIR_CHKPMEM_CALLOC(package_leaders, int *, num_packages * sizeof(int), mpi_errno,
-                        "intra_node_package_leaders", MPL_MEM_OTHER);
+    MPIR_CHKPMEM_CALLOC(package_leaders, num_packages * sizeof(int), MPL_MEM_OTHER);
     MPIR_ERR_CHKANDJUMP(!package_leaders, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
     /* We pick package leaders as the first rank in each package */

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -950,7 +950,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_alpha(const void *se
     MPI_Aint extent = 0;
     void *ori_recvbuf = recvbuf;
 
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
     /* TODO: we can safe the last send/recv if --
      *     1. if node_comm is the same size as original comm, fallback
      *     2. if root is in node_roots_comm but not rank 0, reduce to root rather than 0
@@ -963,8 +963,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_alpha(const void *se
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         MPIR_Datatype_get_extent_macro(datatype, extent);
 
-        MPIR_CHKLMEM_MALLOC(recvbuf, void *, count * (MPL_MAX(extent, true_extent)),
-                            mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(recvbuf, count * (MPL_MAX(extent, true_extent)));
         /* adjust for potential negative lower bound in datatype */
         recvbuf = (void *) ((char *) recvbuf - true_lb);
     }
@@ -1034,7 +1033,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_beta(const void *sen
     MPI_Aint true_extent = 0;
     MPI_Aint extent = 0;
 
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     void *tmp_buf = NULL;
 
@@ -1044,8 +1043,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Reduce_intra_composition_beta(const void *sen
         MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
         MPIR_Datatype_get_extent_macro(datatype, extent);
 
-        MPIR_CHKLMEM_MALLOC(tmp_buf, void *, count * (MPL_MAX(extent, true_extent)),
-                            mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(tmp_buf, count * (MPL_MAX(extent, true_extent)));
         /* adjust for potential negative lower bound in datatype */
         tmp_buf = (void *) ((char *) tmp_buf - true_lb);
     }
@@ -1678,26 +1676,23 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Scan_intra_composition_alpha(const void *send
     MPI_Aint extent = 0;
     int noneed = 1;             /* noneed=1 means no need to bcast tempbuf and
                                  * reduce tempbuf & recvbuf */
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
 
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
 
-    MPIR_CHKLMEM_MALLOC(tempbuf, void *, count * (MPL_MAX(extent, true_extent)),
-                        mpi_errno, "temporary buffer", MPL_MEM_BUFFER);
+    MPIR_CHKLMEM_MALLOC(tempbuf, count * (MPL_MAX(extent, true_extent)));
     tempbuf = (void *) ((char *) tempbuf - true_lb);
 
     /* Create prefulldata and localfulldata on local roots of all nodes */
     if (comm_ptr->node_roots_comm != NULL) {
-        MPIR_CHKLMEM_MALLOC(prefulldata, void *, count * (MPL_MAX(extent, true_extent)),
-                            mpi_errno, "prefulldata for scan", MPL_MEM_BUFFER);
+        MPIR_CHKLMEM_MALLOC(prefulldata, count * (MPL_MAX(extent, true_extent)));
         prefulldata = (void *) ((char *) prefulldata - true_lb);
 
         if (comm_ptr->node_comm != NULL) {
-            MPIR_CHKLMEM_MALLOC(localfulldata, void *, count * (MPL_MAX(extent, true_extent)),
-                                mpi_errno, "localfulldata for scan", MPL_MEM_BUFFER);
+            MPIR_CHKLMEM_MALLOC(localfulldata, count * (MPL_MAX(extent, true_extent)));
             localfulldata = (void *) ((char *) localfulldata - true_lb);
         }
     }

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -413,7 +413,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
      */
     MPIR_FUNC_ENTER;
 
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
     MPIR_CHKLMEM_DECL();
 
     cts_tag = 0 | MPIR_TAG_COLL_BIT;
@@ -462,8 +462,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
                         (MPL_DBG_FDEST, "local size = %d, remote size = %d, pure_intracomm = %d",
                          local_size, *remote_size, pure_intracomm));
 
-        MPIR_CHKPMEM_MALLOC((*remote_gpids), uint64_t *, (*remote_size) * sizeof(uint64_t),
-                            mpi_errno, "remote_gpids", MPL_MEM_ADDRESS);
+        MPIR_CHKPMEM_MALLOC((*remote_gpids), (*remote_size) * sizeof(uint64_t), MPL_MEM_ADDRESS);
         MPIR_CHKLMEM_MALLOC(local_gpids, local_size * sizeof(uint64_t));
         for (i = 0; i < local_size; i++) {
             MPIDIU_comm_rank_to_pid(local_comm, i, &lpid, &avtid);
@@ -578,7 +577,6 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
                                                  remote_upid_size, remote_upids, remote_gpids);
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPIR_CHKPMEM_COMMIT();
   fn_exit:
     MPL_free(local_upid_size);
     MPL_free(local_upids);
@@ -603,7 +601,7 @@ int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm, int local_leader, i
     int *_remote_upid_size = NULL;
     char *_remote_upids = NULL;
 
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
     MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
@@ -642,8 +640,7 @@ int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm, int local_leader, i
         *is_low_group = map_info[2];
         pure_intracomm = map_info[3];
 
-        MPIR_CHKPMEM_MALLOC((*remote_gpids), uint64_t *, (*remote_size) * sizeof(uint64_t),
-                            mpi_errno, "remote_gpids", MPL_MEM_COMM);
+        MPIR_CHKPMEM_MALLOC((*remote_gpids), (*remote_size) * sizeof(uint64_t), MPL_MEM_ADDRESS);
         if (!pure_intracomm) {
             MPIR_CHKLMEM_MALLOC(_remote_upid_size, (*remote_size) * sizeof(int));
             mpi_errno = MPIR_Bcast_allcomm_auto(_remote_upid_size, *remote_size, MPI_INT,
@@ -661,7 +658,6 @@ int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm, int local_leader, i
         }
     }
 
-    MPIR_CHKPMEM_COMMIT();
   fn_exit:
     MPIR_CHKLMEM_FREEALL();
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -414,7 +414,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
     MPIR_FUNC_ENTER;
 
     MPIR_CHKPMEM_DECL(1);
-    MPIR_CHKLMEM_DECL(5);
+    MPIR_CHKLMEM_DECL();
 
     cts_tag = 0 | MPIR_TAG_COLL_BIT;
     local_size = local_comm->local_size;
@@ -464,8 +464,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
 
         MPIR_CHKPMEM_MALLOC((*remote_gpids), uint64_t *, (*remote_size) * sizeof(uint64_t),
                             mpi_errno, "remote_gpids", MPL_MEM_ADDRESS);
-        MPIR_CHKLMEM_MALLOC(local_gpids, uint64_t *, local_size * sizeof(uint64_t),
-                            mpi_errno, "local_gpids", MPL_MEM_ADDRESS);
+        MPIR_CHKLMEM_MALLOC(local_gpids, local_size * sizeof(uint64_t));
         for (i = 0; i < local_size; i++) {
             MPIDIU_comm_rank_to_pid(local_comm, i, &lpid, &avtid);
             local_gpids[i] = MPIDIU_GPID_CREATE(avtid, lpid);
@@ -479,8 +478,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
                         (MPL_DBG_FDEST, "Intercomm map exchange stage 1: leaders"));
         if (!pure_intracomm) {
             /* Stage 1.1 UPID exchange between leaders */
-            MPIR_CHKLMEM_MALLOC(remote_upid_size, int *, (*remote_size) * sizeof(int),
-                                mpi_errno, "remote_upid_size", MPL_MEM_ADDRESS);
+            MPIR_CHKLMEM_MALLOC(remote_upid_size, (*remote_size) * sizeof(int));
 
             mpi_errno = MPIDI_NM_get_local_upids(local_comm, &local_upid_size, &local_upids);
             MPIR_ERR_CHECK(mpi_errno);
@@ -496,8 +494,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm * local_comm, int local_leader, MPIR_C
             upid_recv_size = 0;
             for (i = 0; i < *remote_size; i++)
                 upid_recv_size += remote_upid_size[i];
-            MPIR_CHKLMEM_MALLOC(remote_upids, char *, upid_recv_size * sizeof(char),
-                                mpi_errno, "remote_upids", MPL_MEM_ADDRESS);
+            MPIR_CHKLMEM_MALLOC(remote_upids, upid_recv_size * sizeof(char));
             mpi_errno = MPIC_Sendrecv(local_upids, upid_send_size, MPI_BYTE,
                                       remote_leader, cts_tag,
                                       remote_upids, upid_recv_size, MPI_BYTE,
@@ -607,7 +604,7 @@ int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm, int local_leader, i
     char *_remote_upids = NULL;
 
     MPIR_CHKPMEM_DECL(1);
-    MPIR_CHKLMEM_DECL(3);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -648,13 +645,11 @@ int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm, int local_leader, i
         MPIR_CHKPMEM_MALLOC((*remote_gpids), uint64_t *, (*remote_size) * sizeof(uint64_t),
                             mpi_errno, "remote_gpids", MPL_MEM_COMM);
         if (!pure_intracomm) {
-            MPIR_CHKLMEM_MALLOC(_remote_upid_size, int *, (*remote_size) * sizeof(int),
-                                mpi_errno, "_remote_upid_size", MPL_MEM_COMM);
+            MPIR_CHKLMEM_MALLOC(_remote_upid_size, (*remote_size) * sizeof(int));
             mpi_errno = MPIR_Bcast_allcomm_auto(_remote_upid_size, *remote_size, MPI_INT,
                                                 local_leader, local_comm, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
-            MPIR_CHKLMEM_MALLOC(_remote_upids, char *, upid_recv_size * sizeof(char),
-                                mpi_errno, "_remote_upids", MPL_MEM_COMM);
+            MPIR_CHKLMEM_MALLOC(_remote_upids, upid_recv_size * sizeof(char));
             mpi_errno = MPIR_Bcast_allcomm_auto(_remote_upids, upid_recv_size, MPI_BYTE,
                                                 local_leader, local_comm, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/src/ch4i_comm.c
+++ b/src/mpid/ch4/src/ch4i_comm.c
@@ -933,7 +933,7 @@ int MPIDI_check_disjoint_gpids(uint64_t gpids1[], int n1, uint64_t gpids2[], int
     int mpi_errno = MPI_SUCCESS;
     uint32_t gpidmaskPrealloc[128];
     uint32_t *gpidmask;
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -970,8 +970,7 @@ int MPIDI_check_disjoint_gpids(uint64_t gpids1[], int n1, uint64_t gpids2[], int
 
     uint64_t mask_size = (max_gpid / 32) + 1;
     if (mask_size > 128) {
-        MPIR_CHKLMEM_MALLOC(gpidmask, uint32_t *, mask_size * sizeof(uint32_t),
-                            mpi_errno, "gpidmask", MPL_MEM_COMM);
+        MPIR_CHKLMEM_MALLOC(gpidmask, mask_size * sizeof(uint32_t));
     } else {
         gpidmask = gpidmaskPrealloc;
     }

--- a/src/mpid/ch4/src/mpidig_win.c
+++ b/src/mpid/ch4/src/mpidig_win.c
@@ -501,7 +501,7 @@ static int win_shm_alloc_impl(MPI_Aint size, int disp_unit, MPIR_Comm * comm_ptr
     bool symheap_flag = true, global_symheap_flag = false;
 
     MPIR_CHKPMEM_DECL(2);
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
     MPIR_FUNC_ENTER;
 
     win = *win_ptr;
@@ -529,8 +529,7 @@ static int win_shm_alloc_impl(MPI_Aint size, int disp_unit, MPIR_Comm * comm_ptr
         if (mpi_errno != MPI_SUCCESS)
             goto fn_fail;
 
-        MPIR_CHKLMEM_MALLOC(shm_offsets, MPI_Aint *, shm_comm_ptr->local_size * sizeof(MPI_Aint),
-                            mpi_errno, "shm offset", MPL_MEM_RMA);
+        MPIR_CHKLMEM_MALLOC(shm_offsets, shm_comm_ptr->local_size * sizeof(MPI_Aint));
 
         for (i = 0; i < shm_comm_ptr->local_size; i++) {
             shm_offsets[i] = (MPI_Aint) total_shm_size;

--- a/src/mpid/ch4/src/mpidig_win.c
+++ b/src/mpid/ch4/src/mpidig_win.c
@@ -500,7 +500,7 @@ static int win_shm_alloc_impl(MPI_Aint size, int disp_unit, MPIR_Comm * comm_ptr
     bool symheap_mapfail_flag = false, shm_mapfail_flag = false;
     bool symheap_flag = true, global_symheap_flag = false;
 
-    MPIR_CHKPMEM_DECL(2);
+    MPIR_CHKPMEM_DECL();
     MPIR_CHKLMEM_DECL();
     MPIR_FUNC_ENTER;
 
@@ -511,9 +511,9 @@ static int win_shm_alloc_impl(MPI_Aint size, int disp_unit, MPIR_Comm * comm_ptr
      * we need to count the total size on a node for shared memory allocation. */
     if (shm_comm_ptr != NULL) {
         MPIR_T_PVAR_TIMER_START(RMA, rma_wincreate_allgather);
-        MPIR_CHKPMEM_MALLOC(MPIDIG_WIN(win, shared_table), MPIDIG_win_shared_info_t *,
+        MPIR_CHKPMEM_MALLOC(MPIDIG_WIN(win, shared_table),
                             sizeof(MPIDIG_win_shared_info_t) * shm_comm_ptr->local_size,
-                            mpi_errno, "shared table", MPL_MEM_RMA);
+                            MPL_MEM_SHM);
         shared_table = MPIDIG_WIN(win, shared_table);
         shared_table[shm_comm_ptr->rank].size = size;
         shared_table[shm_comm_ptr->rank].disp_unit = disp_unit;
@@ -603,8 +603,7 @@ static int win_shm_alloc_impl(MPI_Aint size, int disp_unit, MPIR_Comm * comm_ptr
 
         /* If only single process on a node or shm segment allocation fails, try malloc. */
         if ((shm_comm_ptr == NULL || shm_mapfail_flag) && size > 0) {
-            MPIR_CHKPMEM_MALLOC(*base_ptr, void *, size, mpi_errno, "(*win_ptr)->base",
-                                MPL_MEM_RMA);
+            MPIR_CHKPMEM_MALLOC(*base_ptr, size, MPL_MEM_SHM);
             MPL_VG_MEM_INIT(*base_ptr, size);
         }
     }

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -438,15 +438,14 @@ int MPIDU_Sched_create(MPIR_Sched_t * sp, enum MPIR_Sched_kind kind)
 {
     int mpi_errno = MPI_SUCCESS;
     struct MPIDU_Sched *s;
-    MPIR_CHKPMEM_DECL(2);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
     *sp = NULL;
 
     /* this mem will be freed by the progress engine when the request is completed */
-    MPIR_CHKPMEM_MALLOC(s, struct MPIDU_Sched *, sizeof(struct MPIDU_Sched), mpi_errno,
-                        "schedule object", MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(s, sizeof(struct MPIDU_Sched), MPL_MEM_COMM);
 
     s->size = MPIDU_SCHED_INITIAL_ENTRIES;
     s->idx = 0;
@@ -461,13 +460,11 @@ int MPIDU_Sched_create(MPIR_Sched_t * sp, enum MPIR_Sched_kind kind)
     s->prev = NULL;     /* only needed for sanity checks */
 
     /* this mem will be freed by the progress engine when the request is completed */
-    MPIR_CHKPMEM_MALLOC(s->entries, struct MPIDU_Sched_entry *,
-                        MPIDU_SCHED_INITIAL_ENTRIES * sizeof(struct MPIDU_Sched_entry), mpi_errno,
-                        "schedule entries vector", MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(s->entries, MPIDU_SCHED_INITIAL_ENTRIES * sizeof(struct MPIDU_Sched_entry),
+                        MPL_MEM_COMM);
 
     /* TODO in a debug build, defensively mark all entries as status=INVALID */
 
-    MPIR_CHKPMEM_COMMIT();
     *sp = s;
   fn_exit:
     MPIR_FUNC_EXIT;

--- a/src/mpid/common/shm/mpidu_init_shm.c
+++ b/src/mpid/common/shm/mpidu_init_shm.c
@@ -112,7 +112,7 @@ static int Init_shm_barrier(void)
 int MPIDU_Init_shm_init(void)
 {
     int mpi_errno = MPI_SUCCESS, mpl_err = 0;
-    MPIR_CHKPMEM_DECL(1);
+    MPIR_CHKPMEM_DECL();
     MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
@@ -133,8 +133,7 @@ int MPIDU_Init_shm_init(void)
     if (local_size == 1) {
         char *addr;
 
-        MPIR_CHKPMEM_MALLOC(addr, char *, segment_len + MPIDU_SHM_CACHE_LINE_LEN, mpi_errno,
-                            "segment", MPL_MEM_SHM);
+        MPIR_CHKPMEM_MALLOC(addr, segment_len + MPIDU_SHM_CACHE_LINE_LEN, MPL_MEM_SHM);
 
         memory.base_addr = addr;
         baseaddr =
@@ -200,7 +199,6 @@ int MPIDU_Init_shm_init(void)
     }
 
     mpi_errno = Init_shm_barrier();
-    MPIR_CHKPMEM_COMMIT();
 
     init_shm_initialized = 1;
 

--- a/src/mpid/common/shm/mpidu_init_shm.c
+++ b/src/mpid/common/shm/mpidu_init_shm.c
@@ -113,7 +113,7 @@ int MPIDU_Init_shm_init(void)
 {
     int mpi_errno = MPI_SUCCESS, mpl_err = 0;
     MPIR_CHKPMEM_DECL(1);
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
@@ -163,8 +163,7 @@ int MPIDU_Init_shm_init(void)
         } else {
             /* non-root prepare to recv */
             serialized_hnd_size = MPIR_pmi_max_val_size();
-            MPIR_CHKLMEM_MALLOC(serialized_hnd, char *, serialized_hnd_size, mpi_errno, "val",
-                                MPL_MEM_OTHER);
+            MPIR_CHKLMEM_MALLOC(serialized_hnd, serialized_hnd_size);
         }
     }
     /* All processes need call MPIR_pmi_bcast. This is because we may need call MPIR_pmi_barrier

--- a/src/mpid/common/shm/mpidu_init_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_init_shm_alloc.c
@@ -43,14 +43,13 @@ int MPIDU_Init_shm_alloc(size_t len, void **ptr)
     int num_local = MPIR_Process.local_size;
     MPIDU_shm_seg_t *memory = NULL;
     memory_list_t *memory_node = NULL;
-    MPIR_CHKPMEM_DECL(3);
+    MPIR_CHKPMEM_DECL();
 
     MPIR_FUNC_ENTER;
 
     MPIR_Assert(segment_len > 0);
 
-    MPIR_CHKPMEM_MALLOC(memory, MPIDU_shm_seg_t *, sizeof(*memory), mpi_errno, "memory_handle",
-                        MPL_MEM_OTHER);
+    MPIR_CHKPMEM_MALLOC(memory, sizeof(*memory), MPL_MEM_SHM);
 
     mpl_err = MPL_shm_hnd_init(&(memory->hnd));
     MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**alloc_shar_mem");
@@ -63,8 +62,7 @@ int MPIDU_Init_shm_alloc(size_t len, void **ptr)
     if (num_local == 1) {
         char *addr;
 
-        MPIR_CHKPMEM_MALLOC(addr, char *, segment_len + MPIDU_SHM_CACHE_LINE_LEN, mpi_errno,
-                            "segment", MPL_MEM_SHM);
+        MPIR_CHKPMEM_MALLOC(addr, segment_len + MPIDU_SHM_CACHE_LINE_LEN, MPL_MEM_SHM);
 
         memory->base_addr = addr;
         current_addr =
@@ -116,13 +114,11 @@ int MPIDU_Init_shm_alloc(size_t len, void **ptr)
 
     *ptr = current_addr;
 
-    MPIR_CHKPMEM_MALLOC(memory_node, memory_list_t *, sizeof(*memory_node), mpi_errno,
-                        "memory_node", MPL_MEM_OTHER);
+    MPIR_CHKPMEM_MALLOC(memory_node, sizeof(*memory_node), MPL_MEM_SHM);
     memory_node->ptr = *ptr;
     memory_node->memory = memory;
     LL_APPEND(memory_head, memory_tail, memory_node);
 
-    MPIR_CHKPMEM_COMMIT();
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/common/shm/mpidu_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_shm_alloc.c
@@ -568,12 +568,11 @@ int MPIDU_shm_alloc_symm_all(MPIR_Comm * comm_ptr, size_t len, size_t offset, vo
     int mpl_err = MPL_SUCCESS;
     MPIDU_shm_seg_t *shm_seg = NULL;
     seg_list_t *el = NULL;
-    MPIR_CHKPMEM_DECL(2);
+    MPIR_CHKPMEM_DECL();
 
     *ptr = NULL;
 
-    MPIR_CHKPMEM_MALLOC(shm_seg, MPIDU_shm_seg_t *, sizeof(*shm_seg), mpi_errno, "shm_seg_handle",
-                        MPL_MEM_OTHER);
+    MPIR_CHKPMEM_MALLOC(shm_seg, sizeof(*shm_seg), MPL_MEM_SHM);
 
     mpl_err = MPL_shm_hnd_init(&(shm_seg->hnd));
     MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**alloc_shar_mem");
@@ -594,8 +593,7 @@ int MPIDU_shm_alloc_symm_all(MPIR_Comm * comm_ptr, size_t len, size_t offset, vo
     *ptr = shm_seg->base_addr;
 
     /* store shm_seg handle in linked list for later retrieval */
-    MPIR_CHKPMEM_MALLOC(el, seg_list_t *, sizeof(*el), mpi_errno,
-                        "seg_list_element", MPL_MEM_OTHER);
+    MPIR_CHKPMEM_MALLOC(el, sizeof(*el), MPL_MEM_SHM);
     el->key = *ptr;
     el->shm_seg = shm_seg;
     LL_APPEND(seg_list_head, seg_list_tail, el);
@@ -624,15 +622,14 @@ int MPIDU_shm_alloc(MPIR_Comm * shm_comm_ptr, size_t len, void **ptr)
     int mpi_errno = MPI_SUCCESS, mpl_err = MPL_SUCCESS;
     MPIDU_shm_seg_t *shm_seg = NULL;
     seg_list_t *el = NULL;
-    MPIR_CHKPMEM_DECL(2);
+    MPIR_CHKPMEM_DECL();
 
     *ptr = NULL;
 
     MPIR_Assert(shm_comm_ptr != NULL);
     MPIR_Assert(len > 0);
 
-    MPIR_CHKPMEM_MALLOC(shm_seg, MPIDU_shm_seg_t *, sizeof(*shm_seg), mpi_errno, "shm_seg_handle",
-                        MPL_MEM_OTHER);
+    MPIR_CHKPMEM_MALLOC(shm_seg, sizeof(*shm_seg), MPL_MEM_SHM);
 
     mpl_err = MPL_shm_hnd_init(&(shm_seg->hnd));
     MPIR_ERR_CHKANDJUMP(mpl_err, mpi_errno, MPI_ERR_OTHER, "**alloc_shar_mem");
@@ -645,8 +642,7 @@ int MPIDU_shm_alloc(MPIR_Comm * shm_comm_ptr, size_t len, void **ptr)
     *ptr = shm_seg->base_addr;
 
     /* store shm_seg handle in linked list for later retrieval */
-    MPIR_CHKPMEM_MALLOC(el, seg_list_t *, sizeof(*el), mpi_errno,
-                        "seg_list_element", MPL_MEM_OTHER);
+    MPIR_CHKPMEM_MALLOC(el, sizeof(*el), MPL_MEM_SHM);
     el->key = *ptr;
     el->shm_seg = shm_seg;
     LL_APPEND(seg_list_head, seg_list_tail, el);

--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -49,6 +49,7 @@ typedef enum {
     MPL_MEM_DEBUG,              /* Data for the debugging information */
     MPL_MEM_PM,                 /* Data for process managers */
     MPL_MEM_COLL,               /* Memory related to collective operations */
+    MPL_MEM_LOCAL,              /* Temporary allocation that will be freed after the operation */
     MPL_MEM_USER,               /* User memory allocations */
     MPL_MEM_OTHER,              /* Other small memory allocations */
     MPL_MAX_MEMORY_CLASS

--- a/src/mpl/src/mem/mpl_trmem.c
+++ b/src/mpl/src/mem/mpl_trmem.c
@@ -132,6 +132,7 @@ static const char *allocation_class_strings[] = {
     "MPL_MEM_DEBUG",
     "MPL_MEM_PM",
     "MPL_MEM_COLL",
+    "MPL_MEM_LOCAL",
     "MPL_MEM_USER",
     "MPL_MEM_OTHER"
 };
@@ -1192,4 +1193,3 @@ void MPL_Memcpy_stream(void *dest, const void *src, size_t n)
 #endif /* HAVE_SSE2 */
 
 #endif
-

--- a/src/util/mpir_localproc.c
+++ b/src/util/mpir_localproc.c
@@ -40,15 +40,13 @@ int MPIR_Find_local(MPIR_Comm * comm, int *local_size_p, int *local_rank_p,
     int *local_ranks = NULL, *intranode_table = NULL;
     int node_id = -1, my_node_id = -1;
 
-    MPIR_CHKPMEM_DECL(2);
+    MPIR_CHKPMEM_DECL();
 
     /* local_ranks will be realloc'ed later to the appropriate size (currently unknown) */
     /* FIXME: realloc doesn't guarantee that the allocated area will be
      * shrunk - so using realloc is not an appropriate strategy. */
-    MPIR_CHKPMEM_MALLOC(local_ranks, int *, sizeof(int) * comm->remote_size, mpi_errno,
-                        "local_ranks", MPL_MEM_COMM);
-    MPIR_CHKPMEM_MALLOC(intranode_table, int *, sizeof(int) * comm->remote_size, mpi_errno,
-                        "intranode_table", MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(local_ranks, sizeof(int) * comm->remote_size, MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(intranode_table, sizeof(int) * comm->remote_size, MPL_MEM_COMM);
 
     for (i = 0; i < comm->remote_size; ++i)
         intranode_table[i] = -1;
@@ -144,7 +142,7 @@ int MPIR_Find_external(MPIR_Comm * comm, int *external_size_p, int *external_ran
     int node_id;
 
     MPIR_CHKLMEM_DECL();
-    MPIR_CHKPMEM_DECL(2);
+    MPIR_CHKPMEM_DECL();
 
     /* Scan through the list of processes in comm and add one
      * process from each node to the list of "external" processes.  We
@@ -155,10 +153,8 @@ int MPIR_Find_external(MPIR_Comm * comm, int *external_size_p, int *external_ran
     /* external_ranks will be realloc'ed later to the appropriate size (currently unknown) */
     /* FIXME: realloc doesn't guarantee that the allocated area will be
      * shrunk - so using realloc is not an appropriate strategy. */
-    MPIR_CHKPMEM_MALLOC(external_ranks, int *, sizeof(int) * comm->remote_size, mpi_errno,
-                        "external_ranks", MPL_MEM_COMM);
-    MPIR_CHKPMEM_MALLOC(internode_table, int *, sizeof(int) * comm->remote_size, mpi_errno,
-                        "internode_table", MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(external_ranks, sizeof(int) * comm->remote_size, MPL_MEM_COMM);
+    MPIR_CHKPMEM_MALLOC(internode_table, sizeof(int) * comm->remote_size, MPL_MEM_COMM);
 
     int num_nodes = MPIR_Process.num_nodes;
     if (MPIR_Process.node_hostnames) {

--- a/src/util/mpir_localproc.c
+++ b/src/util/mpir_localproc.c
@@ -143,7 +143,7 @@ int MPIR_Find_external(MPIR_Comm * comm, int *external_size_p, int *external_ran
     int *external_ranks, *internode_table;
     int node_id;
 
-    MPIR_CHKLMEM_DECL(1);
+    MPIR_CHKLMEM_DECL();
     MPIR_CHKPMEM_DECL(2);
 
     /* Scan through the list of processes in comm and add one
@@ -164,7 +164,7 @@ int MPIR_Find_external(MPIR_Comm * comm, int *external_size_p, int *external_ran
     if (MPIR_Process.node_hostnames) {
         num_nodes = utarray_len(MPIR_Process.node_hostnames);
     }
-    MPIR_CHKLMEM_MALLOC(nodes, int *, sizeof(int) * num_nodes, mpi_errno, "nodes", MPL_MEM_COMM);
+    MPIR_CHKLMEM_MALLOC(nodes, sizeof(int) * num_nodes);
 
     /* nodes maps node_id to rank in external_ranks of leader for that node */
     for (i = 0; i < num_nodes; ++i)

--- a/src/util/mpir_netloc.c
+++ b/src/util/mpir_netloc.c
@@ -42,7 +42,7 @@ static int get_tree_attributes(hwloc_topology_t hwloc_topology, netloc_topology_
     int prev_width = 0;
     int edges_go_across_levels = 0;
     int out_degree_mismatch_at_level = 0;
-    MPIR_CHKPMEM_DECL(3);
+    MPIR_CHKPMEM_DECL();
 
     network_attr->type = MPIR_NETTOPO_TYPE__INVALID;
 
@@ -54,9 +54,8 @@ static int get_tree_attributes(hwloc_topology_t hwloc_topology, netloc_topology_
         int host_node_at_leaf_level;
 
         /* Traversal order never exceeds the total number of nodes */
-        MPIR_CHKPMEM_MALLOC(traversal_order, netloc_node_t **,
-                            sizeof(netloc_node_t *) * topology->num_nodes, mpi_errno,
-                            "traversal_order", MPL_MEM_OTHER);
+        MPIR_CHKPMEM_MALLOC(traversal_order, sizeof(netloc_node_t *) * topology->num_nodes,
+                            MPL_MEM_OTHER);
 
         hti = netloc_dt_lookup_table_iterator_t_construct(*host_nodes);
 
@@ -161,9 +160,8 @@ static int get_tree_attributes(hwloc_topology_t hwloc_topology, netloc_topology_
             /* Indexed by node id, visited_node_list[i] > -1 indicates that the
              * node i has been visited */
 
-            MPIR_CHKPMEM_MALLOC(network_attr->u.tree.node_levels, int *,
-                                sizeof(int) * topology->num_nodes, mpi_errno,
-                                "network_attr->u.tree.node_levels", MPL_MEM_OTHER);
+            MPIR_CHKPMEM_MALLOC(network_attr->u.tree.node_levels, sizeof(int) * topology->num_nodes,
+                                MPL_MEM_OTHER);
 
             for (i = 0; i < topology->num_nodes; i++) {
                 network_attr->u.tree.node_levels[i] = -1;
@@ -304,13 +302,12 @@ static int get_tree_attributes(hwloc_topology_t hwloc_topology, netloc_topology_
     }
 
   fn_exit:
-    MPIR_CHKPMEM_COMMIT();
-    MPIR_CHKPMEM_REAP();
     MPL_free(host_nodes);
     MPL_free(nodes);
     return mpi_errno;
 
   fn_fail:
+    MPIR_CHKPMEM_REAP();
     goto fn_exit;
 }
 
@@ -1558,11 +1555,10 @@ int MPIR_Netloc_get_hostnode_index_in_tree(MPIR_Netloc_network_attributes attrib
     int max_level = 0;
     netloc_node_t **traversal_order;
     int start_index, end_index, i, j, node_index, num_nodes;
-    MPIR_CHKPMEM_DECL(3);
+    MPIR_CHKPMEM_DECL();
 
-    MPIR_CHKPMEM_MALLOC(traversal_order, netloc_node_t **,
-                        sizeof(netloc_node_t *) * topology->num_nodes, mpi_errno,
-                        "traversal_order", MPL_MEM_OTHER);
+    MPIR_CHKPMEM_MALLOC(traversal_order, sizeof(netloc_node_t *) * topology->num_nodes,
+                        MPL_MEM_OTHER);
 
     /* Assign index to nodes via breadth first traversal starting from nodes with maximum level,
      * corresponding to the top level switches */

--- a/src/util/mpir_nodemap.c
+++ b/src/util/mpir_nodemap.c
@@ -275,7 +275,7 @@ static int pmi_publish_node_id(int sz, int myrank)
     int key_max_sz;
     char hostname[MAX_HOSTNAME_LEN];
     char strerrbuf[MPIR_STRERROR_BUF_SIZE] ATTRIBUTE((unused));
-    MPIR_CHKLMEM_DECL(2);
+    MPIR_CHKLMEM_DECL();
 
     /* set hostname */
 
@@ -287,7 +287,7 @@ static int pmi_publish_node_id(int sz, int myrank)
 
     /* Allocate space for pmi key */
     key_max_sz = MPIR_pmi_max_key_size();
-    MPIR_CHKLMEM_MALLOC(key, char *, key_max_sz, mpi_errno, "key", MPL_MEM_ADDRESS);
+    MPIR_CHKLMEM_MALLOC(key, key_max_sz);
 
     /* Put my hostname id */
     if (sz > 1) {


### PR DESCRIPTION
## Pull Request Description
Reduce the number of trivial parameters to make the MPIR_CHKLMEM macros
easier to use and read.

* Add `MPIR_CHKLMEM_REGISTER` so we also can track local buffers that are
allocated in a subfunction.
* Always use `MPIR_CHKLMEM_MAX` (default to 10) slots. It is a hassle to
track how many local buffers we are tracking.
* Remove the type-cast since it adds no value.
* Local memory just use `MPL_MEM_LOCAL` as memory class.
* Always use mpi_errno and goto fn_fail
* Just use the "**nomem" message. Adding a variable name often does not add
more clarity for temporary local variables anyway.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
