### PR TITLE
topoutil.c: fix compilation on cygwin

### DIFF
--- a/src/mpi/topo/topoutil.c
+++ b/src/mpi/topo/topoutil.c
@@ -199,10 +199,6 @@ static int MPIR_Topology_delete_internal(void *attr_val)
 {
     MPIR_Topology *topology = (MPIR_Topology *) attr_val;
 
-    MPL_UNREFERENCED_ARG(comm);
-    MPL_UNREFERENCED_ARG(keyval);
-    MPL_UNREFERENCED_ARG(extra_data);
-
     /* FIXME - free the attribute data structure */
 
     if (topology->kind == MPI_CART) {


### PR DESCRIPTION
## Pull Request Description

Fix compilation on Cygwin by removing redundant statements. Current 4.3.0 release fails to compile, this is a regression compared to 4.2.3.
```
make[2]: Entering directory '/tmp/mpich-4.3.0'
  CC       src/mpi/topo/topoutil.lo
src/mpi/topo/topoutil.c: In function ‘MPIR_Topology_copy_internal’:
src/mpi/topo/topoutil.c:131:24: error: expected expression before ‘;’ token
  131 |     MPIR_CHKPMEM_DECL();
      |                        ^
src/mpi/topo/topoutil.c:137:75: error: macro "MPIR_CHKPMEM_MALLOC" requires 6 arguments, but only 3 given
  137 |     MPIR_CHKPMEM_MALLOC(copy_topology, sizeof(MPIR_Topology), MPL_MEM_COMM);
      |                                                                           ^
In file included from ./src/include/mpiimpl.h:166,
                 from src/mpi/topo/topoutil.c:6:
./src/include/mpir_mem.h:165: note: macro "MPIR_CHKPMEM_MALLOC" defined here
  165 | #define MPIR_CHKPMEM_MALLOC(pointer_,type_,nbytes_,rc_,name_,class_)    \
      |
src/mpi/topo/topoutil.c:137:5: error: ‘MPIR_CHKPMEM_MALLOC’ undeclared (first use in this function)
  137 |     MPIR_CHKPMEM_MALLOC(copy_topology, sizeof(MPIR_Topology), MPL_MEM_COMM);
      |     ^~~~~~~~~~~~~~~~~~~
src/mpi/topo/topoutil.c:137:5: note: each undeclared identifier is reported only once for each function it appears in
In file included from /tmp/mpich-4.3.0/src/mpl/include/mpl.h:9,
                 from ./src/include/mpiimpl.h:53:
src/mpi/topo/topoutil.c: In function ‘MPIR_Topology_delete_internal’:
src/mpi/topo/topoutil.c:202:26: error: ‘comm’ undeclared (first use in this function)
  202 |     MPL_UNREFERENCED_ARG(comm);
      |                          ^~~~
/tmp/mpich-4.3.0/src/mpl/include/mpl_base.h:111:33: note: in definition of macro ‘MPL_UNREFERENCED_ARG’
  111 | #define MPL_UNREFERENCED_ARG(a) a
      |                                 ^
src/mpi/topo/topoutil.c:203:26: error: ‘keyval’ undeclared (first use in this function)
  203 |     MPL_UNREFERENCED_ARG(keyval);
      |                          ^~~~~~
/tmp/mpich-4.3.0/src/mpl/include/mpl_base.h:111:33: note: in definition of macro ‘MPL_UNREFERENCED_ARG’
  111 | #define MPL_UNREFERENCED_ARG(a) a
      |                                 ^
src/mpi/topo/topoutil.c:204:26: error: ‘extra_data’ undeclared (first use in this function); did you mean ‘ifr_data’?
  204 |     MPL_UNREFERENCED_ARG(extra_data);
      |                          ^~~~~~~~~~
/tmp/mpich-4.3.0/src/mpl/include/mpl_base.h:111:33: note: in definition of macro ‘MPL_UNREFERENCED_ARG’
  111 | #define MPL_UNREFERENCED_ARG(a) a
      |                                 ^
make[2]: *** [Makefile:24573: src/mpi/topo/topoutil.lo] Error 1
```

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
