### PR TITLE
configure: Add version and language info to end report

### DIFF
--- a/confdb/aclocal_util.m4
+++ b/confdb/aclocal_util.m4
@@ -1,3 +1,11 @@
+dnl PAC_APPEND_CSV - Append value to comma separated list
+dnl Usage: PAC_APPEND_CSV([foo], [bar])
+AC_DEFUN([PAC_APPEND_CSV],[
+    AS_IF([test -n "$$2"],
+          [$2="$$2, $1"],
+          [$2=$1])
+])
+
 dnl Nesting safe macros for saving variables
 dnl Usage: PAC_PUSH_FLAG(CFLAGS)
 AC_DEFUN([PAC_PUSH_FLAG],[

--- a/configure.ac
+++ b/configure.ac
@@ -2047,6 +2047,7 @@ if test "$enable_f77" = "yes" ; then
     AC_SUBST(WRAPPER_EXTRA_F77_FLAGS)
 
     bindings="$bindings f77"
+    PAC_APPEND_CSV([mpif.h], [fortran_bindings])
     AC_DEFINE(HAVE_FORTRAN_BINDING,1,[Define if Fortran is supported])
     # Also define the name FORTRAN_BINDING for use in #if @FORTRAN_BINDING@..
     FORTRAN_BINDING=1
@@ -2080,6 +2081,7 @@ bashWorks=$bashWorks)
 if test "$enable_f90" = "yes" ; then
     bindingsubsystems="$bindingsubsystems src/binding/fortran/use_mpi"
     bindings="$bindings f90"
+    PAC_APPEND_CSV([use mpi], [fortran_bindings])
 fi
 
 if test "$enable_f08" = "yes" ; then
@@ -2089,6 +2091,7 @@ AM_CONDITIONAL([BUILD_F08_BINDING], [test "$enable_f08" = "yes"])
 
 if test "$enable_f08" = "yes" ; then
     bindings="$bindings f08"
+    PAC_APPEND_CSV([use mpi_f08], [fortran_bindings])
     AC_DEFINE(HAVE_F08_BINDING, 1, [Define to 1 if we have Fortran 2008 binding])
 fi
 
@@ -4273,19 +4276,31 @@ if test "$enable_f08" = "yes" ; then
 fi
 AC_OUTPUT
 
-echo '*****************************************************'
+# TODO: add info about MPI ABI
+cat <<EOF
+*****************************************************
+***
+*** MPICH $MPICH_VERSION ($MPICH_RELEASE_DATE)
+***
+*** Language Support
+*** ----------------
+*** C       : yes
+*** C++     : $enable_cxx
+*** Fortran : $fortran_bindings
+***
+*** Device Configuration
+*** --------------------
+EOF
 if test ${device_name} = "ch4" ; then
     PAC_CH4_CONFIG_SUMMARY()
 elif test ${DEVICE} = "ch3:nemesis" ; then
 cat <<EOF
-***
 *** device configuration: ch3:nemesis
 *** nemesis networks: ${nemesis_networks}
 ***
 EOF
 else
 cat <<EOF
-***
 *** device configuration: ${DEVICE}
 ***
 EOF

--- a/src/mpid/ch4/subconfigure.m4
+++ b/src/mpid/ch4/subconfigure.m4
@@ -410,7 +410,6 @@ AC_DEFUN([PAC_CH4_CONFIG_SUMMARY], [
         t_ipc="$t_ipc gpudirect"
     fi
     cat <<EOF
-***
 *** device      : ch4:${t_netmod}
 *** ipc feature : ${t_ipc}
 *** gpu support : ${t_gpu}


### PR DESCRIPTION
## Pull Request Description

I often get tripped up thinking `mpi_f08` support is configured when it's not. Expand the configure output to show the current version and language support being built.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
