### PR TITLE
ch3: Fix uninitialized bytes caused by MPIDI_Pkt_init

### DIFF
--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -464,7 +464,7 @@ void MPIDI_DBG_PrintVCState(MPIDI_VC_t *vc);
 #else
 #   define MPIDI_Pkt_init(pkt_, type_)				\
     {								\
-	memset((void *) (pkt_), 0xfc, sizeof(*(pkt_)));	\
+	memset((void *) (pkt_), 0xfc, sizeof(MPIDI_CH3_Pkt_t));	\
 	(pkt_)->type = (type_);					\
     }
 #endif

--- a/src/mpid/ch3/include/mpidimpl.h
+++ b/src/mpid/ch3/include/mpidimpl.h
@@ -456,16 +456,22 @@ void MPIDI_DBG_PrintVCState(MPIDI_VC_t *vc);
 /*--------------------
   BEGIN PACKET SECTION
   --------------------*/
-#if !defined(MPICH_DEBUG_MEMINIT)
+#ifdef MPICH_DEBUG_MEMINIT
+#define MPIDI_PKT_INIT_VAL (0xfc)
+#else
+#define MPIDI_PKT_INIT_VAL (0)
+#endif
+#ifdef NVALGRIND
 #   define MPIDI_Pkt_init(pkt_, type_)		\
     {						\
 	(pkt_)->type = (type_);			\
     }
 #else
-#   define MPIDI_Pkt_init(pkt_, type_)				\
-    {								\
-	memset((void *) (pkt_), 0xfc, sizeof(MPIDI_CH3_Pkt_t));	\
-	(pkt_)->type = (type_);					\
+#   define MPIDI_Pkt_init(pkt_, type_)              \
+    {                                               \
+        memset((void *) (pkt_), MPIDI_PKT_INIT_VAL, \
+               sizeof(MPIDI_CH3_Pkt_t));            \
+        (pkt_)->type = (type_);                     \
     }
 #endif
 


### PR DESCRIPTION
## Pull Request Description

In meminit debug mode, we initialize all packet headers before sending. Since ch3 uses a fixed header size, we need to make sure to initialize the whole header and not just the subtype used for a particular message or else tools like valgrind will complain about accessing uninitialized bytes.

cc @balay

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
