### PR TITLE
abi: set so version for libmpi_abi.so

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -167,7 +167,7 @@ if BUILD_PROFILING_LIB
 # don't contribute any PMPI symbols.
 lib_LTLIBRARIES += lib/lib@PMPIABILIBNAME@.la
 lib_lib@PMPIABILIBNAME@_la_SOURCES = $(mpi_abi_sources) $(mpi_f77_sources) $(mpi_core_sources)
-lib_lib@PMPIABILIBNAME@_la_LDFLAGS = $(external_ldflags) $(ABIVERSIONFLAGS)
+lib_lib@PMPIABILIBNAME@_la_LDFLAGS = $(external_ldflags) $(ABI_ABIVERSIONFLAGS)
 lib_lib@PMPIABILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) -DF77_USE_PMPI $(abi_cppflags)
 lib_lib@PMPIABILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs) $(abi_convenience_libs)
 EXTRA_lib_lib@PMPIABILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs) $(abi_convenience_libs)
@@ -177,7 +177,7 @@ EXTRA_lib_lib@PMPIABILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs) $(abi_c
 # confused. (see https://bugzilla.redhat.com/show_bug.cgi?id=91110)
 lib_LTLIBRARIES += lib/lib@MPIABILIBNAME@.la
 lib_lib@MPIABILIBNAME@_la_SOURCES = $(mpi_abi_sources)
-lib_lib@MPIABILIBNAME@_la_LDFLAGS = $(ABIVERSIONFLAGS)
+lib_lib@MPIABILIBNAME@_la_LDFLAGS = $(ABI_ABIVERSIONFLAGS)
 lib_lib@MPIABILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) -DMPICH_MPI_FROM_PMPI $(abi_cppflags)
 lib_lib@MPIABILIBNAME@_la_LIBADD = lib/lib@PMPIABILIBNAME@.la
 
@@ -185,7 +185,7 @@ else !BUILD_PROFILING_LIB
 
 lib_LTLIBRARIES += lib/lib@MPIABILIBNAME@.la
 lib_lib@MPIABILIBNAME@_la_SOURCES = $(mpi_abi_sources) $(mpi_core_sources)
-lib_lib@MPIABILIBNAME@_la_LDFLAGS = $(external_ldflags) $(ABIVERSIONFLAGS)
+lib_lib@MPIABILIBNAME@_la_LDFLAGS = $(external_ldflags) $(ABI_ABIVERSIONFLAGS)
 lib_lib@MPIABILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) $(abi_cppflags)
 lib_lib@MPIABILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs) $(abi_convenience_libs)
 EXTRA_lib_lib@MPIABILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs) $(abi_convenience_libs)

--- a/configure.ac
+++ b/configure.ac
@@ -495,8 +495,10 @@ AC_ARG_ENABLE(versioning,
 
 if test "$enable_versioning" = "yes" ; then
    ABIVERSIONFLAGS="-version-info \$(ABIVERSION)"
+   ABI_ABIVERSIONFLAGS="-version-info libmpi_abi_so_verion_m4"
 else
    ABIVERSIONFLAGS="-avoid-version"
+   ABI_ABIVERSIONFLAGS="-avoid-version"
 fi
 export ABIVERSIONFLAGS
 AC_SUBST(ABIVERSIONFLAGS)

--- a/maint/version.m4
+++ b/maint/version.m4
@@ -40,4 +40,7 @@ m4_define([MPICH_RELEASE_DATE_m4],[unreleased development copy])dnl
 # last version 4.3.0 - 17:0:5
 m4_define([libmpi_so_version_m4],[0:0:0])dnl
 
+# libmpi_abi.so version
+m4_define([libmpi_abi_so_version_m4],[1:0:0])dnl
+
 [#] end of __file__


### PR DESCRIPTION
## Pull Request Description
We need separate so version for libmpi_abi.so, which is different from that for libmpi.so.

Fixes #7337

[skip warnings]

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
