### PR TITLE
ch4/ofi: default MPIR_CVAR_CH4_OFI_EAGER_THRESHOLD to -1

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -40,7 +40,7 @@ cvars:
     - name        : MPIR_CVAR_CH4_OFI_EAGER_THRESHOLD
       category    : CH4_OFI
       type        : int
-      default     : 16384
+      default     : -1
       class       : none
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_LOCAL


### PR DESCRIPTION
## Pull Request Description
Set default MPIR_CVAR_CH4_OFI_EAGER_THRESHOLD to -1 so we prefer libfabric native path rather than mpich-layer forced rndv.

This was the intention but got neglected during merge.


[skip warnings]

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
