### PR TITLE
request: always enable the progress timeout cvar

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,9 @@
 # MPIR_CHKLMEM_ and MPIR_CHKPMEM_ macros are simplified, removing non-essential
   argument such as type case and custom error messages.
 
+# Rename MPIR_CVAR_DEBUG_PROGRESS_TIMEOUT to MPIR_CVAR_PROGRESS_TIMEOUT, and
+  enable it whether or not --enable-g=progress is used in configure.
+
 ===============================================================================
                                Changes in 4.3
 ===============================================================================

--- a/configure.ac
+++ b/configure.ac
@@ -406,7 +406,7 @@ AC_ARG_ENABLE(g,
                    performance impacts.  Recommended for typical development.
         progress - Enable debugging progress status
         yes      - synonym for "most" (*not* "all")
-        all      - All of the above choices
+        all      - Most of the above choices
 ],,enable_g=none)
 
 AC_ARG_ENABLE([mpit-pvars],
@@ -1290,6 +1290,7 @@ for option in $enable_g ; do
 	perform_dbgmutex=yes
 	perform_handlealloc=yes
         perform_handle=yes
+        perform_dbgprogress=yes
 	;;
 	*)
 	IFS=$save_IFS

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -8,6 +8,24 @@
 
 #include "mpir_process.h"
 
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+
+cvars:
+    - name        : MPIR_CVAR_PROGRESS_TIMEOUT
+      category    : CH4
+      type        : int
+      default     : 0
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        Sets the timeout in seconds to dump outstanding requests when progress wait is not making progress for some time.
+
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
 /* NOTE-R1: MPIR_REQUEST_KIND__MPROBE signifies that this is a request created by
  * MPI_Mprobe or MPI_Improbe.  Since we use MPI_Request objects as our
  * MPI_Message objects, we use this separate kind in order to provide stronger
@@ -329,23 +347,23 @@ extern MPIR_Request MPIR_Request_direct[MPIR_REQUEST_PREALLOC];
     int iter = 0; \
     bool progress_timed_out = false; \
     MPL_time_t time_start; \
-    if (MPIR_CVAR_DEBUG_PROGRESS_TIMEOUT > 0) { \
+    if (MPIR_CVAR_PROGRESS_TIMEOUT > 0) { \
         MPL_wtime(&time_start); \
     }
 
 #define DEBUG_PROGRESS_CHECK \
-    if (MPIR_CVAR_DEBUG_PROGRESS_TIMEOUT > 0) { \
+    if (MPIR_CVAR_PROGRESS_TIMEOUT > 0) { \
         iter++; \
         if (iter == 0xffff) {\
             double time_diff = 0.0; \
             MPL_time_t time_cur; \
             MPL_wtime(&time_cur); \
             MPL_wtime_diff(&time_start, &time_cur, &time_diff); \
-            if (time_diff > MPIR_CVAR_DEBUG_PROGRESS_TIMEOUT && !progress_timed_out) { \
+            if (time_diff > MPIR_CVAR_PROGRESS_TIMEOUT && !progress_timed_out) { \
                 MPIR_Request_debug(); \
                 MPL_backtrace_show(stdout); \
                 progress_timed_out = true; \
-            } else if (time_diff > MPIR_CVAR_DEBUG_PROGRESS_TIMEOUT * 2) { \
+            } else if (time_diff > MPIR_CVAR_PROGRESS_TIMEOUT * 2) { \
                 MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**timeout"); \
             } \
             iter = 0; \

--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -319,6 +319,12 @@ extern MPIR_Request MPIR_Request_direct[MPIR_REQUEST_PREALLOC];
         } \
     } while (0)
 
+#else
+
+#define MPIR_REQUEST_SET_INFO(req, ...) do { } while (0)
+#define MPIR_REQUEST_DEBUG(req) do { } while (0)
+#endif
+
 #define DEBUG_PROGRESS_START \
     int iter = 0; \
     bool progress_timed_out = false; \
@@ -345,14 +351,6 @@ extern MPIR_Request MPIR_Request_direct[MPIR_REQUEST_PREALLOC];
             iter = 0; \
         } \
     }
-
-#else
-
-#define MPIR_REQUEST_SET_INFO(req, ...) do { } while (0)
-#define MPIR_REQUEST_DEBUG(req) do { } while (0)
-#define DEBUG_PROGRESS_START do {} while (0)
-#define DEBUG_PROGRESS_CHECK do {} while (0)
-#endif
 
 void MPII_init_request(void);
 

--- a/src/mpi/request/request_impl.c
+++ b/src/mpi/request/request_impl.c
@@ -53,16 +53,6 @@ cvars:
         in MPI_Waitall and MPI_Testall implementation. A large number
         is likely to cause more cache misses.
 
-    - name        : MPIR_CVAR_DEBUG_PROGRESS_TIMEOUT
-      category    : CH4
-      type        : int
-      default     : 0
-      class       : none
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_LOCAL
-      description : >-
-        Sets the timeout in seconds to dump outstanding requests when progress wait is not making progress for some time.
-
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 


### PR DESCRIPTION
## Pull Request Description
Let users always able to set MPIR_CVAR_DEBUG_PROGRESS_TIMEOUT regardless
whether --enable-g=progress is enabled during build. It only adds a null
if check unless the TIMEOUT cvar is set.

Add --enable-g=progress will provide additional request info on timeout
dump.

Rename `MPIR_CVAR_DEBUG_PROGRESS_TIMEOUT` to `MPIR_CVAR_PROGRESS_TIMEOUT`.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
