### PR TITLE
romio: Add more hints to default list of hints

### DIFF
--- a/src/mpi/romio/adio/common/ad_hints.c
+++ b/src/mpi/romio/adio/common/ad_hints.c
@@ -124,6 +124,11 @@ void ADIOI_GEN_SetInfo(ADIO_File fd, MPI_Info users_info, int *error_code)
         /* still to do: tune this a bit for a variety of file systems. there's
          * no good default value so just leave it unset */
         fd->hints->min_fdomain_size = 0;
+        /* incorporate this hint into the default hints: otherwise,
+         * non-aggregators might have this hint set while aggregators opening a
+         * traditional unix or gpfs file might not, and the "check if all same"
+         * logic below won't work properly. */
+        ADIOI_Info_set(info, "striping_unit", "0");
         fd->hints->striping_unit = 0;
 
         /* temporally synchronizing flush: I think this is going to be a useful


### PR DESCRIPTION
in the deferred-open case some processes ended up with these hints set while others did not.  Possible for users to trigger a hang if they collect all the set hints and try to pass those  hints to ROMIO later.

I think we still need this even after pmodels/mpich#6408 and pmodels/mpich#6494 but haven't heard a lot of complaints about random hangs .   This patch is just an extra layer of protection at this point.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
