### PR TITLE
datatype: set default datatype alignment

### DIFF
--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -154,6 +154,21 @@ int MPIR_Datatype_init_predefined(void)
     return mpi_errno;
 }
 
+#ifndef MPIR_INT128_ALIGN
+#define MPIR_INT128_ALIGN 16
+#endif
+#ifndef MPIR_FLOAT16_ALIGN
+#define MPIR_FLOAT16_ALIGN 2
+#endif
+#ifndef MPIR_FLOAT128_ALIGN
+#define MPIR_FLOAT128_ALIGN 16
+#endif
+#ifndef MPIR_ALT_FLOAT96_ALIGN
+#define MPIR_ALT_FLOAT96_ALIGN 4
+#endif
+#ifndef MPIR_ALT_FLOAT128_ALIGN
+#define MPIR_ALT_FLOAT128_ALIGN 16
+#endif
 int MPIR_Datatype_builtintype_alignment(MPI_Datatype type)
 {
     if (type == MPI_DATATYPE_NULL)
@@ -182,40 +197,30 @@ int MPIR_Datatype_builtintype_alignment(MPI_Datatype type)
         case MPIR_UINT64:
         case MPIR_FORTRAN_LOGICAL64:
             return MPIR_INT64_ALIGN;
-#ifdef MPIR_INT128_ALIGN
         case MPIR_FIXED128:
         case MPIR_INT128:
         case MPIR_UINT128:
         case MPIR_FORTRAN_LOGICAL128:
             return MPIR_INT128_ALIGN;
-#endif
-#ifdef MPIR_FLOAT16_ALIGN
         case MPIR_FLOAT16:
         case MPIR_COMPLEX16:
         case MPIR_BFLOAT16:
             return MPIR_FLOAT16_ALIGN;
-#endif
         case MPIR_FLOAT32:
         case MPIR_COMPLEX32:
             return MPIR_FLOAT32_ALIGN;
         case MPIR_FLOAT64:
         case MPIR_COMPLEX64:
             return MPIR_FLOAT64_ALIGN;
-#ifdef MPIR_FLOAT128_ALIGN
         case MPIR_FLOAT128:
         case MPIR_COMPLEX128:
             return MPIR_FLOAT128_ALIGN;
-#endif
-#ifdef MPIR_ALT_FLOAT96_ALIGN
         case MPIR_ALT_FLOAT96:
         case MPIR_ALT_COMPLEX96:
             return MPIR_ALT_FLOAT96_ALIGN;
-#endif
-#ifdef MPIR_ALT_FLOAT128_ALIGN
         case MPIR_ALT_COMPLEX128:
         case MPIR_ALT_FLOAT128:
             return MPIR_ALT_FLOAT128_ALIGN;
-#endif
         default:
             /* FIXME: throw error */
             MPIR_Assert(0);


### PR DESCRIPTION

## Pull Request Description
In case the compiler doesn't support certain types such as _Float16, we may still support it via emulation. Simply set a default alignment rather than resulting in a assertion failure. If the compiler doesn't support the type, users won't use the type in a struct anyway.

This fixes nightly mpi4py test failures on ch3 due to `MPI_Type_dup(MPIX_C_FLOAT16)`.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
