### PR TITLE
mpir/pmi: Do not always assume singleton if PMIx_Init fails

### DIFF
--- a/maint/extracterrmsgs
+++ b/maint/extracterrmsgs
@@ -875,7 +875,7 @@ sub ExpandDir {
 	elsif (-d "$dir/$filename") {
 	    $otherdirs[$#otherdirs+1] = "$dir/$filename";
 	}
-	elsif ($filename =~ /(.*\.[chi])(pp){0,1}$/) {
+	elsif ($filename =~ /(.*\.([chi])(pp){0,1}|inc)$/) {
 	    # Test for both Unix- and Windows-style directory separators
 	    if (!defined($skipFiles{"$dir/$filename"}) &&
 		!defined($skipFiles{"$dir\\$filename"})) {

--- a/src/pmi/errnames.txt
+++ b/src/pmi/errnames.txt
@@ -95,6 +95,7 @@
 #
 **pmix_init:PMIX_Init failed
 **pmix_init %d:PMIX_Init returned %d
+**pmix_init %s:PMIx_Init failed %s
 **pmix_get:PMIx_Get failed
 **pmix_get %d:PMIx_Get returned %d
 **pmix_get %s:PMIx_Get returned %s

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -52,7 +52,14 @@ static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
     if (pmix_init_count == 1) {
         pmi_errno = PMIx_Init(&pmix_proc, NULL, 0);
         if (pmi_errno == PMIX_ERR_UNREACH) {
-            /* no pmi server, assume we are a singleton */
+            /* Failed to connect to server. Throw an error if an
+             * incompatible server is detected (e.g. hydra), otherwise
+             * proceed as a singleton. */
+            if (getenv("PMI_FD") || getenv("PMI_PORT") || getenv("PMI_HOSTNAME")) {
+                MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**pmix_init",
+                                     "**pmix_init %s",
+                                     "(launcher not compatible with PMIx client)");
+            }
             goto singleton_out;
         }
         MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,


### PR DESCRIPTION
## Pull Request Description

PMIx_Init may fail if an incompatible PMI server is used to launch MPI
processes. For instance, if MPICH is configured to use OpenPMIx but is
launched with Hydra. In that case we can return an error rather than
assuming all processes are singletons. See https://github.com/pmodels/mpich/issues/7064.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
