### PR TITLE
misc: do not use external builtin types internally

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,14 @@
 
 # Yaksa is now maintained inside MPICH rather than as an external submodule.  
 
+# Added internal builtin datatypes and external builtin datatypes are mapped to
+internal types. For example, both MPI_INT and MPI_INT32_T are mapped to internal
+type MPIR_INT32. NOTE: direct usage of external MPI types are disallowed
+in MPICH internally. For example, use MPIR_INT_INTERNAL to replace direct usage
+of MPI_INT. Commonly used types include MPI_BYTE, MPI_CHAR, MPI_AINT, use
+MPIR_BYTE_INTERNAL, MPIR_CHAR_INTERNAL, MPIR_AINT_INTERNAL instead. There is no
+impact to users.
+
 ===============================================================================
                                Changes in 4.3
 ===============================================================================

--- a/doc/wiki/design/Internal_Datatypes.md
+++ b/doc/wiki/design/Internal_Datatypes.md
@@ -1,0 +1,80 @@
+# MPICH Internal Datatypes
+
+MPICH used to directly use MPI builtin datatype internally. There are a few issues -
+
+* The datatype constants such as MPI_INT are decided by `configure`. This is because
+  internally we use handle bits to determine the builtin type size and `configure`
+  figures out the type size. Thus, the MPI datatype constants are not true
+  constants in a strict sense. They change between platforms or compilers.
+
+* Not all MPI datatypes are supported. Configure defines unsupported datatype to
+  MPI_DATATYPE_NULL. This may result in compilation error when application build
+  on different platforms.
+
+* MPI datatypes explodes with addition of new language bindings and new type
+  aliases. Treating every MPI datatype independently creates ever-increasing
+  support burden.
+
+* MPI ABI proposal for MPI 5 requires implementations to dynamically configuring
+  datatypes. For example, MPI_Abi_set_fortran_info can set and enable Fortran
+  datatypes such as MPI_INTEGER and MPI_REAL at runtime. Thus, the original
+  `configure` design won't work.
+
+To address these issues, we redesigned MPICH's builtin datatype support by using
+a set of *internal types*. Internal types are defined in src/include/mpir_datatype.h, 
+with names such as `MPIR_INT32`, `MPIR_INT64`, `MPIR_FLOAT32`, `MPIR_FLOAT64`,
+etc. Because they are all fixed-width types, the handle bits are also fixed and
+all internal code that derives type info from handle bits still work.
+
+In contrast, MPI builtin types such as MPI_INT, are now referred to as
+*external* builtin types. The support of *external* builtin types is by mapping
+them to *internal types*. For example, `configure` will define `MPIR_INT_INTERNAL`
+to `MPIR_INT32` and these `_INTERNAL` macros will be used to construct a
+internal table - `MPIR_Internal_types[]` in `src/mpi/datatype/typeutilc` that
+maps external builtin type to internal types. The table can be updated at
+runtime.
+
+For communication, we usually only need the type size and treat the data as
+bytes. If you directly use *external* builtin types *internally*, it may still
+work as long as the type size derived from the handle bits match. This is true
+for common platforms such as x86-64 but cannot be relied on. Thus, we require
+internal code always use *internal* types, e.g. `MPIR_INT_INTERNAL` rather than
+`MPI_INT`. There are assertions in critical places to catch incidents when
+external types are direct used internally.
+
+To perform reduction operation, internal types need the corresponding "C" type.
+This is set by configure and defined in macros such as `MPIR_INT32_CTYPE`. The
+`_CTYPE` macros may be not defined if the corresponding internal type does not
+have a corresponding C type or it is not supported by the platform and compiler.
+For example, `MPIR_INT128_CTYPE` may be undefined (in contrast, `MPIR_INT128` is
+always defined).
+
+Yaksa kernels may also need map to basic C type to work even for communications.
+
+## External/Internal Type Conversions
+
+The binding layer will use the macro `MPIR_DATATYPE_REPLACE_BUILTIN` to convert
+MPI builtin datatypes from user input into internal types before passing into
+internal routines. Thus, internal routines only need support the finite set of
+internal types. Because we don't need all handle bits to encode an internal
+type, we use the last byte to encode the original MPI builtin type which it is
+converted from. For example, `MPI_INT` will be converted to `0x4c810405`
+althout `MPIR_INT32` is `0x4c810400`. Thus, we can recover the original
+datatype when we need to, such as the case of calling user callbacks.
+
+Because of this, if internally we need to switch and compare to internal
+constants, we need mask off the index bits. There are following helper macros:
+
+* `MPIR_DATATYPE_GET_ORIG_BUILTIN(type)` - retrieve the original builtin type
+* `MPIR_DATATYPE_GET_RAW_INTERNAL(type)` - mask off the index bits
+
+It will be good to know there is no impact to derived datatypes.
+
+## Migration Tips
+
+Downstream migration is simple but unfortunately tedious. Basically, you need to
+find every places where *external* builtin types are directly used and replace
+them by its internal macros. Commonly used internal types include - MPI_INT,
+MPI_BYTE, MPI_AINT, etc. Replace them by `MPIR_INT_INTERNAL`, `MPIR_BYTE_INTERNAL`,
+`MPIR_AINT_INTERNAL`. Of course, if the internal use case is fixed-size types,
+you can directly use internal types such as MPIR_INT64.

--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -149,6 +149,9 @@ extern struct MPIR_Datatype_builtin_entry MPIR_Internal_types[];
 /* The "raw" internal type have index bits set to 0 */
 #define MPIR_DATATYPE_GET_RAW_INTERNAL(type)  ((type) & 0xffffff00)
 
+/* Assertion that internally we should not see external builtin types */
+#define MPIR_DATATYPE_ASSERT_BUILTIN(type)  MPIR_Assert(((type) & 0xffff0000) != 0x4c000000)
+
 struct MPIR_pairtype {
     MPI_Datatype value_type;
     /* index_type is always MPI_INT */

--- a/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
+++ b/src/mpi/coll/allgather/allgather_inter_local_gather_remote_bcast.c
@@ -46,7 +46,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
 
     if (sendcount != 0) {
         mpi_errno = MPIR_Gather(sendbuf, sendcount, sendtype, tmp_buf, sendcount * sendtype_sz,
-                                MPI_BYTE, 0, newcomm_ptr, errflag);
+                                MPIR_BYTE_INTERNAL, 0, newcomm_ptr, errflag);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -57,7 +57,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
         if (sendcount != 0) {
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Bcast(tmp_buf, sendcount * sendtype_sz * local_size,
-                                   MPI_BYTE, root, comm_ptr, errflag);
+                                   MPIR_BYTE_INTERNAL, root, comm_ptr, errflag);
             MPIR_ERR_CHECK(mpi_errno);
         }
 
@@ -81,7 +81,7 @@ int MPIR_Allgather_inter_local_gather_remote_bcast(const void *sendbuf, MPI_Aint
         if (sendcount != 0) {
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Bcast(tmp_buf, sendcount * sendtype_sz * local_size,
-                                   MPI_BYTE, root, comm_ptr, errflag);
+                                   MPIR_BYTE_INTERNAL, root, comm_ptr, errflag);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }

--- a/src/mpi/coll/allgather/allgather_intra_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_brucks.c
@@ -44,11 +44,12 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
     /* copy local data to the top of tmp_buf */
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,
-                                   tmp_buf, recvcount * recvtype_sz, MPI_BYTE);
+                                   tmp_buf, recvcount * recvtype_sz, MPIR_BYTE_INTERNAL);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         mpi_errno = MPIR_Localcopy((char *) recvbuf + rank * recvcount * recvtype_extent,
-                                   recvcount, recvtype, tmp_buf, recvcount * recvtype_sz, MPI_BYTE);
+                                   recvcount, recvtype, tmp_buf, recvcount * recvtype_sz,
+                                   MPIR_BYTE_INTERNAL);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -61,10 +62,10 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
         src = (rank + pof2) % comm_size;
         dst = (rank - pof2 + comm_size) % comm_size;
 
-        mpi_errno = MPIC_Sendrecv(tmp_buf, curr_cnt * recvtype_sz, MPI_BYTE, dst,
+        mpi_errno = MPIC_Sendrecv(tmp_buf, curr_cnt * recvtype_sz, MPIR_BYTE_INTERNAL, dst,
                                   MPIR_ALLGATHER_TAG,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
-                                  curr_cnt * recvtype_sz, MPI_BYTE,
+                                  curr_cnt * recvtype_sz, MPIR_BYTE_INTERNAL,
                                   src, MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
         MPIR_ERR_CHECK(mpi_errno);
         curr_cnt *= 2;
@@ -78,10 +79,10 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
         src = (rank + pof2) % comm_size;
         dst = (rank - pof2 + comm_size) % comm_size;
 
-        mpi_errno = MPIC_Sendrecv(tmp_buf, rem * recvcount * recvtype_sz, MPI_BYTE,
+        mpi_errno = MPIC_Sendrecv(tmp_buf, rem * recvcount * recvtype_sz, MPIR_BYTE_INTERNAL,
                                   dst, MPIR_ALLGATHER_TAG,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
-                                  rem * recvcount * recvtype_sz, MPI_BYTE,
+                                  rem * recvcount * recvtype_sz, MPIR_BYTE_INTERNAL,
                                   src, MPIR_ALLGATHER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
         MPIR_ERR_CHECK(mpi_errno);
     }
@@ -89,15 +90,16 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
     /* Rotate blocks in tmp_buf down by (rank) blocks and store
      * result in recvbuf. */
 
-    mpi_errno = MPIR_Localcopy(tmp_buf, (comm_size - rank) * recvcount * recvtype_sz, MPI_BYTE,
-                               (char *) recvbuf + rank * recvcount * recvtype_extent,
-                               (comm_size - rank) * recvcount, recvtype);
+    mpi_errno =
+        MPIR_Localcopy(tmp_buf, (comm_size - rank) * recvcount * recvtype_sz, MPIR_BYTE_INTERNAL,
+                       (char *) recvbuf + rank * recvcount * recvtype_extent,
+                       (comm_size - rank) * recvcount, recvtype);
     MPIR_ERR_CHECK(mpi_errno);
 
     if (rank) {
         mpi_errno = MPIR_Localcopy((char *) tmp_buf +
                                    (comm_size - rank) * recvcount * recvtype_sz,
-                                   rank * recvcount * recvtype_sz, MPI_BYTE, recvbuf,
+                                   rank * recvcount * recvtype_sz, MPIR_BYTE_INTERNAL, recvbuf,
                                    rank * recvcount, recvtype);
         MPIR_ERR_CHECK(mpi_errno);
     }

--- a/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
@@ -53,13 +53,13 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
     /* copy local data to the top of tmp_buf */
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,
-                                   tmp_buf, recvcounts[rank] * recvtype_sz, MPI_BYTE);
+                                   tmp_buf, recvcounts[rank] * recvtype_sz, MPIR_BYTE_INTERNAL);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         mpi_errno = MPIR_Localcopy(((char *) recvbuf +
                                     displs[rank] * recvtype_extent),
                                    recvcounts[rank], recvtype, tmp_buf,
-                                   recvcounts[rank] * recvtype_sz, MPI_BYTE);
+                                   recvcounts[rank] * recvtype_sz, MPIR_BYTE_INTERNAL);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -71,10 +71,10 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
         src = (rank + pof2) % comm_size;
         dst = (rank - pof2 + comm_size) % comm_size;
 
-        mpi_errno = MPIC_Sendrecv(tmp_buf, curr_cnt * recvtype_sz, MPI_BYTE, dst,
+        mpi_errno = MPIC_Sendrecv(tmp_buf, curr_cnt * recvtype_sz, MPIR_BYTE_INTERNAL, dst,
                                   MPIR_ALLGATHERV_TAG,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
-                                  (total_count - curr_cnt) * recvtype_sz, MPI_BYTE,
+                                  (total_count - curr_cnt) * recvtype_sz, MPIR_BYTE_INTERNAL,
                                   src, MPIR_ALLGATHERV_TAG, comm_ptr, &status, errflag);
         MPIR_ERR_CHECK(mpi_errno);
         if (mpi_errno) {
@@ -98,10 +98,10 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
         for (i = 0; i < rem; i++)
             send_cnt += recvcounts[(rank + i) % comm_size];
 
-        mpi_errno = MPIC_Sendrecv(tmp_buf, send_cnt * recvtype_sz, MPI_BYTE,
+        mpi_errno = MPIC_Sendrecv(tmp_buf, send_cnt * recvtype_sz, MPIR_BYTE_INTERNAL,
                                   dst, MPIR_ALLGATHERV_TAG,
                                   ((char *) tmp_buf + curr_cnt * recvtype_sz),
-                                  (total_count - curr_cnt) * recvtype_sz, MPI_BYTE,
+                                  (total_count - curr_cnt) * recvtype_sz, MPIR_BYTE_INTERNAL,
                                   src, MPIR_ALLGATHERV_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
         MPIR_ERR_CHECK(mpi_errno);
     }
@@ -113,7 +113,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
     for (i = 0; i < (comm_size - rank); i++) {
         j = (rank + i) % comm_size;
         mpi_errno = MPIR_Localcopy((char *) tmp_buf + send_cnt * recvtype_sz,
-                                   recvcounts[j] * recvtype_sz, MPI_BYTE,
+                                   recvcounts[j] * recvtype_sz, MPIR_BYTE_INTERNAL,
                                    (char *) recvbuf + displs[j] * recvtype_extent,
                                    recvcounts[j], recvtype);
         MPIR_ERR_CHECK(mpi_errno);
@@ -122,7 +122,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
 
     for (i = 0; i < rank; i++) {
         mpi_errno = MPIR_Localcopy((char *) tmp_buf + send_cnt * recvtype_sz,
-                                   recvcounts[i] * recvtype_sz, MPI_BYTE,
+                                   recvcounts[i] * recvtype_sz, MPIR_BYTE_INTERNAL,
                                    (char *) recvbuf + displs[i] * recvtype_extent,
                                    recvcounts[i], recvtype);
         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -67,7 +67,8 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype,
                                    ((char *) tmp_buf + position *
-                                    recvtype_sz), recvcounts[rank] * recvtype_sz, MPI_BYTE);
+                                    recvtype_sz), recvcounts[rank] * recvtype_sz,
+                                   MPIR_BYTE_INTERNAL);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* if in_place specified, local data is found in recvbuf */
@@ -75,7 +76,8 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                                     displs[rank] * recvtype_extent),
                                    recvcounts[rank], recvtype,
                                    ((char *) tmp_buf + position *
-                                    recvtype_sz), recvcounts[rank] * recvtype_sz, MPI_BYTE);
+                                    recvtype_sz), recvcounts[rank] * recvtype_sz,
+                                   MPIR_BYTE_INTERNAL);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -107,11 +109,11 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                 recv_offset += recvcounts[j];
 
             mpi_errno = MPIC_Sendrecv(((char *) tmp_buf + send_offset * recvtype_sz),
-                                      curr_cnt * recvtype_sz, MPI_BYTE, dst,
+                                      curr_cnt * recvtype_sz, MPIR_BYTE_INTERNAL, dst,
                                       MPIR_ALLGATHERV_TAG,
                                       ((char *) tmp_buf + recv_offset * recvtype_sz),
-                                      (total_count - recv_offset) * recvtype_sz, MPI_BYTE, dst,
-                                      MPIR_ALLGATHERV_TAG, comm_ptr, &status, errflag);
+                                      (total_count - recv_offset) * recvtype_sz, MPIR_BYTE_INTERNAL,
+                                      dst, MPIR_ALLGATHERV_TAG, comm_ptr, &status, errflag);
             MPIR_ERR_CHECK(mpi_errno);
             if (mpi_errno) {
                 last_recv_cnt = 0;
@@ -174,7 +176,8 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
 
                     mpi_errno = MPIC_Send(((char *) tmp_buf + offset * recvtype_sz),
                                           last_recv_cnt * recvtype_sz,
-                                          MPI_BYTE, dst, MPIR_ALLGATHERV_TAG, comm_ptr, errflag);
+                                          MPIR_BYTE_INTERNAL, dst, MPIR_ALLGATHERV_TAG, comm_ptr,
+                                          errflag);
                     MPIR_ERR_CHECK(mpi_errno);
                     /* last_recv_cnt was set in the previous
                      * receive. that's the amount of data to be
@@ -191,7 +194,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
                         offset += recvcounts[j];
 
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset * recvtype_sz),
-                                          (total_count - offset) * recvtype_sz, MPI_BYTE,
+                                          (total_count - offset) * recvtype_sz, MPIR_BYTE_INTERNAL,
                                           dst, MPIR_ALLGATHERV_TAG, comm_ptr, &status);
                     MPIR_ERR_CHECK(mpi_errno);
                     if (mpi_errno) {
@@ -219,7 +222,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
             /* not necessary to copy if in_place and
              * j==rank. otherwise copy. */
             mpi_errno = MPIR_Localcopy(((char *) tmp_buf + position * recvtype_sz),
-                                       recvcounts[j] * recvtype_sz, MPI_BYTE,
+                                       recvcounts[j] * recvtype_sz, MPIR_BYTE_INTERNAL,
                                        ((char *) recvbuf + displs[j] * recvtype_extent),
                                        recvcounts[j], recvtype);
             MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/coll/alltoall/alltoall_intra_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_brucks.c
@@ -51,7 +51,7 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
     pack_size = recvcount * comm_size * recvtype_sz;
     MPIR_CHKLMEM_MALLOC(tmp_buf, pack_size);
 
-    /* Do Phase 1 of the algorithim. Shift the data blocks on process i
+    /* Do Phase 1 of the algorithm. Shift the data blocks on process i
      * upwards by a distance of i blocks. Store the result in recvbuf. */
     mpi_errno = MPIR_Localcopy((char *) sendbuf +
                                rank * sendcount * sendtype_extent,

--- a/src/mpi/coll/alltoall/alltoall_intra_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_brucks.c
@@ -100,10 +100,10 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
         MPIR_ERR_CHECK(mpi_errno);
 
         newtype_sz = count * recvcount * recvtype_sz;
-        mpi_errno = MPIR_Localcopy(recvbuf, 1, newtype, tmp_buf, newtype_sz, MPI_BYTE);
+        mpi_errno = MPIR_Localcopy(recvbuf, 1, newtype, tmp_buf, newtype_sz, MPIR_BYTE_INTERNAL);
         MPIR_ERR_CHECK(mpi_errno);
 
-        mpi_errno = MPIC_Sendrecv(tmp_buf, newtype_sz, MPI_BYTE, dst,
+        mpi_errno = MPIC_Sendrecv(tmp_buf, newtype_sz, MPIR_BYTE_INTERNAL, dst,
                                   MPIR_ALLTOALL_TAG, recvbuf, 1, newtype,
                                   src, MPIR_ALLTOALL_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
         MPIR_ERR_CHECK(mpi_errno);
@@ -116,12 +116,13 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
     /* Rotate blocks in recvbuf upwards by (rank + 1) blocks */
     mpi_errno = MPIR_Localcopy((char *) recvbuf + (rank + 1) * recvcount * recvtype_extent,
                                (comm_size - rank - 1) * recvcount, recvtype, tmp_buf,
-                               (comm_size - rank - 1) * recvcount * recvtype_sz, MPI_BYTE);
+                               (comm_size - rank - 1) * recvcount * recvtype_sz,
+                               MPIR_BYTE_INTERNAL);
     MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Localcopy(recvbuf, (rank + 1) * recvcount, recvtype,
                                (char *) tmp_buf + (comm_size - rank - 1)
                                * recvcount * recvtype_sz,
-                               (rank + 1) * recvcount * recvtype_sz, MPI_BYTE);
+                               (rank + 1) * recvcount * recvtype_sz, MPIR_BYTE_INTERNAL);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Blocks are in the reverse order now (comm_size-1 to 0).
@@ -129,7 +130,7 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
 
     for (i = 0; i < comm_size; i++) {
         mpi_errno = MPIR_Localcopy((char *) tmp_buf + i * recvcount * recvtype_sz,
-                                   recvcount * recvtype_sz, MPI_BYTE,
+                                   recvcount * recvtype_sz, MPIR_BYTE_INTERNAL,
                                    (char *) recvbuf + (comm_size - i -
                                                        1) * recvcount * recvtype_extent, recvcount,
                                    recvtype);

--- a/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
@@ -246,13 +246,13 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
             }
 
             mpi_errno =
-                MPIC_Irecv(tmp_rbuf[j - 1], packsize, MPI_BYTE, src, MPIR_ALLTOALL_TAG, comm,
-                           &reqs[num_reqs++]);
+                MPIC_Irecv(tmp_rbuf[j - 1], packsize, MPIR_BYTE_INTERNAL, src, MPIR_ALLTOALL_TAG,
+                           comm, &reqs[num_reqs++]);
             MPIR_ERR_CHECK(mpi_errno);
 
             mpi_errno =
-                MPIC_Isend(tmp_sbuf[j - 1], packsize, MPI_BYTE, dst, MPIR_ALLTOALL_TAG, comm,
-                           &reqs[num_reqs++], errflag);
+                MPIC_Isend(tmp_sbuf[j - 1], packsize, MPIR_BYTE_INTERNAL, dst, MPIR_ALLTOALL_TAG,
+                           comm, &reqs[num_reqs++], errflag);
             if (mpi_errno) {
                 MPIR_ERR_POP(mpi_errno);
             }

--- a/src/mpi/coll/barrier/barrier_inter_bcast.c
+++ b/src/mpi/coll/barrier/barrier_inter_bcast.c
@@ -40,22 +40,22 @@ int MPIR_Barrier_inter_bcast(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
     if (comm_ptr->is_low_group) {
         /* bcast to right */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
-        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
+        mpi_errno = MPIR_Bcast(&i, 1, MPIR_BYTE_INTERNAL, root, comm_ptr, errflag);
         MPIR_ERR_CHECK(mpi_errno);
 
         /* receive bcast from right */
         root = 0;
-        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
+        mpi_errno = MPIR_Bcast(&i, 1, MPIR_BYTE_INTERNAL, root, comm_ptr, errflag);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* receive bcast from left */
         root = 0;
-        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
+        mpi_errno = MPIR_Bcast(&i, 1, MPIR_BYTE_INTERNAL, root, comm_ptr, errflag);
         MPIR_ERR_CHECK(mpi_errno);
 
         /* bcast to left */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
-        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, root, comm_ptr, errflag);
+        mpi_errno = MPIR_Bcast(&i, 1, MPIR_BYTE_INTERNAL, root, comm_ptr, errflag);
         MPIR_ERR_CHECK(mpi_errno);
     }
   fn_exit:

--- a/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
+++ b/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
@@ -26,8 +26,8 @@ int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t errfla
     while (mask < size) {
         dst = (rank + mask) % size;
         src = (rank - mask + size) % size;
-        mpi_errno = MPIC_Sendrecv(NULL, 0, MPI_BYTE, dst,
-                                  MPIR_BARRIER_TAG, NULL, 0, MPI_BYTE,
+        mpi_errno = MPIC_Sendrecv(NULL, 0, MPIR_BYTE_INTERNAL, dst,
+                                  MPIR_BARRIER_TAG, NULL, 0, MPIR_BYTE_INTERNAL,
                                   src, MPIR_BARRIER_TAG, comm_ptr, MPI_STATUS_IGNORE, errflag);
         MPIR_ERR_CHECK(mpi_errno);
         mask <<= 1;
@@ -97,7 +97,7 @@ int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t e
 
             /* recv from (k-1) nbrs */
             mpi_errno =
-                MPIC_Irecv(NULL, 0, MPI_BYTE, from, MPIR_BARRIER_TAG, comm,
+                MPIC_Irecv(NULL, 0, MPIR_BYTE_INTERNAL, from, MPIR_BARRIER_TAG, comm,
                            &recv_reqs[(j - 1) + ((k - 1) * (i & 1))]);
             MPIR_ERR_CHECK(mpi_errno);
             /* wait on recvs from prev phase */
@@ -108,8 +108,8 @@ int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t e
             }
 
             mpi_errno =
-                MPIC_Isend(NULL, 0, MPI_BYTE, to, MPIR_BARRIER_TAG, comm, &send_reqs[j - 1],
-                           errflag);
+                MPIC_Isend(NULL, 0, MPIR_BYTE_INTERNAL, to, MPIR_BARRIER_TAG, comm,
+                           &send_reqs[j - 1], errflag);
             MPIR_ERR_CHECK(mpi_errno);
         }
         mpi_errno = MPIC_Waitall(k - 1, send_reqs, MPI_STATUSES_IGNORE);

--- a/src/mpi/coll/barrier/barrier_intra_recexch.c
+++ b/src/mpi/coll/barrier/barrier_intra_recexch.c
@@ -14,7 +14,7 @@ int MPIR_Barrier_intra_recexch(MPIR_Comm * comm, int k, int single_phase_recv,
     int mpi_errno = MPI_SUCCESS;
 
     mpi_errno = MPIR_Allreduce_intra_recexch(MPI_IN_PLACE, NULL, 0,
-                                             MPI_BYTE, MPI_SUM, comm,
+                                             MPIR_BYTE_INTERNAL, MPI_SUM, comm,
                                              k, single_phase_recv, errflag);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpi/coll/barrier/barrier_intra_smp.c
+++ b/src/mpi/coll/barrier/barrier_intra_smp.c
@@ -28,7 +28,7 @@ int MPIR_Barrier_intra_smp(MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
      * anything) */
     if (comm_ptr->node_comm != NULL) {
         int i = 0;
-        mpi_errno = MPIR_Bcast(&i, 1, MPI_BYTE, 0, comm_ptr->node_comm, errflag);
+        mpi_errno = MPIR_Bcast(&i, 1, MPIR_BYTE_INTERNAL, 0, comm_ptr->node_comm, errflag);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -51,7 +51,8 @@ int MPIR_Bcast_intra_binomial(void *buffer,
 
         /* TODO: Pipeline the packing and communication */
         if (rank == root) {
-            mpi_errno = MPIR_Localcopy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE);
+            mpi_errno =
+                MPIR_Localcopy(buffer, count, datatype, tmp_buf, nbytes, MPIR_BYTE_INTERNAL);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }
@@ -90,7 +91,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
             if (src < 0)
                 src += comm_size;
             if (!is_contig)
-                mpi_errno = MPIC_Recv(tmp_buf, nbytes, MPI_BYTE, src,
+                mpi_errno = MPIC_Recv(tmp_buf, nbytes, MPIR_BYTE_INTERNAL, src,
                                       MPIR_BCAST_TAG, comm_ptr, status_p);
             else
                 mpi_errno = MPIC_Recv(buffer, count, datatype, src,
@@ -98,7 +99,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
             MPIR_ERR_CHECK(mpi_errno);
 #ifdef HAVE_ERROR_CHECKING
             /* check that we received as much as we expected */
-            MPIR_Get_count_impl(status_p, MPI_BYTE, &recvd_size);
+            MPIR_Get_count_impl(status_p, MPIR_BYTE_INTERNAL, &recvd_size);
             MPIR_ERR_CHKANDJUMP2(recvd_size != nbytes, mpi_errno, MPI_ERR_OTHER,
                                  "**collective_size_mismatch",
                                  "**collective_size_mismatch %d %d",
@@ -127,7 +128,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
             if (dst >= comm_size)
                 dst -= comm_size;
             if (!is_contig)
-                mpi_errno = MPIC_Send(tmp_buf, nbytes, MPI_BYTE, dst,
+                mpi_errno = MPIC_Send(tmp_buf, nbytes, MPIR_BYTE_INTERNAL, dst,
                                       MPIR_BCAST_TAG, comm_ptr, errflag);
             else
                 mpi_errno = MPIC_Send(buffer, count, datatype, dst,
@@ -139,7 +140,8 @@ int MPIR_Bcast_intra_binomial(void *buffer,
 
     if (!is_contig) {
         if (rank != root) {
-            mpi_errno = MPIR_Localcopy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype);
+            mpi_errno =
+                MPIR_Localcopy(tmp_buf, nbytes, MPIR_BYTE_INTERNAL, buffer, count, datatype);
             MPIR_ERR_CHECK(mpi_errno);
 
         }

--- a/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
@@ -63,7 +63,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
         }
     }
 
-    /* treat all cases as MPI_BYTE */
+    /* treat all cases as MPIR_BYTE_INTERNAL */
     MPIR_Algo_calculate_pipeline_chunk_info(chunk_size, 1, nbytes, &num_chunks,
                                             &chunk_size_floor, &chunk_size_ceil);
 
@@ -115,7 +115,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
 
                 if (src != -1) {        /* post receive from parent */
                     mpi_errno =
-                        MPIC_Irecv((char *) sendbuf + offset, msgsize, MPI_BYTE,
+                        MPIC_Irecv((char *) sendbuf + offset, msgsize, MPIR_BYTE_INTERNAL,
                                    src, MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++]);
                     MPIR_ERR_CHECK(mpi_errno);
                 }
@@ -128,7 +128,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                 MPI_Aint msgsize = (i == 0) ? chunk_size_floor : chunk_size_ceil;
                 if (src != -1) {
                     mpi_errno =
-                        MPIC_Irecv((char *) sendbuf + offset, msgsize, MPI_BYTE,
+                        MPIC_Irecv((char *) sendbuf + offset, msgsize, MPIR_BYTE_INTERNAL,
                                    src, MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++]);
                     MPIR_ERR_CHECK(mpi_errno);
                 }
@@ -146,7 +146,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
             if (src != -1) {
                 mpi_errno = MPIC_Wait(reqs[i]);
                 MPIR_ERR_CHECK(mpi_errno);
-                MPIR_Get_count_impl(&reqs[i]->status, MPI_BYTE, &recvd_size);
+                MPIR_Get_count_impl(&reqs[i]->status, MPIR_BYTE_INTERNAL, &recvd_size);
                 MPIR_ERR_CHKANDJUMP2(recvd_size != msgsize, mpi_errno, MPI_ERR_OTHER,
                                      "**collective_size_mismatch",
                                      "**collective_size_mismatch %d %d",
@@ -157,7 +157,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
             if (src != -1) {
                 mpi_errno = MPIC_Wait(reqs[i]);
                 MPIR_ERR_CHECK(mpi_errno);
-                MPIR_Get_count_impl(&reqs[i]->status, MPI_BYTE, &recvd_size);
+                MPIR_Get_count_impl(&reqs[i]->status, MPIR_BYTE_INTERNAL, &recvd_size);
                 MPIR_ERR_CHKANDJUMP2(recvd_size != msgsize, mpi_errno, MPI_ERR_OTHER,
                                      "**collective_size_mismatch",
                                      "**collective_size_mismatch %d %d",
@@ -167,10 +167,10 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
             /* Receive message from parent */
             if (src != -1) {
                 mpi_errno =
-                    MPIC_Recv((char *) sendbuf + offset, msgsize, MPI_BYTE,
+                    MPIC_Recv((char *) sendbuf + offset, msgsize, MPIR_BYTE_INTERNAL,
                               src, MPIR_BCAST_TAG, comm_ptr, &status);
                 MPIR_ERR_CHECK(mpi_errno);
-                MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
+                MPIR_Get_count_impl(&status, MPIR_BYTE_INTERNAL, &recvd_size);
                 MPIR_ERR_CHKANDJUMP2(recvd_size != msgsize, mpi_errno, MPI_ERR_OTHER,
                                      "**collective_size_mismatch",
                                      "**collective_size_mismatch %d %d",
@@ -188,11 +188,11 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
 
                 if (!is_nb) {
                     mpi_errno =
-                        MPIC_Send((char *) sendbuf + offset, msgsize, MPI_BYTE, dst,
+                        MPIC_Send((char *) sendbuf + offset, msgsize, MPIR_BYTE_INTERNAL, dst,
                                   MPIR_BCAST_TAG, comm_ptr, errflag);
                 } else {
                     mpi_errno =
-                        MPIC_Isend((char *) sendbuf + offset, msgsize, MPI_BYTE, dst,
+                        MPIC_Isend((char *) sendbuf + offset, msgsize, MPIR_BYTE_INTERNAL, dst,
                                    MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++], errflag);
                 }
                 MPIR_ERR_CHECK(mpi_errno);
@@ -204,11 +204,12 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
                 p = (int *) utarray_eltptr(my_tree.children, j);
                 dst = *p;
                 if (!is_nb) {
-                    mpi_errno = MPIC_Send((char *) sendbuf + offset, msgsize, MPI_BYTE, dst,
-                                          MPIR_BCAST_TAG, comm_ptr, errflag);
+                    mpi_errno =
+                        MPIC_Send((char *) sendbuf + offset, msgsize, MPIR_BYTE_INTERNAL, dst,
+                                  MPIR_BCAST_TAG, comm_ptr, errflag);
                 } else {
                     mpi_errno =
-                        MPIC_Isend((char *) sendbuf + offset, msgsize, MPI_BYTE, dst,
+                        MPIC_Isend((char *) sendbuf + offset, msgsize, MPIR_BYTE_INTERNAL, dst,
                                    MPIR_BCAST_TAG, comm_ptr, &reqs[num_req++], errflag);
                 }
                 MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -70,7 +70,8 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
         MPIR_CHKLMEM_MALLOC(tmp_buf, nbytes);
 
         if (rank == root) {
-            mpi_errno = MPIR_Localcopy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE);
+            mpi_errno =
+                MPIR_Localcopy(buffer, count, datatype, tmp_buf, nbytes, MPIR_BYTE_INTERNAL);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }
@@ -116,15 +117,16 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
 
         if (relative_dst < comm_size) {
             mpi_errno = MPIC_Sendrecv(((char *) tmp_buf + send_offset),
-                                      curr_size, MPI_BYTE, dst, MPIR_BCAST_TAG,
+                                      curr_size, MPIR_BYTE_INTERNAL, dst, MPIR_BCAST_TAG,
                                       ((char *) tmp_buf + recv_offset),
                                       (nbytes - recv_offset < 0 ? 0 : nbytes - recv_offset),
-                                      MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, &status, errflag);
+                                      MPIR_BYTE_INTERNAL, dst, MPIR_BCAST_TAG, comm_ptr, &status,
+                                      errflag);
             MPIR_ERR_CHECK(mpi_errno);
             if (mpi_errno) {
                 recv_size = 0;
             } else
-                MPIR_Get_count_impl(&status, MPI_BYTE, &recv_size);
+                MPIR_Get_count_impl(&status, MPIR_BYTE_INTERNAL, &recv_size);
             curr_size += recv_size;
         }
 
@@ -183,7 +185,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                     /* printf("Rank %d, send to %d, offset %d, size %d\n", rank, dst, offset, recv_size);
                      * fflush(stdout); */
                     mpi_errno = MPIC_Send(((char *) tmp_buf + offset),
-                                          recv_size, MPI_BYTE, dst,
+                                          recv_size, MPIR_BYTE_INTERNAL, dst,
                                           MPIR_BCAST_TAG, comm_ptr, errflag);
                     /* recv_size was set in the previous
                      * receive. that's the amount of data to be
@@ -199,14 +201,15 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
                      * relative_rank, dst); */
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset),
                                           nbytes - offset < 0 ? 0 : nbytes - offset,
-                                          MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, &status);
+                                          MPIR_BYTE_INTERNAL, dst, MPIR_BCAST_TAG, comm_ptr,
+                                          &status);
                     /* nprocs_completed is also equal to the no. of processes
                      * whose data we don't have */
                     MPIR_ERR_CHECK(mpi_errno);
                     if (mpi_errno) {
                         recv_size = 0;
                     } else
-                        MPIR_Get_count_impl(&status, MPI_BYTE, &recv_size);
+                        MPIR_Get_count_impl(&status, MPIR_BYTE_INTERNAL, &recv_size);
                     curr_size += recv_size;
                     /* printf("Rank %d, recv from %d, offset %d, size %d\n", rank, dst, offset, recv_size);
                      * fflush(stdout); */
@@ -231,7 +234,8 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
 
     if (!is_contig) {
         if (rank != root) {
-            mpi_errno = MPIR_Localcopy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype);
+            mpi_errno =
+                MPIR_Localcopy(tmp_buf, nbytes, MPIR_BYTE_INTERNAL, buffer, count, datatype);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -89,7 +89,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
     if (curr_size < 0)
         curr_size = 0;
 
-    /* medium size allgather and pof2 comm_size. use recurive doubling. */
+    /* medium size allgather and pof2 comm_size. use recursive doubling. */
 
     mask = 0x1;
     i = 0;

--- a/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
@@ -62,7 +62,8 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
         MPIR_CHKLMEM_MALLOC(tmp_buf, nbytes);
 
         if (rank == root) {
-            mpi_errno = MPIR_Localcopy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE);
+            mpi_errno =
+                MPIR_Localcopy(buffer, count, datatype, tmp_buf, nbytes, MPIR_BYTE_INTERNAL);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }
@@ -101,11 +102,12 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
         right_disp = rel_j * scatter_size;
 
         mpi_errno = MPIC_Sendrecv((char *) tmp_buf + right_disp, right_count,
-                                  MPI_BYTE, right, MPIR_BCAST_TAG,
+                                  MPIR_BYTE_INTERNAL, right, MPIR_BCAST_TAG,
                                   (char *) tmp_buf + left_disp, left_count,
-                                  MPI_BYTE, left, MPIR_BCAST_TAG, comm_ptr, &status, errflag);
+                                  MPIR_BYTE_INTERNAL, left, MPIR_BCAST_TAG, comm_ptr, &status,
+                                  errflag);
         MPIR_ERR_CHECK(mpi_errno);
-        MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
+        MPIR_Get_count_impl(&status, MPIR_BYTE_INTERNAL, &recvd_size);
         curr_size += recvd_size;
         j = jnext;
         jnext = (comm_size + jnext - 1) % comm_size;
@@ -120,7 +122,8 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
 
     if (!is_contig) {
         if (rank != root) {
-            mpi_errno = MPIR_Localcopy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype);
+            mpi_errno =
+                MPIR_Localcopy(tmp_buf, nbytes, MPIR_BYTE_INTERNAL, buffer, count, datatype);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }

--- a/src/mpi/coll/bcast/bcast_intra_smp.c
+++ b/src/mpi/coll/bcast/bcast_intra_smp.c
@@ -6,7 +6,7 @@
 #include "mpiimpl.h"
 
 /* FIXME This function uses some heuristsics based off of some testing on a
- * cluster at Argonne.  We need a better system for detrmining and controlling
+ * cluster at Argonne.  We need a better system for determining and controlling
  * the cutoff points for these algorithms.  If I've done this right, you should
  * be able to make changes along these lines almost exclusively in this function
  * and some new functions. [goodell@ 2008/01/07] */

--- a/src/mpi/coll/bcast/bcast_intra_smp.c
+++ b/src/mpi/coll/bcast/bcast_intra_smp.c
@@ -49,7 +49,7 @@ int MPIR_Bcast_intra_smp(void *buffer, MPI_Aint count, MPI_Datatype datatype, in
                 MPIR_ERR_CHECK(mpi_errno);
 #ifdef HAVE_ERROR_CHECKING
                 /* check that we received as much as we expected */
-                MPIR_Get_count_impl(status_p, MPI_BYTE, &recvd_size);
+                MPIR_Get_count_impl(status_p, MPIR_BYTE_INTERNAL, &recvd_size);
                 MPIR_ERR_CHKANDJUMP2(recvd_size != nbytes, mpi_errno, MPI_ERR_OTHER,
                                      "**collective_size_mismatch",
                                      "**collective_size_mismatch %d %d",

--- a/src/mpi/coll/bcast/bcast_intra_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_tree.c
@@ -61,7 +61,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
             MPIR_ERR_CHECK(mpi_errno);
         }
         count = count * type_size;
-        dtype = MPI_BYTE;
+        dtype = MPIR_BYTE_INTERNAL;
     }
 
     if (tree_type == MPIR_TREE_TYPE_KARY) {
@@ -130,7 +130,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
         mpi_errno = MPIC_Recv(send_buf, count, dtype, src, MPIR_BCAST_TAG, comm_ptr, &status);
         MPIR_ERR_CHECK(mpi_errno);
         /* check that we received as much as we expected */
-        MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
+        MPIR_Get_count_impl(&status, MPIR_BYTE_INTERNAL, &recvd_size);
         MPIR_ERR_CHKANDJUMP2(recvd_size != nbytes, mpi_errno, MPI_ERR_OTHER,
                              "**collective_size_mismatch",
                              "**collective_size_mismatch %d %d", (int) recvd_size, (int) nbytes);

--- a/src/mpi/coll/bcast/bcast_utils.c
+++ b/src/mpi/coll/bcast/bcast_utils.c
@@ -66,10 +66,11 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
             } else {
                 mpi_errno = MPIC_Recv(((char *) tmp_buf +
                                        relative_rank * scatter_size),
-                                      recv_size, MPI_BYTE, src, MPIR_BCAST_TAG, comm_ptr, &status);
+                                      recv_size, MPIR_BYTE_INTERNAL, src, MPIR_BCAST_TAG, comm_ptr,
+                                      &status);
                 MPIR_ERR_CHECK(mpi_errno);
                 /* query actual size of data received */
-                MPIR_Get_count_impl(&status, MPI_BYTE, &curr_size);
+                MPIR_Get_count_impl(&status, MPIR_BYTE_INTERNAL, &curr_size);
             }
             break;
         }
@@ -93,7 +94,8 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
                     dst -= comm_size;
                 mpi_errno = MPIC_Send(((char *) tmp_buf +
                                        scatter_size * (relative_rank + mask)),
-                                      send_size, MPI_BYTE, dst, MPIR_BCAST_TAG, comm_ptr, errflag);
+                                      send_size, MPIR_BYTE_INTERNAL, dst, MPIR_BCAST_TAG, comm_ptr,
+                                      errflag);
                 MPIR_ERR_CHECK(mpi_errno);
 
                 curr_size -= send_size;

--- a/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
+++ b/src/mpi/coll/gather/gather_inter_local_gather_remote_send.c
@@ -64,12 +64,12 @@ int MPIR_Gather_inter_local_gather_remote_send(const void *sendbuf, MPI_Aint sen
 
         /* now do the a local gather on this intracommunicator */
         mpi_errno = MPIR_Gather(sendbuf, sendcount, sendtype,
-                                tmp_buf, sendcount * sendtype_sz, MPI_BYTE, 0, newcomm_ptr,
-                                errflag);
+                                tmp_buf, sendcount * sendtype_sz, MPIR_BYTE_INTERNAL, 0,
+                                newcomm_ptr, errflag);
         MPIR_ERR_CHECK(mpi_errno);
 
         if (rank == 0) {
-            mpi_errno = MPIC_Send(tmp_buf, sendcount * local_size * sendtype_sz, MPI_BYTE,
+            mpi_errno = MPIC_Send(tmp_buf, sendcount * local_size * sendtype_sz, MPIR_BYTE_INTERNAL,
                                   root, MPIR_GATHER_TAG, comm_ptr, errflag);
             MPIR_ERR_CHECK(mpi_errno);
         }

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -110,7 +110,8 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
         }
     } else if (tmp_buf_size && (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE)) {
         /* copy from sendbuf into tmp_buf */
-        mpi_errno = MPIR_Localcopy(sendbuf, sendcount, sendtype, tmp_buf, nbytes, MPI_BYTE);
+        mpi_errno =
+            MPIR_Localcopy(sendbuf, sendcount, sendtype, tmp_buf, nbytes, MPIR_BYTE_INTERNAL);
         MPIR_ERR_CHECK(mpi_errno);
     }
     curr_cnt = nbytes;
@@ -143,7 +144,8 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                         /* small transfer size case. cast ok */
                         MPIR_Assert(recvblks * nbytes == (int) (recvblks * nbytes));
                         mpi_errno = MPIC_Recv(tmp_buf, (int) (recvblks * nbytes),
-                                              MPI_BYTE, src, MPIR_GATHER_TAG, comm_ptr, &status);
+                                              MPIR_BYTE_INTERNAL, src, MPIR_GATHER_TAG, comm_ptr,
+                                              &status);
                         MPIR_ERR_CHECK(mpi_errno);
                         copy_offset = rank + mask;
                         copy_blks = recvblks;
@@ -183,7 +185,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                     else
                         offset = (mask - 1) * nbytes;
                     mpi_errno = MPIC_Recv(((char *) tmp_buf + offset),
-                                          recvblks * nbytes, MPI_BYTE, src,
+                                          recvblks * nbytes, MPIR_BYTE_INTERNAL, src,
                                           MPIR_GATHER_TAG, comm_ptr, &status);
                     MPIR_ERR_CHECK(mpi_errno);
                     curr_cnt += (recvblks * nbytes);
@@ -199,7 +201,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                                       MPIR_GATHER_TAG, comm_ptr, errflag);
                 MPIR_ERR_CHECK(mpi_errno);
             } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
-                mpi_errno = MPIC_Send(tmp_buf, curr_cnt, MPI_BYTE, dst,
+                mpi_errno = MPIC_Send(tmp_buf, curr_cnt, MPIR_BYTE_INTERNAL, dst,
                                       MPIR_GATHER_TAG, comm_ptr, errflag);
                 MPIR_ERR_CHECK(mpi_errno);
             } else {
@@ -211,10 +213,10 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                 /* check for overflow.  work around int limits if needed */
                 if (curr_cnt - nbytes != (int) (curr_cnt - nbytes)) {
                     blocks[1] = 1;
-                    MPIR_Type_contiguous_x_impl(curr_cnt - nbytes, MPI_BYTE, &(types[1]));
+                    MPIR_Type_contiguous_x_impl(curr_cnt - nbytes, MPIR_BYTE_INTERNAL, &(types[1]));
                 } else {
                     MPIR_Assign_trunc(blocks[1], curr_cnt - nbytes, int);
-                    types[1] = MPI_BYTE;
+                    types[1] = MPIR_BYTE_INTERNAL;
                 }
                 struct_displs[1] = (MPI_Aint) tmp_buf;
                 mpi_errno =
@@ -228,7 +230,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
                                       MPIR_GATHER_TAG, comm_ptr, errflag);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_Type_free_impl(&tmp_type);
-                if (types[1] != MPI_BYTE)
+                if (types[1] != MPIR_BYTE_INTERNAL)
                     MPIR_Type_free_impl(&types[1]);
             }
 
@@ -240,13 +242,13 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
     if ((rank == root) && root && (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) && copy_blks) {
         /* reorder and copy from tmp_buf into recvbuf */
         mpi_errno = MPIR_Localcopy(tmp_buf,
-                                   nbytes * (comm_size - copy_offset), MPI_BYTE,
+                                   nbytes * (comm_size - copy_offset), MPIR_BYTE_INTERNAL,
                                    ((char *) recvbuf + extent * recvcount * copy_offset),
                                    recvcount * (comm_size - copy_offset), recvtype);
         MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Localcopy((char *) tmp_buf + nbytes * (comm_size - copy_offset),
-                                   nbytes * (copy_blks - comm_size + copy_offset), MPI_BYTE,
-                                   recvbuf,
+                                   nbytes * (copy_blks - comm_size + copy_offset),
+                                   MPIR_BYTE_INTERNAL, recvbuf,
                                    recvcount * (copy_blks - comm_size + copy_offset), recvtype);
         MPIR_ERR_CHECK(mpi_errno);
     }

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -135,6 +135,8 @@ int MPIC_Send(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest, 
 
     MPIR_FUNC_ENTER;
 
+    MPIR_DATATYPE_ASSERT_BUILTIN(datatype);
+
     /* Return immediately for dummy process */
     if (unlikely(dest == MPI_PROC_NULL)) {
         goto fn_exit;
@@ -176,6 +178,8 @@ int MPIC_Recv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source, int 
     MPIR_Request *request_ptr = NULL;
 
     MPIR_FUNC_ENTER;
+
+    MPIR_DATATYPE_ASSERT_BUILTIN(datatype);
 
     /* Return immediately for dummy process */
     if (unlikely(source == MPI_PROC_NULL)) {
@@ -226,6 +230,9 @@ int MPIC_Sendrecv(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype
     MPIR_Request *recv_req_ptr = NULL, *send_req_ptr = NULL;
 
     MPIR_FUNC_ENTER;
+
+    MPIR_DATATYPE_ASSERT_BUILTIN(sendtype);
+    MPIR_DATATYPE_ASSERT_BUILTIN(recvtype);
 
     MPIR_ERR_CHKANDJUMP1((sendcount < 0), mpi_errno, MPI_ERR_COUNT,
                          "**countneg", "**countneg %d", sendcount);

--- a/src/mpi/coll/helper_fns.c
+++ b/src/mpi/coll/helper_fns.c
@@ -352,7 +352,8 @@ int MPIC_Sendrecv_replace(void *buf, MPI_Aint count, MPI_Datatype datatype,
         MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     } else {
         MPIR_PT2PT_ATTR_SET_ERRFLAG(attr, errflag);
-        DO_MPID_ISEND(tmpbuf, actual_pack_bytes, MPI_PACKED, dest, sendtag, comm_ptr, attr, &sreq);
+        DO_MPID_ISEND(tmpbuf, actual_pack_bytes, MPIR_BYTE_INTERNAL, dest, sendtag, comm_ptr, attr,
+                      &sreq);
         MPIR_ERR_CHECK(mpi_errno);
         if (mpi_errno != MPI_SUCCESS) {
             /* --BEGIN ERROR HANDLING-- */

--- a/src/mpi/coll/iallgather/iallgather_inter_sched_local_gather_remote_bcast.c
+++ b/src/mpi/coll/iallgather/iallgather_inter_sched_local_gather_remote_bcast.c
@@ -45,8 +45,8 @@ int MPIR_Iallgather_inter_sched_local_gather_remote_bcast(const void *sendbuf, M
 
     if (sendcount != 0) {
         mpi_errno = MPIR_Igather_intra_sched_auto(sendbuf, sendcount, sendtype,
-                                                  tmp_buf, sendcount * sendtype_sz, MPI_BYTE, 0,
-                                                  newcomm_ptr, s);
+                                                  tmp_buf, sendcount * sendtype_sz,
+                                                  MPIR_BYTE_INTERNAL, 0, newcomm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
@@ -58,7 +58,7 @@ int MPIR_Iallgather_inter_sched_local_gather_remote_bcast(const void *sendbuf, M
         if (sendcount != 0) {
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Ibcast_inter_sched_auto(tmp_buf, sendcount * local_size * sendtype_sz,
-                                                     MPI_BYTE, root, comm_ptr, s);
+                                                     MPIR_BYTE_INTERNAL, root, comm_ptr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
 
@@ -87,7 +87,7 @@ int MPIR_Iallgather_inter_sched_local_gather_remote_bcast(const void *sendbuf, M
         if (sendcount != 0) {
             root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
             mpi_errno = MPIR_Ibcast_inter_sched_auto(tmp_buf, sendcount * local_size * sendtype_sz,
-                                                     MPI_BYTE, root, comm_ptr, s);
+                                                     MPIR_BYTE_INTERNAL, root, comm_ptr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/iallgather/iallgather_intra_sched_brucks.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_sched_brucks.c
@@ -36,13 +36,13 @@ int MPIR_Iallgather_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
     /* copy local data to the top of tmp_buf */
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype, tmp_buf,
-                                    recvcount * recvtype_sz, MPI_BYTE, s);
+                                    recvcount * recvtype_sz, MPIR_BYTE_INTERNAL, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     } else {
         mpi_errno = MPIR_Sched_copy((char *) recvbuf + rank * recvcount * recvtype_extent,
-                                    recvcount, recvtype, tmp_buf, recvcount * recvtype_sz, MPI_BYTE,
-                                    s);
+                                    recvcount, recvtype, tmp_buf, recvcount * recvtype_sz,
+                                    MPIR_BYTE_INTERNAL, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
@@ -56,11 +56,12 @@ int MPIR_Iallgather_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
         src = (rank + pof2) % comm_size;
         dst = (rank - pof2 + comm_size) % comm_size;
 
-        mpi_errno = MPIR_Sched_send(tmp_buf, curr_cnt * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_send(tmp_buf, curr_cnt * recvtype_sz, MPIR_BYTE_INTERNAL, dst, comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
         /* logically sendrecv, so no barrier here */
         mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + curr_cnt * recvtype_sz),
-                                    curr_cnt * recvtype_sz, MPI_BYTE, src, comm_ptr, s);
+                                    curr_cnt * recvtype_sz, MPIR_BYTE_INTERNAL, src, comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
@@ -76,11 +77,13 @@ int MPIR_Iallgather_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
         dst = (rank - pof2 + comm_size) % comm_size;
 
         mpi_errno =
-            MPIR_Sched_send(tmp_buf, rem * recvcount * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
+            MPIR_Sched_send(tmp_buf, rem * recvcount * recvtype_sz, MPIR_BYTE_INTERNAL, dst,
+                            comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
         /* logically sendrecv, so no barrier here */
         mpi_errno = MPIR_Sched_recv((char *) tmp_buf + curr_cnt * recvtype_sz,
-                                    rem * recvcount * recvtype_sz, MPI_BYTE, src, comm_ptr, s);
+                                    rem * recvcount * recvtype_sz, MPIR_BYTE_INTERNAL, src,
+                                    comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
@@ -88,16 +91,17 @@ int MPIR_Iallgather_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
     /* Rotate blocks in tmp_buf down by (rank) blocks and store
      * result in recvbuf. */
 
-    mpi_errno = MPIR_Sched_copy(tmp_buf, (comm_size - rank) * recvcount * recvtype_sz, MPI_BYTE,
-                                ((char *) recvbuf + rank * recvcount * recvtype_extent),
-                                (comm_size - rank) * recvcount, recvtype, s);
+    mpi_errno =
+        MPIR_Sched_copy(tmp_buf, (comm_size - rank) * recvcount * recvtype_sz, MPIR_BYTE_INTERNAL,
+                        ((char *) recvbuf + rank * recvcount * recvtype_extent),
+                        (comm_size - rank) * recvcount, recvtype, s);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_SCHED_BARRIER(s);
 
     if (rank) {
         mpi_errno =
             MPIR_Sched_copy((char *) tmp_buf + (comm_size - rank) * recvcount * recvtype_sz,
-                            rank * recvcount * recvtype_sz, MPI_BYTE,
+                            rank * recvcount * recvtype_sz, MPIR_BYTE_INTERNAL,
                             recvbuf, rank * recvcount, recvtype, s);
         MPIR_ERR_CHECK(mpi_errno);
     }

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_brucks.c
@@ -37,13 +37,13 @@ int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
     /* copy local data to the top of tmp_buf */
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
-                                    tmp_buf, recvcounts[rank] * recvtype_sz, MPI_BYTE, s);
+                                    tmp_buf, recvcounts[rank] * recvtype_sz, MPIR_BYTE_INTERNAL, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     } else {
         mpi_errno = MPIR_Sched_copy(((char *) recvbuf + displs[rank] * recvtype_extent),
                                     recvcounts[rank], recvtype,
-                                    tmp_buf, recvcounts[rank] * recvtype_sz, MPI_BYTE, s);
+                                    tmp_buf, recvcounts[rank] * recvtype_sz, MPIR_BYTE_INTERNAL, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
@@ -69,11 +69,14 @@ int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
             incoming_count += recvcounts[(src + i) % comm_size];
         }
 
-        mpi_errno = MPIR_Sched_send(tmp_buf, curr_count * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_send(tmp_buf, curr_count * recvtype_sz, MPIR_BYTE_INTERNAL, dst, comm_ptr,
+                            s);
         MPIR_ERR_CHECK(mpi_errno);
         /* sendrecv, no barrier */
         mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + curr_count * recvtype_sz),
-                                    incoming_count * recvtype_sz, MPI_BYTE, src, comm_ptr, s);
+                                    incoming_count * recvtype_sz, MPIR_BYTE_INTERNAL, src, comm_ptr,
+                                    s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
@@ -92,11 +95,12 @@ int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
         for (i = 0; i < rem; i++)
             cnt += recvcounts[(rank + i) % comm_size];
 
-        mpi_errno = MPIR_Sched_send(tmp_buf, cnt * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
+        mpi_errno =
+            MPIR_Sched_send(tmp_buf, cnt * recvtype_sz, MPIR_BYTE_INTERNAL, dst, comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
         /* sendrecv, no barrier */
         mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + curr_count * recvtype_sz),
-                                    (total_count - curr_count) * recvtype_sz, MPI_BYTE,
+                                    (total_count - curr_count) * recvtype_sz, MPIR_BYTE_INTERNAL,
                                     src, comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -110,7 +114,7 @@ int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
     for (i = 0; i < (comm_size - rank); i++) {
         j = (rank + i) % comm_size;
         mpi_errno = MPIR_Sched_copy(((char *) tmp_buf + send_cnt * recvtype_sz),
-                                    recvcounts[j] * recvtype_sz, MPI_BYTE,
+                                    recvcounts[j] * recvtype_sz, MPIR_BYTE_INTERNAL,
                                     ((char *) recvbuf + displs[j] * recvtype_extent),
                                     recvcounts[j], recvtype, s);
         MPIR_ERR_CHECK(mpi_errno);
@@ -119,7 +123,7 @@ int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
 
     for (i = 0; i < rank; i++) {
         mpi_errno = MPIR_Sched_copy(((char *) tmp_buf + send_cnt * recvtype_sz),
-                                    recvcounts[i] * recvtype_sz, MPI_BYTE,
+                                    recvcounts[i] * recvtype_sz, MPIR_BYTE_INTERNAL,
                                     ((char *) recvbuf + displs[i] * recvtype_extent),
                                     recvcounts[i], recvtype, s);
         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_recursive_doubling.c
@@ -49,14 +49,14 @@ int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, MPI_Ain
     if (sendbuf != MPI_IN_PLACE) {
         mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
                                     ((char *) tmp_buf + position * recvtype_sz),
-                                    recvcounts[rank] * recvtype_sz, MPI_BYTE, s);
+                                    recvcounts[rank] * recvtype_sz, MPIR_BYTE_INTERNAL, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* if in_place specified, local data is found in recvbuf */
         mpi_errno = MPIR_Sched_copy(((char *) recvbuf + displs[rank] * recvtype_extent),
                                     recvcounts[rank], recvtype,
                                     ((char *) tmp_buf + position * recvtype_sz),
-                                    recvcounts[rank] * recvtype_sz, MPI_BYTE, s);
+                                    recvcounts[rank] * recvtype_sz, MPIR_BYTE_INTERNAL, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -108,11 +108,13 @@ int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, MPI_Ain
                 incoming_count += recvcounts[j];
 
             mpi_errno = MPIR_Sched_send(((char *) tmp_buf + send_offset * recvtype_sz),
-                                        curr_count * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
+                                        curr_count * recvtype_sz, MPIR_BYTE_INTERNAL, dst, comm_ptr,
+                                        s);
             MPIR_ERR_CHECK(mpi_errno);
             /* sendrecv, no barrier here */
             mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + recv_offset * recvtype_sz),
-                                        incoming_count * recvtype_sz, MPI_BYTE, dst, comm_ptr, s);
+                                        incoming_count * recvtype_sz, MPIR_BYTE_INTERNAL, dst,
+                                        comm_ptr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
 
@@ -176,7 +178,7 @@ int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, MPI_Ain
                      * receive. that's the amount of data to be
                      * sent now. */
                     mpi_errno = MPIR_Sched_send(((char *) tmp_buf + offset),
-                                                incoming_count * recvtype_sz, MPI_BYTE,
+                                                incoming_count * recvtype_sz, MPIR_BYTE_INTERNAL,
                                                 dst, comm_ptr, s);
                     MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
@@ -198,7 +200,7 @@ int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, MPI_Ain
                         incoming_count += recvcounts[j];
 
                     mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + offset * recvtype_sz),
-                                                incoming_count * recvtype_sz, MPI_BYTE,
+                                                incoming_count * recvtype_sz, MPIR_BYTE_INTERNAL,
                                                 dst, comm_ptr, s);
                     MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
@@ -224,7 +226,7 @@ int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, MPI_Ain
             /* not necessary to copy if in_place and
              * j==rank. otherwise copy. */
             mpi_errno = MPIR_Sched_copy(((char *) tmp_buf + position * recvtype_sz),
-                                        recvcounts[j] * recvtype_sz, MPI_BYTE,
+                                        recvcounts[j] * recvtype_sz, MPIR_BYTE_INTERNAL,
                                         ((char *) recvbuf + displs[j] * recvtype_extent),
                                         recvcounts[j], recvtype, s);
             MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_brucks.c
@@ -51,7 +51,7 @@ int MPIR_Ialltoall_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
     tmp_buf = MPIR_Sched_alloc_state(s, nbytes);
     MPIR_ERR_CHKANDJUMP(!tmp_buf, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
-    /* Do Phase 1 of the algorithim. Shift the data blocks on process i
+    /* Do Phase 1 of the algorithm. Shift the data blocks on process i
      * upwards by a distance of i blocks. Store the result in recvbuf. */
     mpi_errno = MPIR_Sched_copy(((char *) sendbuf + rank * sendcount * sendtype_extent),
                                 (comm_size - rank) * sendcount, sendtype,

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_brucks.c
@@ -101,12 +101,13 @@ int MPIR_Ialltoall_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
         MPIR_Datatype_get_size_macro(newtype, newtype_size);
 
         /* we will usually copy much less than nbytes */
-        mpi_errno = MPIR_Sched_copy(recvbuf, 1, newtype, tmp_buf, newtype_size, MPI_BYTE, s);
+        mpi_errno =
+            MPIR_Sched_copy(recvbuf, 1, newtype, tmp_buf, newtype_size, MPIR_BYTE_INTERNAL, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
 
         /* now send and recv in parallel */
-        mpi_errno = MPIR_Sched_send(tmp_buf, newtype_size, MPI_BYTE, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_send(tmp_buf, newtype_size, MPIR_BYTE_INTERNAL, dst, comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_recv(recvbuf, 1, newtype, src, comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
@@ -121,12 +122,12 @@ int MPIR_Ialltoall_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
     mpi_errno = MPIR_Sched_copy(((char *) recvbuf + (rank + 1) * recvcount * recvtype_extent),
                                 (comm_size - rank - 1) * recvcount, recvtype,
                                 tmp_buf, (comm_size - rank - 1) * recvcount * recvtype_sz,
-                                MPI_BYTE, s);
+                                MPIR_BYTE_INTERNAL, s);
     MPIR_ERR_CHECK(mpi_errno);
     mpi_errno = MPIR_Sched_copy(recvbuf, (rank + 1) * recvcount, recvtype,
                                 ((char *) tmp_buf +
                                  (comm_size - rank - 1) * recvcount * recvtype_sz),
-                                (rank + 1) * recvcount * recvtype_sz, MPI_BYTE, s);
+                                (rank + 1) * recvcount * recvtype_sz, MPIR_BYTE_INTERNAL, s);
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_SCHED_BARRIER(s);
 
@@ -135,7 +136,7 @@ int MPIR_Ialltoall_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
 
     for (i = 0; i < comm_size; i++) {
         mpi_errno = MPIR_Sched_copy(((char *) tmp_buf + i * recvcount * recvtype_sz),
-                                    recvcount * recvtype_sz, MPI_BYTE,
+                                    recvcount * recvtype_sz, MPIR_BYTE_INTERNAL,
                                     ((char *) recvbuf +
                                      (comm_size - i - 1) * recvcount * recvtype_extent), recvcount,
                                     recvtype, s);

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_inplace.c
@@ -55,12 +55,13 @@ int MPIR_Ialltoall_intra_sched_inplace(const void *sendbuf, MPI_Aint sendcount,
 
                 /* pack to tmp_buf */
                 mpi_errno = MPIR_Sched_copy(((char *) recvbuf + peer * recvcount * recvtype_extent),
-                                            recvcount, recvtype, tmp_buf, nbytes, MPI_BYTE, s);
+                                            recvcount, recvtype, tmp_buf, nbytes,
+                                            MPIR_BYTE_INTERNAL, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
                 /* now simultaneously send from tmp_buf and recv to recvbuf */
-                mpi_errno = MPIR_Sched_send(tmp_buf, nbytes, MPI_BYTE, peer, comm_ptr, s);
+                mpi_errno = MPIR_Sched_send(tmp_buf, nbytes, MPIR_BYTE_INTERNAL, peer, comm_ptr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_recv(((char *) recvbuf + peer * recvcount * recvtype_extent),
                                             recvcount, recvtype, peer, comm_ptr, s);

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks.c
@@ -281,7 +281,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
             unpack_ninvtcs = 1;
 
             mpi_errno =
-                MPIR_TSP_sched_isend(tmp_sbuf[i][j - 1], packsize, MPI_BYTE, dst, tag,
+                MPIR_TSP_sched_isend(tmp_sbuf[i][j - 1], packsize, MPIR_BYTE_INTERNAL, dst, tag,
                                      comm, sched, 1, &packids[j - 1], &sendids[j - 1]);
             MPIR_ERR_CHECK(mpi_errno);
 
@@ -290,7 +290,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
                 recv_ninvtcs = 1;
             }
             mpi_errno =
-                MPIR_TSP_sched_irecv(tmp_rbuf[i][j - 1], packsize, MPI_BYTE,
+                MPIR_TSP_sched_irecv(tmp_rbuf[i][j - 1], packsize, MPIR_BYTE_INTERNAL,
                                      src, tag, comm, sched, recv_ninvtcs, recv_invtcs,
                                      &recvids[j - 1]);
             MPIR_ERR_CHECK(mpi_errno);
@@ -304,8 +304,8 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
             MPIR_ERR_CHECK(mpi_errno);
             num_unpacks_in_last_phase++;
         }
-        MPIR_Localcopy(unpackids, sizeof(int) * (k - 1), MPI_BYTE,
-                       pack_invtcs, sizeof(int) * (k - 1), MPI_BYTE);
+        MPIR_Localcopy(unpackids, sizeof(int) * (k - 1), MPIR_BYTE_INTERNAL,
+                       pack_invtcs, sizeof(int) * (k - 1), MPIR_BYTE_INTERNAL);
         pack_ninvtcs = k - 1;
 
         delta *= k;

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_inplace.c
@@ -60,14 +60,16 @@ int MPIR_Ialltoallv_intra_sched_inplace(const void *sendbuf, const MPI_Aint send
                 mpi_errno = MPIR_Sched_send(((char *) recvbuf + rdispls[dst] * recvtype_extent),
                                             recvcounts[dst], recvtype, dst, comm_ptr, s);
                 MPIR_ERR_CHECK(mpi_errno);
-                mpi_errno = MPIR_Sched_recv(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
-                                            dst, comm_ptr, s);
+                mpi_errno =
+                    MPIR_Sched_recv(tmp_buf, recvcounts[dst] * recvtype_sz, MPIR_BYTE_INTERNAL, dst,
+                                    comm_ptr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
-                mpi_errno = MPIR_Sched_copy(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
-                                            ((char *) recvbuf + rdispls[dst] * recvtype_extent),
-                                            recvcounts[dst], recvtype, s);
+                mpi_errno =
+                    MPIR_Sched_copy(tmp_buf, recvcounts[dst] * recvtype_sz, MPIR_BYTE_INTERNAL,
+                                    ((char *) recvbuf + rdispls[dst] * recvtype_extent),
+                                    recvcounts[dst], recvtype, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_inplace.c
@@ -69,14 +69,16 @@ int MPIR_Ialltoallw_intra_sched_inplace(const void *sendbuf, const MPI_Aint send
                 mpi_errno = MPIR_Sched_send(((char *) recvbuf + rdispls[dst]),
                                             recvcounts[dst], recvtypes[dst], dst, comm_ptr, s);
                 MPIR_ERR_CHECK(mpi_errno);
-                mpi_errno = MPIR_Sched_recv(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
-                                            dst, comm_ptr, s);
+                mpi_errno =
+                    MPIR_Sched_recv(tmp_buf, recvcounts[dst] * recvtype_sz, MPIR_BYTE_INTERNAL, dst,
+                                    comm_ptr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
 
-                mpi_errno = MPIR_Sched_copy(tmp_buf, recvcounts[dst] * recvtype_sz, MPI_BYTE,
-                                            ((char *) recvbuf + rdispls[dst]),
-                                            recvcounts[dst], recvtypes[dst], s);
+                mpi_errno =
+                    MPIR_Sched_copy(tmp_buf, recvcounts[dst] * recvtype_sz, MPIR_BYTE_INTERNAL,
+                                    ((char *) recvbuf + rdispls[dst]), recvcounts[dst],
+                                    recvtypes[dst], s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }

--- a/src/mpi/coll/ibarrier/ibarrier_inter_sched_bcast.c
+++ b/src/mpi/coll/ibarrier/ibarrier_inter_sched_bcast.c
@@ -40,26 +40,26 @@ int MPIR_Ibarrier_inter_sched_bcast(MPIR_Comm * comm_ptr, MPIR_Sched_t s)
      * left group */
     if (comm_ptr->is_low_group) {
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
-        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPI_BYTE, root, comm_ptr, s);
+        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPIR_BYTE_INTERNAL, root, comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_SCHED_BARRIER(s);
 
         /* receive bcast from right */
         root = 0;
-        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPI_BYTE, root, comm_ptr, s);
+        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPIR_BYTE_INTERNAL, root, comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* receive bcast from left */
         root = 0;
-        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPI_BYTE, root, comm_ptr, s);
+        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPIR_BYTE_INTERNAL, root, comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
 
         MPIR_SCHED_BARRIER(s);
 
         /* bcast to left */
         root = (rank == 0) ? MPI_ROOT : MPI_PROC_NULL;
-        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPI_BYTE, root, comm_ptr, s);
+        mpi_errno = MPIR_Ibcast_inter_sched_auto(buf, 1, MPIR_BYTE_INTERNAL, root, comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/coll/ibarrier/ibarrier_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_sched_recursive_doubling.c
@@ -33,10 +33,10 @@ int MPIR_Ibarrier_intra_sched_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sche
         dst = (rank + mask) % size;
         src = (rank - mask + size) % size;
 
-        mpi_errno = MPIR_Sched_send(NULL, 0, MPI_BYTE, dst, comm_ptr, s);
+        mpi_errno = MPIR_Sched_send(NULL, 0, MPIR_BYTE_INTERNAL, dst, comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
 
-        mpi_errno = MPIR_Sched_recv(NULL, 0, MPI_BYTE, src, comm_ptr, s);
+        mpi_errno = MPIR_Sched_recv(NULL, 0, MPIR_BYTE_INTERNAL, src, comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Sched_barrier(s);

--- a/src/mpi/coll/ibarrier/ibarrier_intra_tsp_dissem.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_tsp_dissem.c
@@ -50,15 +50,15 @@ int MPIR_TSP_Ibarrier_sched_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST, "dissem barrier - scheduling recv from %d\n", from));
             mpi_errno =
-                MPIR_TSP_sched_irecv(NULL, 0, MPI_BYTE, from, tag, comm, sched, 0, NULL,
+                MPIR_TSP_sched_irecv(NULL, 0, MPIR_BYTE_INTERNAL, from, tag, comm, sched, 0, NULL,
                                      &recv_ids[i * (k - 1) + j - 1]);
             MPIR_ERR_CHECK(mpi_errno);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST, "dissem barrier - scheduling send to %d\n", to));
             mpi_errno =
-                MPIR_TSP_sched_isend(NULL, 0, MPI_BYTE, to, tag, comm, sched, i * (k - 1), recv_ids,
-                                     &vtx_id);
+                MPIR_TSP_sched_isend(NULL, 0, MPIR_BYTE_INTERNAL, to, tag, comm, sched, i * (k - 1),
+                                     recv_ids, &vtx_id);
             MPIR_ERR_CHECK(mpi_errno);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,

--- a/src/mpi/coll/ibarrier/ibarrier_intra_tsp_recexch.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_tsp_recexch.c
@@ -13,10 +13,10 @@ int MPIR_TSP_Ibarrier_sched_intra_recexch(MPIR_Comm * comm, int k, MPIR_TSP_sche
     MPIR_FUNC_ENTER;
 
     mpi_errno =
-        MPIR_TSP_Iallreduce_sched_intra_recexch(MPI_IN_PLACE, recvbuf, 0, MPI_BYTE, MPI_SUM,
-                                                comm,
-                                                MPIR_IALLREDUCE_RECEXCH_TYPE_MULTIPLE_BUFFER,
-                                                k, sched);
+        MPIR_TSP_Iallreduce_sched_intra_recexch(MPI_IN_PLACE, recvbuf, 0, MPIR_BYTE_INTERNAL,
+                                                MPI_SUM, comm,
+                                                MPIR_IALLREDUCE_RECEXCH_TYPE_MULTIPLE_BUFFER, k,
+                                                sched);
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpi/coll/ibarrier/ibarrier_tsp_auto.c
+++ b/src/mpi/coll/ibarrier/ibarrier_tsp_auto.c
@@ -22,8 +22,8 @@ int MPIR_TSP_Ibarrier_sched_intra_tsp_auto(MPIR_Comm * comm, MPIR_TSP_sched_t sc
     switch (MPIR_CVAR_IBARRIER_INTRA_ALGORITHM) {
         case MPIR_CVAR_IBARRIER_INTRA_ALGORITHM_tsp_recexch:
             mpi_errno =
-                MPIR_TSP_Iallreduce_sched_intra_recexch(MPI_IN_PLACE, recvbuf, 0, MPI_BYTE, MPI_SUM,
-                                                        comm,
+                MPIR_TSP_Iallreduce_sched_intra_recexch(MPI_IN_PLACE, recvbuf, 0,
+                                                        MPIR_BYTE_INTERNAL, MPI_SUM, comm,
                                                         MPIR_IALLREDUCE_RECEXCH_TYPE_MULTIPLE_BUFFER,
                                                         MPIR_CVAR_IBARRIER_RECEXCH_KVAL, sched);
             break;
@@ -41,8 +41,8 @@ int MPIR_TSP_Ibarrier_sched_intra_tsp_auto(MPIR_Comm * comm, MPIR_TSP_sched_t sc
             switch (cnt->id) {
                 case MPII_CSEL_CONTAINER_TYPE__ALGORITHM__MPIR_Ibarrier_intra_tsp_recexch:
                     mpi_errno =
-                        MPIR_TSP_Iallreduce_sched_intra_recexch(MPI_IN_PLACE, recvbuf, 0, MPI_BYTE,
-                                                                MPI_SUM, comm,
+                        MPIR_TSP_Iallreduce_sched_intra_recexch(MPI_IN_PLACE, recvbuf, 0,
+                                                                MPIR_BYTE_INTERNAL, MPI_SUM, comm,
                                                                 MPIR_IALLREDUCE_RECEXCH_TYPE_MULTIPLE_BUFFER,
                                                                 cnt->u.ibarrier.intra_tsp_recexch.k,
                                                                 sched);
@@ -68,7 +68,8 @@ int MPIR_TSP_Ibarrier_sched_intra_tsp_auto(MPIR_Comm * comm, MPIR_TSP_sched_t sc
 
   fallback:
     mpi_errno = MPIR_TSP_Iallreduce_sched_intra_recexch(MPI_IN_PLACE, NULL, 0,
-                                                        MPI_BYTE, MPI_SUM, comm, 0, 2, sched);
+                                                        MPIR_BYTE_INTERNAL, MPI_SUM, comm, 0, 2,
+                                                        sched);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_binomial.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_binomial.c
@@ -51,7 +51,8 @@ int MPIR_Ibcast_intra_sched_binomial(void *buffer, MPI_Aint count, MPI_Datatype 
     if (!is_contig) {
         /* TODO: Pipeline the packing and communication */
         if (rank == root) {
-            mpi_errno = MPIR_Sched_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
+            mpi_errno =
+                MPIR_Sched_copy(buffer, count, datatype, tmp_buf, nbytes, MPIR_BYTE_INTERNAL, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
@@ -91,7 +92,7 @@ int MPIR_Ibcast_intra_sched_binomial(void *buffer, MPI_Aint count, MPI_Datatype 
             if (src < 0)
                 src += comm_size;
             if (!is_contig)
-                mpi_errno = MPIR_Sched_recv_status(tmp_buf, nbytes, MPI_BYTE, src,
+                mpi_errno = MPIR_Sched_recv_status(tmp_buf, nbytes, MPIR_BYTE_INTERNAL, src,
                                                    comm_ptr, &ibcast_state->status, s);
             else
                 mpi_errno = MPIR_Sched_recv_status(buffer, count, datatype, src,
@@ -125,7 +126,7 @@ int MPIR_Ibcast_intra_sched_binomial(void *buffer, MPI_Aint count, MPI_Datatype 
             if (dst >= comm_size)
                 dst -= comm_size;
             if (!is_contig)
-                mpi_errno = MPIR_Sched_send(tmp_buf, nbytes, MPI_BYTE, dst, comm_ptr, s);
+                mpi_errno = MPIR_Sched_send(tmp_buf, nbytes, MPIR_BYTE_INTERNAL, dst, comm_ptr, s);
             else
                 mpi_errno = MPIR_Sched_send(buffer, count, datatype, dst, comm_ptr, s);
             MPIR_ERR_CHECK(mpi_errno);
@@ -139,7 +140,8 @@ int MPIR_Ibcast_intra_sched_binomial(void *buffer, MPI_Aint count, MPI_Datatype 
     if (!is_contig) {
         if (rank != root) {
             MPIR_SCHED_BARRIER(s);
-            mpi_errno = MPIR_Sched_copy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, s);
+            mpi_errno =
+                MPIR_Sched_copy(tmp_buf, nbytes, MPIR_BYTE_INTERNAL, buffer, count, datatype, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_recursive_doubling_allgather.c
@@ -103,7 +103,8 @@ int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, M
         tmp_buf = MPIR_get_contig_ptr(buffer, true_lb);
     } else {
         if (rank == root) {
-            mpi_errno = MPIR_Sched_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
+            mpi_errno =
+                MPIR_Sched_copy(buffer, count, datatype, tmp_buf, nbytes, MPIR_BYTE_INTERNAL, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
@@ -162,12 +163,13 @@ int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, M
                 incoming_count = 0;
 
             mpi_errno = MPIR_Sched_send(((char *) tmp_buf + send_offset),
-                                        curr_size, MPI_BYTE, dst, comm_ptr, s);
+                                        curr_size, MPIR_BYTE_INTERNAL, dst, comm_ptr, s);
             MPIR_ERR_CHECK(mpi_errno);
             /* sendrecv, no barrier */
             mpi_errno = MPIR_Sched_recv_status(((char *) tmp_buf + recv_offset),
                                                incoming_count,
-                                               MPI_BYTE, dst, comm_ptr, &ibcast_state->status, s);
+                                               MPIR_BYTE_INTERNAL, dst, comm_ptr,
+                                               &ibcast_state->status, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
             mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_add_length, ibcast_state, s);
@@ -228,7 +230,8 @@ int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, M
                      * receive. that's the amount of data to be
                      * sent now. */
                     mpi_errno = MPIR_Sched_send(((char *) tmp_buf + offset),
-                                                incoming_count, MPI_BYTE, dst, comm_ptr, s);
+                                                incoming_count, MPIR_BYTE_INTERNAL, dst, comm_ptr,
+                                                s);
                     MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                 }
@@ -247,8 +250,8 @@ int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, M
                     /* nprocs_completed is also equal to the no. of processes
                      * whose data we don't have */
                     mpi_errno = MPIR_Sched_recv_status(((char *) tmp_buf + offset),
-                                                       incoming_count, MPI_BYTE, dst, comm_ptr,
-                                                       &ibcast_state->status, s);
+                                                       incoming_count, MPIR_BYTE_INTERNAL, dst,
+                                                       comm_ptr, &ibcast_state->status, s);
                     MPIR_ERR_CHECK(mpi_errno);
                     MPIR_SCHED_BARRIER(s);
                     mpi_errno = MPIR_Sched_cb(&MPII_Ibcast_sched_add_length, ibcast_state, s);
@@ -270,7 +273,8 @@ int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, M
     MPIR_ERR_CHECK(mpi_errno);
     if (!is_contig) {
         if (rank != root) {
-            mpi_errno = MPIR_Sched_copy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, s);
+            mpi_errno =
+                MPIR_Sched_copy(tmp_buf, nbytes, MPIR_BYTE_INTERNAL, buffer, count, datatype, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_ring_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_ring_allgather.c
@@ -72,7 +72,8 @@ int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
         tmp_buf = MPIR_get_contig_ptr(buffer, true_lb);
     } else {
         if (rank == root) {
-            mpi_errno = MPIR_Sched_copy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, s);
+            mpi_errno =
+                MPIR_Sched_copy(buffer, count, datatype, tmp_buf, nbytes, MPIR_BYTE_INTERNAL, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         }
@@ -119,11 +120,11 @@ int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
         right_disp = rel_j * scatter_size;
 
         mpi_errno = MPIR_Sched_send(((char *) tmp_buf + right_disp),
-                                    right_count, MPI_BYTE, right, comm_ptr, s);
+                                    right_count, MPIR_BYTE_INTERNAL, right, comm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
         /* sendrecv, no barrier here */
         mpi_errno = MPIR_Sched_recv_status(((char *) tmp_buf + left_disp),
-                                           left_count, MPI_BYTE, left, comm_ptr,
+                                           left_count, MPIR_BYTE_INTERNAL, left, comm_ptr,
                                            &ibcast_state->status, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
@@ -138,7 +139,8 @@ int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
     MPIR_ERR_CHECK(mpi_errno);
 
     if (!is_contig && rank != root) {
-        mpi_errno = MPIR_Sched_copy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, s);
+        mpi_errno =
+            MPIR_Sched_copy(tmp_buf, nbytes, MPIR_BYTE_INTERNAL, buffer, count, datatype, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_smp.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_smp.c
@@ -12,7 +12,7 @@ static int sched_test_length(MPIR_Comm * comm, int tag, void *state)
     int mpi_errno = MPI_SUCCESS;
     MPI_Aint recv_size;
     struct MPII_Ibcast_state *ibcast_state = (struct MPII_Ibcast_state *) state;
-    MPIR_Get_count_impl(&ibcast_state->status, MPI_BYTE, &recv_size);
+    MPIR_Get_count_impl(&ibcast_state->status, MPIR_BYTE_INTERNAL, &recv_size);
     if (ibcast_state->n_bytes != recv_size || ibcast_state->status.MPI_ERROR != MPI_SUCCESS) {
         mpi_errno = MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE,
                                          __func__, __LINE__, MPI_ERR_OTHER,

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
@@ -81,8 +81,8 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
 
         if (rank == root) {
             mpi_errno =
-                MPIR_TSP_sched_localcopy(buffer, count, datatype, tmp_buf, nbytes, MPI_BYTE, sched,
-                                         0, NULL, &vtx_id);
+                MPIR_TSP_sched_localcopy(buffer, count, datatype, tmp_buf, nbytes,
+                                         MPIR_BYTE_INTERNAL, sched, 0, NULL, &vtx_id);
             MPIR_ERR_CHECK(mpi_errno);
             mpi_errno = MPIR_TSP_sched_fence(sched);
             MPIR_ERR_CHECK(mpi_errno);
@@ -149,14 +149,14 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
             MPIR_ERR_POP(mpi_errno);
         ibcast_state->n_bytes = recv_size;
         mpi_errno =
-            MPIR_TSP_sched_irecv_status((char *) tmp_buf + displs[rank], recv_size, MPI_BYTE,
-                                        my_tree.parent, tag, comm, &ibcast_state->status, sched, 0,
-                                        NULL, &recv_id);
+            MPIR_TSP_sched_irecv_status((char *) tmp_buf + displs[rank], recv_size,
+                                        MPIR_BYTE_INTERNAL, my_tree.parent, tag, comm,
+                                        &ibcast_state->status, sched, 0, NULL, &recv_id);
         MPIR_TSP_sched_cb(&MPII_Ibcast_sched_test_length, ibcast_state, sched, 1, &recv_id,
                           &vtx_id);
 #else
         mpi_errno =
-            MPIR_TSP_sched_irecv((char *) tmp_buf + displs[rank], recv_size, MPI_BYTE,
+            MPIR_TSP_sched_irecv((char *) tmp_buf + displs[rank], recv_size, MPIR_BYTE_INTERNAL,
                                  my_tree.parent, tag, comm, sched, 0, NULL, &recv_id);
 #endif
         MPIR_ERR_CHECK(mpi_errno);
@@ -173,7 +173,7 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
             num_send_dependencies = 0;
 
         mpi_errno = MPIR_TSP_sched_isend((char *) tmp_buf + displs[child],
-                                         child_subtree_size[i], MPI_BYTE,
+                                         child_subtree_size[i], MPIR_BYTE_INTERNAL,
                                          child, tag, comm, sched, num_send_dependencies, &recv_id,
                                          &vtx_id);
         MPIR_ERR_CHECK(mpi_errno);
@@ -187,14 +187,15 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
     if (allgatherv_algo == MPIR_CVAR_IALLGATHERV_INTRA_ALGORITHM_tsp_ring)
         /* Schedule Allgatherv ring */
         mpi_errno =
-            MPIR_TSP_Iallgatherv_sched_intra_ring(MPI_IN_PLACE, cnts[rank], MPI_BYTE, tmp_buf,
-                                                  cnts, displs, MPI_BYTE, comm, sched);
+            MPIR_TSP_Iallgatherv_sched_intra_ring(MPI_IN_PLACE, cnts[rank], MPIR_BYTE_INTERNAL,
+                                                  tmp_buf, cnts, displs, MPIR_BYTE_INTERNAL, comm,
+                                                  sched);
     else
         /* Schedule Allgatherv recexch */
         mpi_errno =
-            MPIR_TSP_Iallgatherv_sched_intra_recexch(MPI_IN_PLACE, cnts[rank], MPI_BYTE, tmp_buf,
-                                                     cnts, displs, MPI_BYTE, comm, 0, allgatherv_k,
-                                                     sched);
+            MPIR_TSP_Iallgatherv_sched_intra_recexch(MPI_IN_PLACE, cnts[rank], MPIR_BYTE_INTERNAL,
+                                                     tmp_buf, cnts, displs, MPIR_BYTE_INTERNAL,
+                                                     comm, 0, allgatherv_k, sched);
     MPIR_ERR_CHECK(mpi_errno);
 
     if (!is_contig) {
@@ -204,8 +205,8 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
                 MPIR_ERR_POP(mpi_errno);
 
             mpi_errno =
-                MPIR_TSP_sched_localcopy(tmp_buf, nbytes, MPI_BYTE, buffer, count, datatype, sched,
-                                         1, &sink_id, &vtx_id);
+                MPIR_TSP_sched_localcopy(tmp_buf, nbytes, MPIR_BYTE_INTERNAL, buffer, count,
+                                         datatype, sched, 1, &sink_id, &vtx_id);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }

--- a/src/mpi/coll/ibcast/ibcast_utils.c
+++ b/src/mpi/coll/ibcast/ibcast_utils.c
@@ -12,7 +12,7 @@ int MPII_Ibcast_sched_test_length(MPIR_Comm * comm, int tag, void *state)
     MPI_Aint recv_size;
     struct MPII_Ibcast_state *ibcast_state = (struct MPII_Ibcast_state *) state;
 
-    MPIR_Get_count_impl(&ibcast_state->status, MPI_BYTE, &recv_size);
+    MPIR_Get_count_impl(&ibcast_state->status, MPIR_BYTE_INTERNAL, &recv_size);
     if (ibcast_state->n_bytes != recv_size || ibcast_state->status.MPI_ERROR != MPI_SUCCESS) {
         mpi_errno = MPIR_Err_create_code(mpi_errno, MPIR_ERR_RECOVERABLE,
                                          __func__, __LINE__, MPI_ERR_OTHER,
@@ -54,7 +54,7 @@ int MPII_Ibcast_sched_add_length(MPIR_Comm * comm, int tag, void *state)
     MPI_Aint recv_size;
     struct MPII_Ibcast_state *ibcast_state = (struct MPII_Ibcast_state *) state;
 
-    MPIR_Get_count_impl(&ibcast_state->status, MPI_BYTE, &recv_size);
+    MPIR_Get_count_impl(&ibcast_state->status, MPIR_BYTE_INTERNAL, &recv_size);
     ibcast_state->curr_bytes += recv_size;
 
     return mpi_errno;
@@ -110,7 +110,7 @@ int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr,
 
             if (recv_size > 0) {
                 mpi_errno = MPIR_Sched_recv(((char *) tmp_buf + relative_rank * scatter_size),
-                                            recv_size, MPI_BYTE, src, comm_ptr, s);
+                                            recv_size, MPIR_BYTE_INTERNAL, src, comm_ptr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_SCHED_BARRIER(s);
             }
@@ -135,7 +135,7 @@ int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr,
                     dst -= comm_size;
                 mpi_errno =
                     MPIR_Sched_send(((char *) tmp_buf + scatter_size * (relative_rank + mask)),
-                                    send_size, MPI_BYTE, dst, comm_ptr, s);
+                                    send_size, MPIR_BYTE_INTERNAL, dst, comm_ptr, s);
                 MPIR_ERR_CHECK(mpi_errno);
 
                 curr_size -= send_size;

--- a/src/mpi/coll/igather/igather_inter_sched_short.c
+++ b/src/mpi/coll/igather/igather_inter_sched_short.c
@@ -46,7 +46,7 @@ int MPIR_Igather_inter_sched_short(const void *sendbuf, MPI_Aint sendcount, MPI_
             tmp_buf = MPIR_Sched_alloc_state(s, sendcount * local_size * sendtype_sz);
             MPIR_ERR_CHKANDJUMP(!tmp_buf, mpi_errno, MPI_ERR_OTHER, "**nomem");
         } else {
-            /* silience -Wmaybe-uninitialized due to MPIR_Igather_intra_sched_auto by non-zero ranks */
+            /* silence -Wmaybe-uninitialized due to MPIR_Igather_intra_sched_auto by non-zero ranks */
             sendtype_sz = 0;
         }
 

--- a/src/mpi/coll/igather/igather_inter_sched_short.c
+++ b/src/mpi/coll/igather/igather_inter_sched_short.c
@@ -60,13 +60,14 @@ int MPIR_Igather_inter_sched_short(const void *sendbuf, MPI_Aint sendcount, MPI_
 
         /* now do the a local gather on this intracommunicator */
         mpi_errno = MPIR_Igather_intra_sched_auto(sendbuf, sendcount, sendtype,
-                                                  tmp_buf, sendcount * sendtype_sz, MPI_BYTE, 0,
-                                                  newcomm_ptr, s);
+                                                  tmp_buf, sendcount * sendtype_sz,
+                                                  MPIR_BYTE_INTERNAL, 0, newcomm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
 
         if (rank == 0) {
-            mpi_errno = MPIR_Sched_send(tmp_buf, sendcount * local_size * sendtype_sz, MPI_BYTE,
-                                        root, comm_ptr, s);
+            mpi_errno =
+                MPIR_Sched_send(tmp_buf, sendcount * local_size * sendtype_sz, MPIR_BYTE_INTERNAL,
+                                root, comm_ptr, s);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }

--- a/src/mpi/coll/igather/igather_intra_sched_binomial.c
+++ b/src/mpi/coll/igather/igather_intra_sched_binomial.c
@@ -93,7 +93,7 @@ int MPIR_Igather_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
     if (rank == root) {
         if (sendbuf != MPI_IN_PLACE) {
             mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
-                                       ((char *) recvbuf + extent * recvcount * rank),
+                                        ((char *) recvbuf + extent * recvcount * rank),
                                         recvcount, recvtype, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -101,7 +101,7 @@ int MPIR_Igather_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
     } else if (tmp_buf_size && (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE)) {
         /* copy from sendbuf into tmp_buf */
         mpi_errno = MPIR_Sched_copy(sendbuf, sendcount, sendtype,
-                                    tmp_buf, nbytes, MPI_BYTE, s);
+                                    tmp_buf, nbytes, MPIR_BYTE_INTERNAL, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);
     }
@@ -134,7 +134,7 @@ int MPIR_Igather_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
                         MPIR_ERR_CHECK(mpi_errno);
                     } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
                         mpi_errno =
-                            MPIR_Sched_recv(tmp_buf, (recvblks * nbytes), MPI_BYTE, src,
+                            MPIR_Sched_recv(tmp_buf, (recvblks * nbytes), MPIR_BYTE_INTERNAL, src,
                                             comm_ptr, s);
                         MPIR_ERR_CHECK(mpi_errno);
                         mpi_errno = MPIR_Sched_barrier(s);
@@ -177,7 +177,7 @@ int MPIR_Igather_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
                         offset = (mask - 1) * nbytes;
                     mpi_errno =
                         MPIR_Sched_recv(((char *) tmp_buf + offset), (recvblks * nbytes),
-                                        MPI_BYTE, src, comm_ptr, s);
+                                        MPIR_BYTE_INTERNAL, src, comm_ptr, s);
                     MPIR_ERR_CHECK(mpi_errno);
                     mpi_errno = MPIR_Sched_barrier(s);
                     MPIR_ERR_CHECK(mpi_errno);
@@ -195,7 +195,8 @@ int MPIR_Igather_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
                 mpi_errno = MPIR_Sched_barrier(s);
                 MPIR_ERR_CHECK(mpi_errno);
             } else if (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) {
-                mpi_errno = MPIR_Sched_send(tmp_buf, curr_cnt, MPI_BYTE, dst, comm_ptr, s);
+                mpi_errno =
+                    MPIR_Sched_send(tmp_buf, curr_cnt, MPIR_BYTE_INTERNAL, dst, comm_ptr, s);
                 MPIR_ERR_CHECK(mpi_errno);
                 mpi_errno = MPIR_Sched_barrier(s);
                 MPIR_ERR_CHECK(mpi_errno);
@@ -207,10 +208,10 @@ int MPIR_Igather_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
                 /* check for overflow.  work around int limits if needed */
                 if (curr_cnt - nbytes != (int) (curr_cnt - nbytes)) {
                     blocks[1] = 1;
-                    MPIR_Type_contiguous_x_impl(curr_cnt - nbytes, MPI_BYTE, &(types[1]));
+                    MPIR_Type_contiguous_x_impl(curr_cnt - nbytes, MPIR_BYTE_INTERNAL, &(types[1]));
                 } else {
                     MPIR_Assign_trunc(blocks[1], curr_cnt - nbytes, int);
-                    types[1] = MPI_BYTE;
+                    types[1] = MPIR_BYTE_INTERNAL;
                 }
                 struct_displs[1] = (MPI_Aint) tmp_buf;
 
@@ -236,14 +237,14 @@ int MPIR_Igather_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
     if ((rank == root) && root && (nbytes < MPIR_CVAR_GATHER_VSMALL_MSG_SIZE) && copy_blks) {
         /* reorder and copy from tmp_buf into recvbuf */
         /* FIXME why are there two copies here? */
-        mpi_errno = MPIR_Sched_copy(tmp_buf, nbytes * (comm_size - copy_offset), MPI_BYTE,
+        mpi_errno = MPIR_Sched_copy(tmp_buf, nbytes * (comm_size - copy_offset), MPIR_BYTE_INTERNAL,
                                     ((char *) recvbuf + extent * recvcount * copy_offset),
                                     recvcount * (comm_size - copy_offset), recvtype, s);
         MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPIR_Sched_copy((char *) tmp_buf + nbytes * (comm_size - copy_offset),
-                                    nbytes * (copy_blks - comm_size + copy_offset), MPI_BYTE,
-                                    recvbuf, recvcount * (copy_blks - comm_size + copy_offset),
-                                    recvtype, s);
+                                    nbytes * (copy_blks - comm_size + copy_offset),
+                                    MPIR_BYTE_INTERNAL, recvbuf,
+                                    recvcount * (copy_blks - comm_size + copy_offset), recvtype, s);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/coll/iscatter/iscatter_inter_sched_remote_send_local_scatter.c
+++ b/src/mpi/coll/iscatter/iscatter_inter_sched_remote_send_local_scatter.c
@@ -57,7 +57,7 @@ int MPIR_Iscatter_inter_sched_remote_send_local_scatter(const void *sendbuf, MPI
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
         } else {
-            /* silience -Wmaybe-uninitialized due to MPIR_Iscatter_intra_sched_auto by non-zero ranks */
+            /* silence -Wmaybe-uninitialized due to MPIR_Iscatter_intra_sched_auto by non-zero ranks */
             recvtype_sz = 0;
         }
 

--- a/src/mpi/coll/iscatter/iscatter_inter_sched_remote_send_local_scatter.c
+++ b/src/mpi/coll/iscatter/iscatter_inter_sched_remote_send_local_scatter.c
@@ -52,7 +52,7 @@ int MPIR_Iscatter_inter_sched_remote_send_local_scatter(const void *sendbuf, MPI
             MPIR_ERR_CHKANDJUMP(!tmp_buf, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
             mpi_errno =
-                MPIR_Sched_recv(tmp_buf, recvcount * local_size * recvtype_sz, MPI_BYTE,
+                MPIR_Sched_recv(tmp_buf, recvcount * local_size * recvtype_sz, MPIR_BYTE_INTERNAL,
                                 root, comm_ptr, s);
             MPIR_ERR_CHECK(mpi_errno);
             MPIR_SCHED_BARRIER(s);
@@ -69,7 +69,7 @@ int MPIR_Iscatter_inter_sched_remote_send_local_scatter(const void *sendbuf, MPI
 
         /* now do the usual scatter on this intracommunicator */
         mpi_errno =
-            MPIR_Iscatter_intra_sched_auto(tmp_buf, recvcount * recvtype_sz, MPI_BYTE,
+            MPIR_Iscatter_intra_sched_auto(tmp_buf, recvcount * recvtype_sz, MPIR_BYTE_INTERNAL,
                                            recvbuf, recvcount, recvtype, 0, newcomm_ptr, s);
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_SCHED_BARRIER(s);

--- a/src/mpi/coll/op/opequal.c
+++ b/src/mpi/coll/op/opequal.c
@@ -20,7 +20,7 @@ struct equal_data {
 void MPIR_EQUAL(void *invec, void *inoutvec, MPI_Aint * Len, MPI_Datatype * type)
 {
     MPIR_Assert(*Len >= EQUAL_DATA_OVERHEAD);
-    MPIR_Assert(*type == MPI_BYTE);
+    MPIR_Assert(*type == MPIR_BYTE_INTERNAL);
 
     struct equal_data *in = invec;
     struct equal_data *inout = inoutvec;
@@ -63,10 +63,11 @@ int MPIR_Reduce_equal(const void *sendbuf, MPI_Aint count, MPI_Datatype datatype
 
     /* Not all algorithm will work. In particular, we can't split the message */
     if (comm_ptr->rank == root) {
-        mpi_errno = MPIR_Reduce_intra_binomial(MPI_IN_PLACE, local_buf, byte_count, MPI_BYTE,
-                                               MPIX_EQUAL, root, comm_ptr, MPIR_ERR_NONE);
+        mpi_errno =
+            MPIR_Reduce_intra_binomial(MPI_IN_PLACE, local_buf, byte_count, MPIR_BYTE_INTERNAL,
+                                       MPIX_EQUAL, root, comm_ptr, MPIR_ERR_NONE);
     } else {
-        mpi_errno = MPIR_Reduce_intra_binomial(local_buf, NULL, byte_count, MPI_BYTE,
+        mpi_errno = MPIR_Reduce_intra_binomial(local_buf, NULL, byte_count, MPIR_BYTE_INTERNAL,
                                                MPIX_EQUAL, root, comm_ptr, MPIR_ERR_NONE);
     }
     MPIR_ERR_CHECK(mpi_errno);
@@ -92,7 +93,7 @@ int MPIR_Allreduce_equal(const void *sendbuf, MPI_Aint count, MPI_Datatype datat
 
     /* Not all algorithm will work. In particular, we can't split the message */
     mpi_errno = MPIR_Allreduce_intra_recursive_doubling(MPI_IN_PLACE, local_buf,
-                                                        byte_count, MPI_BYTE,
+                                                        byte_count, MPIR_BYTE_INTERNAL,
                                                         MPIX_EQUAL, comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpi/coll/scan/scan_intra_smp.c
+++ b/src/mpi/coll/scan/scan_intra_smp.c
@@ -97,7 +97,7 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
      * reduce it with recvbuf to get final result if necessary. */
 
     if (comm_ptr->node_comm != NULL) {
-        mpi_errno = MPIR_Bcast(&noneed, 1, MPI_INT, 0, comm_ptr->node_comm, errflag);
+        mpi_errno = MPIR_Bcast(&noneed, 1, MPIR_INT_INTERNAL, 0, comm_ptr->node_comm, errflag);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
@@ -51,7 +51,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
             MPIR_Datatype_get_size_macro(recvtype, recvtype_sz);
             MPIR_CHKLMEM_MALLOC(tmp_buf, recvcount * local_size * recvtype_sz);
 
-            mpi_errno = MPIC_Recv(tmp_buf, recvcount * local_size * recvtype_sz, MPI_BYTE,
+            mpi_errno = MPIC_Recv(tmp_buf, recvcount * local_size * recvtype_sz, MPIR_BYTE_INTERNAL,
                                   root, MPIR_SCATTER_TAG, comm_ptr, &status);
             MPIR_ERR_CHECK(mpi_errno);
         } else {
@@ -66,7 +66,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
         newcomm_ptr = comm_ptr->local_comm;
 
         /* now do the usual scatter on this intracommunicator */
-        mpi_errno = MPIR_Scatter(tmp_buf, recvcount * recvtype_sz, MPI_BYTE,
+        mpi_errno = MPIR_Scatter(tmp_buf, recvcount * recvtype_sz, MPIR_BYTE_INTERNAL,
                                  recvbuf, recvcount, recvtype, 0, newcomm_ptr, errflag);
         MPIR_ERR_CHECK(mpi_errno);
     }

--- a/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
+++ b/src/mpi/coll/scatter/scatter_inter_remote_send_local_scatter.c
@@ -55,7 +55,7 @@ int MPIR_Scatter_inter_remote_send_local_scatter(const void *sendbuf, MPI_Aint s
                                   root, MPIR_SCATTER_TAG, comm_ptr, &status);
             MPIR_ERR_CHECK(mpi_errno);
         } else {
-            /* silience -Wmaybe-uninitialized due to MPIR_Scatter by non-zero ranks */
+            /* silence -Wmaybe-uninitialized due to MPIR_Scatter by non-zero ranks */
             recvtype_sz = 0;
         }
 

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -83,17 +83,17 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
             if (recvbuf != MPI_IN_PLACE)
                 mpi_errno = MPIR_Localcopy(((char *) sendbuf + extent * sendcount * rank),
                                            sendcount * (comm_size - rank), sendtype, tmp_buf,
-                                           nbytes * (comm_size - rank), MPI_BYTE);
+                                           nbytes * (comm_size - rank), MPIR_BYTE_INTERNAL);
             else
                 mpi_errno = MPIR_Localcopy(((char *) sendbuf + extent * sendcount * (rank + 1)),
                                            sendcount * (comm_size - rank - 1),
                                            sendtype, (char *) tmp_buf + nbytes,
-                                           nbytes * (comm_size - rank - 1), MPI_BYTE);
+                                           nbytes * (comm_size - rank - 1), MPIR_BYTE_INTERNAL);
             MPIR_ERR_CHECK(mpi_errno);
 
             mpi_errno = MPIR_Localcopy(sendbuf, sendcount * rank, sendtype,
                                        ((char *) tmp_buf + nbytes * (comm_size - rank)),
-                                       nbytes * rank, MPI_BYTE);
+                                       nbytes * rank, MPIR_BYTE_INTERNAL);
             MPIR_ERR_CHECK(mpi_errno);
 
             curr_cnt = nbytes * comm_size;
@@ -118,7 +118,7 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
                                       src, MPIR_SCATTER_TAG, comm_ptr, &status);
                 MPIR_ERR_CHECK(mpi_errno);
             } else {
-                mpi_errno = MPIC_Recv(tmp_buf, tmp_buf_size, MPI_BYTE, src,
+                mpi_errno = MPIC_Recv(tmp_buf, tmp_buf_size, MPIR_BYTE_INTERNAL, src,
                                       MPIR_SCATTER_TAG, comm_ptr, &status);
                 MPIR_ERR_CHECK(mpi_errno);
                 if (mpi_errno) {
@@ -126,7 +126,7 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
                 } else
                     /* the recv size is larger than what may be sent in
                      * some cases. query amount of data actually received */
-                    MPIR_Get_count_impl(&status, MPI_BYTE, &curr_cnt);
+                    MPIR_Get_count_impl(&status, MPIR_BYTE_INTERNAL, &curr_cnt);
             }
             break;
         }
@@ -158,7 +158,7 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
                 /* mask is also the size of this process's subtree */
                 mpi_errno = MPIC_Send(((char *) tmp_buf + nbytes * mask),
                                       send_subtree_cnt,
-                                      MPI_BYTE, dst, MPIR_SCATTER_TAG, comm_ptr, errflag);
+                                      MPIR_BYTE_INTERNAL, dst, MPIR_SCATTER_TAG, comm_ptr, errflag);
             }
             MPIR_ERR_CHECK(mpi_errno);
             curr_cnt -= send_subtree_cnt;
@@ -173,7 +173,8 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
     } else if (!(relative_rank % 2) && (recvbuf != MPI_IN_PLACE)) {
         /* for non-zero root and non-leaf nodes, copy from tmp_buf
          * into recvbuf */
-        mpi_errno = MPIR_Localcopy(tmp_buf, nbytes, MPI_BYTE, recvbuf, recvcount, recvtype);
+        mpi_errno =
+            MPIR_Localcopy(tmp_buf, nbytes, MPIR_BYTE_INTERNAL, recvbuf, recvcount, recvtype);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpi/coll/transports/gentran/gentran_utils.c
+++ b/src/mpi/coll/transports/gentran/gentran_utils.c
@@ -111,8 +111,8 @@ static int vtx_issue(int vtxid, MPII_Genutil_vtx_t * vtxp, MPII_Genutil_sched_t 
                             MPI_Aint recvd;
                             vtxp->u.irecv_status.status->MPI_ERROR =
                                 vtxp->u.irecv_status.req->status.MPI_ERROR;
-                            MPIR_Get_count_impl(&vtxp->u.irecv_status.req->status, MPI_BYTE,
-                                                &recvd);
+                            MPIR_Get_count_impl(&vtxp->u.irecv_status.req->status,
+                                                MPIR_BYTE_INTERNAL, &recvd);
                             MPIR_STATUS_SET_COUNT(*(vtxp->u.irecv_status.status), recvd);
                         }
                         MPIR_Request_free(vtxp->u.irecv_status.req);
@@ -574,7 +574,8 @@ int MPII_Genutil_sched_poke(MPII_Genutil_sched_t * sched, int *is_complete, int 
                         MPI_Aint recvd;
                         vtxp->u.irecv_status.status->MPI_ERROR =
                             vtxp->u.irecv_status.req->status.MPI_ERROR;
-                        MPIR_Get_count_impl(&vtxp->u.irecv_status.req->status, MPI_BYTE, &recvd);
+                        MPIR_Get_count_impl(&vtxp->u.irecv_status.req->status, MPIR_BYTE_INTERNAL,
+                                            &recvd);
                         MPIR_STATUS_SET_COUNT(*(vtxp->u.irecv_status.status), recvd);
                     }
                     MPIR_Request_free(vtxp->u.irecv_status.req);

--- a/src/mpi/datatype/typerep/dataloop/dataloop_create_struct.c
+++ b/src/mpi/datatype/typerep/dataloop/dataloop_create_struct.c
@@ -250,7 +250,7 @@ static int create_basic_all_bytes_struct(MPI_Aint count,
         }
     }
     err = MPIR_Dataloop_create_indexed(cur_pos, tmp_blklens, tmp_disps, 1,      /* disp in bytes */
-                                       MPI_BYTE, (void **) dlp_p);
+                                       MPIR_BYTE_INTERNAL, (void **) dlp_p);
 
     MPL_free(tmp_blklens);
     MPL_free(tmp_disps);
@@ -385,7 +385,7 @@ static int create_flattened_struct(MPI_Aint count,
 #endif
 
     err = MPIR_Dataloop_create_indexed(nr_blks, tmp_blklens, tmp_disps, 1,      /* disp in bytes */
-                                       MPI_BYTE, (void **) dlp_p);
+                                       MPIR_BYTE_INTERNAL, (void **) dlp_p);
 
     MPL_free(tmp_blklens);
     MPL_free(tmp_disps);

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -383,6 +383,9 @@ int MPIR_Localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtyp
 
     MPIR_FUNC_ENTER;
 
+    MPIR_DATATYPE_ASSERT_BUILTIN(sendtype);
+    MPIR_DATATYPE_ASSERT_BUILTIN(recvtype);
+
     mpi_errno =
         do_localcopy(sendbuf, sendcount, sendtype, 0, recvbuf, recvcount, recvtype, 0,
                      LOCALCOPY_BLOCKING, NULL);
@@ -402,6 +405,9 @@ int MPIR_Ilocalcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendty
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
+
+    MPIR_DATATYPE_ASSERT_BUILTIN(sendtype);
+    MPIR_DATATYPE_ASSERT_BUILTIN(recvtype);
 
     mpi_errno = do_localcopy(sendbuf, sendcount, sendtype, 0, recvbuf, recvcount, recvtype,
                              0, LOCALCOPY_NONBLOCKING, typerep_req);
@@ -447,6 +453,9 @@ int MPIR_Localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sen
 
     MPIR_FUNC_ENTER;
 
+    MPIR_DATATYPE_ASSERT_BUILTIN(sendtype);
+    MPIR_DATATYPE_ASSERT_BUILTIN(recvtype);
+
 #ifdef MPL_HAVE_GPU
     mpi_errno =
         do_localcopy_gpu(sendbuf, sendcount, sendtype, sendoffset, sendattr, recvbuf, recvcount,
@@ -475,6 +484,9 @@ int MPIR_Ilocalcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
+
+    MPIR_DATATYPE_ASSERT_BUILTIN(sendtype);
+    MPIR_DATATYPE_ASSERT_BUILTIN(recvtype);
 
 #ifdef MPL_HAVE_GPU
     mpi_errno =

--- a/src/mpi/pt2pt/bsendutil.c
+++ b/src/mpi/pt2pt/bsendutil.c
@@ -147,10 +147,7 @@ int MPIR_Bsend_isend(const void *buf, int count, MPI_Datatype dtype,
     MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_BSEND_MUTEX);
 
     MPI_Aint packsize = 0;
-    if (dtype != MPI_PACKED)
-        MPIR_Pack_size(count, dtype, &packsize);
-    else
-        packsize = count;
+    MPIR_Pack_size(count, dtype, &packsize);
 
     MPII_BsendBuffer *bsendbuffer;
     if (comm_ptr->bsendbuffer) {
@@ -361,7 +358,8 @@ static int bsend_isend_auto(struct MPII_BsendBuffer_auto *automatic, MPI_Aint pa
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(actual_pack_bytes == packsize);
 
-    mpi_errno = MPID_Isend(elt->buf, packsize, MPI_PACKED, dest, tag, comm_ptr, 0, &elt->req);
+    mpi_errno =
+        MPID_Isend(elt->buf, packsize, MPIR_BYTE_INTERNAL, dest, tag, comm_ptr, 0, &elt->req);
     MPIR_ERR_CHECK(mpi_errno);
 
     struct bsend_auto_elem **head_p = (void *) &(automatic->active_list);
@@ -571,7 +569,7 @@ static int bsend_isend_user(struct MPII_BsendBuffer_user *user, MPI_Aint packsiz
              * either primitive or contiguous types, and just
              * use MPIR_Memcpy and the provided datatype */
             msg->count = 0;
-            if (dtype != MPI_PACKED) {
+            if (1) {
                 MPI_Aint actual_pack_bytes;
                 void *pbuf = (void *) ((char *) p->msg.msgbuf + p->msg.count);
                 mpi_errno =
@@ -585,7 +583,7 @@ static int bsend_isend_user(struct MPII_BsendBuffer_user *user, MPI_Aint packsiz
             }
             /* Try to send the message.  We must use MPID_Isend
              * because this call must not block */
-            mpi_errno = MPID_Isend(msg->msgbuf, msg->count, MPI_PACKED,
+            mpi_errno = MPID_Isend(msg->msgbuf, msg->count, MPIR_BYTE_INTERNAL,
                                    dest, tag, comm_ptr, 0, &p->request);
             MPIR_ERR_CHKINTERNAL(mpi_errno, mpi_errno, "Bsend internal error: isend returned err");
 

--- a/src/mpi/pt2pt/sendrecv.c
+++ b/src/mpi/pt2pt/sendrecv.c
@@ -127,7 +127,7 @@ int MPIR_Sendrecv_replace_impl(void *buf, MPI_Aint count, MPI_Datatype datatype,
         sreq = MPIR_Request_create_complete(MPIR_REQUEST_KIND__SEND);
         MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     } else {
-        mpi_errno = MPID_Isend(tmpbuf, actual_pack_bytes, MPI_PACKED, dest,
+        mpi_errno = MPID_Isend(tmpbuf, actual_pack_bytes, MPIR_BYTE_INTERNAL, dest,
                                sendtag, comm_ptr, 0, &sreq);
         if (mpi_errno != MPI_SUCCESS) {
             /* --BEGIN ERROR HANDLING-- */

--- a/src/mpi/stream/stream_enqueue.c
+++ b/src/mpi/stream/stream_enqueue.c
@@ -32,8 +32,9 @@ static void send_enqueue_cb(void *data)
     if (p->host_buf) {
         MPIR_Assertp(p->actual_pack_bytes == p->data_sz);
 
-        mpi_errno = MPID_Send(p->host_buf, p->data_sz, MPI_BYTE, p->dest, p->tag, p->comm_ptr,
-                              0, &request_ptr);
+        mpi_errno =
+            MPID_Send(p->host_buf, p->data_sz, MPIR_BYTE_INTERNAL, p->dest, p->tag, p->comm_ptr, 0,
+                      &request_ptr);
     } else {
         mpi_errno = MPID_Send(p->buf, p->count, p->datatype, p->dest, p->tag, p->comm_ptr,
                               0, &request_ptr);
@@ -118,8 +119,9 @@ static void recv_enqueue_cb(void *data)
 
     struct recv_data *p = data;
     if (p->host_buf) {
-        mpi_errno = MPID_Recv(p->host_buf, p->data_sz, MPI_BYTE, p->source, p->tag, p->comm_ptr,
-                              0, p->status, &request_ptr);
+        mpi_errno =
+            MPID_Recv(p->host_buf, p->data_sz, MPIR_BYTE_INTERNAL, p->source, p->tag, p->comm_ptr,
+                      0, p->status, &request_ptr);
     } else {
         mpi_errno = MPID_Recv(p->buf, p->count, p->datatype, p->source, p->tag, p->comm_ptr,
                               0, p->status, &request_ptr);
@@ -206,8 +208,9 @@ static void isend_enqueue_cb(void *data)
     if (p->host_buf) {
         MPIR_Assertp(p->actual_pack_bytes == p->data_sz);
 
-        mpi_errno = MPID_Send(p->host_buf, p->data_sz, MPI_BYTE, p->dest, p->tag, p->comm_ptr,
-                              0, &request_ptr);
+        mpi_errno =
+            MPID_Send(p->host_buf, p->data_sz, MPIR_BYTE_INTERNAL, p->dest, p->tag, p->comm_ptr, 0,
+                      &request_ptr);
     } else {
         mpi_errno = MPID_Send(p->buf, p->count, p->datatype, p->dest, p->tag, p->comm_ptr,
                               0, &request_ptr);
@@ -275,8 +278,9 @@ static void irecv_enqueue_cb(void *data)
 
     struct recv_data *p = data;
     if (p->host_buf) {
-        mpi_errno = MPID_Recv(p->host_buf, p->data_sz, MPI_BYTE, p->source, p->tag, p->comm_ptr,
-                              0, p->status, &request_ptr);
+        mpi_errno =
+            MPID_Recv(p->host_buf, p->data_sz, MPIR_BYTE_INTERNAL, p->source, p->tag, p->comm_ptr,
+                      0, p->status, &request_ptr);
     } else {
         mpi_errno = MPID_Recv(p->buf, p->count, p->datatype, p->source, p->tag, p->comm_ptr,
                               0, p->status, &request_ptr);

--- a/src/mpi/threadcomm/threadcomm_impl.c
+++ b/src/mpi/threadcomm/threadcomm_impl.c
@@ -34,8 +34,8 @@ int MPIR_Threadcomm_init_impl(MPIR_Comm * comm, int num_threads, MPIR_Comm ** co
     threads_table = MPL_malloc(comm_size * sizeof(int), MPL_MEM_OTHER);
     MPIR_ERR_CHKANDJUMP(!threads_table, mpi_errno, MPI_ERR_OTHER, "**nomem");
 
-    mpi_errno = MPIR_Allgather_impl(&num_threads, 1, MPI_INT, threads_table, 1, MPI_INT, comm,
-                                    MPIR_ERR_NONE);
+    mpi_errno = MPIR_Allgather_impl(&num_threads, 1, MPIR_INT_INTERNAL, threads_table, 1,
+                                    MPIR_INT_INTERNAL, comm, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     int *rank_offset_table;;

--- a/src/mpid/ch3/channels/nemesis/src/ch3_win_fns.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_win_fns.c
@@ -343,7 +343,7 @@ static int MPIDI_CH3I_Win_gather_info(void *base, MPI_Aint size, int disp_unit, 
         MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno =
-            MPIR_Bcast(serialized_hnd_ptr, MPL_SHM_GHND_SZ, MPI_CHAR, 0, node_comm_ptr,
+            MPIR_Bcast(serialized_hnd_ptr, MPL_SHM_GHND_SZ, MPIR_CHAR_INTERNAL, 0, node_comm_ptr,
                        MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
 
@@ -360,7 +360,7 @@ static int MPIDI_CH3I_Win_gather_info(void *base, MPI_Aint size, int disp_unit, 
 
         /* get serialized handle from rank 0 and deserialize it */
         mpi_errno =
-            MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPI_CHAR, 0, node_comm_ptr,
+            MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPIR_CHAR_INTERNAL, 0, node_comm_ptr,
                        MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
 
@@ -473,7 +473,7 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
     node_sizes[node_rank] = (MPI_Aint) size;
 
     mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
-                               node_sizes, sizeof(MPI_Aint), MPI_BYTE,
+                               node_sizes, sizeof(MPI_Aint), MPIR_BYTE_INTERNAL,
                                node_comm_ptr, MPIR_ERR_NONE);
     MPIR_T_PVAR_TIMER_END(RMA, rma_wincreate_allgather);
     MPIR_ERR_CHECK(mpi_errno);
@@ -512,9 +512,8 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
                                                     &serialized_hnd_ptr);
             MPIR_ERR_CHECK(mpi_errno);
 
-            mpi_errno =
-                MPIR_Bcast(serialized_hnd_ptr, MPL_SHM_GHND_SZ, MPI_CHAR, 0, node_comm_ptr,
-                                MPIR_ERR_NONE);
+            mpi_errno = MPIR_Bcast(serialized_hnd_ptr, MPL_SHM_GHND_SZ, MPIR_CHAR_INTERNAL, 0,
+                                   node_comm_ptr, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
 
             /* wait for other processes to attach to win */
@@ -529,9 +528,8 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
             char serialized_hnd[MPL_SHM_GHND_SZ] = { 0 };
 
             /* get serialized handle from rank 0 and deserialize it */
-            mpi_errno =
-                MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPI_CHAR, 0, node_comm_ptr,
-                           MPIR_ERR_NONE);
+            mpi_errno = MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPIR_CHAR_INTERNAL, 0,
+                                   node_comm_ptr, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
 
             mpi_errno =
@@ -571,9 +569,8 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
                                                     &serialized_hnd_ptr);
             MPIR_ERR_CHECK(mpi_errno);
 
-            mpi_errno =
-                MPIR_Bcast(serialized_hnd_ptr, MPL_SHM_GHND_SZ, MPI_CHAR, 0, node_comm_ptr,
-                           MPIR_ERR_NONE);
+            mpi_errno = MPIR_Bcast(serialized_hnd_ptr, MPL_SHM_GHND_SZ, MPIR_CHAR_INTERNAL, 0,
+                                   node_comm_ptr, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
 
             /* wait for other processes to attach to win */
@@ -588,9 +585,8 @@ static int MPIDI_CH3I_Win_allocate_shm(MPI_Aint size, int disp_unit, MPIR_Info *
             char serialized_hnd[MPL_SHM_GHND_SZ] = { 0 };
 
             /* get serialized handle from rank 0 and deserialize it */
-            mpi_errno =
-                MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPI_CHAR, 0, node_comm_ptr,
-                           MPIR_ERR_NONE);
+            mpi_errno = MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPIR_CHAR_INTERNAL, 0,
+                                   node_comm_ptr, MPIR_ERR_NONE);
             MPIR_ERR_CHECK(mpi_errno);
 
             mpi_errno =

--- a/src/mpid/ch3/src/ch3u_port.c
+++ b/src/mpid/ch3/src/ch3u_port.c
@@ -929,7 +929,7 @@ static int ReceivePGAndDistribute( MPIR_Comm *tmp_comm, MPIR_Comm *comm_ptr,
 	    if (pg_str == NULL) {
 		MPIR_ERR_POP(mpi_errno);
 	    }
-	    mpi_errno = MPIC_Recv(pg_str, j, MPI_CHAR, 0, recvtag++,
+	    mpi_errno = MPIC_Recv(pg_str, j, MPIR_CHAR_INTERNAL, 0, recvtag++,
 				  tmp_comm, MPI_STATUS_IGNORE);
 	    *recvtag_p = recvtag;
 	    MPIR_ERR_CHECK(mpi_errno);
@@ -948,7 +948,7 @@ static int ReceivePGAndDistribute( MPIR_Comm *tmp_comm, MPIR_Comm *comm_ptr,
 	    }
 	}
 	/*printf("accept:broadcasting string of length %d\n", j);fflush(stdout);*/
-	mpi_errno = MPIR_Bcast_allcomm_auto(pg_str, j, MPI_CHAR, root, comm_ptr, MPIR_ERR_NONE);
+	mpi_errno = MPIR_Bcast_allcomm_auto(pg_str, j, MPIR_CHAR_INTERNAL, root, comm_ptr, MPIR_ERR_NONE);
 	MPIR_ERR_CHECK(mpi_errno);
 	/* Then reconstruct the received process group.  This step
 	   also initializes the created process group */
@@ -1019,7 +1019,7 @@ int MPID_PG_BCast( MPIR_Comm *peercomm_p, MPIR_Comm *comm_p, int root )
                 goto fn_exit;
             }
 	}
-	mpi_errno = MPIR_Bcast( pg_str, len, MPI_CHAR, root, comm_p, MPIR_ERR_NONE);
+	mpi_errno = MPIR_Bcast( pg_str, len, MPIR_CHAR_INTERNAL, root, comm_p, MPIR_ERR_NONE);
         if (mpi_errno) {
             if (rank != root)
                 MPL_free( pg_str );
@@ -1080,7 +1080,7 @@ static int SendPGtoPeerAndFree( MPIR_Comm *tmp_comm, int *sendtag_p,
 	MPIR_ERR_CHECK(mpi_errno);
 	
 	/* printf("connect:sending string length %d\n", i);fflush(stdout); */
-	mpi_errno = MPIC_Send(pg_iter->str, i, MPI_CHAR, 0, sendtag++,
+	mpi_errno = MPIC_Send(pg_iter->str, i, MPIR_CHAR_INTERNAL, 0, sendtag++,
 			      tmp_comm, MPIR_ERR_NONE);
 	*sendtag_p = sendtag;
 	MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch3/src/mpid_vc.c
+++ b/src/mpid/ch3/src/mpid_vc.c
@@ -539,7 +539,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
         MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER,VERBOSE,"About to bcast on local_comm");
         mpi_errno = MPIR_Bcast( comm_info, 2, MPIR_INT_INTERNAL, local_leader, local_comm_ptr, MPIR_ERR_NONE );
         MPIR_ERR_CHECK(mpi_errno);
-        mpi_errno = MPIR_Bcast( remote_gpids, (*remote_size)*sizeof(MPIDI_Gpid), MPI_BYTE, local_leader,
+        mpi_errno = MPIR_Bcast( remote_gpids, (*remote_size)*sizeof(MPIDI_Gpid), MPIR_BYTE_INTERNAL, local_leader,
                                      local_comm_ptr, MPIR_ERR_NONE );
         MPIR_ERR_CHECK(mpi_errno);
         MPL_DBG_MSG_D(MPIDI_CH3_DBG_OTHER,VERBOSE,"end of bcast on local_comm of size %d",
@@ -554,7 +554,7 @@ int MPID_Intercomm_exchange_map(MPIR_Comm *local_comm_ptr, int local_leader,
         *remote_size = comm_info[0];
         MPIR_CHKLMEM_MALLOC(remote_gpids, (*remote_size)*sizeof(MPIDI_Gpid));
         *remote_lpids = MPL_malloc((*remote_size)*sizeof(MPIR_Lpid), MPL_MEM_ADDRESS);
-        mpi_errno = MPIR_Bcast( remote_gpids, (*remote_size)*sizeof(MPIDI_Gpid), MPI_BYTE, local_leader,
+        mpi_errno = MPIR_Bcast( remote_gpids, (*remote_size)*sizeof(MPIDI_Gpid), MPIR_BYTE_INTERNAL, local_leader,
                                      local_comm_ptr, MPIR_ERR_NONE );
         MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/netmod/ofi/init_addrxchg.c
+++ b/src/mpid/ch4/netmod/ofi/init_addrxchg.c
@@ -263,8 +263,8 @@ int MPIDI_OFI_addr_exchange_all_ctx(void)
         }
     }
     /* Allgather */
-    mpi_errno = MPIR_Allgather_fallback(MPI_IN_PLACE, 0, MPI_BYTE,
-                                        all_names, my_len, MPI_BYTE, comm, MPIR_ERR_NONE);
+    mpi_errno = MPIR_Allgather_fallback(MPI_IN_PLACE, 0, MPIR_BYTE_INTERNAL,
+                                        all_names, my_len, MPIR_BYTE_INTERNAL, comm, MPIR_ERR_NONE);
 
     /* Step 2: insert and store non-root nic/vci on the root context */
     int root_ctx_idx = MPIDI_OFI_get_ctx_index(0, 0);

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -147,8 +147,9 @@ static int pipeline_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * r, 
                 MPI_Aint actual_unpack_bytes;
                 MPIR_gpu_req yreq;
                 mpi_errno =
-                    MPIR_Ilocalcopy_gpu(wc_buf, wc->len, MPI_BYTE, 0, NULL, recv_buf, recv_count,
-                                        datatype, 0, NULL, MPL_GPU_COPY_H2D, engine_type, 1, &yreq);
+                    MPIR_Ilocalcopy_gpu(wc_buf, wc->len, MPIR_BYTE_INTERNAL, 0, NULL, recv_buf,
+                                        recv_count, datatype, 0, NULL, MPL_GPU_COPY_H2D,
+                                        engine_type, 1, &yreq);
                 MPIR_ERR_CHECK(mpi_errno);
                 actual_unpack_bytes = wc->len;
                 task =
@@ -213,7 +214,7 @@ static int pipeline_recv_event(struct fi_cq_tagged_entry *wc, MPIR_Request * r, 
             MPI_Aint actual_unpack_bytes;
             MPIR_gpu_req yreq;
             mpi_errno =
-                MPIR_Ilocalcopy_gpu(wc_buf, (MPI_Aint) wc->len, MPI_BYTE, 0, NULL,
+                MPIR_Ilocalcopy_gpu(wc_buf, (MPI_Aint) wc->len, MPIR_BYTE_INTERNAL, 0, NULL,
                                     (char *) recv_buf, (MPI_Aint) recv_count, datatype,
                                     req->offset, NULL, MPL_GPU_COPY_H2D, engine_type, 1, &yreq);
             MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -103,7 +103,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_complete(MPIR_Request * rreq, int ev
         (MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer))) {
         MPI_Aint count = MPIR_STATUS_GET_COUNT(rreq->status);
         mpi_errno = MPIR_Localcopy_gpu(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer), count,
-                                       MPI_BYTE, 0, NULL,
+                                       MPIR_BYTE_INTERNAL, 0, NULL,
                                        MPIDI_OFI_REQUEST(rreq, buf),
                                        MPIDI_OFI_REQUEST(rreq, count),
                                        MPIDI_OFI_REQUEST(rreq, datatype), 0, NULL,

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -949,8 +949,8 @@ static int MPIDI_OFI_gpu_progress_send(void)
             mpi_errno =
                 MPIR_Ilocalcopy_gpu((char *) send_task->send_buf, send_task->count,
                                     send_task->datatype, send_task->offset, &send_task->attr,
-                                    host_buf, chunk_sz, MPI_BYTE, 0, NULL, MPL_GPU_COPY_D2H,
-                                    engine_type, commit, &yreq);
+                                    host_buf, chunk_sz, MPIR_BYTE_INTERNAL, 0, NULL,
+                                    MPL_GPU_COPY_D2H, engine_type, commit, &yreq);
             MPIR_ERR_CHECK(mpi_errno);
             actual_pack_bytes = chunk_sz;
             task =

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -609,8 +609,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
         if (need_pack) {
             pack_buf = MPL_aligned_alloc(64, data_sz, MPL_MEM_OTHER);
             mpi_errno = MPIR_Localcopy_gpu(buf, count, datatype, 0, &attr,
-                                           pack_buf, data_sz, MPI_BYTE, 0, MPIR_GPU_ATTR_HOST,
-                                           MPL_GPU_COPY_D2H,
+                                           pack_buf, data_sz, MPIR_BYTE_INTERNAL, 0,
+                                           MPIR_GPU_ATTR_HOST, MPL_GPU_COPY_D2H,
                                            MPIDI_OFI_gpu_get_send_engine_type(), true);
             MPIR_ERR_CHECK(mpi_errno);
             send_buf = pack_buf;
@@ -673,8 +673,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
                                  MPI_ERR_OTHER, "**nomem", "**nomem %s", "Send Pack buffer alloc");
 
             mpi_errno = MPIR_Localcopy_gpu(buf, count, datatype, 0, &attr,
-                                           pack_buf, data_sz, MPI_BYTE, 0, MPIR_GPU_ATTR_HOST,
-                                           MPL_GPU_COPY_D2H,
+                                           pack_buf, data_sz, MPIR_BYTE_INTERNAL, 0,
+                                           MPIR_GPU_ATTR_HOST, MPL_GPU_COPY_D2H,
                                            MPIDI_OFI_gpu_get_send_engine_type(), true);
             MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -240,7 +240,7 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
 
     mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 0,
                                MPI_DATATYPE_NULL,
-                               winfo, sizeof(*winfo), MPI_BYTE, comm_ptr, MPIR_ERR_NONE);
+                               winfo, sizeof(*winfo), MPIR_BYTE_INTERNAL, comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     if (!MPIDI_OFI_ENABLE_MR_PROV_KEY && !MPIDI_OFI_ENABLE_MR_VIRT_ADDRESS) {
@@ -984,7 +984,7 @@ int MPIDI_OFI_mpi_win_attach_hook(MPIR_Win * win, void *base, MPI_Aint size)
     target_mrs[comm_ptr->rank].size = (uintptr_t) size;
     mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 0,
                                MPI_DATATYPE_NULL,
-                               target_mrs, sizeof(dwin_target_mr_t), MPI_BYTE, comm_ptr,
+                               target_mrs, sizeof(dwin_target_mr_t), MPIR_BYTE_INTERNAL, comm_ptr,
                                MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -1039,7 +1039,7 @@ int MPIDI_OFI_mpi_win_detach_hook(MPIR_Win * win, const void *base)
      * that all processes collectively call detach. */
     target_bases[comm_ptr->rank] = base;
     mpi_errno = MPIR_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
-                               target_bases, sizeof(const void *), MPI_BYTE, comm_ptr,
+                               target_bases, sizeof(const void *), MPIR_BYTE_INTERNAL, comm_ptr,
                                MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -168,8 +168,9 @@ int MPIDI_UCX_all_vcis_address_exchange(void)
     }
     /* Allgather */
     MPIR_Comm *comm = MPIR_Process.comm_world;
-    mpi_errno = MPIR_Allgather_allcomm_auto(MPI_IN_PLACE, 0, MPI_BYTE,
-                                            all_names, my_len, MPI_BYTE, comm, MPIR_ERR_NONE);
+    mpi_errno = MPIR_Allgather_allcomm_auto(MPI_IN_PLACE, 0, MPIR_BYTE_INTERNAL,
+                                            all_names, my_len, MPIR_BYTE_INTERNAL, comm,
+                                            MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* insert the addresses */

--- a/src/mpid/ch4/netmod/ucx/ucx_win.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_win.c
@@ -99,9 +99,9 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
     rkey_recv_buff = MPL_malloc(cntr, MPL_MEM_OTHER);
 
     /* allgather */
-    mpi_errno = MPIR_Allgatherv(rkey_buffer, rkey_size, MPI_BYTE,
-                                rkey_recv_buff, rkey_sizes, recv_disps, MPI_BYTE, comm_ptr,
-                                MPIR_ERR_NONE);
+    mpi_errno = MPIR_Allgatherv(rkey_buffer, rkey_size, MPIR_BYTE_INTERNAL,
+                                rkey_recv_buff, rkey_sizes, recv_disps, MPIR_BYTE_INTERNAL,
+                                comm_ptr, MPIR_ERR_NONE);
 
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -141,8 +141,8 @@ static int win_allgather(MPIR_Win * win, size_t length, uint32_t disp_unit, void
     share_data[comm_ptr->rank].addr = (MPI_Aint) * base_ptr;
 
     mpi_errno =
-        MPIR_Allgather(MPI_IN_PLACE, sizeof(struct ucx_share), MPI_BYTE, share_data,
-                       sizeof(struct ucx_share), MPI_BYTE, comm_ptr, MPIR_ERR_NONE);
+        MPIR_Allgather(MPI_IN_PLACE, sizeof(struct ucx_share), MPIR_BYTE_INTERNAL, share_data,
+                       sizeof(struct ucx_share), MPIR_BYTE_INTERNAL, comm_ptr, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     for (i = 0; i < comm_ptr->local_size; i++) {

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -724,7 +724,7 @@ int MPIDI_GPU_copy_data_async(MPIDI_IPC_hdr * ipc_hdr, MPIR_Request * rreq, MPI_
     MPIR_Datatype *src_dt_ptr = NULL;
     if (ipc_hdr->is_contig) {
         src_count = src_data_sz;
-        src_dt = MPI_BYTE;
+        src_dt = MPIR_BYTE_INTERNAL;
     } else {
         /* TODO: get sender datatype and call MPIR_Typerep_op with mapped_device set to dev_id */
         void *flattened_type = ipc_hdr + 1;

--- a/src/mpid/ch4/shm/ipc/src/ipc_win.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_win.c
@@ -89,7 +89,7 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
         /* FIXME: the rank should be remote rank for tracking caching, not local rank
          *        Here we can skip the tracking, e.g. just use MPI_PROC_NULL
          */
-        mpi_errno = MPIDI_GPU_get_ipc_attr(win->base, win->size, MPI_BYTE,
+        mpi_errno = MPIDI_GPU_get_ipc_attr(win->base, win->size, MPIR_BYTE_INTERNAL,
                                            MPI_PROC_NULL, shm_comm_ptr, &ipc_attr);
         MPIR_ERR_CHECK(mpi_errno);
         if (ipc_attr.ipc_type == MPIDI_IPCI_TYPE__SKIP) {
@@ -102,7 +102,7 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
 #endif
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
     if (!done) {
-        mpi_errno = MPIDI_XPMEM_get_ipc_attr(win->base, win->size, MPI_BYTE, &ipc_attr);
+        mpi_errno = MPIDI_XPMEM_get_ipc_attr(win->base, win->size, MPIR_BYTE_INTERNAL, &ipc_attr);
         MPIR_ERR_CHECK(mpi_errno);
         done = (ipc_attr.ipc_type != MPIDI_IPCI_TYPE__NONE);
     }
@@ -151,7 +151,8 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
                                0,
                                MPI_DATATYPE_NULL,
                                ipc_shared_table,
-                               sizeof(win_shared_info_t), MPI_BYTE, shm_comm_ptr, MPIR_ERR_NONE);
+                               sizeof(win_shared_info_t), MPIR_BYTE_INTERNAL, shm_comm_ptr,
+                               MPIR_ERR_NONE);
     MPIR_T_PVAR_TIMER_END(RMA, rma_wincreate_allgather);
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -209,7 +210,7 @@ int MPIDI_IPC_mpi_win_create_hook(MPIR_Win * win)
                         shared_table[i].ipc_handle = handle;
                         int dev_id = MPL_gpu_get_dev_id_from_attr(&ipc_attr.u.gpu.gpu_attr);
                         int map_dev_id = MPIDI_GPU_ipc_get_map_dev(handle.global_dev_id, dev_id,
-                                                                   MPI_BYTE);
+                                                                   MPIR_BYTE_INTERNAL);
                         int fast_copy = 0;
                         if (shared_table[i].size <= MPIR_CVAR_GPU_FAST_COPY_MAX_SIZE) {
                             mpi_errno = MPIDI_GPU_ipc_handle_map(ipc_shared_table[i].ipc_handle.gpu,

--- a/src/mpid/ch4/shm/posix/posix_coll_gpu_ipc.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_gpu_ipc.h
@@ -99,9 +99,10 @@ static int allgather_ipc_handles(const void *buf, MPI_Aint count, MPI_Datatype d
     }
 
     /* allgather is needed to exchange all the IPC handles */
-    mpi_errno = MPIR_Allgather_impl(&my_ipc_handle, sizeof(MPIDI_IPCI_ipc_handle_t), MPI_BYTE,
-                                    ipc_handles, sizeof(MPIDI_IPCI_ipc_handle_t), MPI_BYTE,
-                                    comm, MPIR_ERR_NONE);
+    mpi_errno =
+        MPIR_Allgather_impl(&my_ipc_handle, sizeof(MPIDI_IPCI_ipc_handle_t), MPIR_BYTE_INTERNAL,
+                            ipc_handles, sizeof(MPIDI_IPCI_ipc_handle_t), MPIR_BYTE_INTERNAL, comm,
+                            MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* check the ipc_handles to make sure all the buffers are on GPU */

--- a/src/mpid/ch4/shm/posix/posix_coll_release_gather.h
+++ b/src/mpid/ch4/shm/posix/posix_coll_release_gather.h
@@ -81,14 +81,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
     MPIR_Datatype_get_size_macro(datatype, type_size);
 
     if (!is_contig || type_size >= MPIDI_POSIX_RELEASE_GATHER_BCAST_CELLSIZE) {
-        /* Convert to MPI_BYTE datatype */
+        /* Convert to MPIR_BYTE_INTERNAL datatype */
         count = type_size * count;
-        datatype = MPI_BYTE;
+        datatype = MPIR_BYTE_INTERNAL;
         type_size = 1;
 
         if (!is_contig) {
             buffer = MPL_malloc(count, MPL_MEM_COLL);
-            /* Reset true_lb based on the new datatype (MPI_BYTE) */
+            /* Reset true_lb based on the new datatype (MPIR_BYTE_INTERNAL) */
             true_lb = 0;
             if (my_rank == root) {
                 /* Root packs the data before sending, for non contiguous datatypes */
@@ -121,7 +121,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_bcast_release_gather(void *buffer,
 
         mpi_errno =
             MPIDI_POSIX_mpi_release_gather_release(MPIR_get_contig_ptr(buffer, offset + true_lb),
-                                                   chunk_count, MPI_BYTE, root, comm_ptr,
+                                                   chunk_count, MPIR_BYTE_INTERNAL, root, comm_ptr,
                                                    errflag,
                                                    MPIDI_POSIX_RELEASE_GATHER_OPCODE_BCAST);
         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -283,9 +283,10 @@ int MPIDI_POSIX_post_init(void)
     if (MPIR_CVAR_CH4_SHM_POSIX_TOPO_ENABLE && MPIR_Process.local_size > 1) {
         int topo_info_size = sizeof(MPIDI_POSIX_topo_info_t);
         local_rank_topo = MPL_calloc(MPIR_Process.local_size, topo_info_size, MPL_MEM_SHM);
-        mpi_errno = MPIR_Allgather_fallback(&MPIDI_POSIX_global.topo, topo_info_size, MPI_BYTE,
-                                            local_rank_topo, topo_info_size, MPI_BYTE,
-                                            MPIR_Process.comm_world->node_comm, MPIR_ERR_NONE);
+        mpi_errno =
+            MPIR_Allgather_fallback(&MPIDI_POSIX_global.topo, topo_info_size, MPIR_BYTE_INTERNAL,
+                                    local_rank_topo, topo_info_size, MPIR_BYTE_INTERNAL,
+                                    MPIR_Process.comm_world->node_comm, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
         for (int i = 0; i < MPIR_Process.local_size; i++) {
             if (local_rank_topo[i].l3_cache_id == -1 || local_rank_topo[i].numa_id == -1) {

--- a/src/mpid/ch4/shm/posix/release_gather/nb_bcast_release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/nb_bcast_release_gather.h
@@ -390,7 +390,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_nb_release_gather_ibcast_impl(void *loc
             /* Root packs the data before sending, for non contiguous datatypes */
             mpi_errno =
                 MPIR_TSP_sched_localcopy(ori_local_buf, ori_count, ori_datatype, local_buf, nbytes,
-                                         MPI_BYTE, sched, 0, NULL, &pack_vtx_id);
+                                         MPIR_BYTE_INTERNAL, sched, 0, NULL, &pack_vtx_id);
             MPIR_ERR_CHECK(mpi_errno);
         }
     }
@@ -434,7 +434,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_nb_release_gather_ibcast_impl(void *loc
         data->seq_no = MPIDI_POSIX_COMM(comm_ptr, nb_bcast_seq_no);
         data->local_buf = (char *) local_buf + offset;
         data->count = chunk_count;
-        data->datatype = MPI_BYTE;
+        data->datatype = MPIR_BYTE_INTERNAL;
         data->root = root;
         data->comm_ptr = comm_ptr;
         data->tag = tag;
@@ -479,9 +479,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_nb_release_gather_ibcast_impl(void *loc
             /* Dependency is created from the last vertices of each chunk to the unpack vertex */
             MPIR_Assert(num_chunks <= INT_MAX);
             mpi_errno =
-                MPIR_TSP_sched_localcopy(local_buf, nbytes, MPI_BYTE, ori_local_buf, ori_count,
-                                         ori_datatype, sched, (int) num_chunks, sixth_vtx_id,
-                                         &vtx_id);
+                MPIR_TSP_sched_localcopy(local_buf, nbytes, MPIR_BYTE_INTERNAL, ori_local_buf,
+                                         ori_count, ori_datatype, sched, (int) num_chunks,
+                                         sixth_vtx_id, &vtx_id);
             if (mpi_errno)
                 MPIR_ERR_POP(mpi_errno);
         }

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.h
@@ -120,7 +120,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
                     MPIC_Recv((char *) bcast_data_addr + 2 * MPIDU_SHM_CACHE_LINE_LEN, count,
                               datatype, root, MPIR_BCAST_TAG, comm_ptr, &status);
                 MPIR_ERR_CHECK(mpi_errno);
-                MPIR_Get_count_impl(&status, MPI_BYTE, &recv_bytes);
+                MPIR_Get_count_impl(&status, MPIR_BYTE_INTERNAL, &recv_bytes);
                 MPIR_Typerep_copy(bcast_data_addr, &recv_bytes, sizeof(int),
                                   MPIR_TYPEREP_FLAG_NONE);
                 /* It is necessary to copy the errflag as well to handle the case when non-root

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -190,10 +190,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Barrier_intra_composition_alpha(MPIR_Comm * c
     if (comm->node_comm != NULL) {
         int i = 0;
 #ifndef MPIDI_CH4_DIRECT_NETMOD
-        mpi_errno = MPIDI_SHM_mpi_bcast(&i, 1, MPI_BYTE, 0, comm->node_comm, errflag);
+        mpi_errno = MPIDI_SHM_mpi_bcast(&i, 1, MPIR_BYTE_INTERNAL, 0, comm->node_comm, errflag);
         MPIR_ERR_CHECK(mpi_errno);
 #else
-        mpi_errno = MPIDI_NM_mpi_bcast(&i, 1, MPI_BYTE, 0, comm->node_comm, errflag);
+        mpi_errno = MPIDI_NM_mpi_bcast(&i, 1, MPIR_BYTE_INTERNAL, 0, comm->node_comm, errflag);
         MPIR_ERR_CHECK(mpi_errno);
 #endif /* MPIDI_CH4_DIRECT_NETMOD */
     }
@@ -259,7 +259,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_alpha(void *buffer, M
             MPIR_Datatype_get_size_macro(datatype, type_size);
             nbytes = type_size * count;
             /* check that we received as much as we expected */
-            MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
+            MPIR_Get_count_impl(&status, MPIR_BYTE_INTERNAL, &recvd_size);
             MPIR_ERR_CHKANDJUMP2(recvd_size != nbytes, mpi_errno, MPI_ERR_OTHER,
                                  "**collective_size_mismatch",
                                  "**collective_size_mismatch %d %d", recvd_size, nbytes);
@@ -473,7 +473,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Bcast_intra_composition_delta(void *buffer, M
             MPIR_Datatype_get_size_macro(datatype, type_size);
             nbytes = type_size * count;
             /* check that we received as much as we expected */
-            MPIR_Get_count_impl(&status, MPI_BYTE, &recvd_size);
+            MPIR_Get_count_impl(&status, MPIR_BYTE_INTERNAL, &recvd_size);
             MPIR_ERR_CHKANDJUMP2(recvd_size != nbytes, mpi_errno, MPI_ERR_OTHER,
                                  "**collective_size_mismatch",
                                  "**collective_size_mismatch %d %d", recvd_size, nbytes);

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -227,6 +227,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irecv(void *buf,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
+    MPIR_DATATYPE_ASSERT_BUILTIN(datatype);
     if (MPIR_is_self_comm(comm)) {
         mpi_errno = MPIDI_Self_irecv(buf, count, datatype, rank, tag, comm, attr, request);
     } else {

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -99,7 +99,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Irsend(const void *buf,
     /*
      * FIXME: this implementation of MPID_Irsend is identical to that of MPID_Isend.
      * Need to support irsend protocol, i.e., check if receive is posted on the
-     * reveiver side before the send is posted.
+     * receiver side before the send is posted.
      */
 
     int mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/src/ch4_send.h
+++ b/src/mpid/ch4/src/ch4_send.h
@@ -50,6 +50,7 @@ MPL_STATIC_INLINE_PREFIX int MPID_Isend(const void *buf,
     MPIDI_av_entry_t *av = NULL;
     MPIR_FUNC_ENTER;
 
+    MPIR_DATATYPE_ASSERT_BUILTIN(datatype);
     if (MPIR_is_self_comm(comm)) {
         mpi_errno = MPIDI_Self_isend(buf, count, datatype, rank, tag, comm, attr, request);
     } else {

--- a/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
@@ -254,9 +254,9 @@ static int create_unexp_rreq(int rank, int tag, int context_id,
 
     *req = rreq;
 
-    /* for unexpected message, always recv as MPI_BYTE into unexpected buffer. They will be
+    /* for unexpected message, always recv as MPIR_BYTE_INTERNAL into unexpected buffer. They will be
      * set to the recv side datatype and count when it is matched */
-    MPIDIG_REQUEST(rreq, datatype) = MPI_BYTE;
+    MPIDIG_REQUEST(rreq, datatype) = MPIR_BYTE_INTERNAL;
     MPIDIG_REQUEST(rreq, count) = data_sz;
     MPIDIG_REQUEST(rreq, buffer) = NULL;        /* default */
     MPIDIG_REQUEST(rreq, u.recv.context_id) = context_id;

--- a/src/mpid/ch4/src/mpidig_rma.h
+++ b/src/mpid/ch4/src/mpidig_rma.h
@@ -80,7 +80,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, MPI_Aint ori
             am_hdr.target_datatype = target_datatype;
         } else {
             am_hdr.target_count = target_data_sz;
-            am_hdr.target_datatype = MPI_BYTE;
+            am_hdr.target_datatype = MPIR_BYTE_INTERNAL;
         }
         am_hdr.flattened_sz = 0;
         MPIR_Datatype_get_true_lb(target_datatype, &am_hdr.target_true_lb);
@@ -134,8 +134,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_put(const void *origin_addr, MPI_Aint ori
         MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
 
         CH4_CALL(am_isend(target_rank, win->comm_ptr, MPIDIG_PUT_DT_REQ, &am_hdr, sizeof(am_hdr),
-                          flattened_dt, flattened_sz, MPI_BYTE, vci, vci_target, sreq), is_local,
-                 mpi_errno);
+                          flattened_dt, flattened_sz, MPIR_BYTE_INTERNAL, vci, vci_target, sreq),
+                 is_local, mpi_errno);
     }
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -210,7 +210,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get(void *origin_addr, MPI_Aint origin_co
         am_hdr.target_datatype = target_datatype;
     } else {
         am_hdr.target_count = target_data_sz;
-        am_hdr.target_datatype = MPI_BYTE;
+        am_hdr.target_datatype = MPIR_BYTE_INTERNAL;
     }
     am_hdr.greq_ptr = sreq;
     am_hdr.win_id = MPIDIG_WIN(win, win_id);
@@ -241,7 +241,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get(void *origin_addr, MPI_Aint origin_co
     MPIR_T_PVAR_TIMER_END(RMA, rma_amhdr_set);
 
     CH4_CALL(am_isend(target_rank, win->comm_ptr, MPIDIG_GET_REQ, &am_hdr, sizeof(am_hdr),
-                      flattened_dt, flattened_sz, MPI_BYTE, vci, vci_target, sreq),
+                      flattened_dt, flattened_sz, MPIR_BYTE_INTERNAL, vci, vci_target, sreq),
              MPIDI_rank_is_local(target_rank, win->comm_ptr), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -371,8 +371,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_accumulate(const void *origin_addr, MPI_A
         MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
 
         CH4_CALL(am_isend(target_rank, win->comm_ptr, MPIDIG_ACC_DT_REQ, &am_hdr, sizeof(am_hdr),
-                          flattened_dt, flattened_sz, MPI_BYTE, vci, vci_target, sreq), is_local,
-                 mpi_errno);
+                          flattened_dt, flattened_sz, MPIR_BYTE_INTERNAL, vci, vci_target, sreq),
+                 is_local, mpi_errno);
     }
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -525,7 +525,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_do_get_accumulate(const void *origin_addr,
         MPIR_Datatype_add_ref_if_not_builtin(target_datatype);
 
         CH4_CALL(am_isend(target_rank, win->comm_ptr, MPIDIG_GET_ACC_DT_REQ,
-                          &am_hdr, sizeof(am_hdr), flattened_dt, flattened_sz, MPI_BYTE,
+                          &am_hdr, sizeof(am_hdr), flattened_dt, flattened_sz, MPIR_BYTE_INTERNAL,
                           vci, vci_target, sreq), is_local, mpi_errno);
     }
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/src/mpidig_rma_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_rma_callbacks.c
@@ -547,8 +547,8 @@ static int ack_get_acc(MPIR_Request * rreq)
     CH4_CALL(am_isend_reply(rreq->u.rma.win->comm_ptr, MPIDIG_REQUEST(rreq, u.target.origin_rank),
                             MPIDIG_GET_ACC_ACK, &ack_msg, sizeof(ack_msg),
                             MPIDIG_REQUEST(rreq, req->areq.data),
-                            MPIDIG_REQUEST(rreq, req->areq.result_data_sz), MPI_BYTE, local_vci,
-                            remote_vci, rreq), MPIDI_REQUEST(rreq, is_local), mpi_errno);
+                            MPIDIG_REQUEST(rreq, req->areq.result_data_sz), MPIR_BYTE_INTERNAL,
+                            local_vci, remote_vci, rreq), MPIDI_REQUEST(rreq, is_local), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch4/src/mpidig_win.c
+++ b/src/mpid/ch4/src/mpidig_win.c
@@ -523,8 +523,8 @@ static int win_shm_alloc_impl(MPI_Aint size, int disp_unit, MPIR_Comm * comm_ptr
                                    0,
                                    MPI_DATATYPE_NULL,
                                    shared_table,
-                                   sizeof(MPIDIG_win_shared_info_t), MPI_BYTE, shm_comm_ptr,
-                                   MPIR_ERR_NONE);
+                                   sizeof(MPIDIG_win_shared_info_t), MPIR_BYTE_INTERNAL,
+                                   shm_comm_ptr, MPIR_ERR_NONE);
         MPIR_T_PVAR_TIMER_END(RMA, rma_wincreate_allgather);
         if (mpi_errno != MPI_SUCCESS)
             goto fn_fail;

--- a/src/mpid/common/bc/mpidu_bc.c
+++ b/src/mpid/common/bc/mpidu_bc.c
@@ -106,9 +106,9 @@ int MPIDU_bc_allgather(MPIR_Comm * allgather_comm, void *bc, int bc_len, int sam
     /* a 64k memcpy is small (< 1ms), MPI_IN_PLACE not critical here */
     void *recv_buf = segment + local_size * recv_bc_len;
     if (rank == node_root) {
-        mpi_errno = MPIR_Allgatherv_fallback(segment, local_size * recv_bc_len, MPI_BYTE, recv_buf,
-                                             recv_cnts, recv_offs, MPI_BYTE, allgather_comm,
-                                             MPIR_ERR_NONE);
+        mpi_errno = MPIR_Allgatherv_fallback(segment, local_size * recv_bc_len, MPIR_BYTE_INTERNAL,
+                                             recv_buf, recv_cnts, recv_offs, MPIR_BYTE_INTERNAL,
+                                             allgather_comm, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
 
     }

--- a/src/mpid/common/sched/mpidu_sched.c
+++ b/src/mpid/common/sched/mpidu_sched.c
@@ -1070,7 +1070,8 @@ static int MPIDU_Sched_progress_state(struct MPIDU_Sched_state *state, int *made
                         if (e->u.recv.status != MPI_STATUS_IGNORE) {
                             MPI_Aint recvd;
                             e->u.recv.status->MPI_ERROR = e->u.recv.rreq->status.MPI_ERROR;
-                            MPIR_Get_count_impl(&e->u.recv.rreq->status, MPI_BYTE, &recvd);
+                            MPIR_Get_count_impl(&e->u.recv.rreq->status, MPIR_BYTE_INTERNAL,
+                                                &recvd);
                             MPIR_STATUS_SET_COUNT(*(e->u.recv.status), recvd);
                         }
                         if (err)

--- a/src/mpid/common/shm/mpidu_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_shm_alloc.c
@@ -289,7 +289,7 @@ static int map_symm_shm(MPIR_Comm * shm_comm_ptr, MPIDU_shm_seg_t * shm_seg, int
                 if (*map_result_ptr != SYMSHM_SUCCESS)
                     goto map_fail;
 
-                mpi_errno = MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPI_BYTE, 0,
+                mpi_errno = MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPIR_BYTE_INTERNAL, 0,
                                        shm_comm_ptr, MPIR_ERR_NONE);
                 MPIR_ERR_CHECK(mpi_errno);
 
@@ -307,7 +307,7 @@ static int map_symm_shm(MPIR_Comm * shm_comm_ptr, MPIDU_shm_seg_t * shm_seg, int
                 /* if rank 0 mapped successfully, others on the node attach shared memory region */
 
                 /* get serialized handle from rank 0 and deserialize it */
-                mpi_errno = MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPI_BYTE, 0,
+                mpi_errno = MPIR_Bcast(serialized_hnd, MPL_SHM_GHND_SZ, MPIR_BYTE_INTERNAL, 0,
                                        shm_comm_ptr, MPIR_ERR_NONE);
                 MPIR_ERR_CHECK(mpi_errno);
 
@@ -494,8 +494,8 @@ static int shm_alloc(MPIR_Comm * shm_comm_ptr, MPIDU_shm_seg_t * shm_seg)
         if (shm_fail_flag)
             serialized_hnd = &mpl_err_hnd[0];
 
-        mpi_errno = MPIR_Bcast_impl(serialized_hnd, MPL_SHM_GHND_SZ, MPI_BYTE, 0, shm_comm_ptr,
-                                    MPIR_ERR_NONE);
+        mpi_errno = MPIR_Bcast_impl(serialized_hnd, MPL_SHM_GHND_SZ, MPIR_BYTE_INTERNAL, 0,
+                                    shm_comm_ptr, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
 
         if (shm_fail_flag)

--- a/src/util/mpir_nodemap.c
+++ b/src/util/mpir_nodemap.c
@@ -451,8 +451,8 @@ int MPIR_nodeid_init(void)
                              MPIR_Strerror(errno, strerrbuf, MPIR_STRERROR_BUF_SIZE), errno);
         my_hostname[MAX_HOSTNAME_LEN - 1] = '\0';
 
-        mpi_errno = MPIR_Allgather_impl(MPI_IN_PLACE, MAX_HOSTNAME_LEN, MPI_CHAR,
-                                        allhostnames, MAX_HOSTNAME_LEN, MPI_CHAR,
+        mpi_errno = MPIR_Allgather_impl(MPI_IN_PLACE, MAX_HOSTNAME_LEN, MPIR_CHAR_INTERNAL,
+                                        allhostnames, MAX_HOSTNAME_LEN, MPIR_CHAR_INTERNAL,
                                         node_roots_comm, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
     }
@@ -460,7 +460,7 @@ int MPIR_nodeid_init(void)
     MPIR_Comm *node_comm = MPIR_Process.comm_world->node_comm;
     if (node_comm) {
         mpi_errno = MPIR_Bcast_impl(allhostnames, MAX_HOSTNAME_LEN * MPIR_Process.num_nodes,
-                                    MPI_CHAR, 0, node_comm, MPIR_ERR_NONE);
+                                    MPIR_CHAR_INTERNAL, 0, node_comm, MPIR_ERR_NONE);
         MPIR_ERR_CHECK(mpi_errno);
     }
 


### PR DESCRIPTION
## Pull Request Description
* Replace MPI_BYTE with MPIR_BYTE_INTERNAL
* Add MPIR_DATATYPE_ASSERT_BUILTIN to prevent internally using external
builtin types.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
