### PR TITLE
coll: improve alltoallv

### DIFF
--- a/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
@@ -24,16 +24,14 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
                                                    const MPI_Aint * rdispls, MPI_Datatype recvtype,
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
-    int comm_size, i, j;
-    MPI_Aint recv_extent;
     int mpi_errno = MPI_SUCCESS;
-    MPI_Status status;
-    int rank;
 
+    int comm_size, rank;
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;
 
     /* Get extent of recv type, but send type is only valid if (sendbuf!=MPI_IN_PLACE) */
+    MPI_Aint recv_extent;
     MPIR_Datatype_get_extent_macro(recvtype, recv_extent);
 
 #ifdef HAVE_ERROR_CHECKING
@@ -49,28 +47,27 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
      * time and there will be multiple repeated malloc/free's rather than
      * maintaining a single buffer across the whole loop.  Something like
      * MADRE is probably the best solution for the MPI_IN_PLACE scenario. */
-    for (i = 0; i < comm_size; ++i) {
-        /* start inner loop at i to avoid re-exchanging data */
-        for (j = i; j < comm_size; ++j) {
-            if (rank == i) {
-                /* also covers the (rank == i && rank == j) case */
-                mpi_errno = MPIC_Sendrecv_replace(((char *) recvbuf + rdispls[j] * recv_extent),
-                                                  recvcounts[j], recvtype,
-                                                  j, MPIR_ALLTOALLV_TAG,
-                                                  j, MPIR_ALLTOALLV_TAG,
-                                                  comm_ptr, &status, errflag);
-                MPIR_ERR_CHECK(mpi_errno);
 
-            } else if (rank == j) {
-                /* same as above with i/j args reversed */
-                mpi_errno = MPIC_Sendrecv_replace(((char *) recvbuf + rdispls[i] * recv_extent),
-                                                  recvcounts[i], recvtype,
-                                                  i, MPIR_ALLTOALLV_TAG,
-                                                  i, MPIR_ALLTOALLV_TAG,
-                                                  comm_ptr, &status, errflag);
-                MPIR_ERR_CHECK(mpi_errno);
-            }
-        }
+    MPIR_Assert(comm_ptr->intranode_table);
+    /* -- 1st exchange within intranode -- */
+    for (int i = 0; i < comm_size; ++i) {
+        if (comm_ptr->intranode_table[i] == -1)
+            continue;
+        mpi_errno = MPIC_Sendrecv_replace(((char *) recvbuf + rdispls[i] * recv_extent),
+                                          recvcounts[i], recvtype, i, MPIR_ALLTOALLV_TAG,
+                                          i, MPIR_ALLTOALLV_TAG,
+                                          comm_ptr, MPI_STATUS_IGNORE, errflag);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+    /* -- 2nd exchange over internode -- */
+    for (int i = 0; i < comm_size; ++i) {
+        if (comm_ptr->intranode_table[i] > -1)
+            continue;
+        mpi_errno = MPIC_Sendrecv_replace(((char *) recvbuf + rdispls[i] * recv_extent),
+                                          recvcounts[i], recvtype, i, MPIR_ALLTOALLV_TAG,
+                                          i, MPIR_ALLTOALLV_TAG,
+                                          comm_ptr, MPI_STATUS_IGNORE, errflag);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpid/ch4/src/ch4_progress.h
+++ b/src/mpid/ch4/src/ch4_progress.h
@@ -23,6 +23,19 @@ cvars:
       description : >-
         If on, poll global progress every once a while. With per-vci configuration, turning global progress off may improve the threading performance.
 
+    - name        : MPIR_CVAR_CH4_PROGRESS_THROTTLE
+      category    : CH4
+      type        : boolean
+      default     : 0
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        When running high PPN (high number of processes on a single node), keep polling progress may monopolize
+        the underlying atomic queue and preventing packets being enqueued. A work around is to hold back progress
+        polling. Setting MPIR_CVAR_CH4_PROGRESS_THROTTLE=true will throttle the progress polling by injecting
+        usleep(1) every once a while.
+
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
@@ -35,7 +48,8 @@ extern MPL_TLS int global_vci_poll_count;
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_do_global_progress(void)
 {
-    if (MPIDI_global.n_vcis == 1 || !MPIR_CVAR_CH4_GLOBAL_PROGRESS) {
+    if ((MPIDI_global.n_vcis == 1 || !MPIR_CVAR_CH4_GLOBAL_PROGRESS) &&
+        !MPIR_CVAR_CH4_PROGRESS_THROTTLE) {
         return 0;
     } else {
         global_vci_poll_count++;
@@ -132,6 +146,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_progress_test(MPID_Progress_state * state)
     if (!is_explicit_vci && MPIDI_do_global_progress()) {
         for (int vci = 0; vci < MPIDI_global.n_vcis; vci++) {
             MPIDI_PROGRESS(vci);
+        }
+        if (!made_progress && MPIR_CVAR_CH4_PROGRESS_THROTTLE) {
+            usleep(1);
         }
     } else {
         for (int i = 0; i < state->vci_count; i++) {


### PR DESCRIPTION
## Pull Request Description
* add `MPIR_CVAR_CH4_PROGRESS_THROTTLE`
* The naive linear pairing will hold the large ranks until lower ranks get
them. Rank N-1 will blocked at first exchange until Rank 0 near finish.

Slightly improve the algorithm, esp. for the high PPN case, do pair-wise
exhcanges within each node first. Then finish the rest naive pairing
over internode.

Also, the double loop then selecting rank seem to be a silly way of a
single loop.



TODO: fix the naive pairing order.
[skip warnings]
## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
