### PR TITLE
ch4: remove netmod api init_vcis

### DIFF
--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -40,8 +40,6 @@ Non Native API:
   mpi_finalize_hook : int
       NM : void
      SHM : void
-  init_vcis: int
-      NM : num_vcis, num_vcis_actual
   post_init : int
       NM : void
      SHM : void

--- a/src/mpid/ch4/netmod/ofi/ofi_vci.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_vci.c
@@ -33,6 +33,7 @@ int MPIDI_OFI_vci_init(void)
 }
 
 /* Address exchange within comm and setup multiple vcis */
+static int init_vcis(int num_vcis, int *num_vcis_actual);
 static int addr_exchange_all_ctx(MPIR_Comm * comm, int *all_num_vcis);
 
 int MPIDI_OFI_comm_set_vcis(MPIR_Comm * comm, int num_vcis, int *all_num_vcis)
@@ -41,7 +42,7 @@ int MPIDI_OFI_comm_set_vcis(MPIR_Comm * comm, int num_vcis, int *all_num_vcis)
 
     /* set up local vcis */
     int num_vcis_actual;
-    mpi_errno = MPIDI_OFI_init_vcis(num_vcis, &num_vcis_actual);
+    mpi_errno = init_vcis(num_vcis, &num_vcis_actual);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* gather the number of remote vcis */
@@ -71,12 +72,12 @@ int MPIDI_OFI_comm_set_vcis(MPIR_Comm * comm, int num_vcis, int *all_num_vcis)
     goto fn_exit;
 }
 
-/* MPIDI_OFI_init_vcis: locally create multiple vcis */
+/* init_vcis: locally create multiple vcis */
 
 static int check_num_nics(void);
 static int setup_additional_vcis(void);
 
-int MPIDI_OFI_init_vcis(int num_vcis, int *num_vcis_actual)
+static int init_vcis(int num_vcis, int *num_vcis_actual)
 {
     int mpi_errno = MPI_SUCCESS;
 

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -286,13 +286,6 @@ int MPIDI_UCX_init_world(void)
     goto fn_exit;
 }
 
-int MPIDI_UCX_init_vcis(int num_vcis, int *num_vcis_actual)
-{
-    int mpi_errno = MPI_SUCCESS;
-    *num_vcis_actual = num_vcis;
-    return mpi_errno;
-}
-
 /* static functions for MPIDI_UCX_post_init */
 static void flush_cb(void *request, ucs_status_t status)
 {


### PR DESCRIPTION
## Pull Request Description
The function of init_vcis has been wrapped inside comm_set_vcis and it is no longer needed.

This fixes a potential build error --
```
../mpich/src/mpid/ch4/netmod/ofi/ofi_vci.c: In function 'MPIDI_OFI_comm_set_vcis':
../mpich/src/mpid/ch4/netmod/ofi/ofi_vci.c:44:17: error: implicit declaration of function 'MPIDI_OFI_init_vcis'; did you mean 'MPIDI_NM_init_vcis'? [-Wimplicit-function-declaration]
   44 |     mpi_errno = MPIDI_OFI_init_vcis(num_vcis, &num_vcis_actual);
      |                 ^~~~~~~~~~~~~~~~~~~
      |                 MPIDI_NM_init_vcis
make[2]: *** [Makefile:27230: src/mpid/ch4/netmod/ofi/lib_libmpi_abi_la-ofi_vci.lo] Error 1


```


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
