### PR TITLE
configure: use AC_LINK_IFELSE to check __fp16

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2890,8 +2890,12 @@ if test "$MPID_NO_INT128" != "yes" ; then
 fi
 
 if test "$MPID_NO_FLOAT16" != "yes" ; then
-    AC_CHECK_SIZEOF(_Float16)
-    AC_CHECK_SIZEOF(__fp16)
+    # some compilers (e.g. clang) can compile but not link come types.
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[_Float16 a = 0.1;]], [[return (int) a;]])],
+        [AC_CHECK_SIZEOF(_Float16)])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[__fp16 a = 0.1;]], [[return (int) a;]])],
+        [AC_CHECK_SIZEOF(__fp16)])
+
     if test "$ac_cv_sizeof__Float16" -eq 2 ; then
         AC_DEFINE_UNQUOTED([MPIR_FLOAT16_CTYPE],[_Float16], [The C type for MPIR_FLOAT16])
         AC_CHECK_ALIGNOF(_Float16)


### PR DESCRIPTION
## Pull Request Description
Clang can compile __fp16 even when it doesn't support it. When we try link, it will report:
```
    /usr/bin/ld: lib/.libs/libmpi.so: undefined reference to `__gnu_h2f_ieee'
```
Thus we need a deeper configure check.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
