### PR TITLE
ch4/ipc: adjust xpmem threshold

### DIFF
--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
@@ -35,6 +35,20 @@ cvars:
         bytes), then enable XPMEM-based single copy protocol for intranode communication. The
         environment variable is valid only when the XPMEM submodule is enabled.
 
+    - name        : MPIR_CVAR_CH4_IPC_XPMEM_P2P_UPPER_THRESHOLD
+      category    : CH4
+      type        : int
+      default     : -1
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        If a send message size is greater than or equal to MPIR_CVAR_CH4_IPC_XPMEM_P2P_UPPER_THRESHOLD (in
+        bytes), then skip XPMEM-based single copy protocol for intranode communication. The
+        environment variable is valid only when the XPMEM submodule is enabled. The default is -1, which
+        does not limit the upper threshold.
+
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
@@ -53,7 +67,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_get_ipc_attr(const void *buf, MPI_Aint 
     MPIDI_Datatype_get_info(count, datatype, dt_contig, data_sz, dt_ptr, true_lb);
 
     if (!MPIR_CVAR_CH4_XPMEM_ENABLE || buf == MPI_BOTTOM ||
-        data_sz < MPIR_CVAR_CH4_IPC_XPMEM_P2P_THRESHOLD) {
+        data_sz < MPIR_CVAR_CH4_IPC_XPMEM_P2P_THRESHOLD ||
+        (MPIR_CVAR_CH4_IPC_XPMEM_P2P_UPPER_THRESHOLD > 0 &&
+         data_sz > MPIR_CVAR_CH4_IPC_XPMEM_P2P_UPPER_THRESHOLD)) {
         goto fn_exit;
     } else {
         ipc_attr->ipc_type = MPIDI_IPCI_TYPE__XPMEM;

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
@@ -26,7 +26,7 @@ cvars:
     - name        : MPIR_CVAR_CH4_IPC_XPMEM_P2P_THRESHOLD
       category    : CH4
       type        : int
-      default     : 1024
+      default     : 65536
       class       : none
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_ALL_EQ


### PR DESCRIPTION
## Pull Request Description
* Small buffers are less likely be used persistently. XPMEM's mapping cost
will slow down the intranode message performance unless the buffer is
persistent and the mapping cost get amortized.

Apply a larger threshold to avoid slow down applications that use ad-hoc
memory for small messages.

* Add `MPIR_CVAR_CH4_IPC_XPMEM_P2P_UPPER_THRESHOLD` so user can limit the
larger messages from using xpmem. XPMEM's performance boost diminishes
at large message and sometime may not be beneficial.

The default is no limit.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
