### PR TITLE
abi:  Update and additions

### DIFF
--- a/src/binding/abi/mpi_abi.h
+++ b/src/binding/abi/mpi_abi.h
@@ -568,8 +568,12 @@ typedef void (MPI_T_event_free_cb_function)(MPI_T_event_registration event_regis
 typedef void (MPI_T_event_dropped_cb_function)(MPI_Count count, MPI_T_event_registration event_registration, int source_index, MPI_T_cb_safety cb_safety, void *user_data);
 
 /* MPI functions */
+int MPI_Abi_get_fortran_booleans(int logical_size, void *logical_true, void *logical_false);
+int MPI_Abi_get_fortran_info(MPI_Info *info);
 int MPI_Abi_get_info(MPI_Info *info);
 int MPI_Abi_get_version(int *abi_major, int *abi_minor);
+int MPI_Abi_set_fortran_booleans(int logical_size, void *logical_true, void *logical_false);
+int MPI_Abi_set_fortran_info(MPI_Info info);
 int MPI_Abort(MPI_Comm comm, int errorcode);
 int MPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
 int MPI_Accumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
@@ -1237,8 +1241,12 @@ int MPI_T_source_get_num(int *num_sources);
 int MPI_T_source_get_timestamp(int source_index, MPI_Count *timestamp);
 
 /* PMPI functions */
+int PMPI_Abi_get_fortran_booleans(int logical_size, void *logical_true, void *logical_false);
+int PMPI_Abi_get_fortran_info(MPI_Info *info);
 int PMPI_Abi_get_info(MPI_Info *info);
 int PMPI_Abi_get_version(int *abi_major, int *abi_minor);
+int PMPI_Abi_set_fortran_booleans(int logical_size, void *logical_true, void *logical_false);
+int PMPI_Abi_set_fortran_info(MPI_Info info);
 int PMPI_Abort(MPI_Comm comm, int errorcode);
 int PMPI_Accumulate(const void *origin_addr, int origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, int target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);
 int PMPI_Accumulate_c(const void *origin_addr, MPI_Count origin_count, MPI_Datatype origin_datatype, int target_rank, MPI_Aint target_disp, MPI_Count target_count, MPI_Datatype target_datatype, MPI_Op op, MPI_Win win);

--- a/src/binding/abi/mpi_abi.h
+++ b/src/binding/abi/mpi_abi.h
@@ -244,6 +244,7 @@ enum {
     MPI_ERR_VALUE_TOO_LARGE            = 59, /* added: MPI-4.0 */
     MPI_ERR_SESSION                    = 60, /* added: MPI-4.0 */
     MPI_ERR_ERRHANDLER                 = 61, /* added: MPI-4.1 */
+    MPI_ERR_ABI                        = 62, /* added: MPI-5.0 */
 
     MPI_T_ERR_CANNOT_INIT              = 1001,
     MPI_T_ERR_NOT_ACCESSIBLE           = 1002,

--- a/src/binding/c/abi_api.txt
+++ b/src/binding/c/abi_api.txt
@@ -1,54 +1,45 @@
 # vim: set ft=c:
 
-MPI_Abi_get_info:
+MPI_Abi_get_fortran_info:
     info: INFO, direction=out, [info object]
-    .desc: Return an info object that provides information related to the ABI
-    .impl: direct
+    .desc: Return an info object that provides information related to the Fortran ABI
+    .seealso: MPI_Abi_get_info
 {
-    *info = MPI_INFO_NULL;
-    return MPI_SUCCESS;
-}
-{ -- is_abi --
-    int mpi_errno = MPI_SUCCESS;
-    *info = MPI_INFO_NULL;
-
+#ifdef HAVE_FORTRAN_BINDING
     MPIR_Info *info_ptr;
     mpi_errno = MPIR_Info_alloc(&info_ptr);
     MPIR_ERR_CHECK(mpi_errno);
 
-    MPI_Aint size;
-    char str[10];
-#define PUSH_TYPE_INFO(type, keyname) \
+    MPI_Datatype type;
+    char str[8];
+#define PUSH_TYPE_INFO(type_, keyname) \
     do { \
-        MPIR_Type_size_impl(type, &size); \
-        snprintf(str, 10, "%d", (int) size); \
+        type = type_; \
+        MPIR_DATATYPE_REPLACE_BUILTIN(type); \
+        snprintf(str, sizeof(str), "%d", MPIR_Datatype_get_basic_size(type)); \
         MPIR_Info_push(info_ptr, keyname, str); \
     } while (0)
-    PUSH_TYPE_INFO(MPI_AINT, "mpi_aint_size");
-    PUSH_TYPE_INFO(MPI_COUNT, "mpi_count_size");
-    PUSH_TYPE_INFO(MPI_OFFSET, "mpi_offset_size");
+    PUSH_TYPE_INFO(MPI_LOGICAL, "mpi_logical_size");
     PUSH_TYPE_INFO(MPI_INTEGER, "mpi_integer_size");
     PUSH_TYPE_INFO(MPI_REAL, "mpi_real_size");
     PUSH_TYPE_INFO(MPI_DOUBLE_PRECISION, "mpi_double_precision_size");
 #undef PUSH_TYPE_INFO
-#define PUSH_TYPE_INFO(type, keyname) \
+#define PUSH_TYPE_INFO(type_, keyname) \
     do { \
-        MPIR_Type_size_impl(type, &size); \
-        snprintf(str, 10, "%d", (size > 0) ? 1 : 0); \
-        MPIR_Info_push(info_ptr, keyname, str); \
+        type = type_; \
+        MPIR_DATATYPE_REPLACE_BUILTIN(type); \
+        MPIR_Info_push(info_ptr, keyname, type != MPI_DATATYPE_NULL ? "true" : "false"); \
     } while (0)
-    PUSH_TYPE_INFO(MPI_INTEGER1, "mpi_integer1_supported");
-    PUSH_TYPE_INFO(MPI_INTEGER2, "mpi_integer2_supported");
-    PUSH_TYPE_INFO(MPI_INTEGER4, "mpi_integer4_supported");
-    PUSH_TYPE_INFO(MPI_INTEGER8, "mpi_integer8_supported");
-    PUSH_TYPE_INFO(MPI_INTEGER16, "mpi_integer16_supported");
-    /*
     PUSH_TYPE_INFO(MPI_LOGICAL1, "mpi_logical1_supported");
     PUSH_TYPE_INFO(MPI_LOGICAL2, "mpi_logical2_supported");
     PUSH_TYPE_INFO(MPI_LOGICAL4, "mpi_logical4_supported");
     PUSH_TYPE_INFO(MPI_LOGICAL8, "mpi_logical8_supported");
     PUSH_TYPE_INFO(MPI_LOGICAL16, "mpi_logical16_supported");
-    */
+    PUSH_TYPE_INFO(MPI_INTEGER1, "mpi_integer1_supported");
+    PUSH_TYPE_INFO(MPI_INTEGER2, "mpi_integer2_supported");
+    PUSH_TYPE_INFO(MPI_INTEGER4, "mpi_integer4_supported");
+    PUSH_TYPE_INFO(MPI_INTEGER8, "mpi_integer8_supported");
+    PUSH_TYPE_INFO(MPI_INTEGER16, "mpi_integer16_supported");
     PUSH_TYPE_INFO(MPI_REAL2, "mpi_real2_supported");
     PUSH_TYPE_INFO(MPI_REAL4, "mpi_real4_supported");
     PUSH_TYPE_INFO(MPI_REAL8, "mpi_real8_supported");
@@ -60,25 +51,51 @@ MPI_Abi_get_info:
     PUSH_TYPE_INFO(MPI_DOUBLE_COMPLEX, "mpi_double_complex_supported");
 #undef PUSH_TYPE_INFO
     *info = info_ptr->handle;
+#else
+    *info = MPI_INFO_NULL;
+#endif
+}
 
-  fn_fail:
-    return MPI_SUCCESS;
+MPI_Abi_get_info:
+    info: INFO, direction=out, [info object]
+    .desc: Return an info object that provides information related to the ABI
+    .seealso: MPI_Abi_get_version, MPI_Abi_get_fortran_info
+    .skip: initcheck
+{
+    MPIR_Info *info_ptr;
+    mpi_errno = MPIR_Info_alloc(&info_ptr);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    char str[8];
+#define PUSH_TYPE_INFO(type, keyname) \
+    do { \
+        snprintf(str, sizeof(str), "%d", (int) sizeof(type)); \
+        MPIR_Info_push(info_ptr, keyname, str); \
+    } while (0)
+    PUSH_TYPE_INFO(MPI_Aint, "mpi_aint_size");
+    PUSH_TYPE_INFO(MPI_Count, "mpi_count_size");
+    PUSH_TYPE_INFO(MPI_Offset, "mpi_offset_size");
+#undef PUSH_TYPE_INFO
+    *info = info_ptr->handle;
 }
 
 MPI_Abi_get_version:
     abi_major: VERSION, direction=out, [version number]
     abi_minor: VERSION, direction=out, [subversion number]
     .desc: Return the standard ABI version
-    .impl: direct
+    .seealso: MPI_Abi_get_info
+    .skip: initcheck
 {
     *abi_major = -1;
     *abi_minor = -1;
-    return MPI_SUCCESS;
+    if (mpi_errno != MPI_SUCCESS)
+        goto fn_fail;
 }
 { -- is_abi --
     *abi_major = MPI_ABI_VERSION;
     *abi_minor = MPI_ABI_SUBVERSION;
-    return MPI_SUCCESS;
+    if (mpi_errno != MPI_SUCCESS)
+        goto fn_fail;
 }
 
 

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -762,12 +762,14 @@ enum MPIR_Combiner_enum {
 
 #define MPI_ERR_ERRHANDLER         80  /* Invalid errhandler handle */
 
+#define MPI_ERR_ABI                81  /* Fortran ABI already set */
+
 #define MPI_ERR_LASTCODE    0x3fffffff  /* Last valid error code for a
 					   predefined error class */
 #endif /* BUILD_MPI_ABI */
 
 
-#define MPICH_ERR_LAST_CLASS 80     /* It is also helpful to know the
+#define MPICH_ERR_LAST_CLASS 81     /* It is also helpful to know the
 				       last valid class */
 #define MPICH_ERR_FIRST_MPIX 100 /* Define a gap here because sock is
                                   * already using some of the values in this

--- a/src/mpi/errhan/baseerrnames.txt
+++ b/src/mpi/errhan/baseerrnames.txt
@@ -87,3 +87,4 @@ MPI_ERR_SESSION      **session
 MPI_ERR_PROC_ABORTED **proc_aborted
 MPI_ERR_VALUE_TOO_LARGE **valuetoolarge
 MPI_ERR_ERRHANDLER   **errhandler
+MPI_ERR_ABI          **abi

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -908,6 +908,8 @@ is too big (> MPIU_SHMW_GHND_SZ)
 **notsuppmultithread:this functionality is not supported when the thread level is greater than MPI_THREAD_SINGLE
 **valuetoolarge:Value is too large to store
 
+**abi:Fortran ABI already set
+
 #
 # mpi functions
 #


### PR DESCRIPTION
## Pull Request Description

Minor update to `MPI_Abi_get_info` and addition of `MPI_Abi_get_fortran_info` and `MPI_ERR_ABI`.
This mpi4py [branch](https://github.com/mpi4py/mpi4py/tree/mpi5/abi-info) has some basic [tests](https://github.com/mpi4py/mpi4py/blob/mpi5/abi-info/test/test_mpiabi.py) for the new APIs.

The error class `MPI_ERR_ABI` is currently not used anywhere, it is only relevant to `MPI_Abi_set_fortran_info`, which is currently unimplemented. `MPI_Abi_set_fortran_info`, and the APIs to set Fortran true/false, are a bit more involved, as they should allow MPICH to effectively change the Fortran ABI to whatever the user asks, plus checking the request for nonsense/unsupported input. All that should be handled in another PR.

[Hui] Adding the text link for easy reference: https://github.com/mpi-forum/mpi-standard/blob/mpi-50-rc/chap-abi/abi.tex
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
