### PR TITLE
dataloop: Use calloc to allocate dataloop structure

### DIFF
--- a/src/mpi/datatype/typerep/dataloop/dataloop.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop.c
@@ -397,7 +397,7 @@ void MPII_Dataloop_alloc_and_copy(int kind,
     new_loop_sz += loop_sz + off_sz + blk_sz + ptr_sz + extent_sz + old_loop_sz;
 
     /* allocate space */
-    new_loop = (MPII_Dataloop *) MPL_malloc(new_loop_sz, MPL_MEM_DATATYPE);
+    new_loop = (MPII_Dataloop *) MPL_calloc(1, new_loop_sz, MPL_MEM_DATATYPE);
     if (new_loop == NULL) {
         *new_loop_p = NULL;
         return;


### PR DESCRIPTION
## Pull Request Description

Dataloop structures may be flattened and sent to other processes e.g. in RMA communication. Use calloc to zero-init the structure and avoid valgrind warnings for accessing uninitialized bytes during communication.

cc @balay

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
