### PR TITLE
datatype: avoid adding refcount for stuct of pairtypes

### DIFF
--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -554,7 +554,6 @@ static inline int MPIR_Datatype_set_contents(MPIR_Datatype * new_dtp,
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint struct_sz, ints_sz, aints_sz, counts_sz, types_sz, contents_size;
     MPIR_Datatype_contents *cp;
-    MPIR_Datatype *old_dtp;
     char *ptr;
 
     struct_sz = sizeof(MPIR_Datatype_contents);
@@ -634,11 +633,7 @@ static inline int MPIR_Datatype_set_contents(MPIR_Datatype * new_dtp,
 
     /* increment reference counts on all the derived types used here */
     for (MPI_Aint i = 0; i < nr_types; i++) {
-        if (!HANDLE_IS_BUILTIN(array_of_types[i])) {
-            MPIR_Datatype_get_ptr(array_of_types[i], old_dtp);
-            MPIR_Datatype_valid_ptr(old_dtp, mpi_errno);
-            MPIR_Datatype_ptr_add_ref(old_dtp);
-        }
+        MPIR_Datatype_add_ref_if_not_builtin(array_of_types[i]);
     }
 
     return mpi_errno;
@@ -692,11 +687,7 @@ MPL_STATIC_INLINE_PREFIX void MPIR_Datatype_free_contents(MPIR_Datatype * dtp)
     MPIR_Datatype_access_contents(cp, &ints, &aints, &counts, &types);
 
     for (int i = 0; i < cp->nr_types; i++) {
-        if (!HANDLE_IS_BUILTIN(types[i])) {
-            MPIR_Datatype *old_dtp;
-            MPIR_Datatype_get_ptr(types[i], old_dtp);
-            MPIR_Datatype_ptr_release(old_dtp);
-        }
+        MPIR_Datatype_release_if_not_builtin(types[i]);
     }
 
     MPL_free(cp);

--- a/src/mpi/datatype/type_contents.c
+++ b/src/mpi/datatype/type_contents.c
@@ -72,10 +72,7 @@ int MPIR_Type_get_contents_impl(MPI_Datatype datatype, int max_integers, int max
     }
 
     for (int i = 0; i < cp->nr_types; i++) {
-        if (!HANDLE_IS_BUILTIN(array_of_datatypes[i])) {
-            MPIR_Datatype_get_ptr(array_of_datatypes[i], dtp);
-            MPIR_Datatype_ptr_add_ref(dtp);
-        }
+        MPIR_Datatype_add_ref_if_not_builtin(array_of_datatypes[i]);
     }
 
     return mpi_errno;
@@ -125,10 +122,7 @@ int MPIR_Type_get_contents_large_impl(MPI_Datatype datatype, MPI_Aint max_intege
     }
 
     for (int i = 0; i < cp->nr_types; i++) {
-        if (!HANDLE_IS_BUILTIN(array_of_datatypes[i])) {
-            MPIR_Datatype_get_ptr(array_of_datatypes[i], dtp);
-            MPIR_Datatype_ptr_add_ref(dtp);
-        }
+        MPIR_Datatype_add_ref_if_not_builtin(array_of_datatypes[i]);
     }
 
     return mpi_errno;


### PR DESCRIPTION

## Pull Request Description
When returning type contents that contains builtin pairtypes, we should not add refcount since users are not supposed to free predefined types. Use `MPIR_Datatype_add_ref_if_not_builtin` fixes it.

Also use `MPIR_Datatype_{add,release}_ref_if_not_builtin` in `MPIR_Type_{set,free}_contents` for consistency.

Fixes #7313

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
