### PR TITLE
ch4: fix wrong initialization of MPIDI_global.n_reserved_vcis

### DIFF
--- a/src/binding/c/abi_api.txt
+++ b/src/binding/c/abi_api.txt
@@ -53,6 +53,7 @@ MPI_Abi_get_fortran_info:
     *info = info_ptr->handle;
 #else
     *info = MPI_INFO_NULL;
+    MPIR_ERR_CHECK(mpi_errno);
 #endif
 }
 

--- a/src/mpid/ch4/src/ch4_vci.c
+++ b/src/mpid/ch4/src/ch4_vci.c
@@ -121,7 +121,6 @@ int MPIDI_Comm_set_vcis(MPIR_Comm * comm, int num_vcis)
     /* update global vci settings */
     MPIDI_global.n_total_vcis = all_num_vcis[comm->rank];
     MPIDI_global.n_vcis = MPL_MIN(MPIR_CVAR_CH4_NUM_VCIS, MPIDI_global.n_total_vcis);
-    MPIDI_global.n_reserved_vcis = MPIDI_global.n_total_vcis - MPIDI_global.n_vcis;
     for (int i = 0; i < nprocs; i++) {
         MPIDI_global.all_num_vcis[granks[i]] = all_num_vcis[i];
     }


### PR DESCRIPTION
## Pull Request Description
MPIDI_global.n_reserved_vcis should be initialized to 0 and increment upon MPID_Allocate_vci.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
