### PR TITLE
test/mpi/f08: switch to 'use mpi_f08' in util

### DIFF
--- a/test/mpi/util/mtest_f08.f90
+++ b/test/mpi/util/mtest_f08.f90
@@ -22,7 +22,7 @@
         end
 !
         subroutine MTest_Finalize( errs )
-        use mpi
+        use mpi_f08
         integer errs
         integer rank, toterrs, ierr
 
@@ -108,7 +108,7 @@
         end
 
         subroutine MTestSpawnPossible( can_spawn, errs )
-        use mpi
+        use mpi_f08
         integer can_spawn
         integer errs
         integer(kind=MPI_ADDRESS_KIND) val


### PR DESCRIPTION
Switch to `use mpi_f08` in MTest_Finalize and MTestSpawnPossible.

## Pull Request Description
Fortran 2008 tests should use the `mpi_f08` module everywhere. Two functions in `test/mpi/util/mtest_f08.f90` still had `use mpi`.
Leftover from  #5755 

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
