### PR TITLE
session: implement true MPI sessions

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -122,6 +122,7 @@ struct MPIR_Comm {
     MPIR_Group *local_group;    /* Groups in communicator. */
     MPIR_Comm_kind_t comm_kind; /* MPIR_COMM_KIND__INTRACOMM or MPIR_COMM_KIND__INTERCOMM */
     MPID_Thread_mutex_t mutex;
+    const char *stringtag;      /* A string tag used to support multi-threaded MPI_Comm_create_from_group */
     struct MPIR_CCLcomm *cclcomm;       /* Not NULL only if CCL subcommunication is enabled */
 
     /* -- unset unless (attr | MPIR_COMM_ATTR__HIERARCHY) -- */

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -125,7 +125,7 @@ struct MPIR_Comm {
     struct MPIR_CCLcomm *cclcomm;       /* Not NULL only if CCL subcommunication is enabled */
 
     /* -- unset unless (attr | MPIR_COMM_ATTR__HIERARCHY) -- */
-    int hierarchy_flags;        /* bit flags for hierarchy charateristics. See bit definitions below. */
+    int hierarchy_flags;        /* bit flags for hierarchy characteristics. See bit definitions below. */
     int local_rank;
     int num_local;
     int external_rank;
@@ -241,6 +241,7 @@ struct MPIR_Comm {
 /* Bit flags for comm->attr */
 #define MPIR_COMM_ATTR__SUBCOMM   0x1
 #define MPIR_COMM_ATTR__HIERARCHY 0x2
+#define MPIR_COMM_ATTR__BOOTSTRAP 0x4
 
 #define MPIR_COMM_HIERARCHY__NO_LOCAL    0x1
 #define MPIR_COMM_HIERARCHY__SINGLE_NODE 0x2

--- a/src/include/mpir_contextid.h
+++ b/src/include/mpir_contextid.h
@@ -91,6 +91,18 @@
 #define MPIR_MAX_CONTEXT_MASK \
     ((1 << (MPIR_CONTEXT_ID_BITS - (MPIR_CONTEXT_PREFIX_SHIFT + MPIR_CONTEXT_DYNAMIC_PROC_WIDTH))) / MPIR_CONTEXT_INT_BITS)
 
+/* Reserved context_id:
+ *   0 - for bootstrapping communicators
+ *   1 - for comm_world
+ *   2 - for comm_self
+ *   3 - for the internal-only copy of comm_world (if needed by mpid)
+ */
+#define MPIR_CTXID_BOOTSTRAP   (0 << MPIR_CONTEXT_PREFIX_SHIFT)
+#define MPIR_CTXID_COMM_WORLD  (1 << MPIR_CONTEXT_PREFIX_SHIFT)
+#define MPIR_CTXID_COMM_SELF   (2 << MPIR_CONTEXT_PREFIX_SHIFT)
+
+#define MPIR_CONTEXT_MASK_0 0xFFFFFFF8;
+
 void MPIR_context_id_init(void);
 
 /* Utility routines.  Where possible, these are kept in the source directory

--- a/src/include/mpir_contextid.h
+++ b/src/include/mpir_contextid.h
@@ -91,18 +91,6 @@
 #define MPIR_MAX_CONTEXT_MASK \
     ((1 << (MPIR_CONTEXT_ID_BITS - (MPIR_CONTEXT_PREFIX_SHIFT + MPIR_CONTEXT_DYNAMIC_PROC_WIDTH))) / MPIR_CONTEXT_INT_BITS)
 
-/* Reserved context_id:
- *   0 - for bootstrapping communicators
- *   1 - for comm_world
- *   2 - for comm_self
- *   3 - for the internal-only copy of comm_world (if needed by mpid)
- */
-#define MPIR_CTXID_BOOTSTRAP   (0 << MPIR_CONTEXT_PREFIX_SHIFT)
-#define MPIR_CTXID_COMM_WORLD  (1 << MPIR_CONTEXT_PREFIX_SHIFT)
-#define MPIR_CTXID_COMM_SELF   (2 << MPIR_CONTEXT_PREFIX_SHIFT)
-
-#define MPIR_CONTEXT_MASK_0 0xFFFFFFF8;
-
 void MPIR_context_id_init(void);
 
 /* Utility routines.  Where possible, these are kept in the source directory

--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -95,7 +95,8 @@ int MPIR_pmi_allgather_shm(const void *sendbuf, int sendsize, void *shm_buf, int
  *   * if count is 0, then group must be one of the special value PMI_GROUP_WORLD.
  */
 int MPIR_pmi_allgather_group(const char *name, const void *sendbuf, int sendsize,
-                             void *recvbuf, int recvsize, int *group, int count);
+                             void *recvbuf, int recvsize, int *group, int count,
+                             const char *stringtag);
 
 /* * bcast_local: all processes will participate.
  *   Each local leader bcast to each local proc (within a node).

--- a/src/include/mpir_session.h
+++ b/src/include/mpir_session.h
@@ -8,6 +8,11 @@
 
 #include "mpiimpl.h"
 
+typedef struct MPIR_Pset {
+    char *name;
+    struct MPIR_Group *group;
+} MPIR_Pset;
+
 /* Session structure */
 struct MPIR_Session {
     MPIR_OBJECT_HEADER;
@@ -16,6 +21,8 @@ struct MPIR_Session {
     struct MPII_BsendBuffer *bsendbuffer;       /* for MPI_Session_attach_buffer */
     bool strict_finalize;
     char *memory_alloc_kinds;
+    int num_psets;
+    struct MPIR_Pset *psets;
 };
 
 extern MPIR_Object_alloc_t MPIR_Session_mem;

--- a/src/mpi/coll/allgather/allgather_intra_smp.c
+++ b/src/mpi/coll/allgather/allgather_intra_smp.c
@@ -28,6 +28,12 @@ int MPIR_Allgather_intra_smp_no_order(const void *sendbuf, MPI_Aint sendcount,
     int external_size = comm_ptr->num_external;
     int external_rank = comm_ptr->external_rank;
 
+    if (local_size == comm_size || external_size == comm_size) {
+        mpi_errno = MPIR_Allgather_impl(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
+                                        comm_ptr, coll_attr);
+        goto fn_exit;
+    }
+
     MPIR_Comm *node_comm, *node_roots_comm;
     node_comm = MPIR_Comm_get_node_comm(comm_ptr);
     MPIR_Assert(node_comm);

--- a/src/mpi/comm/builtin_comms.c
+++ b/src/mpi/comm/builtin_comms.c
@@ -5,6 +5,9 @@
 
 #include "mpiimpl.h"
 
+#define COMM_WORLD_CTXID (0 << MPIR_CONTEXT_PREFIX_SHIFT)
+#define COMM_SELF_CTXID  (1 << MPIR_CONTEXT_PREFIX_SHIFT)
+
 int MPIR_init_comm_world(void)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -16,7 +19,7 @@ int MPIR_init_comm_world(void)
 
     MPIR_Process.comm_world->rank = MPIR_Process.rank;
     MPIR_Process.comm_world->handle = MPI_COMM_WORLD;
-    MPIR_Process.comm_world->context_id = MPIR_CTXID_COMM_WORLD;
+    MPIR_Process.comm_world->context_id = COMM_WORLD_CTXID;
     MPIR_Process.comm_world->recvcontext_id = MPIR_Process.comm_world->context_id;
     MPIR_Process.comm_world->comm_kind = MPIR_COMM_KIND__INTRACOMM;
 
@@ -51,7 +54,7 @@ int MPIR_init_comm_self(void)
     MPIR_Process.comm_self = MPIR_Comm_builtin + 1;
     MPII_Comm_init(MPIR_Process.comm_self);
     MPIR_Process.comm_self->handle = MPI_COMM_SELF;
-    MPIR_Process.comm_self->context_id = MPIR_CTXID_COMM_SELF;
+    MPIR_Process.comm_self->context_id = COMM_SELF_CTXID;
     MPIR_Process.comm_self->recvcontext_id = MPIR_Process.comm_self->context_id;
     MPIR_Process.comm_self->comm_kind = MPIR_COMM_KIND__INTRACOMM;
 
@@ -126,7 +129,7 @@ int MPIR_finalize_builtin_comms(void)
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_Process.comm_self = NULL;
     } else {
-        MPIR_Free_contextid(MPIR_CTXID_COMM_SELF);
+        MPIR_Free_contextid(COMM_SELF_CTXID);
     }
 
     if (MPIR_Process.comm_world) {
@@ -134,7 +137,7 @@ int MPIR_finalize_builtin_comms(void)
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_Process.comm_world = NULL;
     } else {
-        MPIR_Free_contextid(MPIR_CTXID_COMM_WORLD);
+        MPIR_Free_contextid(COMM_WORLD_CTXID);
     }
 
     if (MPIR_Process.comm_parent) {
@@ -142,9 +145,6 @@ int MPIR_finalize_builtin_comms(void)
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_Process.comm_parent = NULL;
     }
-
-    /* Free all the remaining reserved context ids */
-    MPIR_Free_contextid(MPIR_CTXID_BOOTSTRAP);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/comm/builtin_comms.c
+++ b/src/mpi/comm/builtin_comms.c
@@ -5,9 +5,6 @@
 
 #include "mpiimpl.h"
 
-#define COMM_WORLD_CTXID (0 << MPIR_CONTEXT_PREFIX_SHIFT)
-#define COMM_SELF_CTXID  (1 << MPIR_CONTEXT_PREFIX_SHIFT)
-
 int MPIR_init_comm_world(void)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -19,7 +16,7 @@ int MPIR_init_comm_world(void)
 
     MPIR_Process.comm_world->rank = MPIR_Process.rank;
     MPIR_Process.comm_world->handle = MPI_COMM_WORLD;
-    MPIR_Process.comm_world->context_id = COMM_WORLD_CTXID;
+    MPIR_Process.comm_world->context_id = MPIR_CTXID_COMM_WORLD;
     MPIR_Process.comm_world->recvcontext_id = MPIR_Process.comm_world->context_id;
     MPIR_Process.comm_world->comm_kind = MPIR_COMM_KIND__INTRACOMM;
 
@@ -54,7 +51,7 @@ int MPIR_init_comm_self(void)
     MPIR_Process.comm_self = MPIR_Comm_builtin + 1;
     MPII_Comm_init(MPIR_Process.comm_self);
     MPIR_Process.comm_self->handle = MPI_COMM_SELF;
-    MPIR_Process.comm_self->context_id = COMM_SELF_CTXID;
+    MPIR_Process.comm_self->context_id = MPIR_CTXID_COMM_SELF;
     MPIR_Process.comm_self->recvcontext_id = MPIR_Process.comm_self->context_id;
     MPIR_Process.comm_self->comm_kind = MPIR_COMM_KIND__INTRACOMM;
 
@@ -129,7 +126,7 @@ int MPIR_finalize_builtin_comms(void)
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_Process.comm_self = NULL;
     } else {
-        MPIR_Free_contextid(COMM_SELF_CTXID);
+        MPIR_Free_contextid(MPIR_CTXID_COMM_SELF);
     }
 
     if (MPIR_Process.comm_world) {
@@ -137,7 +134,7 @@ int MPIR_finalize_builtin_comms(void)
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_Process.comm_world = NULL;
     } else {
-        MPIR_Free_contextid(COMM_WORLD_CTXID);
+        MPIR_Free_contextid(MPIR_CTXID_COMM_WORLD);
     }
 
     if (MPIR_Process.comm_parent) {
@@ -145,6 +142,9 @@ int MPIR_finalize_builtin_comms(void)
         MPIR_ERR_CHECK(mpi_errno);
         MPIR_Process.comm_parent = NULL;
     }
+
+    /* Free all the remaining reserved context ids */
+    MPIR_Free_contextid(MPIR_CTXID_BOOTSTRAP);
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/comm/builtin_comms.c
+++ b/src/mpi/comm/builtin_comms.c
@@ -31,6 +31,8 @@ int MPIR_init_comm_world(void)
     MPIR_Group_add_ref(MPIR_GROUP_WORLD_PTR);
     MPIR_Process.comm_world->remote_group = NULL;
 
+    MPIR_Process.comm_world->attr = MPIR_COMM_ATTR__BOOTSTRAP;  /* device need bootstrap this comm */
+
     mpi_errno = MPIR_Comm_commit(MPIR_Process.comm_world);
     MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -514,74 +514,62 @@ static int get_tag_from_stringtag(const char *stringtag)
     return hash % (MPIR_Process.attrs.tag_ub);
 }
 
-static bool is_world_group(MPIR_Group * group_ptr)
-{
-    return (group_ptr->size == MPIR_Process.size && group_ptr->size > 1);
-}
-
-static bool is_self_group(MPIR_Group * group_ptr)
-{
-    return (group_ptr->size == 1);
-}
-
 int MPIR_Comm_create_from_group_impl(MPIR_Group * group_ptr, const char *stringtag,
                                      MPIR_Info * info_ptr, MPIR_Errhandler * errhan_ptr,
                                      MPIR_Comm ** p_newcom_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
-    int use_comm_world = 0;
+    MPIR_FUNC_ENTER;
 
-    /* NOTE: only world or self is supported without first establishing comm_world.  */
+    int tag = get_tag_from_stringtag(stringtag);
 
-    MPL_initlock_lock(&MPIR_init_lock);
-    if (MPIR_Process.comm_world) {
-        use_comm_world = 1;
-    } else if (is_world_group(group_ptr)) {
-        mpi_errno = MPIR_init_comm_world();
-        use_comm_world = 1;
-    } else if (!MPIR_Process.comm_self && is_self_group(group_ptr)) {
-        mpi_errno = MPIR_init_comm_self();
-    }
-    MPL_initlock_unlock(&MPIR_init_lock);
+    MPIR_Comm *new_comm = (MPIR_Comm *) MPIR_Handle_obj_alloc(&MPIR_Comm_mem);
+    MPIR_ERR_CHKANDJUMP(!new_comm, mpi_errno, MPI_ERR_OTHER, "**nomem");
+
+    mpi_errno = MPII_Comm_init(new_comm);
     MPIR_ERR_CHECK(mpi_errno);
 
-    if (use_comm_world) {
-        /* NOTE: tag will be used with MPIR_TAG_COLL_BIT on, ref. MPIR_Get_contextid_sparse_group */
-        int tag = get_tag_from_stringtag(stringtag);
+    new_comm->attr |= MPIR_COMM_ATTR__BOOTSTRAP;
+    new_comm->context_id = MPIR_CTXID_BOOTSTRAP;
+    new_comm->recvcontext_id = new_comm->context_id;
+    new_comm->comm_kind = MPIR_COMM_KIND__INTRACOMM;
+    new_comm->rank = group_ptr->rank;
+    new_comm->local_size = group_ptr->size;
+    new_comm->remote_size = new_comm->local_size;
+    new_comm->local_group = group_ptr;
+    MPIR_Group_add_ref(group_ptr);
+    MPIR_Comm_set_session_ptr(new_comm, group_ptr->session_ptr);
 
-        /* Because the group_ptr may not be derived from a communicator, local_group in
-         * comm_world may not have been created */
-        static MPL_initlock_t lock = MPL_INITLOCK_INITIALIZER;
-        MPL_initlock_lock(&lock);
-        if (!MPIR_Process.comm_world->local_group) {
-            mpi_errno = comm_create_local_group(MPIR_Process.comm_world);
-        }
-        MPL_initlock_unlock(&lock);
-        MPIR_ERR_CHECK(mpi_errno);
-        mpi_errno =
-            MPIR_Comm_create_group_impl(MPIR_Process.comm_world, group_ptr, tag, p_newcom_ptr);
-        MPIR_ERR_CHECK(mpi_errno);
-    } else {
-        /* Currently only self comm is allowed here */
-        MPIR_Assert(is_self_group(group_ptr));
+    mpi_errno = MPIR_Comm_commit(new_comm);
+    MPIR_ERR_CHECK(mpi_errno);
 
-        mpi_errno = MPIR_Comm_dup_impl(MPIR_Process.comm_self, p_newcom_ptr);
-        MPIR_ERR_CHECK(mpi_errno);
+    /* allocate a new context id */
+    int new_context_id;
+    mpi_errno = MPIR_Get_contextid_sparse_group(new_comm, group_ptr, tag, &new_context_id, 0);
+    MPIR_ERR_CHECK(mpi_errno);
 
-        MPIR_Comm_set_session_ptr(*p_newcom_ptr, group_ptr->session_ptr);
+    new_comm->context_id = new_context_id;
+    new_comm->recvcontext_id = new_comm->context_id;
+    if (new_comm->node_comm) {
+        new_comm->node_comm->context_id = new_context_id + MPIR_CONTEXT_INTRANODE_OFFSET;
+        new_comm->node_comm->recvcontext_id = new_comm->node_comm->context_id;
+    }
+    if (new_comm->node_roots_comm) {
+        new_comm->node_roots_comm->context_id = new_context_id + MPIR_CONTEXT_INTERNODE_OFFSET;
+        new_comm->node_roots_comm->recvcontext_id = new_comm->node_roots_comm->context_id;
     }
 
-    if (*p_newcom_ptr) {
-        if (info_ptr) {
-            MPII_Comm_set_hints(*p_newcom_ptr, info_ptr, true);
-        }
+    if (info_ptr) {
+        MPII_Comm_set_hints(new_comm, info_ptr, true);
+    }
 
-        if (errhan_ptr) {
-            MPIR_Comm_set_errhandler_impl(*p_newcom_ptr, errhan_ptr);
-        }
+    if (errhan_ptr) {
+        MPIR_Comm_set_errhandler_impl(new_comm, errhan_ptr);
     }
 
   fn_exit:
+    *p_newcom_ptr = new_comm;
+    MPIR_FUNC_EXIT;
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -601,7 +601,10 @@ static int create_peer_comm(MPIR_Lpid my_lpid, MPIR_Lpid remote_lpid,
 
     bool is_low_group = (lpid_cmp(my_lpid, remote_lpid) < 0);
 
-    MPIR_Lpid peer_map[2];
+    MPIR_Lpid *peer_map;
+    peer_map = MPL_malloc(2 * sizeof(MPIR_Lpid), MPL_MEM_OTHER);
+    MPIR_ERR_CHKANDJUMP(!peer_map, mpi_errno, MPI_ERR_OTHER, "**nomem");
+
     int my_rank, remote_rank;
     if (is_low_group) {
         peer_map[0] = my_lpid;

--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -530,6 +530,7 @@ int MPIR_Comm_create_from_group_impl(MPIR_Group * group_ptr, const char *stringt
     MPIR_ERR_CHECK(mpi_errno);
 
     new_comm->attr |= MPIR_COMM_ATTR__BOOTSTRAP;
+    new_comm->stringtag = stringtag;
     new_comm->context_id = MPIR_CTXID_BOOTSTRAP;
     new_comm->recvcontext_id = new_comm->context_id;
     new_comm->comm_kind = MPIR_COMM_KIND__INTRACOMM;
@@ -566,6 +567,8 @@ int MPIR_Comm_create_from_group_impl(MPIR_Group * group_ptr, const char *stringt
     if (errhan_ptr) {
         MPIR_Comm_set_errhandler_impl(new_comm, errhan_ptr);
     }
+
+    new_comm->stringtag = NULL;
 
   fn_exit:
     *p_newcom_ptr = new_comm;

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -275,6 +275,7 @@ int MPII_Comm_init(MPIR_Comm * comm_p)
 
     comm_p->attr = 0;
     comm_p->hierarchy_flags = 0;
+    comm_p->stringtag = NULL;
 
     /* initialize local and remote sizes to -1 to allow other parts of
      * the stack to detect errors more easily */

--- a/src/mpi/comm/contextid.c
+++ b/src/mpi/comm/contextid.c
@@ -159,7 +159,8 @@ void MPIR_context_id_init(void)
     for (i = 1; i < MPIR_MAX_CONTEXT_MASK; i++) {
         context_mask[i] = 0xFFFFFFFF;
     }
-    context_mask[0] = MPIR_CONTEXT_MASK_0;
+    /* reserve the first two values for comm_world and comm_self */
+    context_mask[0] = 0xFFFFFFFC;
 
 #ifdef MPICH_DEBUG_HANDLEALLOC
     /* check for context ID leaks in MPI_Finalize.  Use (_PRIO-1) to make sure

--- a/src/mpi/comm/contextid.c
+++ b/src/mpi/comm/contextid.c
@@ -159,8 +159,7 @@ void MPIR_context_id_init(void)
     for (i = 1; i < MPIR_MAX_CONTEXT_MASK; i++) {
         context_mask[i] = 0xFFFFFFFF;
     }
-    /* reserve the first two values for comm_world and comm_self */
-    context_mask[0] = 0xFFFFFFFC;
+    context_mask[0] = MPIR_CONTEXT_MASK_0;
 
 #ifdef MPICH_DEBUG_HANDLEALLOC
     /* check for context ID leaks in MPI_Finalize.  Use (_PRIO-1) to make sure

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -16,6 +16,7 @@
 **sessionnull: NULL MPI_Session
 **sessioninuse:MPI_Session is referenced and cannot be released
 **sessioninuse %d:MPI_Session is referenced by %d other objects and cannot be released
+**session_mixed: groups are from different session
 **nomem:Out of memory
 **nomem %s %d:Out of memory (unable to allocate a '%s' of size %d)
 **nomem %s:Out of memory (unable to allocate a '%s')

--- a/src/mpi/group/group_impl.c
+++ b/src/mpi/group/group_impl.c
@@ -437,16 +437,16 @@ int MPIR_Group_from_session_pset_impl(MPIR_Session * session_ptr, const char *ps
 {
     int mpi_errno = MPI_SUCCESS;
 
-    if (MPL_stricmp(pset_name, "mpi://WORLD") == 0) {
-        mpi_errno = MPIR_Group_dup(MPIR_GROUP_WORLD_PTR, session_ptr, new_group_ptr);
-        MPIR_ERR_CHECK(mpi_errno);
-    } else if (MPL_stricmp(pset_name, "mpi://SELF") == 0) {
-        mpi_errno = MPIR_Group_dup(MPIR_GROUP_SELF_PTR, session_ptr, new_group_ptr);
-        MPIR_ERR_CHECK(mpi_errno);
-    } else {
-        /* TODO: Implement pset struct, locate pset struct ptr */
-        MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_ARG, goto fn_fail, "**psetinvalidname");
+    for (int i = 0; i < session_ptr->num_psets; i++) {
+        if (MPL_stricmp(pset_name, session_ptr->psets[i].name) == 0) {
+            mpi_errno = MPIR_Group_dup(session_ptr->psets[i].group, session_ptr, new_group_ptr);
+            MPIR_ERR_CHECK(mpi_errno);
+            goto fn_exit;
+        }
     }
+
+    /* not found */
+    MPIR_ERR_SETANDSTMT(mpi_errno, MPI_ERR_ARG, goto fn_fail, "**psetinvalidname");
 
   fn_exit:
     return mpi_errno;

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -384,26 +384,6 @@ int MPII_Finalize(MPIR_Session * session_ptr)
 
     MPL_initlock_lock(&MPIR_init_lock);
 
-    if (!is_world_model) {
-        int session_refs = MPIR_Object_get_ref(session_ptr);
-        if ((session_refs > 1) && session_ptr->strict_finalize) {
-            /* For strict_finalize, we return an error if there still exist
-             * other refs to the session (other than the self-ref).
-             * In addition, we call MPID_Progress_poke() to allow users to
-             * poll for success of the session finalize.
-             */
-            MPID_Progress_poke();
-            mpi_errno =
-                MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
-                                     MPI_ERR_PENDING, "**sessioninuse", "**sessioninuse %d",
-                                     session_refs - 1);
-            goto fn_fail;
-        }
-
-        mpi_errno = MPIR_Session_release(session_ptr);
-        MPIR_ERR_CHECK(mpi_errno);
-    }
-
     init_counter--;
     if (init_counter > 0) {
         goto fn_exit;

--- a/src/mpi/session/session_impl.c
+++ b/src/mpi/session/session_impl.c
@@ -51,6 +51,11 @@ int MPIR_Session_init_impl(MPIR_Info * info_ptr, MPIR_Errhandler * errhandler_pt
         session_ptr->memory_alloc_kinds = MPL_strdup(MPIR_Process.memory_alloc_kinds);
     }
 
+    if (errhandler_ptr) {
+        session_ptr->errhandler = errhandler_ptr;
+        MPIR_Errhandler_add_ref(errhandler_ptr);
+    }
+
     *p_session_ptr = session_ptr;
 
   fn_exit:

--- a/src/mpi/session/session_impl.c
+++ b/src/mpi/session/session_impl.c
@@ -38,6 +38,9 @@ int MPIR_Session_init_impl(MPIR_Info * info_ptr, MPIR_Errhandler * errhandler_pt
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_Assert(provided == MPIR_ThreadInfo.thread_provided);
 
+    /* Enter global CS after system initialized */
+    MPID_THREAD_CS_ENTER(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+
     session_ptr->strict_finalize = strict_finalize;
 
     /* Get memory allocation kinds requested by the user (if any). This depends on CVAR
@@ -75,6 +78,9 @@ int MPIR_Session_init_impl(MPIR_Info * info_ptr, MPIR_Errhandler * errhandler_pt
     *p_session_ptr = session_ptr;
 
   fn_exit:
+    if (session_ptr) {
+        MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
+    }
     return mpi_errno;
 
   fn_fail:

--- a/src/mpi/session/session_impl.c
+++ b/src/mpi/session/session_impl.c
@@ -56,6 +56,22 @@ int MPIR_Session_init_impl(MPIR_Info * info_ptr, MPIR_Errhandler * errhandler_pt
         MPIR_Errhandler_add_ref(errhandler_ptr);
     }
 
+    /* populate psets */
+    session_ptr->num_psets = 2;
+    session_ptr->psets = MPL_malloc(session_ptr->num_psets * sizeof(struct MPIR_Pset),
+                                    MPL_MEM_GROUP);
+    MPIR_ERR_CHKANDJUMP(!session_ptr->psets, mpi_errno, MPI_ERR_OTHER, "**nomem");
+
+    session_ptr->psets[0].name = MPL_strdup("mpi://WORLD");
+    mpi_errno = MPIR_Group_dup(MPIR_GROUP_WORLD_PTR, session_ptr, &session_ptr->psets[0].group);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    session_ptr->psets[1].name = MPL_strdup("mpi://SELF");
+    mpi_errno = MPIR_Group_dup(MPIR_GROUP_SELF_PTR, session_ptr, &session_ptr->psets[1].group);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* TODO: append a list of dynamically updated global psets */
+
     *p_session_ptr = session_ptr;
 
   fn_exit:
@@ -71,6 +87,15 @@ int MPIR_Session_init_impl(MPIR_Info * info_ptr, MPIR_Errhandler * errhandler_pt
 int MPIR_Session_finalize_impl(MPIR_Session * session_ptr)
 {
     int mpi_errno = MPI_SUCCESS;
+
+    for (int i = 0; i < session_ptr->num_psets; i++) {
+        mpi_errno = MPIR_Group_free_impl(session_ptr->psets[i].group);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        MPL_free(session_ptr->psets[i].name);
+    }
+    MPL_free(session_ptr->psets);
+    session_ptr->num_psets = 0;
 
     /* MPII_Finalize will free the session_ptr */
     mpi_errno = MPII_Finalize(session_ptr);

--- a/src/mpi/session/session_util.c
+++ b/src/mpi/session/session_util.c
@@ -34,6 +34,8 @@ int MPIR_Session_create(MPIR_Session ** p_session_ptr)
     /* disable strict finalize feature by default */
     (*p_session_ptr)->strict_finalize = false;
     (*p_session_ptr)->memory_alloc_kinds = NULL;
+    (*p_session_ptr)->num_psets = 0;
+    (*p_session_ptr)->psets = NULL;
 
     {
         int thr_err;

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -21,6 +21,7 @@ struct MPIR_Request;
 #endif
 
 #define MPID_TAG_DEV_BITS 0
+#define MPID_SESSION_USE_WORLD 1
 
 typedef struct {
 #ifdef HAVE_HCOLL

--- a/src/mpid/ch4/netmod/ofi/init_addrxchg.c
+++ b/src/mpid/ch4/netmod/ofi/init_addrxchg.c
@@ -17,12 +17,7 @@ int MPIDI_OFI_comm_addr_exchange(MPIR_Comm * comm)
     int mpi_errno = MPI_SUCCESS;
     MPIR_CHKLMEM_DECL();
 
-    /* only comm_world for now
-     * TODO: Use an attribute to mark whether this is a comm from
-     *       MPI_Comm_create_from_group and to be checked in NM_mpi_comm_pre_hook.
-     */
-    MPIR_Assert(comm == MPIR_Process.comm_world);
-
+    MPIR_Assert(comm->attr & MPIR_COMM_ATTR__BOOTSTRAP);
     MPIR_Assert(comm->attr & MPIR_COMM_ATTR__HIERARCHY);
 
     /* First, each get its own name */

--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -136,9 +136,8 @@ int MPIDI_OFI_mpi_comm_commit_pre_hook(MPIR_Comm * comm)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    if (comm == MPIR_Process.comm_world && !MPIDI_OFI_global.got_named_av) {
-        MPIR_Assert(MPIR_Process.comm_world);
-        mpi_errno = MPIDI_OFI_comm_addr_exchange(MPIR_Process.comm_world);
+    if ((comm->attr & MPIR_COMM_ATTR__BOOTSTRAP) && !MPIDI_OFI_global.got_named_av) {
+        mpi_errno = MPIDI_OFI_comm_addr_exchange(comm);
         MPIR_ERR_CHECK(mpi_errno);
     }
 
@@ -178,13 +177,8 @@ int MPIDI_OFI_mpi_comm_commit_post_hook(MPIR_Comm * comm)
 
     MPIR_FUNC_ENTER;
 
-    /* When setting up built in communicators, there won't be any way to do collectives yet. We also
-     * won't have any info hints to propagate so there won't be any preferences that need to be
-     * communicated. */
-    if (comm != MPIR_Process.comm_world) {
-        mpi_errno = update_nic_preferences(comm);
-        MPIR_ERR_CHECK(mpi_errno);
-    }
+    mpi_errno = update_nic_preferences(comm);
+    MPIR_ERR_CHECK(mpi_errno);
 
   fn_exit:
     MPIR_FUNC_EXIT;

--- a/src/mpid/ch4/netmod/ucx/ucx_comm.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_comm.c
@@ -14,8 +14,8 @@ int MPIDI_UCX_mpi_comm_commit_pre_hook(MPIR_Comm * comm)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    if (comm == MPIR_Process.comm_world) {
-        mpi_errno = MPIDI_UCX_comm_addr_exchange(MPIR_Process.comm_world);
+    if (comm->attr & MPIR_COMM_ATTR__BOOTSTRAP) {
+        mpi_errno = MPIDI_UCX_comm_addr_exchange(comm);
         MPIR_ERR_CHECK(mpi_errno);
     }
 #if defined HAVE_HCOLL

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -81,9 +81,6 @@ int MPIDI_UCX_comm_addr_exchange(MPIR_Comm * comm)
     int mpi_errno = MPI_SUCCESS;
     MPIR_CHKLMEM_DECL();
 
-    /* only comm_world for now */
-    MPIR_Assert(comm == MPIR_Process.comm_world);
-
     MPIR_Assert(comm->attr & MPIR_COMM_ATTR__HIERARCHY);
 
     char *addrname = (void *) MPIDI_UCX_global.ctx[0].if_address;

--- a/src/mpid/ch4/shm/posix/posix_types.h
+++ b/src/mpid/ch4/shm/posix/posix_types.h
@@ -46,8 +46,10 @@ typedef struct {
 /* the structure of MPIDI_POSIX_global.shm_slab */
 #define MPIDI_POSIX_READY_FLAG 0x12345678       /* arbitrary sentinel to avoid coincidence */
 typedef struct {
+    MPL_atomic_int_t num_shared;        /* number of processes currently using shm_slab */
+    MPL_atomic_int_t num_shared_vci;    /* number of processes currently using shm_vci_slab */
+    MPL_atomic_int_t shm_ready; /* root (1st proc that allocates shm_slab) set it to MPIDI_POSIX_READY_FLAG */
     MPL_atomic_uint64_t shm_limit_counter;      /* release_gather use this to track total amount of shared memory allocated */
-    MPL_atomic_int_t root_ready;        /* root (1st proc that allocates shm_slab) set it to MPIDI_POSIX_READY_FLAG */
     MPL_atomic_int_t eager_ready[];     /* size of local_size. Each process update its flag to MPIDI_POSIX_READY_FLAG */
 } MPIDI_POSIX_shm_t;
 
@@ -66,6 +68,8 @@ typedef struct {
 #endif
     void *shm_slab;             /* the main shared memory slab */
     void *shm_vci_slab;         /* extra shared memory slab for multiple vcis */
+    int shm_slab_size;
+    int shm_vci_slab_size;
 } MPIDI_POSIX_global_t;
 
 extern MPIDI_POSIX_global_t MPIDI_POSIX_global;

--- a/src/mpid/ch4/shm/posix/posix_vci.c
+++ b/src/mpid/ch4/shm/posix/posix_vci.c
@@ -29,7 +29,12 @@ int MPIDI_POSIX_comm_set_vcis(MPIR_Comm * comm, int num_vcis)
 
         void *slab;
         int slab_size = MPIDI_POSIX_eager_shm_vci_size(MPIR_Process.local_size, max_vcis);
+        MPIDI_POSIX_global.shm_vci_slab_size = slab_size;
 #ifdef MPL_HAVE_INITSHM
+        MPL_atomic_int_t *num_shared =
+            &((MPIDI_POSIX_shm_t *) MPIDI_POSIX_global.shm_slab)->num_shared_vci;
+        MPL_atomic_fetch_add_int(num_shared, 1);
+        /* FIXME: do we worry about leaking num_shared in the error case? */
         slab = MPL_initshm_open(MPIDI_POSIX_global.shm_vci_name, slab_size, NULL);
         MPIR_ERR_CHKANDJUMP(!slab, mpi_errno, MPI_ERR_OTHER, "**nomem");
 

--- a/src/mpid/ch4/shm/src/shm_hooks.c
+++ b/src/mpid/ch4/shm/src/shm_hooks.c
@@ -13,7 +13,7 @@ int MPIDI_SHM_mpi_comm_commit_pre_hook(MPIR_Comm * comm)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    if (comm == MPIR_Process.comm_world) {
+    if (comm->attr & MPIR_COMM_ATTR__BOOTSTRAP) {
         mpi_errno = MPIDI_SHM_comm_bootstrap(comm);
         MPIR_ERR_CHECK(mpi_errno);
     }

--- a/src/mpid/ch4/src/ch4_proc.c
+++ b/src/mpid/ch4/src/ch4_proc.c
@@ -364,7 +364,8 @@ int MPIDIU_bc_exchange_node_roots(MPIR_Comm * comm, const char *addrname, int ad
                 procs[i] = MPIDIU_get_grank(i, node_roots_comm);
             }
             mpi_errno = MPIR_pmi_allgather_group("BC", addrname, addrnamelen,
-                                                 roots_names, addrnamelen, procs, external_size);
+                                                 roots_names, addrnamelen, procs, external_size,
+                                                 comm->stringtag);
             MPIR_ERR_CHECK(mpi_errno);
         }
     } else {

--- a/src/mpid/ch4/src/ch4_proc.c
+++ b/src/mpid/ch4/src/ch4_proc.c
@@ -351,8 +351,13 @@ int MPIDIU_bc_exchange_node_roots(MPIR_Comm * comm, const char *addrname, int ad
 
     bool is_node_root = (node_comm->rank == 0);
 
-    int rc = MPIR_pmi_barrier_group(MPIR_PMI_GROUP_SELF, 0, 0);
-    if (rc == MPI_SUCCESS) {
+    if (MPIR_CVAR_PMI_DISABLE_GROUP) {
+        /* use MPIR_pmi_allgather, all processes need participate in a PMI barrier */
+        MPIR_Assert(comm->local_size == MPIR_Process.size);
+        mpi_errno = MPIR_pmi_allgather(addrname, addrnamelen, roots_names, addrnamelen,
+                                       MPIR_PMI_DOMAIN_NODE_ROOTS);
+        MPIR_ERR_CHECK(mpi_errno);
+    } else {
         /* MPIR_pmi_allgather_group is supported */
         if (is_node_root) {
             MPIR_Comm *node_roots_comm = MPIR_Comm_get_node_roots_comm(comm);
@@ -368,12 +373,6 @@ int MPIDIU_bc_exchange_node_roots(MPIR_Comm * comm, const char *addrname, int ad
                                                  comm->stringtag);
             MPIR_ERR_CHECK(mpi_errno);
         }
-    } else {
-        /* use MPIR_pmi_allgather, all processes need participate in a PMI barrier */
-        MPIR_Assert(comm->local_size == MPIR_Process.size);
-        mpi_errno = MPIR_pmi_allgather(addrname, addrnamelen, roots_names, addrnamelen,
-                                       MPIR_PMI_DOMAIN_NODE_ROOTS);
-        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -223,11 +223,7 @@ MPL_STATIC_INLINE_PREFIX void MPID_Progress_end(MPID_Progress_state * state)
 
 MPL_STATIC_INLINE_PREFIX int MPID_Progress_test(MPID_Progress_state * state)
 {
-    if (!MPIR_Process.comm_world) {
-        /* skip progress if the world is not initialized (e.g. a session) */
-        /* TODO: update once we support partial world */
-        return MPI_SUCCESS;
-    } else if (state == NULL) {
+    if (state == NULL) {
         MPID_Progress_state progress_state;
 
         MPIDI_progress_state_init(&progress_state);

--- a/src/mpid/ch4/src/mpidig_win.c
+++ b/src/mpid/ch4/src/mpidig_win.c
@@ -378,12 +378,14 @@ static int win_init(MPI_Aint length, int disp_unit, MPIR_Win ** win_ptr, MPIR_In
      * - check if SAME_OP_NO_OP is set for accumulates */
     MPIDI_WIN(win, winattr) = 0;
 
-    int comm_compare_result = MPI_UNEQUAL;
-    mpi_errno = MPIR_Comm_compare_impl(comm_ptr, MPIR_Process.comm_world, &comm_compare_result);
-    MPIR_ERR_CHECK(mpi_errno);
+    if (MPIR_Process.comm_world) {
+        int comm_compare_result = MPI_UNEQUAL;
+        mpi_errno = MPIR_Comm_compare_impl(comm_ptr, MPIR_Process.comm_world, &comm_compare_result);
+        MPIR_ERR_CHECK(mpi_errno);
 
-    if (comm_compare_result == MPI_CONGRUENT || comm_compare_result == MPI_IDENT)
-        MPIDI_WIN(win, winattr) |= MPIDI_WINATTR_DIRECT_INTRA_COMM;
+        if (comm_compare_result == MPI_CONGRUENT || comm_compare_result == MPI_IDENT)
+            MPIDI_WIN(win, winattr) |= MPIDI_WINATTR_DIRECT_INTRA_COMM;
+    }
 
     update_winattr_after_set_info(win);
 

--- a/src/mpl/include/mpl_initshm.h
+++ b/src/mpl/include/mpl_initshm.h
@@ -21,6 +21,6 @@
  */
 
 void *MPL_initshm_open(const char *name, int size, bool * is_root);
-int MPL_initshm_freeall(void);
+int MPL_initshm_free(const char *name, void *slab, int size, bool need_unlink);
 
 #endif /* MPL_INITSHM_H_INCLUDED */

--- a/src/pm/hydra/mpiexec/pmiserv_misc.c
+++ b/src/pm/hydra/mpiexec/pmiserv_misc.c
@@ -48,7 +48,7 @@ static HYD_status barrier_group_finish(struct HYD_pg *pg, struct HYD_barrier *s,
     PMIU_cmd_free_buf(&pmi_response);
 
     HASH_DEL(pg->barriers, s);
-    MPL_free(s->name);
+    MPL_free((char *) s->name);
     utarray_free(s->proxy_list);
     MPL_free(s);
 

--- a/src/pm/hydra/proxy/pmip_barrier.c
+++ b/src/pm/hydra/proxy/pmip_barrier.c
@@ -219,7 +219,7 @@ HYD_status PMIP_barrier_complete(struct pmip_pg *pg, struct pmip_barrier **barri
 
     if (!barrier->epochs) {
         /* free the barrier */
-        MPL_free(barrier->name);
+        MPL_free((char *) barrier->name);
         MPL_free(barrier->proc_list);
         HASH_DEL(pg->barriers, barrier);
         MPL_free(barrier);

--- a/src/pmi/src/pmi_v1.c
+++ b/src/pmi/src/pmi_v1.c
@@ -354,7 +354,7 @@ PMI_API_PUBLIC int PMI_Barrier_group(const int *group, int count, const char *ta
         snprintf(group_str, 20, "NODE:%d", inttag);
     } else {
         /* convert the int array into a comma-separated int list */
-        int size = count * 8;
+        int size = count * 8 + 10;      /* Enough space for 7-digit ranks plus a 9-digit tag */
         group_str = MPL_malloc(size, MPL_MEM_OTHER);
         char *s = group_str;
         for (int i = 0; i < count; i++) {

--- a/src/pmi/src/pmi_wire.c
+++ b/src/pmi/src/pmi_wire.c
@@ -937,13 +937,14 @@ static int cmd_read_expect(int fd, struct PMIU_cmd *pmicmd, const char *expected
                  * enqueue and continue for such response when it not expected. */
                 if (strcmp("barrier_out", pmicmd->cmd) == 0) {
                     const char *tag = PMIU_cmd_find_keyval(pmicmd, "tag");
-                    if (tag) {
-                        struct barrier_response *r = MPL_malloc(sizeof(struct barrier_response),
-                                                                MPL_MEM_OTHER);
-                        r->tag = atoi(tag);
-                        DL_APPEND(barrier_response_queue, r);
-                        continue;
-                    }
+                    PMIU_Assert(tag);
+                    struct barrier_response *r = MPL_malloc(sizeof(struct barrier_response),
+                                                            MPL_MEM_OTHER);
+                    r->tag = atoi(tag);
+                    DL_APPEND(barrier_response_queue, r);
+                    pmicmd->buf_need_free = true;
+                    PMIU_cmd_free_buf(pmicmd);
+                    continue;
                 }
             }
             PMIU_ERR_SETANDJUMP2(pmi_errno, PMIU_FAIL,

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -735,7 +735,7 @@ int MPIR_pmi_allgather_shm(const void *sendbuf, int sendsize, void *shm_buf, int
  *       omit the last barrier.
  */
 int MPIR_pmi_allgather_group(const char *name, const void *sendbuf, int sendsize, void *recvbuf,
-                             int recvsize, int *group, int count)
+                             int recvsize, int *group, int count, const char *stringtag)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -763,7 +763,7 @@ int MPIR_pmi_allgather_group(const char *name, const void *sendbuf, int sendsize
     MPIR_ERR_CHECK(mpi_errno);
 
     /* FIXME: set stringtag to thread id */
-    mpi_errno = MPIR_pmi_barrier_group(group, count, NULL);
+    mpi_errno = MPIR_pmi_barrier_group(group, count, stringtag);
     MPIR_ERR_CHECK(mpi_errno);
 
     for (int i = 0; i < count; i++) {

--- a/test/mpi/session/Makefile.am
+++ b/test/mpi/session/Makefile.am
@@ -16,6 +16,7 @@ noinst_PROGRAMS = \
     session_re_init \
     session_psets \
     session_self \
+    session_inter \
     session_4x4 \
     session_bsend
 

--- a/test/mpi/session/Makefile.am
+++ b/test/mpi/session/Makefile.am
@@ -16,6 +16,7 @@ noinst_PROGRAMS = \
     session_re_init \
     session_psets \
     session_self \
+    session_4x4 \
     session_bsend
 
 session_mult_init_SOURCES = session.c

--- a/test/mpi/session/session_4x4.c
+++ b/test/mpi/session/session_4x4.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpi.h"
+#include <stdio.h>
+#include <assert.h>
+#include "mpitest.h"
+
+/* This test divide 16 processes into 4 groups (nodes), each group
+ * creates a node_comm. Then roots of each node group creates a roots_comm.
+ */
+
+#define NP 16
+#define PPN 4
+#define N 4
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+
+    int ret;
+    MPI_Session session;
+    MPI_Group world_group;
+    MPI_Comm comm;
+
+    MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL, &session);
+
+    MPI_Group_from_session_pset(session, "mpi://world", &world_group);
+
+    int world_rank, world_size;
+    MPI_Group_rank(world_group, &world_rank);
+    MPI_Group_size(world_group, &world_size);
+
+    if (world_size != NP) {
+        printf("This test require %d processes, world_size is %d.\n", NP, world_size);
+        goto fn_exit;
+    }
+    if (N * PPN != NP) {
+        printf("N(%d) x PPN(%d) != NP(%d)\n", N, PPN, NP);
+        goto fn_exit;
+    }
+
+    MPI_Group node_group, roots_group;
+    MPI_Comm node_comm, roots_comm;
+
+    int proc_list[NP];
+    int node_root = (world_rank / PPN) * PPN;
+    int is_root = (world_rank == node_root);
+
+    for (int i = 0; i < PPN; i++) {
+        proc_list[i] = node_root + i;
+    }
+    MPI_Group_incl(world_group, PPN, proc_list, &node_group);
+    MPI_Comm_create_from_group(node_group, "tag", MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL, &node_comm);
+
+    if (is_root) {
+        for (int i = 0; i < N; i++) {
+            proc_list[i] = i * PPN;
+        }
+        MPI_Group_incl(world_group, N, proc_list, &roots_group);
+        MPI_Comm_create_from_group(roots_group, "tag", MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL,
+                                   &roots_comm);
+    }
+
+    int node_sum, world_sum;
+    MPI_Reduce(&world_rank, &node_sum, 1, MPI_INT, MPI_SUM, 0, node_comm);
+    if (is_root) {
+        MPI_Reduce(&node_sum, &world_sum, 1, MPI_INT, MPI_SUM, 0, roots_comm);
+    }
+
+    if (world_rank == 0) {
+        int expect_sum = NP * (NP - 1) / 2;
+        if (world_sum != expect_sum) {
+            printf("Expect world_sum %d, got %d\n", expect_sum, world_sum);
+        } else {
+            printf("No Errors\n");
+        }
+    }
+
+    MPI_Comm_free(&node_comm);
+    MPI_Group_free(&node_group);
+    if (is_root) {
+        MPI_Comm_free(&roots_comm);
+        MPI_Group_free(&roots_group);
+    }
+    MPI_Group_free(&world_group);
+
+    MPI_Session_finalize(&session);
+
+  fn_exit:
+    return errs;
+}

--- a/test/mpi/session/session_inter.c
+++ b/test/mpi/session/session_inter.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpitest.h"
+#include <stdio.h>
+#include <assert.h>
+
+/* This test tests MPI_Intercomm_create_from_groups */
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+
+    int ret;
+    MPI_Session session;
+    MPI_Group world_group;
+    MPI_Comm comm;
+
+    MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL, &session);
+
+    MPI_Group_from_session_pset(session, "mpi://world", &world_group);
+
+    int world_rank, world_size;
+    MPI_Group_rank(world_group, &world_rank);
+    MPI_Group_size(world_group, &world_size);
+    if (world_size == 1) {
+        printf("The test require more than 1 process.\n");
+        goto fn_exit;
+    }
+
+    int *proc_list;
+    int local_leader, remote_leader;
+    proc_list = malloc(world_size * sizeof(int));
+    for (int i = 0; i < world_size; i++) {
+        proc_list[i] = i;
+    }
+
+    int n1 = world_size / 2;
+    int n2 = world_size - n1;
+    MPI_Group local_group, remote_group;
+    if (world_rank < n1) {
+        MPI_Group_incl(world_group, n1, proc_list, &local_group);
+        MPI_Group_incl(world_group, n2, proc_list + n1, &remote_group);
+    } else {
+        MPI_Group_incl(world_group, n1, proc_list, &remote_group);
+        MPI_Group_incl(world_group, n2, proc_list + n1, &local_group);
+    }
+
+    free(proc_list);
+
+    MPI_Comm inter_comm;
+    MPI_Intercomm_create_from_groups(local_group, 0, remote_group, 0, "string tag",
+                                     MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL, &inter_comm);
+
+    errs = MTestTestIntercomm(inter_comm);
+
+    MPI_Group_free(&world_group);
+    MPI_Group_free(&local_group);
+    MPI_Group_free(&remote_group);
+    MPI_Comm_free(&inter_comm);
+
+    MPI_Session_finalize(&session);
+
+    if (world_rank == 0 && errs == 0) {
+        printf("No Errors\n");
+    }
+
+  fn_exit:
+    return errs;
+}

--- a/test/mpi/session/testlist
+++ b/test/mpi/session/testlist
@@ -4,4 +4,5 @@ session_mult_init 4 arg=5
 session_re_init 4
 session_psets 1
 session_self 1
+session_4x4 16
 session_bsend 2

--- a/test/mpi/session/testlist
+++ b/test/mpi/session/testlist
@@ -4,5 +4,6 @@ session_mult_init 4 arg=5
 session_re_init 4
 session_psets 1
 session_self 1
+session_inter 5
 session_4x4 16
 session_bsend 2

--- a/test/mpi/util/mtest.c
+++ b/test/mpi/util/mtest.c
@@ -879,11 +879,10 @@ int MTestGetIntercomm(MPI_Comm * comm, int *isLeftGroup, int min_size)
 int MTestTestIntercomm(MPI_Comm comm)
 {
     int local_size, remote_size, rank, **bufs, *bufmem, rbuf[2], j;
-    int errs = 0, wrank, nsize;
+    int errs = 0, nsize;
     char commname[MPI_MAX_OBJECT_NAME + 1];
     MPI_Request *reqs;
 
-    MPI_Comm_rank(MPI_COMM_WORLD, &wrank);
     MPI_Comm_size(comm, &local_size);
     MPI_Comm_remote_size(comm, &remote_size);
     MPI_Comm_rank(comm, &rank);
@@ -894,22 +893,21 @@ int MTestTestIntercomm(MPI_Comm comm)
 
     reqs = (MPI_Request *) malloc(remote_size * sizeof(MPI_Request));
     if (!reqs) {
-        printf("[%d] Unable to allocated %d requests for testing intercomm %s\n",
-               wrank, remote_size, commname);
+        printf("Unable to allocated %d requests for testing intercomm %s\n", remote_size, commname);
         errs++;
         return errs;
     }
     bufs = (int **) malloc(remote_size * sizeof(int *));
     if (!bufs) {
-        printf("[%d] Unable to allocated %d int pointers for testing intercomm %s\n",
-               wrank, remote_size, commname);
+        printf("Unable to allocated %d int pointers for testing intercomm %s\n",
+               remote_size, commname);
         errs++;
         return errs;
     }
     bufmem = (int *) malloc(remote_size * 2 * sizeof(int));
     if (!bufmem) {
-        printf("[%d] Unable to allocated %d int data for testing intercomm %s\n",
-               wrank, 2 * remote_size, commname);
+        printf("Unable to allocated %d int data for testing intercomm %s\n",
+               2 * remote_size, commname);
         errs++;
         return errs;
     }
@@ -930,12 +928,12 @@ int MTestTestIntercomm(MPI_Comm comm)
     for (j = 0; j < remote_size; j++) {
         MPI_Recv(rbuf, 2, MPI_INT, j, 0, comm, MPI_STATUS_IGNORE);
         if (rbuf[0] != j) {
-            printf("[%d] Expected rank %d but saw %d in %s\n", wrank, j, rbuf[0], commname);
+            printf("Expected rank %d but saw %d in %s\n", j, rbuf[0], commname);
             errs++;
         }
         if (rbuf[1] != rank) {
-            printf("[%d] Expected target rank %d but saw %d from %d in %s\n",
-                   wrank, rank, rbuf[1], j, commname);
+            printf("Expected target rank %d but saw %d from %d in %s\n",
+                   rank, rbuf[1], j, commname);
             errs++;
         }
     }


### PR DESCRIPTION
## Pull Request Description
Now we have communicator-independent way of describing processes, group, and psets, we can properly implement session psets. This is a re-try of PR #6430. Refer to the comments in #6430 for background.

* With so much preparation, `MPI_Comm_create_from_group` is now as simple as -
https://github.com/pmodels/mpich/blob/35e16c2ff3a6769e3c7d9e764c2679840793e2f3/src/mpi/comm/comm_impl.c#L524-L549

* Added a new test for true MPI sessions:
https://github.com/pmodels/mpich/blob/35e16c2ff3a6769e3c7d9e764c2679840793e2f3/test/mpi/session/session_4x4.c#L28-L90

![image](https://github.com/user-attachments/assets/3bc39110-c0f9-49b8-b69d-de3615d98c9a)

#### Resource scalability
If the job size is `n x m` (PPN multiply number of nodes), the number of connections (including self-connection) are -
* each process:
    * World model: `n x m`
    * True sessions: `n + m`  - roots
    * True sessions:  `n`        - non-roots
* each node:
    * World model: `n x n x m`
    * True sessions:  `n x n + m`
* total:
     * World model: `n x n x m x m`
     * True sessions:  `n x n x m + m x m`

If `n = 64` and `m = 1000`, it is `1000:1`, roughly a saving by PPN. Almost all of the reduction is in inter-node network traffic.
Actually, if we only look at inter-node connections, the reduction is `n^2`.

[skip warnings]
## Reference
#### previous drafts
* https://github.com/pmodels/mpich/pull/6430
* https://github.com/pmodels/mpich/pull/6661
#### dependencies of this PR
* https://github.com/pmodels/mpich/pull/7235
* https://github.com/pmodels/mpich/pull/7237
* https://github.com/pmodels/mpich/pull/7242
* https://github.com/pmodels/mpich/pull/7325
* https://github.com/pmodels/mpich/pull/7326
* https://github.com/pmodels/mpich/pull/7355
* https://github.com/pmodels/mpich/pull/7353
* https://github.com/pmodels/mpich/pull/7240
* https://github.com/pmodels/mpich/pull/7367
* https://github.com/pmodels/mpich/pull/7366
* https://github.com/pmodels/mpich/pull/7374
* https://github.com/pmodels/mpich/pull/7392

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
