### PR TITLE
ch4/ipc: limit xpmem send only if the buffer is used repeatedly

### DIFF
--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -374,8 +374,9 @@ int MPIDI_GPU_get_ipc_attr(const void *buf, MPI_Aint count, MPI_Datatype datatyp
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_get_buffer_info");
 
     /* Don't create or search for an ipc handle if the buffer doesn't meet the threshold
-     * requirement */
-    if (bounds_len < MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD && !MPIDI_IPCI_is_repeat_addr(bounds_base)) {
+     * requirement or it isn't a repeat address */
+    if (bounds_len < MPIR_CVAR_CH4_IPC_GPU_P2P_THRESHOLD &&
+        (MPIDI_IPCI_is_repeat_addr(bounds_base) < 1)) {
         goto fn_exit;
     }
 

--- a/src/mpid/ch4/shm/ipc/src/globals.c
+++ b/src/mpid/ch4/shm/ipc/src/globals.c
@@ -6,8 +6,44 @@
 #include "mpidimpl.h"
 #include "ipc_types.h"
 
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+cvars:
+    - name        : MPIR_CVAR_CH4_IPC_MAP_REPEAT_ADDR
+      category    : CH4
+      type        : boolean
+      default     : true
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_ALL_EQ
+      description : >-
+        If an address is used more than once in the last ten send operations,
+        map it for IPC use even if it is below the IPC threshold.
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
 MPIDI_IPCI_global_t MPIDI_IPCI_global;
 
 #ifdef MPL_USE_DBG_LOGGING
 MPL_dbg_class MPIDI_IPCI_DBG_GENERAL;
 #endif
+
+bool MPIDI_IPCI_is_repeat_addr(void *addr)
+{
+    if (!MPIR_CVAR_CH4_IPC_MAP_REPEAT_ADDR) {
+        return false;
+    }
+
+    static void *repeat_addr[10] = { 0 };
+    static int addr_idx = 0;
+
+    for (int i = 0; i < 10; i++) {
+        if (addr == repeat_addr[i]) {
+            return true;
+        }
+    }
+
+    repeat_addr[addr_idx] = addr;
+    addr_idx = (addr_idx + 1) % 10;
+    return false;
+}

--- a/src/mpid/ch4/shm/ipc/src/globals.c
+++ b/src/mpid/ch4/shm/ipc/src/globals.c
@@ -17,8 +17,15 @@ cvars:
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_ALL_EQ
       description : >-
-        If an address is used more than once in the last ten send operations,
-        map it for IPC use even if it is below the IPC threshold.
+        Enable to track how often a buffer is being sent repeatedly. This will
+        be used in determine whether to use IPC algorithm to deliver the message.
+        The choice will depend on the IPC driver. In the case of high-latency
+        buffers such as GPU device buffer, we will enable IPC if EITHER the
+        message size is above a threshold or the message buffer is being repeated.
+        On the other hand, if the address mapping overhead is relatively high,
+        such as the case for XPMEM, we will enable IPC when BOTH conditions --
+        message size and repeat count -- are met.
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
@@ -28,22 +35,25 @@ MPIDI_IPCI_global_t MPIDI_IPCI_global;
 MPL_dbg_class MPIDI_IPCI_DBG_GENERAL;
 #endif
 
-bool MPIDI_IPCI_is_repeat_addr(void *addr)
+int MPIDI_IPCI_is_repeat_addr(const void *addr)
 {
     if (!MPIR_CVAR_CH4_IPC_MAP_REPEAT_ADDR) {
-        return false;
+        return 0;
     }
-
-    static void *repeat_addr[10] = { 0 };
+#define MAX_REPEAT_ADDRS 16     /* a bit arbitrary - TODO: make it tunable */
+    static const void *repeat_addr[MAX_REPEAT_ADDRS] = { 0 };
+    static int repeat_addr_count[MAX_REPEAT_ADDRS];
     static int addr_idx = 0;
 
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < MAX_REPEAT_ADDRS; i++) {
         if (addr == repeat_addr[i]) {
-            return true;
+            repeat_addr_count[i]++;
+            return repeat_addr_count[i];
         }
     }
 
     repeat_addr[addr_idx] = addr;
-    addr_idx = (addr_idx + 1) % 10;
-    return false;
+    repeat_addr_count[addr_idx] = 0;
+    addr_idx = (addr_idx + 1) % MAX_REPEAT_ADDRS;
+    return 0;
 }

--- a/src/mpid/ch4/shm/ipc/src/ipc_send.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_send.h
@@ -13,42 +13,6 @@
 #include "../gpu/gpu_post.h"
 #include "ipc_p2p.h"
 
-/*
-=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
-cvars:
-    - name        : MPIR_CVAR_CH4_IPC_MAP_REPEAT_ADDR
-      category    : CH4
-      type        : boolean
-      default     : true
-      class       : none
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_ALL_EQ
-      description : >-
-        If an address is used more than once in the last ten send operations,
-        map it for IPC use even if it is below the IPC threshold.
-=== END_MPI_T_CVAR_INFO_BLOCK ===
-*/
-
-MPL_STATIC_INLINE_PREFIX bool MPIDI_IPCI_is_repeat_addr(void *addr)
-{
-    if (!MPIR_CVAR_CH4_IPC_MAP_REPEAT_ADDR) {
-        return false;
-    }
-
-    static void *repeat_addr[10] = { 0 };
-    static int addr_idx = 0;
-
-    for (int i = 0; i < 10; i++) {
-        if (addr == repeat_addr[i]) {
-            return true;
-        }
-    }
-
-    repeat_addr[addr_idx] = addr;
-    addr_idx = (addr_idx + 1) % 10;
-    return false;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_try_lmt_isend(const void *buf, MPI_Aint count,
                                                       MPI_Datatype datatype, int rank, int tag,
                                                       MPIR_Comm * comm, int attr,

--- a/src/mpid/ch4/shm/ipc/src/ipc_types.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_types.h
@@ -61,6 +61,6 @@ extern MPL_dbg_class MPIDI_IPCI_DBG_GENERAL;
 
 extern MPIDI_IPCI_global_t MPIDI_IPCI_global;
 
-bool MPIDI_IPCI_is_repeat_addr(void *addr);
+int MPIDI_IPCI_is_repeat_addr(const void *addr);
 
 #endif /* IPC_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/src/ipc_types.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_types.h
@@ -61,4 +61,6 @@ extern MPL_dbg_class MPIDI_IPCI_DBG_GENERAL;
 
 extern MPIDI_IPCI_global_t MPIDI_IPCI_global;
 
+bool MPIDI_IPCI_is_repeat_addr(void *addr);
+
 #endif /* IPC_TYPES_H_INCLUDED */

--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_post.h
@@ -69,7 +69,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_XPMEM_get_ipc_attr(const void *buf, MPI_Aint 
     if (!MPIR_CVAR_CH4_XPMEM_ENABLE || buf == MPI_BOTTOM ||
         data_sz < MPIR_CVAR_CH4_IPC_XPMEM_P2P_THRESHOLD ||
         (MPIR_CVAR_CH4_IPC_XPMEM_P2P_UPPER_THRESHOLD > 0 &&
-         data_sz > MPIR_CVAR_CH4_IPC_XPMEM_P2P_UPPER_THRESHOLD)) {
+         data_sz > MPIR_CVAR_CH4_IPC_XPMEM_P2P_UPPER_THRESHOLD) ||
+        (MPIDI_IPCI_is_repeat_addr(buf) < 5)) {
         goto fn_exit;
     } else {
         ipc_attr->ipc_type = MPIDI_IPCI_TYPE__XPMEM;


### PR DESCRIPTION
## Pull Request Description
The xpmem ipc_send path is only beneficial if the buffer address is
repeated sufficiently to overcome its mapping overhead. Add a repeat
count check in addition to MPIR_CVAR_CH4_IPC_XPMEM_P2P_THRESHOLD.

Fixes #7348
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
