### PR TITLE
datatype: Fix pack external by using the MPIR layer

### DIFF
--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -416,6 +416,17 @@ void MPII_Datatype_printf(MPI_Datatype type, int depth, MPI_Aint displacement, i
     } \
 } while (0)
 
+#define MPIR_Datatype_is_complex(a, is_complex) do { \
+    MPI_Datatype basic_type; \
+    MPIR_Datatype_get_basic_type(a, basic_type); \
+    int type = basic_type & MPIR_TYPE_TYPE_MASK; \
+    if (type == MPIR_TYPE_COMPLEX || type == MPIR_TYPE_ALT_COMPLEX) { \
+        is_complex = true; \
+    } else { \
+        is_complex = false; \
+    } \
+} while (0)
+
 #define MPIR_Datatype_get_ptr(a,ptr)   MPIR_Getb_ptr(Datatype,DATATYPE,a,0x000000ff,ptr)
 
 /* Note: Probably there is some clever way to build all of these from a macro.

--- a/src/mpi/datatype/typerep/dataloop/looputil.c
+++ b/src/mpi/datatype/typerep/dataloop/looputil.c
@@ -102,12 +102,16 @@ static int contig_pack_to_iov(MPI_Aint * blocks_p,
 
 static inline int is_float_type(MPI_Datatype el_type)
 {
-    return ((el_type == MPI_FLOAT) || (el_type == MPI_DOUBLE) ||
-            (el_type == MPI_LONG_DOUBLE) ||
-            (el_type == MPI_DOUBLE_PRECISION) ||
-            (el_type == MPI_COMPLEX) || (el_type == MPI_DOUBLE_COMPLEX));
-/*             (el_type == MPI_REAL4) || (el_type == MPI_REAL8) || */
-/*             (el_type == MPI_REAL16)); */
+    bool is_float;
+    MPIR_Datatype_is_float(el_type, is_float);
+    return is_float;
+}
+
+static inline int is_complex_type(MPI_Datatype el_type)
+{
+    bool is_complex;
+    MPIR_Datatype_is_complex(el_type, is_complex);
+    return is_complex;
 }
 
 static int external32_basic_convert(char *dest_buf,
@@ -683,7 +687,7 @@ static int contig_pack_external32_to_buf(MPI_Aint * blocks_p,
     /* TODO: DEAL WITH CASE WHERE ALL DATA DOESN'T FIT! */
     if ((src_el_size == dest_el_size) && (src_el_size == 1)) {
         MPIR_Memcpy(paramp->u.pack.pack_buffer, ((char *) bufp) + rel_off, *blocks_p);
-    } else if (MPII_Typerep_basic_type_is_complex(el_type)) {
+    } else if (is_complex_type(el_type)) {
         /* treat as 2x floating point */
         external32_float_convert(paramp->u.pack.pack_buffer,
                                  ((char *) bufp) + rel_off,


### PR DESCRIPTION
## Pull Request Description

Fixes #7313.

This PR could be an opportunity to refactor/consolidate the implementation and use of the following two routines.
```c 
// src/mpi/datatype/typerep/src/typerep_util.h
bool MPII_Typerep_basic_type_is_complex(MPI_Datatype el_type);
bool MPII_Typerep_basic_type_is_unsigned(MPI_Datatype el_type);
```

@hzhou Feel free to push/force-push to my branch, or pick the commit and continue in your clone.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
