### PR TITLE
hydra: remove dependency on libslurm

### DIFF
--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -440,14 +440,6 @@ AC_MSG_CHECKING([available processor topology libraries])
 AC_MSG_RESULT([$available_topolibs])
 
 #########################################################################
-# Slurm hostlist parsing
-#########################################################################
-PAC_CHECK_HEADER_LIB_OPTIONAL([slurm],[slurm/slurm.h],[slurm],[slurm_hostlist_create])
-if test "$pac_have_slurm" = "yes" ; then
-    AC_DEFINE(HAVE_SLURM,1,[Define if slurm is available])
-fi
-
-#########################################################################
 # POSIX Regcomp
 #########################################################################
 AX_CHECK_POSIX_REGCOMP

--- a/src/pm/hydra/lib/tools/bootstrap/external/slurm_query_node_list.c
+++ b/src/pm/hydra/lib/tools/bootstrap/external/slurm_query_node_list.c
@@ -9,9 +9,7 @@
 #include "slurm.h"
 
 /* START UNIT - list_to_nodes */
-#if defined(HAVE_SLURM)
-#include <slurm/slurm.h>        /* for slurm_hostlist_create */
-#elif defined(HAVE_POSIX_REGCOMP)
+#if defined(HAVE_POSIX_REGCOMP)
 #include <regex.h>      /* for POSIX regular expressions */
 
 #define MAX_GMATCH 5    /* max number of atoms in group matches + 1 */
@@ -23,33 +21,7 @@
 static int *tasks_per_node = NULL;
 static struct HYD_node *global_node_list = NULL;
 
-#if defined(HAVE_SLURM)
-static HYD_status list_to_nodes(char *str)
-{
-    hostlist_t *hostlist;
-    char *host;
-    int k = 0;
-    HYD_status status = HYD_SUCCESS;
-
-    if ((hostlist = slurm_hostlist_create(str)) == NULL) {
-        status = HYD_FAILURE;
-        goto fn_fail;
-    }
-
-    for (host = slurm_hostlist_shift(hostlist); host; host = slurm_hostlist_shift(hostlist)) {
-        status = HYDU_add_to_node_list(host, tasks_per_node[k++], &global_node_list);
-        HYDU_ERR_POP(status, "unable to add to node list\n");
-    }
-
-    slurm_hostlist_destroy(hostlist);
-
-  fn_exit:
-    return status;
-
-  fn_fail:
-    goto fn_exit;
-}
-#elif defined(HAVE_POSIX_REGCOMP)
+#if defined(HAVE_POSIX_REGCOMP)
 static HYD_status list_to_nodes(char *str)
 {
     regex_t gmatch_old[2];


### PR DESCRIPTION
## Pull Request Description
We use libslurm for host list string parsing if it is available. However, libslurm's interface for slurm_hostlist_create changed recently -- from return `hostlist_t` to returning `hostlist_t *`. However, users may have different slurm library installed, makding supporting it difficult. Because we always have the fallback parsing routines, let's remove the dependency on libslurm for simplicity.

Reference issue #6806, #7257, PR #6820

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
