### PR TITLE
binding/io: skip error checking in MPI_Register_datarep

### DIFF
--- a/src/binding/c/io_api.txt
+++ b/src/binding/c/io_api.txt
@@ -212,3 +212,6 @@ MPI_File_write_shared:
 MPI_Register_datarep:
     .desc: Register a set of user-provided data conversion
     .poly_impl: separate
+{ -- error_check -- read_conversion_fn, write_conversion_fn
+    /* both read_conversion_fn and write_conversion_fn may be MPI_CONVERSION_FN_NULL, which could be NULL */
+}


### PR DESCRIPTION
## Pull Request Description
Both read_conversion_fn and write_conversion_fn may be MPI_CONVERSION_FN_NULL, which could be NULL. Thus, we need skip the default arg check, which assumes non-NULL input.


Fixes #7282 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
