### PR TITLE
mpir/init: Move GPU init after PMI

### DIFF
--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -195,8 +195,6 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
      * other and can be initialized in any order. */
     /**********************************************************************/
 
-    mpi_errno = MPII_init_gpu();
-    MPIR_ERR_CHECK(mpi_errno);
     MPIR_context_id_init();
     MPIR_Typerep_init();
     MPII_thread_mutex_create();
@@ -207,6 +205,10 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     MPII_nettopo_init();
     MPII_init_windows();
     MPII_init_binding_cxx();
+
+    /* gpu init must come after pmi to avoid spamming debug messages */
+    mpi_errno = MPII_init_gpu();
+    MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPII_init_local_proc_attrs(&required);
     MPIR_ERR_CHECK(mpi_errno);


### PR DESCRIPTION
## Pull Request Description

GPU initialization may include debug summary messages which are only intended for world rank 0 to output. If we do not first run PMI initialization, world rank information is not setup, causing debug messages from every process. Move GPU initialization after PMI to prevent spamming messages from every process.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
