### PR TITLE
hydra: fix line-continuation in --configfile option

### DIFF
--- a/src/pm/hydra/lib/utils/args.c
+++ b/src/pm/hydra/lib/utils/args.c
@@ -328,7 +328,6 @@ HYD_status HYDU_parse_hostfile(const char *hostfile, void *data,
 
         linep = line;
 
-        strtok(linep, "#");
         while (isspace(*linep))
             linep++;
 

--- a/src/pm/hydra/mansrc/mpiexec.txt
+++ b/src/pm/hydra/mansrc/mpiexec.txt
@@ -19,10 +19,11 @@ The MPI standard suggests the following arguments and their meanings\:
 + \-n <np> - Specify the number of processes to use
 . \-host <hostname> - Name of host on which to run processes
 . \-wdir <working directory> - cd to this one `before` running executable
-- \-configfile <name> - file containing specifications of host/program,
-   one per line, with # as a comment indicator, e.g., the usual
-   mpiexec input. The lines excluding comments are concatenated with newlines
-   replaced with spaces, and are then parsed as command line options.
+- \-configfile <name> - file containing command-line options.
+   The lines are of the form separated by the colons in the commandline form:
+       mpiexec {<option arguments>} : {...} : {...} : ... : {...}
+   Lines beginning with '#' are comments, and lines may be continued by
+   terminating the partial line with '\'.
 
 The following options are reserved by the MPI standard, but they are not
 supported by MPICH (hydra)\:

--- a/src/pm/hydra/mpiexec/get_parameters.c
+++ b/src/pm/hydra/mpiexec/get_parameters.c
@@ -281,16 +281,18 @@ static HYD_status check_environment(void)
 
 static HYD_status process_config_token(char *token, int newline, void *data)
 {
-    static int idx = 0;
     UT_array *args = data;
 
     char **last_arg = (char **) utarray_back(args);
-    if (idx && newline && strcmp(*last_arg, ":")) {
-        /* If this is a newline, but not the first one, and the
-         * previous token was not a ":", add an executable delimiter
-         * ':' */
-        static const char *colon = ":";
-        utarray_push_back(args, &colon, MPL_MEM_OTHER);
+    if (last_arg && newline) {
+        if (strcmp(*last_arg, "\\") == 0) {
+            /* remove the trailing line-continuation mark */
+            utarray_pop_back(args);
+        } else if (strcmp(*last_arg, ":") != 0) {
+            /* add ":" delimiter unless it is already there */
+            static const char *colon = ":";
+            utarray_push_back(args, &colon, MPL_MEM_OTHER);
+        }
     }
 
     utarray_push_back(args, &token, MPL_MEM_OTHER);

--- a/src/pm/hydra/mpiexec/options.c
+++ b/src/pm/hydra/mpiexec/options.c
@@ -646,7 +646,8 @@ static void config_help_fn(void)
     printf("-configfile: Configuration file for MPMD launch argument information\n\n");
     printf("Notes:\n");
     printf("  * The config file contains information very similar to a command-line\n");
-    printf("    launch, except ':' is replaced with a new line character\n");
+    printf("    launch, except ':' is replaced with a new line character. Use '\'\n");
+    printf("    partial lines.\n");
 }
 
 static HYD_status config_fn(char *arg, char ***argv)


### PR DESCRIPTION
## Pull Request Description
According MPI standard:

> Form A:
> ```
> mpiexec { <above arguments> } : { ... } : { ... } : ... : { ... }
> ```
> As with MPI_COMM_SPAWN, all the arguments are optional. (Even the -n x argument is optional; the default is implementation dependent. It might be 1, it might be taken from an environment variable, or it might be specified at compile time.) The names and meanings of the arguments are taken from the keys in the info argument to MPI_COMM_SPAWN. There may be other, implementation-dependent arguments as well. Note that Form A, though convenient to type, prevents colons from being program arguments. Therefore an alternate, file-based form is allowed:
>
>  Form B:
> ```
> mpiexec -configfile <filename>
> ```
> where the lines of <filename> are of the form separated by the colons in Form A. Lines beginning with ‘#’ are comments, and lines may be continued by terminating the partial line with ‘\’.

Previously there was a bug in checking the `last_arg` for `:`. This PR fixes that; and it also checks for potential line-continuation marks (`\`). Amend the doc to reflect the usages.

Fixes #7290 
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
