### PR TITLE
romio: fix recursive CS_ENTER in MPIOI_Register_datarep

### DIFF
--- a/src/mpi/romio/mpi-io/io_impl.c
+++ b/src/mpi/romio/mpi-io/io_impl.c
@@ -3000,8 +3000,6 @@ static int MPIOI_Register_datarep(const char *datarep,
     ADIOI_Datarep *adio_datarep;
     static char myname[] = "MPI_REGISTER_DATAREP";
 
-    ROMIO_THREAD_CS_ENTER();
-
     /* --BEGIN ERROR HANDLING-- */
     /* check datarep name (use strlen instead of strnlen because
      * strnlen is not portable) */
@@ -3075,7 +3073,5 @@ static int MPIOI_Register_datarep(const char *datarep,
     error_code = MPI_SUCCESS;
 
   fn_exit:
-    ROMIO_THREAD_CS_EXIT();
-
     return error_code;
 }


### PR DESCRIPTION

## Pull Request Description
A mistake from the last refactor.


Fixes #7262

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
