### PR TITLE
typerep: Call device commit hook when unflattening type

### DIFF
--- a/src/mpi/datatype/typerep/src/typerep_flatten.c
+++ b/src/mpi/datatype/typerep/src/typerep_flatten.c
@@ -132,6 +132,9 @@ int MPIR_Typerep_unflatten(MPIR_Datatype * datatype_ptr, void *flattened_type)
     MPIR_ERR_CHECK(mpi_errno);
 #endif
 
+    mpi_errno = MPID_Type_commit_hook(datatype_ptr);
+    MPIR_ERR_CHECK(mpi_errno);
+
   fn_exit:
     return mpi_errno;
 


### PR DESCRIPTION
## Pull Request Description

Unflattened types are considered "committed" and used in communication. When they are eventually freed, the device free hook will be invoked, so we need to make sure that the commit hook is invoked at creation time. Otherwise we may read uninitialized values during free. Issue was found using valgrind and the ch4:ucx device with PETSc CI tests.

Reported-by: Satish Balay <balay@mcs.anl.gov>

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
