### PR TITLE
datatype: allow MPI_Type_size on unspported types

### DIFF
--- a/src/binding/c/datatype_api.txt
+++ b/src/binding/c/datatype_api.txt
@@ -330,6 +330,20 @@ MPI_Type_size:
     .desc: Return the number of bytes occupied by entries in the datatype
     .skip: global_cs
     .poly_impl: use_aint
+{ -- error_check -- datatype
+    /* allow MPI_DATATYPE_NULL */
+    if (HANDLE_GET_MPI_KIND(datatype) != MPIR_DATATYPE) {
+        MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_TYPE, "**dtype");
+    }
+    if (!HANDLE_IS_BUILTIN(datatype)) {
+        MPIR_Datatype *datatype_ptr ATTRIBUTE((unused)) = NULL;
+        MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+        MPIR_Datatype_valid_ptr(datatype_ptr, mpi_errno);
+        if (mpi_errno) {
+            goto fn_fail;
+        }
+    }
+}
 
 MPI_Type_size_x:
     .desc: Return the number of bytes occupied by entries in the datatype


### PR DESCRIPTION
## Pull Request Description
Builitin MPI types may not be supported, for example, when the compiler does not support the type. A common case is for Fortran types such as MPI_REAL when MPICH is configured without Fortran binding. Since there is no standard way for users check whether a builtin type is supported, MPI_Type_size can be used as a check. MPI_Type_size will return 0 if a builtin type is not supported. For MPI_Type_size to work as a check, it should not return error when the datatype is not supported. Thus, we need a custom error_check, rather than the default MPIR_ERRTEST_DATATYPE which will return error  on unsupported types.

Fixes #7341 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
