### PR TITLE
ch4/ofi: add MPIR_CVAR_CH4_OFI_ENABLE_SHARED_AV

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -50,6 +50,16 @@ cvars:
         If true, the OFI addressing information will be stored with an FI_AV_TABLE.
         If false, an FI_AV_MAP will be used.
 
+    - name        : MPIR_CVAR_CH4_OFI_ENABLE_SHARED_AV
+      category    : CH4_OFI
+      type        : boolean
+      default     : false
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        If true, it will try open shared av at initialization.
+
     - name        : MPIR_CVAR_CH4_OFI_ENABLE_SCALABLE_ENDPOINTS
       category    : CH4_OFI
       type        : int
@@ -1420,7 +1430,7 @@ static int create_vci_domain(struct fid_domain **p_domain, struct fid_av **p_av,
      * Otherwise, set MPIDI_OFI_global.got_named_av and
      * copy the map_addr.
      */
-    if (try_open_shared_av(domain, p_av, nic)) {
+    if (MPIR_CVAR_CH4_OFI_ENABLE_SHARED_AV && try_open_shared_av(domain, p_av, nic)) {
         MPIDI_OFI_global.got_named_av = 1;
     } else {
         mpi_errno = open_local_av(domain, p_av);


### PR DESCRIPTION

## Pull Request Description
Add a cvar to enable/disable trying open shared av. Default false to avoid confusing warning messages in libfabric logging.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
