### PR TITLE
mpl/ze: remove MPL_gpu_init_device_mappings

### DIFF
--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -73,9 +73,6 @@ int MPIDI_GPU_init_world(void)
     }
     MPIDU_Init_shm_barrier();
 
-    /* Initialize the local and global device mappings */
-    MPL_gpu_init_device_mappings(node_max_dev_id, node_max_subdev_id);
-
     MPIDI_GPUI_global.local_procs = MPIR_Process.node_local_map;
     MPIDI_GPUI_global.local_ranks =
         (int *) MPL_malloc(MPIR_Process.size * sizeof(int), MPL_MEM_SHM);

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -174,10 +174,7 @@ static int ipc_track_cache_remove(const void *addr)
         MPL_free(entry);
     }
 
-  fn_exit:
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 /* -- mapped_track_tree -- */
@@ -235,10 +232,7 @@ static int ipc_mapped_cache_insert(const void *remote_addr, int remote_rank, int
                  MPL_MEM_SHM);
     }
 
-  fn_exit:
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 static int ipc_mapped_cache_delete(const void *remote_addr, int remote_rank)

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -144,8 +144,6 @@ int MPL_gpu_get_dev_count(int *dev_cnt, int *dev_id, int *subdevice_id);
 int MPL_gpu_get_dev_list(int *dev_count, char ***dev_list, bool is_subdev);
 int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env);
 
-int MPL_gpu_init_device_mappings(int max_devid, int max_subdev_id);
-
 int MPL_gpu_fast_memcpy(void *src, MPL_pointer_attr_t * src_attr, void *dest,
                         MPL_pointer_attr_t * dest_attr, size_t size);
 

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -81,11 +81,6 @@ int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env)
     return ret;
 }
 
-int MPL_gpu_init_device_mappings(int max_devid, int max_subdev_id)
-{
-    return MPL_SUCCESS;
-}
-
 int MPL_gpu_query_pointer_attr(const void *ptr, MPL_pointer_attr_t * attr)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -26,11 +26,6 @@ int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env)
     return ret;
 }
 
-int MPL_gpu_init_device_mappings(int max_devid, int max_subdev_id)
-{
-    return MPL_SUCCESS;
-}
-
 int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
                               MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -74,11 +74,6 @@ int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env)
     return ret;
 }
 
-int MPL_gpu_init_device_mappings(int max_devid, int max_subdev_id)
-{
-    return MPL_SUCCESS;
-}
-
 #ifdef MPL_HIP_USE_MEMORYTYPE
 /* pre-ROCm 6.0 */
 #define DEVICE_ATTR_TYPE attr->device_attr.memoryType

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -278,6 +278,7 @@ static void MPL_event_pool_destroy(void);
 #ifdef ZE_PCI_PROPERTIES_EXT_NAME
 static int search_physical_devices(ze_pci_address_ext_t pci);
 #endif
+static int init_device_mappings(void);
 
 /* For zeMemFree callbacks */
 static gpu_free_hook_s *free_hook_chain = NULL;
@@ -413,7 +414,7 @@ int MPL_gpu_dev_affinity_to_env(int dev_count, char **dev_list, char **env)
     return ret;
 }
 
-int MPL_gpu_init_device_mappings(int dummy1, int dummy2)
+static int init_device_mappings(void)
 {
     int mpl_err = MPL_SUCCESS;
 
@@ -567,6 +568,10 @@ int MPL_gpu_init(int debug_summary)
         goto fn_fail;
 
     get_max_dev_id(&max_dev_id, &max_subdev_id);
+
+    mpl_err = init_device_mappings();
+    if (mpl_err != MPL_SUCCESS)
+        goto fn_fail;
 
     ipc_max_entries = MPL_malloc(local_ze_device_count * sizeof(int), MPL_MEM_OTHER);
     if (ipc_max_entries == NULL) {


### PR DESCRIPTION
## Pull Request Description
Let each process to use its own global_dev_count and global_subdev_count
due to visibility. Use a 2-byte scheme for global device id: hi-byte is
the root device id, lo-byte is 0 for root device, 1 for tile 0, 2 for
tile 1, and so on. This ensures consistency between ranks even when max
visible devices are different. The global_to_local_map are essentially
global_to_local_map[global_subdev_count][global_dev_count]. That is,
they are ordered by all root devices, then all tile 0 devices, then all
tile 1 devices.

Remove global_to_root_map since we can compare the hi-byte of global
device id directly.

Now that we eliminated the collective (allreduce to get max global
device id), we no longer need expose this function.


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
