### PR TITLE
binding/f08: support device attribute in choice buffers

### DIFF
--- a/confdb/aclocal_fc.m4
+++ b/confdb/aclocal_fc.m4
@@ -1269,6 +1269,30 @@ AC_DEFUN([PAC_FC_CHECK_IGNORE_TKR],[
 ])
 
 dnl
+dnl PAC_FC_CHECK_DEVICE_BUFFER check whether device attribute
+dnl (nvfortran extension) is available (may need FCFLAGS -cuda).
+dnl Set pac_fc_has_device to yes if supported, otherwise, no.
+dnl
+AC_DEFUN([PAC_FC_CHECK_DEVICE_BUFFER],[
+    AC_LANG_PUSH(Fortran)
+    AC_MSG_CHECKING([whether device attribute is available])
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+        program main
+            INTERFACE A
+                SUBROUTINE A1(buf)
+                TYPE(*), DIMENSION(..), INTENT(in) :: buf
+                END SUBROUTINE
+                SUBROUTINE A2(buf)
+                TYPE(*), DIMENSION(..), DEVICE, INTENT(in) :: buf
+                END SUBROUTINE
+            END INTERFACE
+        end
+    ])],[pac_fc_has_device=yes],[pac_fc_has_device=no])
+    AC_MSG_RESULT([$pac_fc_ignore_tkr])
+    AC_LANG_POP(Fortran)
+])
+
+dnl
 dnl PAC_FC_ISO_C_BINDING check whether ISO_C_BINDING is supported.
 dnl set pac_fc_iso_c_binding to yes if it's supported, otherwise, no.
 dnl

--- a/configure.ac
+++ b/configure.ac
@@ -4207,6 +4207,7 @@ fi
 
 if test "$enable_f08" = "yes" ; then
     PAC_FC_CHECK_REAL128
+    PAC_FC_CHECK_DEVICE_BUFFER
     if test -z "$PYTHON" ; then
         if test -f src/binding/fortran/use_mpi_f08/mpi_f08.f90 ; then
             AC_MSG_NOTICE([Using pre-generated Fortran mpi_f08 binding source. To prevent issues, install Python 3 and rerun configure.])
@@ -4217,6 +4218,9 @@ if test "$enable_f08" = "yes" ; then
         cmd_f08="$PYTHON $srcdir/maint/gen_binding_f08.py"
         if test "$pac_fc_has_real128" = "no" ; then
             cmd_f08="$cmd_f08 -no-real128"
+        fi
+        if test "$pac_fc_has_device" = "yes" ; then
+            cmd_f08="$cmd_f08 -has-device"
         fi
         if test "$enable_romio" = "no" ; then
             cmd_f08="$cmd_f08 -no-mpiio"

--- a/maint/gen_binding_f08.py
+++ b/maint/gen_binding_f08.py
@@ -11,7 +11,7 @@ from local_python import RE
 import os
 
 def main():
-    # currently support -no-real128, -fint-size, -aint-size, -count-size, -cint-size
+    # currently support -no-real128, -has-device, -fint-size, -aint-size, -count-size, -cint-size
     G.parse_cmdline()
 
     binding_dir = G.get_srcdir_path("src/binding")
@@ -58,6 +58,11 @@ def main():
         dump_f08_wrappers_f(func, False)
         if func['_need_large']:
             dump_f08_wrappers_f(func, True)
+        
+        if 'has-device' in G.opts and need_cdesc(func):
+            dump_f08_wrappers_f(func, False, True)
+            if func['_need_large']:
+                dump_f08_wrappers_f(func, True, True)
     f = "%s/wrappers_f/f08ts.f90" % f08_dir
     dump_f90_file(f, G.out)
 
@@ -109,10 +114,19 @@ def main():
         func_name = get_function_name(func, False)
         G.out.append("INTERFACE %s" % func_name)
         G.out.append("INDENT")
+
         dump_mpi_f08(func, False)
         if func['_need_large'] and '_need_large_separate' not in func:
             G.out.append("")
             dump_mpi_f08(func, True)
+
+        if "has-device" in G.opts and need_cdesc(func):
+            # interface for device buffer
+            dump_mpi_f08(func, False, True)
+            if func['_need_large'] and '_need_large_separate' not in func:
+                G.out.append("")
+                dump_mpi_f08(func, True, True)
+
         G.out.append("DEDENT")
         G.out.append("END INTERFACE %s" % func_name)
 


### PR DESCRIPTION
## Pull Request Description
NVHPC fortran compiler (nvfortran) support device attribute extension,
which requires separate interfaces. Add configure check for this
feature. Generate extra interfaces for device buffers in `use mpi_f08`.

Fixes #7250 

[skip warnings]

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
