### PR TITLE
ch4: move vci init from post_init to comm_set_vcis

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -212,11 +212,8 @@ struct MPIR_Comm {
      * because context_id is non-sequential and can't be used to identify user-level
      * communicators (due to sub-comms). */
     int seq;
-    /* Certain comm and its offsprings should be restricted to sequence 0 due to
-     * various restrictions. E.g. multiple-vci doesn't support dynamic process,
-     * nor intercomms (even after its merge).
-     */
-    int tainted;
+    /* Whether multiple-vci is enabled. This is ONLY inherited in Comm_dup and Comm_split */
+    bool vcis_enabled;
 
 
     int hints[MPIR_COMM_HINT_MAX];      /* Hints to the communicator

--- a/src/include/mpir_objects.h
+++ b/src/include/mpir_objects.h
@@ -526,12 +526,6 @@ typedef struct MPIR_Object_alloc_t {
     void *direct;               /* Pointer to direct block, used
                                  * for allocation */
     int direct_size;            /* Size of direct block */
-    void *lock;                 /* lower-layer may register a lock to use. This is
-                                 * mostly for multipool requests. For other objects
-                                 * or not per-vci thread granularity, this lock
-                                 * pointer is ignored. Ref. mpir_request.h.
-                                 * NOTE: it is `void *` because mutex type not defined yet.
-                                 */
     /* The following padding is to avoid cache line sharing with other MPIR_Object_alloc_t.  This
      * padding is particularly important for an array of per-vci MPI_Request pools. */
     char pad[MPL_CACHELINE_SIZE];

--- a/src/include/mpir_thread.h
+++ b/src/include/mpir_thread.h
@@ -84,6 +84,7 @@ extern MPID_Thread_mutex_t MPIR_THREAD_VCI_HANDLE_MUTEX;
 extern MPID_Thread_mutex_t MPIR_THREAD_VCI_CTX_MUTEX;
 extern MPID_Thread_mutex_t MPIR_THREAD_VCI_PMI_MUTEX;
 extern MPID_Thread_mutex_t MPIR_THREAD_VCI_BSEND_MUTEX;
+extern MPID_Thread_mutex_t MPIR_THREAD_VCI_REQUEST_POOL_MUTEXES[];
 #endif /* MPICH_THREAD_GRANULARITY */
 #endif /* MPICH_IS_THREADED */
 

--- a/src/mpi/attr/attrutil.c
+++ b/src/mpi/attr/attrutil.c
@@ -25,7 +25,7 @@ MPIR_Object_alloc_t MPII_Keyval_mem = { 0, 0, 0, 0, 0, 0, 0, MPIR_KEYVAL,
     sizeof(MPII_Keyval),
     MPII_Keyval_direct,
     MPID_KEYVAL_PREALLOC,
-    NULL, {0}
+    {0}
 };
 
 /* Preallocated keyval objects */
@@ -35,7 +35,7 @@ MPIR_Object_alloc_t MPID_Attr_mem = { 0, 0, 0, 0, 0, 0, 0, MPIR_ATTR,
     sizeof(MPIR_Attribute),
     MPID_Attr_direct,
     MPIR_ATTR_PREALLOC,
-    NULL, {0}
+    {0}
 };
 
 /* Provides a way to trap all attribute allocations when debugging leaks. */

--- a/src/mpi/coll/op/op_impl.c
+++ b/src/mpi/coll/op/op_impl.c
@@ -13,7 +13,7 @@ MPIR_Object_alloc_t MPIR_Op_mem = { 0, 0, 0, 0, 0, 0, 0, MPIR_OP,
     sizeof(MPIR_Op),
     MPIR_Op_direct,
     MPIR_OP_PREALLOC,
-    NULL, {0}
+    {0}
 };
 
 int MPIR_Op_create_impl(MPI_User_function * user_fn, int commute, MPIR_Op ** p_op_ptr)

--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -346,7 +346,7 @@ int MPIR_Comm_create_intra(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Co
         mpi_errno = MPII_Comm_create_map(n, 0, mapping, NULL, mapping_comm, *newcomm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
 
-        (*newcomm_ptr)->tainted = comm_ptr->tainted;
+        (*newcomm_ptr)->vcis_enabled = comm_ptr->vcis_enabled;
         mpi_errno = MPIR_Comm_commit(*newcomm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
@@ -520,7 +520,7 @@ int MPIR_Comm_create_inter(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, MPIR_Co
                                       &remote_group);
     (*newcomm_ptr)->remote_group = remote_group;
 
-    (*newcomm_ptr)->tainted = comm_ptr->tainted;
+    (*newcomm_ptr)->vcis_enabled = comm_ptr->vcis_enabled;
     mpi_errno = MPIR_Comm_commit(*newcomm_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -613,7 +613,7 @@ int MPIR_Comm_create_group_impl(MPIR_Comm * comm_ptr, MPIR_Group * group_ptr, in
         mpi_errno = MPII_Comm_create_map(n, 0, mapping, NULL, mapping_comm, *newcomm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
 
-        (*newcomm_ptr)->tainted = comm_ptr->tainted;
+        (*newcomm_ptr)->vcis_enabled = comm_ptr->vcis_enabled;
         mpi_errno = MPIR_Comm_commit(*newcomm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
@@ -1066,7 +1066,6 @@ int MPIR_Intercomm_create_impl(MPIR_Comm * local_comm_ptr, int local_leader,
     }
     MPID_THREAD_CS_EXIT(VCI, local_comm_ptr->mutex);
 
-    (*new_intercomm_ptr)->tainted = 1;
     mpi_errno = MPIR_Comm_commit(*new_intercomm_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -1121,7 +1120,6 @@ int MPIR_peer_intercomm_create(int context_id, int recvcontext_id,
                                          &(*newcomm)->remote_group);
     MPIR_ERR_CHECK(mpi_errno);
 
-    (*newcomm)->tainted = 1;
     mpi_errno = MPIR_Comm_commit(*newcomm);
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -1279,7 +1277,6 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm * comm_ptr, int high, MPIR_Comm ** new_i
      * operations within the context id algorithm, since we already
      * have a valid (almost - see comm_create_hook) communicator.
      */
-    (*new_intracomm_ptr)->tainted = 1;
     mpi_errno = MPIR_Comm_commit((*new_intracomm_ptr));
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -1312,7 +1309,6 @@ int MPIR_Intercomm_merge_impl(MPIR_Comm * comm_ptr, int high, MPIR_Comm ** new_i
     mpi_errno = create_and_map(comm_ptr, local_high, (*new_intracomm_ptr));
     MPIR_ERR_CHECK(mpi_errno);
 
-    (*new_intracomm_ptr)->tainted = 1;
     mpi_errno = MPIR_Comm_commit((*new_intracomm_ptr));
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpi/comm/comm_split.c
+++ b/src/mpi/comm/comm_split.c
@@ -348,7 +348,7 @@ int MPIR_Comm_split_impl(MPIR_Comm * comm_ptr, int color, int key, MPIR_Comm ** 
         }
         MPID_THREAD_CS_EXIT(VCI, comm_ptr->mutex);
 
-        (*newcomm_ptr)->tainted = comm_ptr->tainted;
+        (*newcomm_ptr)->vcis_enabled = comm_ptr->vcis_enabled;
         mpi_errno = MPIR_Comm_commit(*newcomm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
     }

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -289,7 +289,7 @@ int MPII_Comm_init(MPIR_Comm * comm_p)
     comm_p->bsendbuffer = NULL;
     comm_p->name[0] = '\0';
     comm_p->seq = 0;    /* default to 0, to be updated at Comm_commit */
-    comm_p->tainted = 0;
+    comm_p->vcis_enabled = false;
     memset(comm_p->hints, 0, sizeof(comm_p->hints));
     for (int i = 0; i < next_comm_hint_index; i++) {
         if (MPIR_comm_hint_list[i].key) {
@@ -416,9 +416,6 @@ int MPII_Setup_intercomm_localcomm(MPIR_Comm * intercomm_ptr)
     intercomm_ptr->local_comm = localcomm_ptr;
 
     /* sets up the SMP-aware sub-communicators and tables */
-    /* This routine maybe used inside MPI_Comm_idup, so we can't synchronize
-     * seq using blocking collectives, thus mark as tainted. */
-    localcomm_ptr->tainted = 1;
     mpi_errno = MPIR_Comm_commit(localcomm_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -597,13 +594,13 @@ static void propagate_hints_to_subcomm(MPIR_Comm * comm, MPIR_Comm * subcomm)
     subcomm->hints[MPIR_COMM_HINT_VCI] = comm->hints[MPIR_COMM_HINT_VCI];
 }
 
-static void propagate_tainted_to_subcomms(MPIR_Comm * comm)
+static void propagate_vcis_enabled(MPIR_Comm * comm)
 {
     if (comm->node_comm != NULL)
-        comm->node_comm->tainted = comm->tainted;
+        comm->node_comm->vcis_enabled = comm->vcis_enabled;
 
     if (comm->node_roots_comm != NULL)
-        comm->node_roots_comm->tainted = comm->tainted;
+        comm->node_roots_comm->vcis_enabled = comm->vcis_enabled;
 }
 
 int MPIR_Comm_create_subcomms(MPIR_Comm * comm)
@@ -734,7 +731,7 @@ int MPIR_Comm_create_subcomms(MPIR_Comm * comm)
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    propagate_tainted_to_subcomms(comm);
+    propagate_vcis_enabled(comm);
 
     comm->hierarchy_kind = MPIR_COMM_HIERARCHY_KIND__PARENT;
 
@@ -840,7 +837,7 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    if (comm->comm_kind == MPIR_COMM_KIND__INTRACOMM && !comm->tainted) {
+    if (comm->comm_kind == MPIR_COMM_KIND__INTRACOMM && comm->vcis_enabled) {
         mpi_errno = init_comm_seq(comm);
         MPIR_ERR_CHECK(mpi_errno);
     }
@@ -1038,7 +1035,7 @@ int MPII_Comm_copy(MPIR_Comm * comm_ptr, int size, MPIR_Info * info, MPIR_Comm *
         MPII_Comm_set_hints(newcomm_ptr, info, true);
     }
 
-    newcomm_ptr->tainted = comm_ptr->tainted;
+    newcomm_ptr->vcis_enabled = comm_ptr->vcis_enabled;
     mpi_errno = MPIR_Comm_commit(newcomm_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
@@ -1121,9 +1118,8 @@ int MPII_Comm_copy_data(MPIR_Comm * comm_ptr, MPIR_Info * info, MPIR_Comm ** out
     newcomm_ptr->attributes = 0;
     *outcomm_ptr = newcomm_ptr;
 
-    /* inherit tainted flag */
-    newcomm_ptr->tainted = comm_ptr->tainted;
-    propagate_tainted_to_subcomms(newcomm_ptr);
+    newcomm_ptr->vcis_enabled = comm_ptr->vcis_enabled;
+    propagate_vcis_enabled(newcomm_ptr);
 
   fn_fail:
     MPIR_FUNC_EXIT;

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -22,7 +22,7 @@ MPIR_Object_alloc_t MPIR_Comm_mem = { 0, 0, 0, 0, 0, 0, 0, MPIR_COMM,
     sizeof(MPIR_Comm),
     MPIR_Comm_direct,
     MPIR_COMM_PREALLOC,
-    NULL, {0}
+    {0}
 };
 
 /* Communicator creation functions */

--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -16,7 +16,7 @@ MPIR_Datatype MPIR_Datatype_direct[MPIR_DATATYPE_PREALLOC];
 MPIR_Object_alloc_t MPIR_Datatype_mem = { 0, 0, 0, 0, 0, 0, 0, MPIR_DATATYPE,
     sizeof(MPIR_Datatype), MPIR_Datatype_direct,
     MPIR_DATATYPE_PREALLOC,
-    NULL, {0}
+    {0}
 };
 
 static int datatype_attr_finalize_cb(void *dummy);

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -120,7 +120,7 @@ MPIR_Object_alloc_t MPIR_Errhandler_mem = { 0, 0, 0, 0, 0, 0, 0, MPIR_ERRHANDLER
     sizeof(MPIR_Errhandler),
     MPIR_Errhandler_direct,
     MPIR_ERRHANDLER_PREALLOC,
-    NULL, {0}
+    {0}
 };
 
 static void init_builtins(void)

--- a/src/mpi/group/grouputil.c
+++ b/src/mpi/group/grouputil.c
@@ -39,7 +39,7 @@ MPIR_Group MPIR_Group_direct[MPIR_GROUP_PREALLOC];
 MPIR_Object_alloc_t MPIR_Group_mem = { 0, 0, 0, 0, 0, 0, 0, MPIR_GROUP,
     sizeof(MPIR_Group), MPIR_Group_direct,
     MPIR_GROUP_PREALLOC,
-    NULL, {0}
+    {0}
 };
 
 MPIR_Group *const MPIR_Group_empty = &MPIR_Group_builtin[0];

--- a/src/mpi/info/infoutil.c
+++ b/src/mpi/info/infoutil.c
@@ -17,7 +17,7 @@ MPIR_Info MPIR_Info_direct[MPIR_INFO_PREALLOC];
 MPIR_Object_alloc_t MPIR_Info_mem = { 0, 0, 0, 0, 0, 0, 0, MPIR_INFO,
     sizeof(MPIR_Info), MPIR_Info_direct,
     MPIR_INFO_PREALLOC,
-    NULL, {0}
+    {0}
 };
 
 /* Free an info structure.  In the multithreaded case, this routine

--- a/src/mpi/init/mutex.c
+++ b/src/mpi/init/mutex.c
@@ -18,6 +18,7 @@ MPID_Thread_mutex_t MPIR_THREAD_VCI_HANDLE_MUTEX;
 MPID_Thread_mutex_t MPIR_THREAD_VCI_CTX_MUTEX;
 MPID_Thread_mutex_t MPIR_THREAD_VCI_PMI_MUTEX;
 MPID_Thread_mutex_t MPIR_THREAD_VCI_BSEND_MUTEX;
+MPID_Thread_mutex_t MPIR_THREAD_VCI_REQUEST_POOL_MUTEXES[MPIR_REQUEST_NUM_POOLS];
 #endif /* MPICH_THREAD_GRANULARITY */
 
 /* called the first thing in init so it can enter critical section immediately */
@@ -41,6 +42,11 @@ void MPII_thread_mutex_create(void)
 
     MPID_Thread_mutex_create(&MPIR_THREAD_VCI_BSEND_MUTEX, &err);
     MPIR_Assert(err == 0);
+
+    for (int i = 0; i < MPIR_REQUEST_NUM_POOLS; i++) {
+        MPID_Thread_mutex_create(&MPIR_THREAD_VCI_REQUEST_POOL_MUTEXES[i], &err);
+        MPIR_Assert(err == 0);
+    }
 
 #elif MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__LOCKFREE
     /* Updates to shared data and access to shared services is handled
@@ -78,6 +84,11 @@ void MPII_thread_mutex_destroy(void)
 
     MPID_Thread_mutex_destroy(&MPIR_THREAD_VCI_BSEND_MUTEX, &err);
     MPIR_Assert(err == 0);
+
+    for (int i = 0; i < MPIR_REQUEST_NUM_POOLS; i++) {
+        MPID_Thread_mutex_destroy(&MPIR_THREAD_VCI_REQUEST_POOL_MUTEXES[i], &err);
+        MPIR_Assert(err == 0);
+    }
 
 #elif MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__LOCKFREE
     /* Updates to shared data and access to shared services is handled

--- a/src/mpi/request/mpir_greq.c
+++ b/src/mpi/request/mpir_greq.c
@@ -12,7 +12,7 @@ MPIR_Object_alloc_t MPIR_Grequest_class_mem = { 0, 0, 0, 0, 0, 0, 0, MPIR_GREQ_C
     sizeof(MPIR_Grequest_class),
     MPIR_Grequest_class_direct,
     MPIR_GREQ_CLASS_PREALLOC,
-    NULL, {0}
+    {0}
 };
 
 /* We jump through some minor hoops to manage the list of classes ourselves and

--- a/src/mpi/request/mpir_request.c
+++ b/src/mpi/request/mpir_request.c
@@ -31,15 +31,10 @@ static void init_builtin_request(MPIR_Request * req, int handle, MPIR_Request_ki
 
 void MPII_init_request(void)
 {
-    MPID_Thread_mutex_t *lock_ptr = NULL;
-#if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
-    lock_ptr = &MPIR_THREAD_VCI_HANDLE_MUTEX;
-#endif
-
     /* *INDENT-OFF* */
-    MPIR_Request_mem[0] = (MPIR_Object_alloc_t) { 0, 0, 0, 0, 0, 0, 0, MPIR_REQUEST, sizeof(MPIR_Request), MPIR_Request_direct, MPIR_REQUEST_PREALLOC, lock_ptr, {0}};
+    MPIR_Request_mem[0] = (MPIR_Object_alloc_t) { 0, 0, 0, 0, 0, 0, 0, MPIR_REQUEST, sizeof(MPIR_Request), MPIR_Request_direct, MPIR_REQUEST_PREALLOC, {0}};
     for (int i = 1; i < MPIR_REQUEST_NUM_POOLS; i++) {
-        MPIR_Request_mem[i] = (MPIR_Object_alloc_t) { 0, 0, 0, 0, 0, 0, 0, MPIR_REQUEST, sizeof(MPIR_Request), NULL, 0, lock_ptr, {0}};
+        MPIR_Request_mem[i] = (MPIR_Object_alloc_t) { 0, 0, 0, 0, 0, 0, 0, MPIR_REQUEST, sizeof(MPIR_Request), NULL, 0, {0}};
     }
     /* *INDENT-ON* */
 

--- a/src/mpi/rma/winutil.c
+++ b/src/mpi/rma/winutil.c
@@ -14,5 +14,5 @@ MPIR_Win MPIR_Win_direct[MPIR_WIN_PREALLOC];
 MPIR_Object_alloc_t MPIR_Win_mem = { 0, 0, 0, 0, 0, 0, 0, MPIR_WIN,
     sizeof(MPIR_Win), MPIR_Win_direct,
     MPIR_WIN_PREALLOC,
-    NULL, {0}
+    {0}
 };

--- a/src/mpi/session/session_util.c
+++ b/src/mpi/session/session_util.c
@@ -16,7 +16,7 @@ MPIR_Session MPIR_Session_direct[MPIR_SESSION_PREALLOC];
 MPIR_Object_alloc_t MPIR_Session_mem = { 0, 0, 0, 0, 0, 0, 0,
     MPIR_SESSION, sizeof(MPIR_Session),
     MPIR_Session_direct, MPIR_SESSION_PREALLOC,
-    NULL, {0}
+    {0}
 };
 
 int MPIR_Session_create(MPIR_Session ** p_session_ptr, int thread_level)

--- a/src/mpi/stream/stream_impl.c
+++ b/src/mpi/stream/stream_impl.c
@@ -60,7 +60,7 @@ MPIR_Stream MPIR_Stream_direct[MPIR_STREAM_PREALLOC];
 MPIR_Object_alloc_t MPIR_Stream_mem = { 0, 0, 0, 0, 0, 0, 0, MPIR_STREAM,
     sizeof(MPIR_Stream), MPIR_Stream_direct,
     MPIR_STREAM_PREALLOC,
-    NULL, {0}
+    {0}
 };
 
 /* utilities for managing streams in a communicator */

--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -87,6 +87,9 @@ Non Native API:
   am_tag_recv : int
       NM*: rank, comm, handler_id, tag, buf-2, count, datatype, src_vci, dst_vci, rreq
      SHM*: rank, comm, handler_id, tag, buf-2, count, datatype, src_vci, dst_vci, rreq
+  comm_set_vcis : int
+      NM : comm, num_vcis, all_num_vcis
+     SHM : comm, num_vcis
   get_local_upids : int
       NM : comm, local_upid_size, local_upids
   upids_to_lpids : int
@@ -481,6 +484,7 @@ PARAM:
     newcomm_ptr: MPIR_Comm **
     num_vcis: int
     num_vcis_actual: int *
+    all_num_vcis: int *
     op: MPI_Op
     op_p: MPIR_Op *
     origin_addr: const void *

--- a/src/mpid/ch4/include/mpidimpl.h
+++ b/src/mpid/ch4/include/mpidimpl.h
@@ -20,5 +20,6 @@
 
 int MPIDI_world_pre_init(void);
 int MPIDI_world_post_init(void);
+int MPIDI_Comm_set_vcis(MPIR_Comm * comm, int num_vcis);
 
 #endif /* MPIDIMPL_H_INCLUDED */

--- a/src/mpid/ch4/include/mpidpost.h
+++ b/src/mpid/ch4/include/mpidpost.h
@@ -14,9 +14,9 @@ MPL_STATIC_INLINE_PREFIX MPIR_Request *MPID_Request_create_from_comm(MPIR_Reques
 {
     MPIR_Request *req;
     int vci = MPIDI_get_comm_vci(comm);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     req = MPIR_Request_create_from_pool(kind, vci, 1);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     return req;
 }
 

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_probe.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_probe.h
@@ -16,10 +16,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_improbe(int source,
     int mpi_errno = MPI_SUCCESS;
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(0));
     mpi_errno = MPIDIG_mpi_improbe(source, tag, comm, context_offset, 0, flag,
                                    false /* is_local */ , message, status);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(0));
 
     return mpi_errno;
 }
@@ -33,10 +33,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_iprobe(int source,
     int mpi_errno = MPI_SUCCESS;
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(0));
     mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, 0, flag,
                                   false /* is_local */ , status);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(0));
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_recv.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_recv.h
@@ -15,9 +15,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_imrecv(void *buf,
 #if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
     int vci = MPIDI_Request_get_vci(message);
 #endif
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     mpi_errno = MPIDIG_mpi_imrecv(buf, count, datatype, message);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
 
     return mpi_errno;
 }
@@ -43,17 +43,17 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
     need_cs = (rank != MPI_ANY_SOURCE);
 #endif
     if (need_cs) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(0));
     } else {
 #ifdef MPICH_DEBUG_MUTEX
-        MPID_THREAD_ASSERT_IN_CS(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_ASSERT_IN_CS(VCI, MPIDI_VCI_LOCK(0));
 #endif
     }
 
     mpi_errno = MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset, 0,
                                  request, 0, partner);
     if (need_cs) {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(0));
     }
 
     return mpi_errno;

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_send.h
@@ -24,10 +24,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_isend(const void *buf,
     vci_src = 0;
     vci_dst = 0;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci_src).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci_src));
     mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                  vci_src, vci_dst, request, syncflag, errflag);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci_src).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci_src));
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ofi/Makefile.mk
+++ b/src/mpid/ch4/netmod/ofi/Makefile.mk
@@ -22,6 +22,7 @@ mpi_core_sources   += src/mpid/ch4/netmod/ofi/func_table.c \
                       src/mpid/ch4/netmod/ofi/ofi_progress.c \
                       src/mpid/ch4/netmod/ofi/ofi_am_events.c \
                       src/mpid/ch4/netmod/ofi/ofi_nic.c \
+                      src/mpid/ch4/netmod/ofi/ofi_vci.c \
                       src/mpid/ch4/netmod/ofi/globals.c \
                       src/mpid/ch4/netmod/ofi/init_provider.c \
                       src/mpid/ch4/netmod/ofi/init_settings.c \

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -139,9 +139,9 @@ int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret);
 #define MPIDI_OFI_VCI_PROGRESS(vci_)                                    \
     do {                                                                \
         int made_progress = 0; \
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci_).lock);                \
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci_));                \
         mpi_errno = MPIDI_NM_progress(vci_, &made_progress); \
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci_).lock);                 \
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci_));                 \
         MPIR_ERR_CHECK(mpi_errno);                                      \
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
     } while (0)
@@ -149,23 +149,23 @@ int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret);
 #define MPIDI_OFI_VCI_PROGRESS_WHILE(vci_, cond)                            \
     do {                                                                    \
         int made_progress = 0; \
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci_).lock);                    \
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci_));                    \
         while (cond) {                                                      \
             mpi_errno = MPIDI_NM_progress(vci_, &made_progress);                        \
             if (mpi_errno) {                                                \
-                MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci_).lock);             \
+                MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci_));             \
                 MPIR_ERR_POP(mpi_errno);                                    \
             }                                                               \
             MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
         }                                                                   \
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci_).lock);                     \
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci_));                     \
     } while (0)
 
 #define MPIDI_OFI_VCI_CALL(FUNC,vci_,STR)                   \
     do {                                                    \
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci_).lock);    \
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci_));    \
         ssize_t _ret = FUNC;                                \
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci_).lock);     \
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci_));     \
         MPIDI_OFI_ERR(_ret<0,                               \
                               mpi_errno,                    \
                               MPI_ERR_OTHER,                \
@@ -178,14 +178,14 @@ int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret);
 #define MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vci_)            \
     do {                                                        \
         if (!MPIDI_VCI_IS_EXPLICIT(vci_) && MPIDI_CH4_MT_MODEL != MPIDI_CH4_MT_LOCKLESS) {      \
-            MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci_).lock);    \
+            MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci_));    \
         }                                                       \
     } while (0)
 
 #define MPIDI_OFI_THREAD_CS_EXIT_VCI_OPTIONAL(vci_)         \
     do {                                                    \
         if (!MPIDI_VCI_IS_EXPLICIT(vci_) && MPIDI_CH4_MT_MODEL != MPIDI_CH4_MT_LOCKLESS) {  \
-            MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci_).lock); \
+            MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci_)); \
         }                                                   \
     } while (0)
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -551,7 +551,6 @@ cvars:
 
 static int update_global_limits(struct fi_info *prov);
 static void dump_global_settings(void);
-static void dump_dynamic_settings(void);
 static int create_vci_context(int vci, int nic);
 static int destroy_vci_context(int vci, int nic);
 static int ofi_pvar_init(void);
@@ -847,10 +846,6 @@ int MPIDI_OFI_init_vcis(int num_vcis, int *num_vcis_actual)
 int MPIDI_OFI_post_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
-
-    if (MPIR_CVAR_DEBUG_SUMMARY && MPIR_Process.rank == 0) {
-        dump_dynamic_settings();
-    }
 
     return mpi_errno;
 }
@@ -1718,14 +1713,6 @@ static void dump_global_settings(void)
     fprintf(stdout, "MPIDI_OFI_AM_HDR_POOL_CELL_SIZE: %d\n", (int) MPIDI_OFI_AM_HDR_POOL_CELL_SIZE);
     fprintf(stdout, "MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE: %d\n",
             (int) MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE);
-    fprintf(stdout, "======================================\n");
-}
-
-static void dump_dynamic_settings(void)
-{
-    fprintf(stdout, "==== OFI dynamic settings ====\n");
-    fprintf(stdout, "num_vcis: %d\n", MPIDI_OFI_global.num_vcis);
-    fprintf(stdout, "num_nics: %d\n", MPIDI_OFI_global.num_nics);
     fprintf(stdout, "======================================\n");
 }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -34,6 +34,8 @@ bool MPIDI_OFI_nic_already_used(const struct fi_info *prov, struct fi_info **oth
 
 int MPIDI_OFI_addr_exchange_root_ctx(void);
 int MPIDI_OFI_addr_exchange_all_ctx(void);
+int MPIDI_OFI_am_init(int vci);
+int MPIDI_OFI_am_post_recv(int vci, int nic);
 
 bool MPIDI_OFI_nic_is_up(struct fi_info *prov);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -413,7 +413,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
         MPIDI_OFI_THREAD_CS_ENTER_VCI_OPTIONAL(vci_dst);
     } else {
 #ifdef MPICH_DEBUG_MUTEX
-        MPID_THREAD_ASSERT_IN_CS(VCI, MPIDI_VCI(vci_dst).lock);
+        MPID_THREAD_ASSERT_IN_CS(VCI, MPIDI_VCI_LOCK(vci_dst));
 #endif
     }
     if (!MPIDI_OFI_ENABLE_TAGGED) {

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -243,7 +243,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
      * very slow */
     if (origin_contig && target_contig &&
         (origin_bytes <= MPIDI_OFI_global.max_buffered_write && !MPL_gpu_attr_is_dev(&attr))) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         MPIDI_OFI_win_cntr_incr(win);
         MPIDI_OFI_CALL_RETRY(fi_inject_write(MPIDI_OFI_WIN(win).ep,
                                              MPIR_get_contig_ptr(origin_addr, origin_true_lb),
@@ -251,13 +251,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
                                              MPIDI_OFI_av_to_phys(addr, nic_target, vci_target),
                                              target_mr.addr + target_true_lb,
                                              target_mr.mr_key), vci, rdma_inject_write);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         goto null_op_exit;
     }
 
     /* large contiguous messages */
     if (origin_contig && target_contig) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         if (sigreq) {
             MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, 0);
             flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
@@ -286,7 +286,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         MPIDI_OFI_CALL_RETRY(fi_writemsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         goto fn_exit;
     }
 
@@ -297,22 +297,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
 
     if (origin_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         mpi_errno =
             MPIDI_OFI_nopack_putget(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_count, target_datatype, target_mr, win, addr,
                                     MPIDI_OFI_PUT, sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         goto fn_exit;
     }
 
     if (origin_density < MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         mpi_errno =
             MPIDI_OFI_pack_put(origin_addr, origin_count, origin_datatype, target_rank,
                                target_count, target_datatype, target_mr, win, addr, sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         goto fn_exit;
     }
 
@@ -432,7 +432,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
 
     /* contiguous messages */
     if (origin_contig && target_contig) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         if (sigreq) {
             MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, 0);
             flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
@@ -463,7 +463,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         MPIDI_OFI_CALL_RETRY(fi_readmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         goto fn_exit;
     }
 
@@ -474,22 +474,22 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
 
     if (origin_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         mpi_errno =
             MPIDI_OFI_nopack_putget(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_count, target_datatype, target_mr, win, addr,
                                     MPIDI_OFI_GET, sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         goto fn_exit;
     }
 
     if (origin_density < MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
         target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         mpi_errno =
             MPIDI_OFI_pack_get(origin_addr, origin_count, origin_datatype, target_rank,
                                target_count, target_datatype, target_mr, win, addr, sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         goto fn_exit;
     }
 
@@ -687,12 +687,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     msg.context = NULL;
     msg.data = 0;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     MPIDI_OFI_win_cntr_incr(win);
     MPIDI_OFI_CALL_RETRY(fi_compare_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg,
                                               &comparev, compare_desc, 1, &resultv, result_desc, 1,
                                               0), vci, atomicto);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -701,9 +701,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
   am_fallback:
     /* Wait for OFI case to complete for atomicity.
      * For now, there is no FI flag to track atomic only ops, we use RMA level cntr. */
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     MPIDI_OFI_win_do_progress(win, vci);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     return MPIDIG_mpi_compare_and_swap(origin_addr, compare_addr, result_addr, datatype,
                                        target_rank, target_disp, win);
 }
@@ -779,7 +779,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
         /* Ensure completion of outstanding AMs for atomicity. */
         MPIDIG_wait_am_acc(win, target_rank);
 
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         uint64_t flags;
         if (sigreq) {
             MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, 0);
@@ -816,16 +816,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
         MPIDI_OFI_CALL_RETRY(fi_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_atomicto);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         goto fn_exit;
     }
 
   am_fallback:
     /* Wait for OFI acc to complete for atomicity.
      * For now, there is no FI flag to track atomic only ops, we use RMA level cntr. */
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     MPIDI_OFI_win_do_progress(win, vci);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     if (sigreq)
         mpi_errno = MPIDIG_mpi_raccumulate(origin_addr, origin_count, origin_datatype, target_rank,
                                            target_disp, target_count, target_datatype, op, win,
@@ -920,7 +920,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
         /* Ensure completion of outstanding AMs for atomicity. */
         MPIDIG_wait_am_acc(win, target_rank);
 
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         uint64_t flags;
         if (sigreq) {
             MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, 0);
@@ -963,16 +963,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
                                                 result_desc, 1, flags), vci, rdma_readfrom);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         goto fn_exit;
     }
 
   am_fallback:
     /* Wait for OFI getacc to complete for atomicity.
      * For now, there is no FI flag to track atomic only ops, we use RMA level cntr. */
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     MPIDI_OFI_win_do_progress(win, vci);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     if (sigreq)
         mpi_errno =
             MPIDIG_mpi_rget_accumulate(origin_addr, origin_count, origin_datatype, result_addr,
@@ -1190,11 +1190,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
     msg.context = NULL;
     msg.data = 0;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     MPIDI_OFI_win_cntr_incr(win);
     MPIDI_OFI_CALL_RETRY(fi_fetch_atomicmsg(MPIDI_OFI_WIN(win).ep, &msg, &resultv,
                                             result_desc, 1, 0), vci, rdma_readfrom);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -1204,9 +1204,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_fetch_and_op(const void *origin_addr,
   am_fallback:
     /* Wait for OFI fetch_and_op to complete for atomicity.
      * For now, there is no FI flag to track atomic only ops, we use RMA level cntr. */
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     MPIDI_OFI_win_do_progress(win, vci);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     return MPIDIG_mpi_fetch_and_op(origin_addr, result_addr, datatype, target_rank, target_disp, op,
                                    win);
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_spawn.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_spawn.c
@@ -20,7 +20,7 @@ int MPIDI_OFI_dynamic_send(MPIR_Lpid remote_lpid, int tag, const void *buf, int 
     int lpid = MPIDIU_GPID_GET_LPID(remote_lpid);
     fi_addr_t remote_addr = MPIDI_OFI_av_to_phys(&MPIDIU_get_av(avtid, lpid), nic, vci);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
 
     MPIDI_OFI_dynamic_process_request_t req;
     req.done = 0;
@@ -69,7 +69,7 @@ int MPIDI_OFI_dynamic_send(MPIR_Lpid remote_lpid, int tag, const void *buf, int 
     }
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -91,7 +91,7 @@ int MPIDI_OFI_dynamic_recv(int tag, void *buf, int size, int timeout)
     match_bits = MPIDI_OFI_init_recvtag(&mask_bits, 0, MPI_ANY_SOURCE, tag);
     match_bits |= MPIDI_OFI_DYNPROC_SEND;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
 
     MPL_time_t time_start, time_now;
     double time_gap;
@@ -126,7 +126,7 @@ int MPIDI_OFI_dynamic_recv(int tag, void *buf, int size, int timeout)
     }
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpid/ch4/netmod/ofi/ofi_vci.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_vci.c
@@ -5,9 +5,33 @@
 
 #include "mpidimpl.h"
 #include "ofi_impl.h"
+#include "ofi_init.h"
 
 int MPIDI_OFI_comm_set_vcis(MPIR_Comm * comm, int num_vcis, int *all_num_vcis)
 {
     int mpi_errno = MPI_SUCCESS;
+
+    /* set up local vcis */
+    int num_vcis_actual;
+    mpi_errno = MPIDI_NM_init_vcis(num_vcis, &num_vcis_actual);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* gather the number of remote vcis */
+    mpi_errno = MPIR_Allgather_impl(&num_vcis_actual, 1, MPIR_INT_INTERNAL,
+                                    all_num_vcis, 1, MPIR_INT_INTERNAL, comm, MPIR_ERR_NONE);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* Since we allow different process to have different num_vcis, we always need run exchange. */
+    mpi_errno = MPIDI_OFI_addr_exchange_all_ctx();
+    MPIR_ERR_CHECK(mpi_errno);
+
+    for (int vci = 1; vci < MPIDI_OFI_global.num_vcis; vci++) {
+        MPIDI_OFI_am_init(vci);
+        MPIDI_OFI_am_post_recv(vci, 0);
+    }
+
+  fn_exit:
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }

--- a/src/mpid/ch4/netmod/ofi/ofi_vci.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_vci.c
@@ -30,6 +30,13 @@ int MPIDI_OFI_comm_set_vcis(MPIR_Comm * comm, int num_vcis, int *all_num_vcis)
         MPIDI_OFI_am_post_recv(vci, 0);
     }
 
+    if (MPIR_CVAR_DEBUG_SUMMARY && comm->rank == 0) {
+        fprintf(stdout, "==== OFI dynamic settings ====\n");
+        fprintf(stdout, "num_vcis: %d\n", MPIDI_OFI_global.num_vcis);
+        fprintf(stdout, "num_nics: %d\n", MPIDI_OFI_global.num_nics);
+        fprintf(stdout, "======================================\n");
+    }
+
   fn_exit:
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/netmod/ofi/ofi_vci.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_vci.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpidimpl.h"
+#include "ofi_impl.h"
+
+int MPIDI_OFI_comm_set_vcis(MPIR_Comm * comm, int num_vcis, int *all_num_vcis)
+{
+    int mpi_errno = MPI_SUCCESS;
+    return mpi_errno;
+}

--- a/src/mpid/ch4/netmod/ucx/Makefile.mk
+++ b/src/mpid/ch4/netmod/ucx/Makefile.mk
@@ -15,6 +15,7 @@ mpi_core_sources   += src/mpid/ch4/netmod/ucx/func_table.c\
                       src/mpid/ch4/netmod/ucx/ucx_win.c \
                       src/mpid/ch4/netmod/ucx/ucx_part.c \
                       src/mpid/ch4/netmod/ucx/ucx_am.c \
+                      src/mpid/ch4/netmod/ucx/ucx_vci.c \
                       src/mpid/ch4/netmod/ucx/globals.c
 
 errnames_txt_files += src/mpid/ch4/netmod/ucx/errnames.txt

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -148,4 +148,7 @@ void MPIDI_UCX_am_recv_callback_nbx(void *request, ucs_status_t status, size_t l
                                     void *user_data);
 #endif
 
+int MPIDI_UCX_init_worker(int vci);
+int MPIDI_UCX_all_vcis_address_exchange(void);
+
 #endif /* UCX_IMPL_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ucx/ucx_impl.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_impl.h
@@ -30,14 +30,14 @@
 #define MPIDI_UCX_THREAD_CS_ENTER_VCI(vci) \
     do { \
         if (!MPIDI_VCI_IS_EXPLICIT(vci)) { \
-            MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock); \
+            MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci)); \
         } \
     } while (0)
 
 #define MPIDI_UCX_THREAD_CS_EXIT_VCI(vci) \
     do { \
         if (!MPIDI_VCI_IS_EXPLICIT(vci)) { \
-            MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock); \
+            MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci)); \
         } \
     } while (0)
 

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -28,13 +28,9 @@ static void request_init_callback(void *request)
 
 }
 
-static void init_num_vcis(void)
-{
-    /* TODO: check capabilities, abort if we can't support the requested number of vcis. */
-    MPIDI_UCX_global.num_vcis = MPIDI_global.n_total_vcis;
-}
+static void flush_all(void);
 
-static int init_worker(int vci)
+int MPIDI_UCX_init_worker(int vci)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -147,7 +143,7 @@ static int initial_address_exchange(void)
     goto fn_exit;
 }
 
-static int all_vcis_address_exchange(void)
+int MPIDI_UCX_all_vcis_address_exchange(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -197,6 +193,10 @@ static int all_vcis_address_exchange(void)
             }
         }
     }
+
+    /* Flush all pending wireup operations or it may interfere with RMA flush_ops count. */
+    flush_all();
+
   fn_exit:
     MPL_free(all_names);
     return mpi_errno;
@@ -213,7 +213,7 @@ int MPIDI_UCX_init_local(int *tag_bits)
     uint64_t features = 0;
     ucp_params_t ucp_params;
 
-    init_num_vcis();
+    MPIDI_UCX_global.num_vcis = 1;
 
     /* unable to support extended context id in current match bit configuration */
     MPL_COMPILE_TIME_ASSERT(MPIR_CONTEXT_ID_BITS <= MPIDI_UCX_CONTEXT_ID_BITS);
@@ -271,7 +271,7 @@ int MPIDI_UCX_init_world(void)
     int mpi_errno = MPI_SUCCESS;
 
     /* initialize worker for vci 0 */
-    mpi_errno = init_worker(0);
+    mpi_errno = MPIDI_UCX_init_worker(0);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = initial_address_exchange();
@@ -324,26 +324,9 @@ int MPIDI_UCX_post_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    if (MPIDI_UCX_global.num_vcis == 1) {
-        goto fn_exit;
-    }
-
-    for (int i = 1; i < MPIDI_UCX_global.num_vcis; i++) {
-        mpi_errno = init_worker(i);
-        MPIR_ERR_CHECK(mpi_errno);
-    }
-    mpi_errno = all_vcis_address_exchange();
-    MPIR_ERR_CHECK(mpi_errno);
-
-    /* Flush all pending wireup operations or it may interfere with RMA flush_ops count.
-     * Since this require progress in non-zero vcis, we need switch on is_initialized. */
     MPIDI_global.is_initialized = 1;
-    flush_all();
 
-  fn_exit:
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 int MPIDI_UCX_mpi_finalize_hook(void)

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -252,7 +252,6 @@ int MPIDI_UCX_init_local(int *tag_bits)
         printf("==== UCX netmod Capability ====\n");
         printf("MPIDI_UCX_CONTEXT_ID_BITS: %d\n", MPIDI_UCX_CONTEXT_ID_BITS);
         printf("MPIDI_UCX_RANK_BITS: %d\n", MPIDI_UCX_RANK_BITS);
-        printf("num_vcis: %d\n", MPIDI_UCX_global.num_vcis);
         printf("tag_bits: %d\n", *tag_bits);
         printf("===============================\n");
     }

--- a/src/mpid/ch4/netmod/ucx/ucx_spawn.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_spawn.c
@@ -27,7 +27,7 @@ int MPIDI_UCX_dynamic_send(MPIR_Lpid remote_lpid, int tag, const void *buf, int 
     uint64_t ucx_tag = MPIDI_UCX_DYNPROC_MASK + tag;
     int vci = 0;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
 
     int avtid = MPIDIU_GPID_GET_AVTID(remote_lpid);
     int lpid = MPIDIU_GPID_GET_LPID(remote_lpid);
@@ -68,7 +68,7 @@ int MPIDI_UCX_dynamic_send(MPIR_Lpid remote_lpid, int tag, const void *buf, int 
     }
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     return mpi_errno;
 }
 
@@ -80,7 +80,7 @@ int MPIDI_UCX_dynamic_recv(int tag, void *buf, int size, int timeout)
     uint64_t tag_mask = 0xffffffffffffffff;
     int vci = 0;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
 
     bool done = false;
     ucp_request_param_t param = {
@@ -117,7 +117,7 @@ int MPIDI_UCX_dynamic_recv(int tag, void *buf, int size, int timeout)
     }
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     return mpi_errno;
 }
 

--- a/src/mpid/ch4/netmod/ucx/ucx_vci.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_vci.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpidimpl.h"
+#include "ucx_impl.h"
+
+int MPIDI_UCX_comm_set_vcis(MPIR_Comm * comm, int num_vcis, int *all_num_vcis)
+{
+    int mpi_errno = MPI_SUCCESS;
+    return mpi_errno;
+}

--- a/src/mpid/ch4/netmod/ucx/ucx_vci.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_vci.c
@@ -9,5 +9,28 @@
 int MPIDI_UCX_comm_set_vcis(MPIR_Comm * comm, int num_vcis, int *all_num_vcis)
 {
     int mpi_errno = MPI_SUCCESS;
+
+    MPIDI_UCX_global.num_vcis = num_vcis;
+
+    /* set up local vcis */
+    for (int i = 1; i < MPIDI_UCX_global.num_vcis; i++) {
+        mpi_errno = MPIDI_UCX_init_worker(i);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
+    /* UCX netmod only support the same number of vcis on all procs */
+    for (int i = 0; i < comm->local_size; i++) {
+        all_num_vcis[i] = num_vcis;
+    }
+
+    /* address exchange */
+    if (num_vcis > 1) {
+        mpi_errno = MPIDI_UCX_all_vcis_address_exchange();
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
+  fn_exit:
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }

--- a/src/mpid/ch4/netmod/ucx/ucx_vci.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_vci.c
@@ -29,6 +29,10 @@ int MPIDI_UCX_comm_set_vcis(MPIR_Comm * comm, int num_vcis, int *all_num_vcis)
         MPIR_ERR_CHECK(mpi_errno);
     }
 
+    if (MPIR_CVAR_DEBUG_SUMMARY && comm->rank == 0) {
+        printf("num_vcis: %d\n", MPIDI_UCX_global.num_vcis);
+    }
+
   fn_exit:
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -665,12 +665,12 @@ static int gpu_ipc_async_poll(MPIX_Async_thing thing)
     if (is_done) {
         int vci = MPIDIG_REQUEST(p->rreq, req->local_vci);
 
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         err = MPIDI_GPU_ipc_handle_unmap(p->src_buf, p->gpu_handle, 0);
         MPIR_Assertp(err == MPI_SUCCESS);
         err = MPIDI_IPC_complete(p->rreq, MPIDI_IPCI_TYPE__GPU);
         MPIR_Assertp(err == MPI_SUCCESS);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
 
         MPL_free(p);
         return MPIX_ASYNC_DONE;

--- a/src/mpid/ch4/shm/posix/Makefile.mk
+++ b/src/mpid/ch4/shm/posix/Makefile.mk
@@ -34,6 +34,7 @@ mpi_core_sources += src/mpid/ch4/shm/posix/globals.c    \
                     src/mpid/ch4/shm/posix/posix_datatype.c \
                     src/mpid/ch4/shm/posix/posix_win.c \
                     src/mpid/ch4/shm/posix/posix_part.c \
+                    src/mpid/ch4/shm/posix/posix_vci.c \
                     src/mpid/ch4/shm/posix/posix_eager_array.c
 
 include $(top_srcdir)/src/mpid/ch4/shm/posix/eager/Makefile.mk

--- a/src/mpid/ch4/shm/posix/posix_impl.h
+++ b/src/mpid/ch4/shm/posix/posix_impl.h
@@ -17,14 +17,14 @@
 #define MPIDI_POSIX_THREAD_CS_ENTER_VCI(vci) \
     do { \
         if (!MPIDI_VCI_IS_EXPLICIT(vci)) { \
-            MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock); \
+            MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci)); \
         } \
     } while (0)
 
 #define MPIDI_POSIX_THREAD_CS_EXIT_VCI(vci) \
     do { \
         if (!MPIDI_VCI_IS_EXPLICIT(vci)) { \
-            MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock); \
+            MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci)); \
         } \
     } while (0)
 

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -149,7 +149,7 @@ static void *create_container(struct json_object *obj)
     return cnt;
 }
 
-static int init_vci(int vci)
+int MPIDI_POSIX_init_vci(int vci)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -255,7 +255,7 @@ int MPIDI_POSIX_init_world(void)
 
     MPIDI_POSIX_global.num_vcis = 1;
 
-    mpi_errno = init_vci(0);
+    mpi_errno = MPIDI_POSIX_init_vci(0);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = MPIDI_POSIX_eager_init(rank, size);
@@ -278,15 +278,6 @@ int MPIDI_POSIX_post_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIDI_POSIX_topo_info_t *local_rank_topo = NULL;
-
-    MPIDI_POSIX_global.num_vcis = MPIDI_global.n_total_vcis;
-    for (int i = 1; i < MPIDI_POSIX_global.num_vcis; i++) {
-        mpi_errno = init_vci(i);
-        MPIR_ERR_CHECK(mpi_errno);
-    }
-
-    mpi_errno = MPIDI_POSIX_eager_post_init();
-    MPIR_ERR_CHECK(mpi_errno);
 
     /* gather topo info from local procs and calculate distance */
     if (MPIR_CVAR_CH4_SHM_POSIX_TOPO_ENABLE && MPIR_Process.local_size > 1) {

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -336,7 +336,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get_accumulate(const void *origin_ad
     if (winattr & MPIDI_WINATTR_SHM_ALLOCATED) {
         MPIDI_POSIX_RMA_MUTEX_LOCK(posix_win->shm_mutex_ptr);
     } else {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     }
 
     mpi_errno = MPIR_Localcopy((char *) base + disp_unit * target_disp, target_count,
@@ -353,7 +353,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get_accumulate(const void *origin_ad
     if (winattr & MPIDI_WINATTR_SHM_ALLOCATED) {
         MPIDI_POSIX_RMA_MUTEX_UNLOCK(posix_win->shm_mutex_ptr);
     } else {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
 
   fn_exit:
@@ -404,7 +404,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_accumulate(const void *origin_addr,
     if (winattr & MPIDI_WINATTR_SHM_ALLOCATED) {
         MPIDI_POSIX_RMA_MUTEX_LOCK(posix_win->shm_mutex_ptr);
     } else {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     }
 
     mpi_errno = MPIDI_POSIX_compute_accumulate((void *) origin_addr, origin_count, origin_datatype,
@@ -413,7 +413,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_accumulate(const void *origin_addr,
     if (winattr & MPIDI_WINATTR_SHM_ALLOCATED) {
         MPIDI_POSIX_RMA_MUTEX_UNLOCK(posix_win->shm_mutex_ptr);
     } else {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
 
   fn_exit:
@@ -445,10 +445,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_put(const void *origin_addr,
 #if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
         int vci = MPIDI_WIN(win, am_vci);
 #endif
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         mpi_errno = MPIDI_POSIX_do_put(origin_addr, origin_count, origin_datatype, target_rank,
                                        target_disp, target_count, target_datatype, win, winattr);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
 
     MPIR_FUNC_EXIT;
@@ -477,10 +477,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_get(void *origin_addr,
 #if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
         int vci = MPIDI_WIN(win, am_vci);
 #endif
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         mpi_errno = MPIDI_POSIX_do_get(origin_addr, origin_count, origin_datatype, target_rank,
                                        target_disp, target_count, target_datatype, win, winattr);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
 
     MPIR_FUNC_EXIT;
@@ -511,14 +511,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rput(const void *origin_addr,
     }
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     mpi_errno = MPIDI_POSIX_do_put(origin_addr, origin_count, origin_datatype,
                                    target_rank, target_disp, target_count, target_datatype, win,
                                    winattr);
     if (mpi_errno == MPI_SUCCESS) {
         *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
     }
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
 
   fn_exit:
     MPIR_FUNC_EXIT;
@@ -575,7 +575,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_compare_and_swap(const void *origin
     if (winattr & MPIDI_WINATTR_SHM_ALLOCATED) {
         MPIDI_POSIX_RMA_MUTEX_LOCK(posix_win->shm_mutex_ptr);
     } else {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     }
 
     MPIR_Typerep_copy(result_addr, target_addr, dtype_sz, MPIR_TYPEREP_FLAG_NONE);
@@ -586,7 +586,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_compare_and_swap(const void *origin
     if (winattr & MPIDI_WINATTR_SHM_ALLOCATED) {
         MPIDI_POSIX_RMA_MUTEX_UNLOCK(posix_win->shm_mutex_ptr);
     } else {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
 
   fn_exit:
@@ -726,7 +726,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_fetch_and_op(const void *origin_add
     if (winattr & MPIDI_WINATTR_SHM_ALLOCATED) {
         MPIDI_POSIX_RMA_MUTEX_LOCK(posix_win->shm_mutex_ptr);
     } else {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     }
 
     MPIR_Typerep_copy(result_addr, target_addr, dtype_sz, MPIR_TYPEREP_FLAG_NONE);
@@ -745,7 +745,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_fetch_and_op(const void *origin_add
     if (winattr & MPIDI_WINATTR_SHM_ALLOCATED) {
         MPIDI_POSIX_RMA_MUTEX_UNLOCK(posix_win->shm_mutex_ptr);
     } else {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
 
   fn_exit:
@@ -779,14 +779,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_rget(void *origin_addr,
     }
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     mpi_errno = MPIDI_POSIX_do_get(origin_addr, origin_count, origin_datatype,
                                    target_rank, target_disp, target_count, target_datatype, win,
                                    winattr);
     if (mpi_errno == MPI_SUCCESS) {
         *request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__RMA);
     }
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
 
   fn_exit:
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch4/shm/posix/posix_types.h
+++ b/src/mpid/ch4/shm/posix/posix_types.h
@@ -97,4 +97,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_POSIX_rma_outstanding_req_flushall(MPIDI_POS
         MPL_free(req);
     }
 }
+
+int MPIDI_POSIX_init_vci(int vci);
+
 #endif /* POSIX_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/shm/posix/posix_vci.c
+++ b/src/mpid/ch4/shm/posix/posix_vci.c
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpidimpl.h"
+#include "posix_types.h"
+
+int MPIDI_POSIX_comm_set_vcis(MPIR_Comm * comm, int num_vcis)
+{
+    int mpi_errno = MPI_SUCCESS;
+    return mpi_errno;
+}

--- a/src/mpid/ch4/shm/posix/posix_vci.c
+++ b/src/mpid/ch4/shm/posix/posix_vci.c
@@ -9,5 +9,19 @@
 int MPIDI_POSIX_comm_set_vcis(MPIR_Comm * comm, int num_vcis)
 {
     int mpi_errno = MPI_SUCCESS;
+
+    MPIDI_POSIX_global.num_vcis = num_vcis;
+
+    for (int i = 1; i < MPIDI_POSIX_global.num_vcis; i++) {
+        mpi_errno = MPIDI_POSIX_init_vci(i);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
+    mpi_errno = MPIDI_POSIX_eager_post_init();
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }

--- a/src/mpid/ch4/shm/src/shm_am_fallback_probe.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_probe.h
@@ -15,10 +15,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_improbe(int source,
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(0));
     mpi_errno = MPIDIG_mpi_improbe(source, tag, comm, context_offset, 0, flag,
                                    true /* is_local */ , message, status);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(0));
 
     return mpi_errno;
 }
@@ -31,10 +31,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_iprobe(int source,
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(0));
     mpi_errno = MPIDIG_mpi_iprobe(source, tag, comm, context_offset, 0, flag,
                                   true /* is_local */ , status);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(0));
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/shm/src/shm_am_fallback_recv.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_recv.h
@@ -15,9 +15,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf,
 #if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
     int vci = MPIDI_Request_get_vci(message);
 #endif
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     mpi_errno = MPIDIG_mpi_imrecv(buf, count, datatype, message);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
 
     return mpi_errno;
 }
@@ -40,13 +40,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf,
     } else {
         need_lock = true;
         vci = 0;
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     }
 
     mpi_errno = MPIDIG_mpi_irecv(buf, count, datatype, rank, tag, comm, context_offset,
                                  vci, request, 1, NULL);
     if (need_lock) {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
 
     return mpi_errno;

--- a/src/mpid/ch4/shm/src/shm_am_fallback_send.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_send.h
@@ -24,10 +24,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_isend(const void *buf,
     vci_src = 0;
     vci_dst = 0;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci_src).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci_src));
     mpi_errno = MPIDIG_mpi_isend(buf, count, datatype, rank, tag, comm, context_offset, addr,
                                  vci_src, vci_dst, request, syncflag, errflag);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci_src).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci_src));
 
     return mpi_errno;
 }

--- a/src/mpid/ch4/shm/src/shm_hooks.c
+++ b/src/mpid/ch4/shm/src/shm_hooks.c
@@ -198,3 +198,8 @@ int MPIDI_SHM_mpi_win_free_hook(MPIR_Win * win)
   fn_fail:
     goto fn_exit;
 }
+
+int MPIDI_SHM_comm_set_vcis(MPIR_Comm * comm, int num_vcis)
+{
+    return MPIDI_POSIX_comm_set_vcis(comm, num_vcis);
+}

--- a/src/mpid/ch4/src/Makefile.mk
+++ b/src/mpid/ch4/src/Makefile.mk
@@ -51,6 +51,7 @@ mpi_core_sources += src/mpid/ch4/src/ch4_globals.c        \
                     src/mpid/ch4/src/ch4_proc.c           \
                     src/mpid/ch4/src/ch4_stream_enqueue.c \
                     src/mpid/ch4/src/ch4_persist.c \
+                    src/mpid/ch4/src/ch4_vci.c \
 		    src/mpid/ch4/src/mpidig_init.c \
                     src/mpid/ch4/src/mpidig_recvq.c \
                     src/mpid/ch4/src/mpidig_pt2pt_callbacks.c \

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -232,6 +232,19 @@ int MPID_Comm_commit_post_hook(MPIR_Comm * comm)
     MPIR_ERR_CHECK(mpi_errno);
 #endif
 
+    /* set_vcis for comm_world.
+     * TODO: expose MPIX_Comm_set_vcis to allow vcis for arbitrary comm
+     */
+    if (comm == MPIR_Process.comm_world) {
+        int n_total_vcis = MPIR_CVAR_CH4_NUM_VCIS + MPIR_CVAR_CH4_RESERVE_VCIS;
+        /* we always need call set_vcis even when n_total_vcis is 1 because -
+         * 1. in case netmod need support multi-nics.
+         * 2. remote processes may have multiple vcis.
+         */
+        mpi_errno = MPIDI_Comm_set_vcis(comm, n_total_vcis);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
     /* prune selection tree */
     if (MPIDI_global.csel_root) {
         mpi_errno = MPIR_Csel_prune(MPIDI_global.csel_root, comm, &MPIDI_COMM(comm, csel_comm));

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -419,7 +419,7 @@ do { \
         mpi_errno = MPIDI_progress_test_vci(vci);   \
         MPIR_ERR_CHECK(mpi_errno); \
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
-        MPID_THREAD_CS_YIELD(VCI, MPIDI_VCI(vci).lock);                 \
+        MPID_THREAD_CS_YIELD(VCI, MPIDI_VCI_LOCK(vci));                 \
         DEBUG_PROGRESS_CHECK; \
     } \
 } while (0)
@@ -431,7 +431,7 @@ do { \
         mpi_errno = MPIDI_progress_test_vci(vci); \
         MPIR_ERR_CHECK(mpi_errno); \
         MPID_THREAD_CS_YIELD(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX); \
-        MPID_THREAD_CS_YIELD(VCI, MPIDI_VCI(vci).lock);                 \
+        MPID_THREAD_CS_YIELD(VCI, MPIDI_VCI_LOCK(vci));                 \
         DEBUG_PROGRESS_CHECK; \
     } while (cond); \
 } while (0)

--- a/src/mpid/ch4/src/ch4_impl.h
+++ b/src/mpid/ch4/src/ch4_impl.h
@@ -13,6 +13,10 @@
 #include "ch4_self.h"
 #include "ch4_vci.h"
 
+int MPIDI_vci_init(void);
+int MPIDI_vci_finalize(void);
+int MPIDI_init_per_vci(int vci);
+int MPIDI_destroy_per_vci(int vci);
 int MPIDIU_Intercomm_map_bcast_intra(MPIR_Comm * local_comm, int local_leader, int *remote_size,
                                      int *is_low_group, int pure_intracomm,
                                      int *remote_upid_size, char *remote_upids,

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -659,10 +659,6 @@ int MPIDI_world_post_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    int n_total_vcis = MPIR_CVAR_CH4_NUM_VCIS + MPIR_CVAR_CH4_RESERVE_VCIS;
-    mpi_errno = MPIDI_Comm_set_vcis(MPIR_Process.comm_world, n_total_vcis);
-    MPIR_ERR_CHECK(mpi_errno);
-
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_post_init();
     MPIR_ERR_CHECK(mpi_errno);
@@ -670,7 +666,6 @@ int MPIDI_world_post_init(void)
     mpi_errno = MPIDI_NM_post_init();
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPIR_Process.comm_world->vcis_enabled = true;
     MPIDI_global.is_initialized = 1;
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -75,26 +75,6 @@ cvars:
         direct (default)
         lockless
 
-    - name        : MPIR_CVAR_CH4_NUM_VCIS
-      category    : CH4
-      type        : int
-      default     : 1
-      class       : none
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_LOCAL
-      description : >-
-        Sets the number of VCIs to be implicitly used (should be a subset of MPIDI_CH4_MAX_VCIS).
-
-    - name        : MPIR_CVAR_CH4_RESERVE_VCIS
-      category    : CH4
-      type        : int
-      default     : 0
-      class       : none
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_LOCAL
-      description : >-
-        Sets the number of VCIs that user can explicitly allocate (should be a subset of MPIDI_CH4_MAX_VCIS).
-
     - name        : MPIR_CVAR_CH4_COLL_SELECTION_TUNING_JSON_FILE
       category    : COLLECTIVE
       type        : string
@@ -420,6 +400,43 @@ static void register_comm_hints(void)
                             MPIR_COMM_HINT_TYPE_INT, 0, MPIDI_VCI_INVALID);
 }
 
+int MPIDI_init_per_vci(int vci)
+{
+    int mpi_errno = MPI_SUCCESS;
+    /* Initialize registered host buffer pool to be used as temporary unpack buffers */
+    mpi_errno = MPIDU_genq_private_pool_create(MPIR_CVAR_CH4_PACK_BUFFER_SIZE,
+                                               MPIR_CVAR_CH4_NUM_PACK_BUFFERS_PER_CHUNK,
+                                               MPIR_CVAR_CH4_MAX_NUM_PACK_BUFFERS,
+                                               host_alloc_registered,
+                                               host_free_registered,
+                                               &MPIDI_global.per_vci[vci].pack_buf_pool);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = MPIDIG_init_per_vci(vci);
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIDI_destroy_per_vci(int vci)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = MPIDU_genq_private_pool_destroy(MPIDI_global.per_vci[vci].pack_buf_pool);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = MPIDIG_destroy_per_vci(vci);
+    MPIR_ERR_CHECK(mpi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 int MPID_Init(int requested, int *provided)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -504,31 +521,11 @@ int MPID_Init(int requested, int *provided)
     MPIDI_global.csel_root = NULL;
     MPIDI_global.csel_root_gpu = NULL;
 
-    /* Initialize multiple VCIs */
-    /* TODO: add checks to ensure MPIDI_vci_t is padded or aligned to MPL_CACHELINE_SIZE */
-    MPIR_Assert(MPIR_CVAR_CH4_NUM_VCIS >= 1);   /* number of vcis used in implicit vci hashing */
-    MPIR_Assert(MPIR_CVAR_CH4_RESERVE_VCIS >= 0);       /* maximum number of vcis can be reserved */
+    mpi_errno = MPIDI_vci_init();
+    MPIR_ERR_CHECK(mpi_errno);
 
-    MPIDI_global.n_vcis = 1;
-    MPIDI_global.n_total_vcis = 1;
-    MPIDI_global.n_reserved_vcis = 0;
-    MPIDI_global.share_reserved_vcis = false;
-
-    MPIDI_global.all_num_vcis = MPL_calloc(MPIR_Process.size, size(int), MPL_MEM_OTHER);
-    MPIR_Assert(MPIDI_global.all_num_vcis);
-
-    for (int i = 0; i < MPIDI_global.n_total_vcis; i++) {
-        /* Initialize registered host buffer pool to be used as temporary unpack buffers */
-        mpi_errno = MPIDU_genq_private_pool_create(MPIR_CVAR_CH4_PACK_BUFFER_SIZE,
-                                                   MPIR_CVAR_CH4_NUM_PACK_BUFFERS_PER_CHUNK,
-                                                   MPIR_CVAR_CH4_MAX_NUM_PACK_BUFFERS,
-                                                   host_alloc_registered,
-                                                   host_free_registered,
-                                                   &MPIDI_global.per_vci[i].pack_buf_pool);
-        MPIR_ERR_CHECK(mpi_errno);
-
-    }
-
+    mpi_errno = MPIDI_init_per_vci(0);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* internally does per-vci am initialization */
     MPIDIG_am_init();
@@ -662,32 +659,9 @@ int MPIDI_world_post_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    /* FIXME: currently ofi require each process to have the same number of nics,
-     *        thus need access to world_comm for collectives. We should remove
-     *        this restriction, then we can move MPIDI_NM_init_vcis to
-     *        MPIDI_world_pre_init.
-     */
     int n_total_vcis = MPIR_CVAR_CH4_NUM_VCIS + MPIR_CVAR_CH4_RESERVE_VCIS;
-    MPIR_Assert(n_total_vcis <= MPIDI_CH4_MAX_VCIS);
-    MPIR_Assert(n_total_vcis <= MPIR_REQUEST_NUM_POOLS);
-
-    int num_vcis_actual;
-    mpi_errno = MPIDI_NM_init_vcis(n_total_vcis, &num_vcis_actual);
+    mpi_errno = MPIDI_Comm_set_vcis(MPIR_Process.comm_world, n_total_vcis);
     MPIR_ERR_CHECK(mpi_errno);
-
-#if MPIDI_CH4_MAX_VCIS == 1
-    MPIR_Assert(num_vcis_actual == 1);
-#else
-    MPIR_Assert(num_vcis_actual > 0 && num_vcis_actual <= MPIDI_global.n_total_vcis);
-
-    MPIDI_global.n_total_vcis = num_vcis_actual;
-    MPIDI_global.n_vcis = MPL_MIN(MPIR_CVAR_CH4_NUM_VCIS, MPIDI_global.n_total_vcis);
-
-    mpi_errno = MPIR_Allgather_fallback(&MPIDI_global.n_vcis, 1, MPIR_INT_INTERNAL,
-                                        MPIDI_global.all_num_vcis, 1, MPIR_INT_INTERNAL,
-                                        MPIR_Process.comm_world, MPIR_ERR_NONE);
-    MPIR_ERR_CHECK(mpi_errno);
-#endif
 
 #ifndef MPIDI_CH4_DIRECT_NETMOD
     mpi_errno = MPIDI_SHM_post_init();
@@ -703,43 +677,6 @@ int MPIDI_world_post_init(void)
     return mpi_errno;
   fn_fail:
     goto fn_exit;
-}
-
-int MPID_Allocate_vci(int *vci, bool is_shared)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    *vci = 0;
-#if MPIDI_CH4_MAX_VCIS == 1
-    MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**ch4nostream");
-#else
-
-    if (MPIDI_global.n_vcis + MPIDI_global.n_reserved_vcis >= MPIDI_global.n_total_vcis) {
-        MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**outofstream");
-    } else {
-        MPIDI_global.n_reserved_vcis++;
-        for (int i = MPIDI_global.n_vcis; i < MPIDI_global.n_total_vcis; i++) {
-            if (!MPIDI_VCI(i).allocated) {
-                MPIDI_VCI(i).allocated = true;
-                *vci = i;
-                break;
-            }
-        }
-    }
-#endif
-    if (is_shared) {
-        MPIDI_global.share_reserved_vcis = true;
-    }
-    return mpi_errno;
-}
-
-int MPID_Deallocate_vci(int vci)
-{
-    MPIR_Assert(vci < MPIDI_global.n_total_vcis && vci >= MPIDI_global.n_vcis);
-    MPIR_Assert(MPIDI_VCI(vci).allocated);
-    MPIDI_VCI(vci).allocated = false;
-    MPIDI_global.n_reserved_vcis--;
-    return MPI_SUCCESS;
 }
 
 int MPID_Stream_create_hook(MPIR_Stream * stream)
@@ -816,11 +753,12 @@ int MPID_Finalize(void)
         MPIR_Assert(err == 0);
     }
 
-    for (int i = 0; i < MPIDI_global.n_total_vcis; i++) {
-        MPIDU_genq_private_pool_destroy(MPIDI_global.per_vci[i].pack_buf_pool);
-    }
 
-    MPL_free(MPIDI_global.all_num_vcis);
+    mpi_errno = MPIDI_destroy_per_vci(0);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = MPIDI_vci_finalize();
+    MPIR_ERR_CHECK(mpi_errno);
 
     memset(&MPIDI_global, 0, sizeof(MPIDI_global));
 

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -716,6 +716,7 @@ int MPIDI_world_post_init(void)
     mpi_errno = MPIDI_NM_post_init();
     MPIR_ERR_CHECK(mpi_errno);
 
+    MPIR_Process.comm_world->vcis_enabled = true;
     MPIDI_global.is_initialized = 1;
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_persist.c
+++ b/src/mpid/ch4/src/ch4_persist.c
@@ -20,9 +20,9 @@ static int psend_init(MPIDI_ptype ptype,
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vci = MPIDI_get_vci(SRC_VCI_FROM_SENDER, comm, comm->rank, rank, tag);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     MPIDI_CH4_REQUEST_CREATE(sreq, MPIR_REQUEST_KIND__PREQUEST_SEND, vci, 1);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_ERR_CHKANDSTMT(sreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
     *request = sreq;
 
@@ -137,9 +137,9 @@ int MPID_Recv_init(void *buf,
     int context_offset = MPIR_PT2PT_ATTR_CONTEXT_OFFSET(attr);
     int vci = MPIDI_get_vci(DST_VCI_FROM_RECVER, comm, rank, comm->rank, tag);
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     MPIDI_CH4_REQUEST_CREATE(rreq, MPIR_REQUEST_KIND__PREQUEST_RECV, vci, 1);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_ERR_CHKANDSTMT(rreq == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
     *request = rreq;

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -45,12 +45,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_global_progress(void)
 
 #define MPIDI_THREAD_CS_ENTER_VCI_OPTIONAL(vci)         \
     if (!MPIDI_VCI_IS_EXPLICIT(vci) && !(state->flag & MPIDI_PROGRESS_NM_LOCKLESS)) {	\
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock); \
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci)); \
     }
 
 #define MPIDI_THREAD_CS_EXIT_VCI_OPTIONAL(vci)          \
     if (!MPIDI_VCI_IS_EXPLICIT(vci) && !(state->flag & MPIDI_PROGRESS_NM_LOCKLESS)) {  \
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);	\
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));	\
     } while (0)
 
 
@@ -70,9 +70,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_do_global_progress(void)
 #define MPIDI_PROGRESS(vci)			\
     do {                                                \
         if (state->flag & MPIDI_PROGRESS_SHM && !made_progress) { \
-            MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);             \
+            MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));             \
             mpi_errno = MPIDI_SHM_progress(vci, &made_progress); \
-            MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);              \
+            MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));              \
             MPIR_ERR_CHECK(mpi_errno); \
         }                                                               \
         if (state->flag & MPIDI_PROGRESS_NM && !made_progress) { \
@@ -189,9 +189,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_progress_test_vci(int vci)
     int mpi_errno = MPI_SUCCESS;
 
     if (!MPIDI_VCI_IS_EXPLICIT(vci) && MPIDI_do_global_progress()) {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         mpi_errno = MPID_Progress_test(NULL);
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     } else {
         int made_progress = 0;
         mpi_errno = MPIDI_NM_progress(vci, &made_progress);

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -24,7 +24,7 @@ MPL_STATIC_INLINE_PREFIX int anysource_irecv(void *buf, MPI_Aint count, MPI_Data
 #if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
     int vci;
     MPIDI_POSIX_RECV_VSI(vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
 
     MPIDI_CH4_REQUEST_CREATE(*request, MPIR_REQUEST_KIND__RECV, vci, 1);
     MPIR_Assert(*request);
@@ -45,7 +45,7 @@ MPL_STATIC_INLINE_PREFIX int anysource_irecv(void *buf, MPI_Aint count, MPI_Data
     }
   fn_exit:
 #if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
 #endif
     return mpi_errno;
   fn_fail:
@@ -156,9 +156,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_safe(MPIR_Request * rreq)
      * usage it's often used inside a critical section (e.g. progress and anysource
      * receive). Therefore, we allow recursive lock usage here.
      */
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     mpi_errno = MPIDI_cancel_recv_unsafe(rreq);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -254,6 +254,7 @@ typedef struct MPIDI_per_vci {
 } MPIDI_per_vci_t;
 
 #define MPIDI_VCI(i) MPIDI_global.per_vci[i]
+#define MPIDI_VCI_LOCK(i) MPIR_THREAD_VCI_REQUEST_POOL_MUTEXES[i]
 
 typedef struct MPIDI_CH4_Global_t {
     int pname_set;

--- a/src/mpid/ch4/src/ch4_vci.c
+++ b/src/mpid/ch4/src/ch4_vci.c
@@ -96,6 +96,8 @@ int MPIDI_Comm_set_vcis(MPIR_Comm * comm, int num_vcis)
     MPIR_ERR_CHECK(mpi_errno);
 #endif
 
+    comm->vcis_enabled = true;
+
     for (int vci = 1; vci < MPIDI_global.n_total_vcis; vci++) {
         mpi_errno = MPIDI_init_per_vci(vci);
         MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/src/ch4_vci.c
+++ b/src/mpid/ch4/src/ch4_vci.c
@@ -100,32 +100,34 @@ int MPIDI_Comm_set_vcis(MPIR_Comm * comm, int num_vcis)
         MPIR_Assert(MPIDI_global.all_num_vcis[granks[i]] == 0);
     }
 
-    /* set up local vcis */
-    int num_vcis_actual;
-    mpi_errno = MPIDI_NM_init_vcis(num_vcis, &num_vcis_actual);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    MPIDI_global.n_total_vcis = num_vcis_actual;
-    MPIDI_global.n_vcis = MPL_MIN(MPIR_CVAR_CH4_NUM_VCIS, MPIDI_global.n_total_vcis);
-    MPIDI_global.n_reserved_vcis = MPIDI_global.n_total_vcis - MPIDI_global.n_vcis;
-
-    /* gather the number of remote vcis */
+    /* setup vcis in netmod and shm */
+    /* Netmod will decide that actual number of vcis (and nics) and gather from all ranks in all_num_vcis */
     int *all_num_vcis;
     MPIR_CHKLMEM_MALLOC(all_num_vcis, nprocs * sizeof(int));
-    mpi_errno = MPIR_Allgather_impl(&num_vcis_actual, 1, MPIR_INT_INTERNAL,
-                                    all_num_vcis, 1, MPIR_INT_INTERNAL, comm, MPIR_ERR_NONE);
+    mpi_errno = MPIDI_NM_comm_set_vcis(comm, num_vcis, all_num_vcis);
     MPIR_ERR_CHECK(mpi_errno);
 
+    int n_total_vcis = all_num_vcis[comm->rank];
+#ifndef MPIDI_CH4_DIRECT_NETMOD
+    mpi_errno = MPIDI_SHM_comm_set_vcis(comm, n_total_vcis);
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
+
+    for (int vci = 1; vci < n_total_vcis; vci++) {
+        mpi_errno = MPIDI_init_per_vci(vci);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
+    /* update global vci settings */
+    MPIDI_global.n_total_vcis = all_num_vcis[comm->rank];
+    MPIDI_global.n_vcis = MPL_MIN(MPIR_CVAR_CH4_NUM_VCIS, MPIDI_global.n_total_vcis);
+    MPIDI_global.n_reserved_vcis = MPIDI_global.n_total_vcis - MPIDI_global.n_vcis;
     for (int i = 0; i < nprocs; i++) {
         MPIDI_global.all_num_vcis[granks[i]] = all_num_vcis[i];
     }
 
+    /* enable multiple vcis */
     comm->vcis_enabled = true;
-
-    for (int vci = 1; vci < MPIDI_global.n_total_vcis; vci++) {
-        mpi_errno = MPIDI_init_per_vci(vci);
-        MPIR_ERR_CHECK(mpi_errno);
-    }
 
   fn_exit:
     MPIR_CHKLMEM_FREEALL();

--- a/src/mpid/ch4/src/ch4_vci.c
+++ b/src/mpid/ch4/src/ch4_vci.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpidimpl.h"
+
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+
+cvars:
+    - name        : MPIR_CVAR_CH4_NUM_VCIS
+      category    : CH4
+      type        : int
+      default     : 1
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        Sets the number of VCIs to be implicitly used (should be a subset of MPIDI_CH4_MAX_VCIS).
+
+    - name        : MPIR_CVAR_CH4_RESERVE_VCIS
+      category    : CH4
+      type        : int
+      default     : 0
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        Sets the number of VCIs that user can explicitly allocate (should be a subset of MPIDI_CH4_MAX_VCIS).
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
+int MPIDI_vci_init(void)
+{
+    /* Initialize multiple VCIs */
+    /* TODO: add checks to ensure MPIDI_vci_t is padded or aligned to MPL_CACHELINE_SIZE */
+    MPIR_Assert(MPIR_CVAR_CH4_NUM_VCIS >= 1);   /* number of vcis used in implicit vci hashing */
+    MPIR_Assert(MPIR_CVAR_CH4_RESERVE_VCIS >= 0);       /* maximum number of vcis can be reserved */
+
+    MPIDI_global.n_vcis = 1;
+    MPIDI_global.n_total_vcis = 1;
+    MPIDI_global.n_reserved_vcis = 0;
+    MPIDI_global.share_reserved_vcis = false;
+
+    MPIDI_global.all_num_vcis = MPL_calloc(MPIR_Process.size, sizeof(int), MPL_MEM_OTHER);
+    MPIR_Assert(MPIDI_global.all_num_vcis);
+
+    return MPI_SUCCESS;
+}
+
+int MPIDI_vci_finalize(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    for (int vci = 1; vci < MPIDI_global.n_total_vcis; vci++) {
+        mpi_errno = MPIDI_destroy_per_vci(vci);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+    MPL_free(MPIDI_global.all_num_vcis);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIDI_Comm_set_vcis(MPIR_Comm * comm, int num_vcis)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    /* FIXME: currently ofi require each process to have the same number of nics,
+     *        thus need access to world_comm for collectives. We should remove
+     *        this restriction, then we can move MPIDI_NM_init_vcis to
+     *        MPIDI_world_pre_init.
+     */
+    MPIR_Assert(n_total_vcis <= MPIDI_CH4_MAX_VCIS);
+    MPIR_Assert(n_total_vcis <= MPIR_REQUEST_NUM_POOLS);
+
+    int num_vcis_actual;
+    mpi_errno = MPIDI_NM_init_vcis(n_total_vcis, &num_vcis_actual);
+    MPIR_ERR_CHECK(mpi_errno);
+
+#if MPIDI_CH4_MAX_VCIS == 1
+    MPIR_Assert(num_vcis_actual == 1);
+#else
+    MPIR_Assert(num_vcis_actual > 0 && num_vcis_actual <= MPIDI_global.n_total_vcis);
+
+    MPIDI_global.n_total_vcis = num_vcis_actual;
+    MPIDI_global.n_vcis = MPL_MIN(MPIR_CVAR_CH4_NUM_VCIS, MPIDI_global.n_total_vcis);
+
+    mpi_errno = MPIR_Allgather_fallback(&MPIDI_global.n_vcis, 1, MPIR_INT_INTERNAL,
+                                        MPIDI_global.all_num_vcis, 1, MPIR_INT_INTERNAL,
+                                        MPIR_Process.comm_world, MPIR_ERR_NONE);
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
+
+    for (int vci = 1; vci < MPIDI_global.n_total_vcis; vci++) {
+        mpi_errno = MPIDI_init_per_vci(vci);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPID_Allocate_vci(int *vci, bool is_shared)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    *vci = 0;
+#if MPIDI_CH4_MAX_VCIS == 1
+    MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**ch4nostream");
+#else
+
+    if (MPIDI_global.n_vcis + MPIDI_global.n_reserved_vcis >= MPIDI_global.n_total_vcis) {
+        MPIR_ERR_SET(mpi_errno, MPI_ERR_OTHER, "**outofstream");
+    } else {
+        MPIDI_global.n_reserved_vcis++;
+        for (int i = MPIDI_global.n_vcis; i < MPIDI_global.n_total_vcis; i++) {
+            if (!MPIDI_VCI(i).allocated) {
+                MPIDI_VCI(i).allocated = true;
+                *vci = i;
+                break;
+            }
+        }
+    }
+#endif
+    if (is_shared) {
+        MPIDI_global.share_reserved_vcis = true;
+    }
+    return mpi_errno;
+}
+
+int MPID_Deallocate_vci(int vci)
+{
+    MPIR_Assert(vci < MPIDI_global.n_total_vcis && vci >= MPIDI_global.n_vcis);
+    MPIR_Assert(MPIDI_VCI(vci).allocated);
+    MPIDI_VCI(vci).allocated = false;
+    MPIDI_global.n_reserved_vcis--;
+    return MPI_SUCCESS;
+}

--- a/src/mpid/ch4/src/mpidig.h
+++ b/src/mpid/ch4/src/mpidig.h
@@ -152,6 +152,8 @@ void MPIDIG_am_tag_recv_reg_cb(int tag_recv_id, MPIDIG_am_tag_recv_cb tag_recv_c
 
 int MPIDIG_am_init(void);
 void MPIDIG_am_finalize(void);
+int MPIDIG_init_per_vci(int vci);
+int MPIDIG_destroy_per_vci(int vci);
 
 /* am protocol prototypes */
 

--- a/src/mpid/ch4/src/mpidig_part.c
+++ b/src/mpid/ch4/src/mpidig_part.c
@@ -98,7 +98,7 @@ int MPIDIG_mpi_psend_init(const void *buf, int partitions, MPI_Aint count,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(0));
 
     /* Create and initialize device-layer partitioned request */
     mpi_errno = part_req_create((void *) buf, partitions, count, datatype, dest, tag, comm,
@@ -123,7 +123,7 @@ int MPIDIG_mpi_psend_init(const void *buf, int partitions, MPI_Aint count,
              MPIDI_REQUEST(*request, is_local), mpi_errno);
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(0));
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:
@@ -138,7 +138,7 @@ int MPIDIG_mpi_precv_init(void *buf, int partitions, MPI_Aint count,
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(0));
 
     /* Create and initialize device-layer partitioned request */
     mpi_errno = part_req_create(buf, partitions, count, datatype, source, tag, comm,
@@ -168,7 +168,7 @@ int MPIDIG_mpi_precv_init(void *buf, int partitions, MPI_Aint count,
     }
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(0));
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/src/mpidig_part.h
+++ b/src/mpid/ch4/src/mpidig_part.h
@@ -23,7 +23,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_start(MPIR_Request * request)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(0));
 
     /* Indicate data transfer starts.
      * Decrease when am request completes on sender (via completion_notification),
@@ -39,7 +39,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_part_start(MPIR_Request * request)
 
     MPIR_Part_request_activate(request);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(0));
     MPIR_FUNC_EXIT;
     return mpi_errno;
 }
@@ -55,9 +55,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_pready_range(int partition_low, int part
         MPIR_cc_decr(&MPIDIG_PART_REQUEST(part_sreq, u.send).ready_cntr, &incomplete);
 
     if (!incomplete) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(0));
         mpi_errno = MPIDIG_part_issue_data(part_sreq, MPIDIG_PART_REGULAR);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(0));
     }
 
     MPIR_FUNC_EXIT;
@@ -75,9 +75,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_pready_list(int length, const int array_
         MPIR_cc_decr(&MPIDIG_PART_REQUEST(part_sreq, u.send).ready_cntr, &incomplete);
 
     if (!incomplete) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(0));
         mpi_errno = MPIDIG_part_issue_data(part_sreq, MPIDIG_PART_REGULAR);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(0));
     }
 
     MPIR_FUNC_EXIT;
@@ -89,7 +89,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_parrived(MPIR_Request * request, int par
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(0));
 
     /* Do not maintain per-partition completion. Arrived when full data transfer is done.
      * An inactive request returns TRUE (same for NULL req, handled at MPIR layer). */
@@ -104,7 +104,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_parrived(MPIR_Request * request, int par
     }
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(0).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(0));
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/src/mpidig_rma.h
+++ b/src/mpid/ch4/src/mpidig_rma.h
@@ -557,11 +557,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_put(const void *origin_addr, MPI_Aint or
     MPIR_FUNC_ENTER;
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     mpi_errno = MPIDIG_do_put(origin_addr, origin_count, origin_datatype,
                               target_rank, target_disp, target_count, target_datatype, win, vci,
                               NULL);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -582,10 +582,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rput(const void *origin_addr, MPI_Aint o
     MPIR_FUNC_ENTER;
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     mpi_errno = MPIDIG_do_put(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
                               target_count, target_datatype, win, vci, &sreq);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -606,11 +606,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_get(void *origin_addr, MPI_Aint origin_c
     MPIR_FUNC_ENTER;
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     mpi_errno = MPIDIG_do_get(origin_addr, origin_count, origin_datatype,
                               target_rank, target_disp, target_count, target_datatype,
                               win, vci, NULL);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -631,10 +631,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rget(void *origin_addr, MPI_Aint origin_
     MPIR_FUNC_ENTER;
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     mpi_errno = MPIDIG_do_get(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
                               target_count, target_datatype, win, vci, &sreq);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -657,11 +657,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_raccumulate(const void *origin_addr, MPI
     MPIR_FUNC_ENTER;
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     mpi_errno = MPIDIG_do_accumulate(origin_addr, origin_count, origin_datatype, target_rank,
                                      target_disp, target_count, target_datatype, op, win, vci,
                                      &sreq);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -682,11 +682,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_accumulate(const void *origin_addr, MPI_
     MPIR_FUNC_ENTER;
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     mpi_errno = MPIDIG_do_accumulate(origin_addr, origin_count, origin_datatype,
                                      target_rank, target_disp, target_count, target_datatype, op,
                                      win, vci, NULL);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -712,11 +712,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_rget_accumulate(const void *origin_addr,
     MPIR_FUNC_ENTER;
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     mpi_errno = MPIDIG_do_get_accumulate(origin_addr, origin_count, origin_datatype, result_addr,
                                          result_count, result_datatype, target_rank, target_disp,
                                          target_count, target_datatype, op, win, vci, &sreq);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -741,12 +741,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_get_accumulate(const void *origin_addr,
     MPIR_FUNC_ENTER;
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     mpi_errno = MPIDIG_do_get_accumulate(origin_addr, origin_count, origin_datatype,
                                          result_addr, result_count, result_datatype,
                                          target_rank, target_disp, target_count, target_datatype,
                                          op, win, vci, NULL);
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
@@ -770,7 +770,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
 
     MPIR_FUNC_ENTER;
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
 
     MPIDIG_RMA_OP_CHECK_SYNC(target_rank, win);
 
@@ -812,7 +812,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_compare_and_swap(const void *origin_addr
              MPIDI_rank_is_local(target_rank, win->comm_ptr), mpi_errno);
     MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/src/mpidig_win.h
+++ b/src/mpid/ch4/src/mpidig_win.h
@@ -134,7 +134,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_start(MPIR_Group * group, int assert
     MPIR_FUNC_ENTER;
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
 
     MPIDIG_ACCESS_EPOCH_CHECK_NONE(win, mpi_errno, goto fn_fail);
 
@@ -153,7 +153,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_start(MPIR_Group * group, int assert
     MPIDIG_WIN(win, sync).access_epoch_type = MPIDIG_EPOTYPE_START;
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:
@@ -177,7 +177,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_complete(MPIR_Win * win)
     MPIR_Assert(group != NULL);
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     need_unlock = 1;
 
     /* Ensure op completion in netmod and shmmod */
@@ -225,7 +225,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_complete(MPIR_Win * win)
     MPL_free(ranks_in_win_grp);
 
     if (need_unlock) {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -242,7 +242,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_post(MPIR_Group * group, int assert,
 
     MPIR_FUNC_ENTER;
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
 
     MPIDIG_EXPOSURE_EPOCH_CHECK_NONE(win, mpi_errno, goto fn_fail);
 
@@ -280,7 +280,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_post(MPIR_Group * group, int assert,
   fn_exit:
     MPL_free(ranks_in_win_grp);
 
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:
@@ -294,7 +294,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_wait(MPIR_Win * win)
 
     MPIR_FUNC_ENTER;
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
 
     MPIDIG_EXPOSURE_EPOCH_CHECK(win, MPIDIG_EPOTYPE_POST, mpi_errno, goto fn_fail);
     group = MPIDIG_WIN(win, sync).pw.group;
@@ -306,7 +306,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_wait(MPIR_Win * win)
     MPIDIG_WIN(win, sync).exposure_epoch_type = MPIDIG_EPOTYPE_NONE;
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:
@@ -321,7 +321,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_test(MPIR_Win * win, int *flag)
 #if MPICH_THREAD_GRANULARITY == MPICH_THREAD_GRANULARITY__VCI
     int vci = MPIDI_WIN(win, am_vci);
 #endif
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
 
     MPIDIG_EXPOSURE_EPOCH_CHECK(win, MPIDIG_EPOTYPE_POST, mpi_errno, goto fn_fail);
 
@@ -335,14 +335,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_test(MPIR_Win * win, int *flag)
         MPIR_Group_release(group);
         MPIDIG_WIN(win, sync).exposure_epoch_type = MPIDIG_EPOTYPE_NONE;
     } else {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         mpi_errno = MPID_Progress_test(NULL);
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         *flag = 0;
     }
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:
@@ -358,7 +358,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_lock(int lock_type, int rank, int as
     MPIR_FUNC_ENTER;
     int vci = MPIDI_WIN(win, am_vci);
     int vci_target = MPIDI_WIN_TARGET_VCI(win, rank);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
 
     MPIDIG_LOCK_EPOCH_CHECK_NONE(win, rank, mpi_errno, goto fn_fail);
 
@@ -392,7 +392,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_lock(int lock_type, int rank, int as
     MPIDIG_WIN(win, sync).lock.count++;
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:
@@ -423,7 +423,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
 
     int vci = MPIDI_WIN(win, am_vci);
     int vci_target = MPIDI_WIN_TARGET_VCI(win, rank);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     need_unlock = 1;
 
     /* Ensure op completion in netmod and shmmod */
@@ -470,7 +470,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock(int rank, MPIR_Win * win)
 
   fn_exit:
     if (need_unlock) {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -488,7 +488,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_fence(int massert, MPIR_Win * win)
     MPIDIG_FENCE_EPOCH_CHECK(win, mpi_errno, goto fn_fail);
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     need_unlock = 1;
 
     /* Ensure op completion in netmod and shmmod */
@@ -520,13 +520,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_fence(int massert, MPIR_Win * win)
     /* MPIR_Barrier's state is protected by ALLFUNC_MUTEX.
      * In VCI granularity, individual send/recv/wait operations will take
      * the VCI lock internally. */
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     need_unlock = 0;
     mpi_errno = MPIR_Barrier(win->comm_ptr, MPIR_ERR_NONE);
 
   fn_exit:
     if (need_unlock) {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -641,7 +641,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush(int rank, MPIR_Win * win)
     MPIDIG_EPOCH_CHECK_PASSIVE(win, mpi_errno, return mpi_errno);
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     need_unlock = 1;
 
     /* Ensure op completion in netmod and shmmod */
@@ -670,7 +670,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush(int rank, MPIR_Win * win)
 
   fn_exit:
     if (need_unlock) {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -687,7 +687,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local_all(MPIR_Win * win)
     MPIDIG_EPOCH_CHECK_PASSIVE(win, mpi_errno, goto fn_fail);
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     need_unlock = 1;
 
     /* Ensure op local completion in netmod and shmmod */
@@ -710,7 +710,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local_all(MPIR_Win * win)
 
   fn_exit:
     if (need_unlock) {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -730,7 +730,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock_all(MPIR_Win * win)
     MPIR_Assert(MPIDIG_WIN(win, sync).lockall.allLocked == win->comm_ptr->local_size);
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     need_unlock = 1;
 
     /* Ensure op completion in netmod and shmmod */
@@ -775,7 +775,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_unlock_all(MPIR_Win * win)
 
   fn_exit:
     if (need_unlock) {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -793,7 +793,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local(int rank, MPIR_Win * win
     MPIDIG_EPOCH_CHECK_PASSIVE(win, mpi_errno, return mpi_errno);
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     need_unlock = 1;
 
     /* Ensure op local completion in netmod and shmmod */
@@ -821,7 +821,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_local(int rank, MPIR_Win * win
 
   fn_exit:
     if (need_unlock) {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -853,7 +853,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_all(MPIR_Win * win)
     MPIDIG_EPOCH_CHECK_PASSIVE(win, mpi_errno, goto fn_fail);
 
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     need_unlock = 1;
 
     /* Ensure op completion in netmod and shmmod */
@@ -876,7 +876,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_flush_all(MPIR_Win * win)
 
   fn_exit:
     if (need_unlock) {
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
     MPIR_FUNC_EXIT;
     return mpi_errno;
@@ -890,7 +890,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_lock_all(int assert, MPIR_Win * win)
 
     MPIR_FUNC_ENTER;
     int vci = MPIDI_WIN(win, am_vci);
-    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
 
     MPIDIG_ACCESS_EPOCH_CHECK_NONE(win, mpi_errno, goto fn_fail);
 
@@ -924,7 +924,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDIG_mpi_win_lock_all(int assert, MPIR_Win * win)
     MPIDIG_WIN(win, sync).access_epoch_type = MPIDIG_EPOTYPE_LOCK_ALL;
 
   fn_exit:
-    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI(vci).lock);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:


### PR DESCRIPTION
## Pull Request Description
This is a split of https://github.com/pmodels/mpich/pull/7255

* Gather ch4-layer vci code into `ch4_vci.c`
* Separate initialization of root vci from the rest of the multiple vcis
* Remove the assumed world context, prepare for per comm vci ennoblement.

**NOTE**:  This PR only moves ch4-layer vci setup (`MPIDI_Comm_set_vcis`) after `MPIDI_world_post_init`. Because netmod and shm initializes multiple vcis in `MPIDI_world_post_init` , multiple vcis won't be functional, but single vci should work.
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
