### PR TITLE
ch4/shm: skip usage of initshm if local_size is 1

### DIFF
--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -62,6 +62,10 @@ int MPIDI_GPU_init_world(void)
     if (device_count < 0)
         goto fn_exit;
 
+    if (MPIR_Process.local_size == 1) {
+        goto fn_exit;
+    }
+
     local_gpu_info.max_dev_id = remote_gpu_info.max_dev_id = my_max_dev_id;
     local_gpu_info.max_subdev_id = remote_gpu_info.max_subdev_id = my_max_subdev_id;
 

--- a/src/mpid/ch4/shm/ipc/src/ipc_fd.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_fd.c
@@ -58,6 +58,11 @@ static int MPIDI_IPC_mpi_fd_cleanup(void)
     char strerrbuf[MPIR_STRERROR_BUF_SIZE] ATTRIBUTE((unused));
     int i;
 
+    if (!MPIDI_IPCI_global_fd_pids || !MPIDI_IPCI_global_fd_socks) {
+        /* skip if not initialized */
+        goto fn_exit;
+    }
+
     /* Close sockets */
     for (i = 0; i < MPIR_Process.local_size; ++i) {
         if (MPIDI_IPCI_global_fd_socks[i] != -1) {
@@ -150,6 +155,11 @@ int MPIDI_IPC_mpi_socks_init(void)
     char strerrbuf[MPIR_STRERROR_BUF_SIZE] ATTRIBUTE((unused));
     pid_t pid;
     int enable = 1;
+
+    if (MPIR_Process.local_size == 1) {
+        /* skip if not needed */
+        goto fn_exit;
+    }
 
     memset(&sockaddr, 0, sizeof(sockaddr));
 
@@ -322,6 +332,8 @@ int MPIDI_IPC_mpi_fd_send(int rank, int fd, void *payload, size_t payload_len)
     char strerrbuf[MPIR_STRERROR_BUF_SIZE] ATTRIBUTE((unused));
     char empty_buf;
 
+    MPIR_Assert(rank != MPIR_Process.local_rank);
+
     /* Setup a payload if provided */
     if (payload == NULL) {
         iov.iov_base = &empty_buf;
@@ -368,6 +380,8 @@ int MPIDI_IPC_mpi_fd_recv(int rank, int *fd, void *payload, size_t payload_len, 
     char strerrbuf[MPIR_STRERROR_BUF_SIZE] ATTRIBUTE((unused));
     char empty_buf;
     bool trunc_check;
+
+    MPIR_Assert(rank != MPIR_Process.local_rank);
 
     /* Setup a payload if provided */
     if (payload == NULL) {

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
@@ -25,6 +25,10 @@ int MPIDI_XPMEM_init_world(void)
         goto fn_exit;
     }
 
+    if (MPIR_Process.local_size == 1) {
+        goto fn_exit;
+    }
+
     MPIR_FUNC_ENTER;
     MPIR_CHKPMEM_DECL();
 


### PR DESCRIPTION
## Pull Request Description
`MPIDU_Init_shm_get` will assert fail for single local process since the initshm won't be created.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
