### PR TITLE
test: reduce the stress in the manyrma2 test

### DIFF
--- a/test/mpi/rma/manyrma2.c
+++ b/test/mpi/rma/manyrma2.c
@@ -17,7 +17,7 @@
 
 #define MAX_COUNT 65536*4/16
 #define MAX_RMA_SIZE 2  /* 16 in manyrma performance test */
-#define MAX_RUNS 8
+#define MAX_RUNS 2
 #define MAX_ITER_TIME  5.0      /* seconds */
 
 typedef enum { SYNC_NONE = 0,


### PR DESCRIPTION
## Pull Request Description
The manyrma2 tests are often falsely triggered due to performance issue, especially for some configuration such as the `asan` tests. Lower the MAX_RUNS from 8 to 2 since our CI tests should focus on correctness. We'll focus on catching performance CI in the bench tests.


[skip warnings]

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
