### PR TITLE
ch4/ipc: Use IPC handle validation instead of free hooks

### DIFF
--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -962,6 +962,7 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **gpu_ipc_handle_map: gpu_ipc_handle_map failed
 **gpu_ipc_handle_create: gpu_ipc_handle_create failed
 **gpu_ipc_handle_unmap: gpu_ipc_handle_unmap failed
+**gpu_ipc_handle_destroy: gpu_ipc_handle_destroy failed
 **gpu_init: gpu_init failed
 **gpu_finalize: gpu_finalize failed
 **gpu_get_global_dev_ids: gpu_get_global_dev_ids failed

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -140,13 +140,12 @@ MPL_STATIC_INLINE_PREFIX bool MPIDI_OFI_prepare_target_mr(int target_rank,
     if (winattr & MPIDI_WINATTR_NM_DYNAMIC_MR) {
         /* Special path for dynamic window with per-attach memory registration. */
         offset = target_disp;   /* dynamic win is always with disp_unit=1 */
-        void *target_mr_found = NULL;
         uint64_t target_addr = (uintptr_t) MPI_BOTTOM + offset;
         /* Return valid node only when [target_addr:target_extent] matches within a
          * single region. If it crosses two regions, NULL is returned. */
-        MPL_gavl_tree_search(MPIDI_OFI_WIN(win).dwin_target_mrs[target_rank],
-                             (const void *) (uintptr_t) target_addr, target_extent,
-                             &target_mr_found);
+        void *target_mr_found =
+            MPL_gavl_tree_search(MPIDI_OFI_WIN(win).dwin_target_mrs[target_rank],
+                                 (const void *) (uintptr_t) target_addr, target_extent);
 
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, VERBOSE,
                         (MPL_DBG_FDEST, "target_mr found %d addr 0x%" PRIx64 ", extent 0x%lx",

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -1093,9 +1093,9 @@ int MPIDI_OFI_mpi_win_free_hook(MPIR_Win * win)
             !MPIDI_OFI_WIN(win).mr && MPIDIG_WIN(win, info_args).coll_attach) {
             int i;
             for (i = 0; i < win->comm_ptr->local_size; i++)
-                MPL_gavl_tree_destory(MPIDI_OFI_WIN(win).dwin_target_mrs[i]);
+                MPL_gavl_tree_destroy(MPIDI_OFI_WIN(win).dwin_target_mrs[i]);
             MPL_free(MPIDI_OFI_WIN(win).dwin_target_mrs);
-            MPL_gavl_tree_destory(MPIDI_OFI_WIN(win).dwin_mrs);
+            MPL_gavl_tree_destroy(MPIDI_OFI_WIN(win).dwin_mrs);
         }
 
     }

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -140,7 +140,7 @@ int MPIDI_GPU_mpi_finalize_hook(void)
                     if (MPIDI_GPUI_global.ipc_handle_mapped_trees[i][j]) {
                         for (int k = 0; k < MPIDI_GPUI_global.local_device_count; ++k) {
                             if (MPIDI_GPUI_global.ipc_handle_mapped_trees[i][j][k])
-                                MPL_gavl_tree_destory(MPIDI_GPUI_global.ipc_handle_mapped_trees[i]
+                                MPL_gavl_tree_destroy(MPIDI_GPUI_global.ipc_handle_mapped_trees[i]
                                                       [j]
                                                       [k]);
                         }
@@ -158,7 +158,7 @@ int MPIDI_GPU_mpi_finalize_hook(void)
             if (MPIDI_GPUI_global.ipc_handle_track_trees[i]) {
                 for (int j = 0; j < (MPIDI_GPUI_global.global_max_dev_id + 1); ++j) {
                     if (MPIDI_GPUI_global.ipc_handle_track_trees[i][j])
-                        MPL_gavl_tree_destory(MPIDI_GPUI_global.ipc_handle_track_trees[i][j]);
+                        MPL_gavl_tree_destroy(MPIDI_GPUI_global.ipc_handle_track_trees[i][j]);
                 }
             }
             MPL_free(MPIDI_GPUI_global.ipc_handle_track_trees[i]);

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -203,11 +203,7 @@ static void ipc_track_cache_free(void *obj)
 static int ipc_track_cache_search(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len,
                                   MPL_gpu_ipc_mem_handle_t * handle_out, bool * found)
 {
-    int mpi_errno = MPI_SUCCESS;
-
-    void *obj;
-    int mpl_err = MPL_gavl_tree_search(gavl_tree, addr, len, &obj);
-    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**mpl_gavl_search");
+    void *obj = MPL_gavl_tree_search(gavl_tree, addr, len);
 
     if (obj) {
         *handle_out = *((MPL_gpu_ipc_mem_handle_t *) obj);
@@ -216,10 +212,7 @@ static int ipc_track_cache_search(MPL_gavl_tree_t gavl_tree, const void *addr, u
         *found = false;
     }
 
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
+    return MPI_SUCCESS;
 }
 
 static int ipc_track_cache_insert(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len,
@@ -257,15 +250,9 @@ static void ipc_mapped_cache_free(void *obj)
 static int ipc_mapped_cache_search(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len,
                                    void **mapped_base_addr_out)
 {
-    int mpi_errno = MPI_SUCCESS;
+    *mapped_base_addr_out = MPL_gavl_tree_search(gavl_tree, addr, len);
 
-    int mpl_err = MPL_gavl_tree_search(gavl_tree, addr, len, mapped_base_addr_out);
-    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**mpl_gavl_search");
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
+    return MPI_SUCCESS;
 }
 
 static int ipc_mapped_cache_insert(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len,

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -206,9 +206,11 @@ static int ipc_track_cache_search(MPL_gavl_tree_t gavl_tree, const void *addr, u
     void *obj = MPL_gavl_tree_search(gavl_tree, addr, len);
 
     if (obj) {
+        MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "cached gpu ipc handle HIT for %p", addr);
         *handle_out = *((MPL_gpu_ipc_mem_handle_t *) obj);
         *found = true;
     } else {
+        MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "cached gpu ipc handle MISS for %p", addr);
         *found = false;
     }
 
@@ -219,6 +221,8 @@ static int ipc_track_cache_insert(MPL_gavl_tree_t gavl_tree, const void *addr, u
                                   MPL_gpu_ipc_mem_handle_t handle)
 {
     int mpi_errno = MPI_SUCCESS;
+
+    MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "caching NEW gpu ipc handle for %p", addr);
 
     MPL_gpu_ipc_mem_handle_t *cache_obj = MPL_malloc(sizeof(handle), MPL_MEM_OTHER);
     MPIR_ERR_CHKANDJUMP(!cache_obj, mpi_errno, MPI_ERR_OTHER, "**nomem");
@@ -240,6 +244,8 @@ static int ipc_track_cache_remove(const void *addr, uintptr_t len, int local_dev
 {
     int mpi_errno = MPI_SUCCESS;
     int mpl_err;
+
+    MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "removing STALE gpu ipc handle for %p", addr);
 
     for (int i = 0; i < MPIR_Process.local_size; ++i) {
         MPL_gavl_tree_t track_tree = MPIDI_GPUI_global.ipc_handle_track_trees[i][local_dev_id];

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
@@ -105,7 +105,7 @@ int MPIDI_XPMEM_mpi_finalize_hook(void)
     for (i = 0; i < MPIR_Process.local_size; i++) {
         /* should be called before xpmem_release
          * MPIDI_XPMEMI_segtree_delete_all will call xpmem_detach */
-        MPL_gavl_tree_destory(MPIDI_XPMEMI_global.segmaps[i].segcache_ubuf);
+        MPL_gavl_tree_destroy(MPIDI_XPMEMI_global.segmaps[i].segcache_ubuf);
         if (MPIDI_XPMEMI_global.segmaps[i].apid != -1) {
             XPMEM_TRACE("finalize: release apid: node_rank %d, 0x%lx\n",
                         i, (uint64_t) MPIDI_XPMEMI_global.segmaps[i].apid);

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_seg.c
@@ -70,9 +70,7 @@ int MPIDI_XPMEMI_seg_regist(int node_rank, uintptr_t size,
         MPL_ROUND_UP_ALIGN(size + ((uintptr_t) remote_vaddr - seg_low),
                            MPIDI_XPMEMI_global.sys_page_sz);
 
-    mpl_err = MPL_gavl_tree_search(segcache, remote_vaddr, size, (void **) &seg);
-    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**mpl_gavl_search");
-
+    seg = MPL_gavl_tree_search(segcache, remote_vaddr, size);
     if (seg == NULL) {
         struct xpmem_addr xpmem_addr;
         void *att_vaddr;

--- a/src/mpid/ch4/src/ch4_globals.c
+++ b/src/mpid/ch4/src/ch4_globals.c
@@ -163,4 +163,5 @@ MPL_dbg_class MPIDI_CH4_DBG_GENERAL;
 MPL_dbg_class MPIDI_CH4_DBG_MAP;
 MPL_dbg_class MPIDI_CH4_DBG_COMM;
 MPL_dbg_class MPIDI_CH4_DBG_MEMORY;
+MPL_dbg_class MPIDI_CH4_DBG_IPC;
 #endif

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -445,6 +445,7 @@ int MPID_Init(int requested, int *provided)
     MPIDI_CH4_DBG_MAP = MPL_dbg_class_alloc("CH4_MAP", "ch4_map");
     MPIDI_CH4_DBG_COMM = MPL_dbg_class_alloc("CH4_COMM", "ch4_comm");
     MPIDI_CH4_DBG_MEMORY = MPL_dbg_class_alloc("CH4_MEMORY", "ch4_memory");
+    MPIDI_CH4_DBG_IPC = MPL_dbg_class_alloc("CH4_IPC", "ch4_ipc");
 #endif
 
 #ifdef HAVE_SIGNAL

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -300,6 +300,7 @@ extern MPL_dbg_class MPIDI_CH4_DBG_GENERAL;
 extern MPL_dbg_class MPIDI_CH4_DBG_MAP;
 extern MPL_dbg_class MPIDI_CH4_DBG_COMM;
 extern MPL_dbg_class MPIDI_CH4_DBG_MEMORY;
+extern MPL_dbg_class MPIDI_CH4_DBG_IPC;
 #endif
 
 #endif /* CH4_TYPES_H_INCLUDED */

--- a/src/mpl/include/mpl_gavl.h
+++ b/src/mpl/include/mpl_gavl.h
@@ -14,8 +14,8 @@ int MPL_gavl_tree_insert(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t 
 int MPL_gavl_tree_destroy(MPL_gavl_tree_t gavl_tree);
 int MPL_gavl_tree_delete_range(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len);
 int MPL_gavl_tree_delete_start_addr(MPL_gavl_tree_t gavl_tree, const void *addr);
-MPL_STATIC_INLINE_PREFIX int MPL_gavl_tree_search(MPL_gavl_tree_t gavl_tree, const void *addr,
-                                                  uintptr_t len, void **val);
+MPL_STATIC_INLINE_PREFIX void *MPL_gavl_tree_search(MPL_gavl_tree_t gavl_tree, const void *addr,
+                                                    uintptr_t len);
 
 /*
  * We assume AVL tree height will not exceed 64. AVL tree with 64 height in worst case
@@ -132,20 +132,17 @@ MPL_STATIC_INLINE_PREFIX int MPLI_gavl_start_addr_cmp_func(MPLI_gavl_tree_node_s
  * len              - (IN) input buffer length
  * val              - (OUT) matched buffer object
  */
-MPL_STATIC_INLINE_PREFIX int MPL_gavl_tree_search(MPL_gavl_tree_t gavl_tree, const void *addr,
-                                                  uintptr_t len, void **val)
+MPL_STATIC_INLINE_PREFIX void *MPL_gavl_tree_search(MPL_gavl_tree_t gavl_tree, const void *addr,
+                                                    uintptr_t len)
 {
-    int mpl_err = MPL_SUCCESS;
     MPLI_gavl_tree_node_s *cur_node;
     MPLI_gavl_tree_s *tree_ptr = (MPLI_gavl_tree_s *) gavl_tree;
 
-    *val = NULL;
     cur_node = tree_ptr->root;
     while (cur_node) {
         int cmp_ret = MPLI_gavl_subset_cmp_func(cur_node, (uintptr_t) addr, len);
         if (cmp_ret == MPLI_GAVL_BUFFER_MATCH) {
-            *val = (void *) cur_node->val;
-            break;
+            return (void *) cur_node->val;
         } else if (cmp_ret == MPLI_GAVL_SEARCH_LEFT) {
             cur_node = cur_node->u.s.left;
         } else {
@@ -153,7 +150,7 @@ MPL_STATIC_INLINE_PREFIX int MPL_gavl_tree_search(MPL_gavl_tree_t gavl_tree, con
         }
     }
 
-    return mpl_err;
+    return NULL;
 }
 
 #endif /* MPL_GAVL_H_INCLUDED  */

--- a/src/mpl/include/mpl_gavl.h
+++ b/src/mpl/include/mpl_gavl.h
@@ -11,7 +11,7 @@ typedef void *MPL_gavl_tree_t;
 int MPL_gavl_tree_create(void (*free_fn) (void *), MPL_gavl_tree_t * gavl_tree);
 int MPL_gavl_tree_insert(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len,
                          const void *val);
-int MPL_gavl_tree_destory(MPL_gavl_tree_t gavl_tree);
+int MPL_gavl_tree_destroy(MPL_gavl_tree_t gavl_tree);
 int MPL_gavl_tree_delete_range(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t len);
 int MPL_gavl_tree_delete_start_addr(MPL_gavl_tree_t gavl_tree, const void *addr);
 MPL_STATIC_INLINE_PREFIX int MPL_gavl_tree_search(MPL_gavl_tree_t gavl_tree, const void *addr,

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -119,6 +119,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
 int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr);
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle, int dev_id, void **ptr);
 int MPL_gpu_ipc_handle_unmap(void *ptr);
+bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr);
 
 int MPL_gpu_malloc_host(void **ptr, size_t size);
 int MPL_gpu_free_host(void *ptr);

--- a/src/mpl/include/mpl_gpu_cuda.h
+++ b/src/mpl/include/mpl_gpu_cuda.h
@@ -9,7 +9,10 @@
 #include "cuda.h"
 #include "cuda_runtime_api.h"
 
-typedef cudaIpcMemHandle_t MPL_gpu_ipc_mem_handle_t;
+typedef struct {
+    cudaIpcMemHandle_t handle;
+    unsigned long long id;
+} MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
 typedef struct cudaPointerAttributes MPL_gpu_device_attr;
 typedef int MPL_gpu_request;

--- a/src/mpl/include/mpl_gpu_hip.h
+++ b/src/mpl/include/mpl_gpu_hip.h
@@ -13,7 +13,10 @@
 #include "hip/hip_runtime.h"
 #include "hip/hip_runtime_api.h"
 
-typedef hipIpcMemHandle_t MPL_gpu_ipc_mem_handle_t;
+typedef struct {
+    hipIpcMemHandle_t handle;
+    uint32_t id;
+} MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
 typedef struct hipPointerAttribute_t MPL_gpu_device_attr;
 typedef int MPL_gpu_request;

--- a/src/mpl/src/gavl/mpl_gavl.c
+++ b/src/mpl/src/gavl/mpl_gavl.c
@@ -310,12 +310,12 @@ int MPL_gavl_tree_insert(MPL_gavl_tree_t gavl_tree, const void *addr, uintptr_t 
 }
 
 /*
- * MPL_gavl_tree_destory
+ * MPL_gavl_tree_destroy
  * Description: free all nodes and buffer objects in the tree and tree itself.
  * Parameters:
  * gavl_tree        - (IN)  gavl tree object
  */
-int MPL_gavl_tree_destory(MPL_gavl_tree_t gavl_tree)
+int MPL_gavl_tree_destroy(MPL_gavl_tree_t gavl_tree)
 {
     int mpl_err = MPL_SUCCESS;
     MPLI_gavl_tree_s *tree_ptr = (MPLI_gavl_tree_s *) gavl_tree;

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -208,6 +208,11 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
     goto fn_exit;
 }
 
+bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr)
+{
+    return true;
+}
+
 int MPL_gpu_malloc_host(void **ptr, size_t size)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -235,6 +235,11 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
     goto fn_exit;
 }
 
+bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr)
+{
+    return true;
+}
+
 int MPL_gpu_malloc_host(void **ptr, size_t size)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -2004,6 +2004,11 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
     goto fn_exit;
 }
 
+bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr)
+{
+    return true;
+}
+
 /* at finalize, to free a cache entry in ipc_cache_removal cache */
 static int remove_ipc_handle_entry(MPL_ze_mapped_buffer_entry_t * cache_entry, int dev_id)
 {


### PR DESCRIPTION
## Pull Request Description

The CUDA and HIP memory hooks are unreliable because they rely on specific link
order at application build time. Implement IPC handle validation instead
which should always work. Fixes pmodels/mpich#7304.

~TODO: check ~HIP and~ ZE support and switch to validation if necessary~
TODO: check the ZE implementation of the generic IPC cache and see if we can use validation. the specialized cache does look to already validate buffers.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
