### PR TITLE
ch4/vci: allgather the number of both implicit and total vcis

### DIFF
--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -86,7 +86,7 @@ Non Native API:
       NM*: rank, comm, handler_id, tag, buf-2, count, datatype, src_vci, dst_vci, rreq
      SHM*: rank, comm, handler_id, tag, buf-2, count, datatype, src_vci, dst_vci, rreq
   comm_set_vcis : int
-      NM : comm, num_vcis, all_num_vcis
+      NM : comm, num_implicit, num_reserved, all_num_vcis
      SHM : comm, num_vcis
   get_local_upids : int
       NM : comm, local_upid_size, local_upids
@@ -485,7 +485,9 @@ PARAM:
     newcomm_ptr: MPIR_Comm **
     num_vcis: int
     num_vcis_actual: int *
-    all_num_vcis: int *
+    num_implicit: int
+    num_reserved: int
+    all_num_vcis: MPIDI_num_vci_t *
     op: MPI_Op
     op_p: MPIR_Op *
     origin_addr: const void *

--- a/src/mpid/ch4/include/mpidimpl.h
+++ b/src/mpid/ch4/include/mpidimpl.h
@@ -20,6 +20,6 @@
 
 int MPIDI_world_pre_init(void);
 int MPIDI_world_post_init(void);
-int MPIDI_Comm_set_vcis(MPIR_Comm * comm, int num_vcis);
+int MPIDI_Comm_set_vcis(MPIR_Comm * comm, int num_implicit, int num_reserved);
 
 #endif /* MPIDIMPL_H_INCLUDED */

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -636,6 +636,11 @@ typedef struct MPIDI_av_entry {
 #endif
 } MPIDI_av_entry_t;
 
+typedef struct MPIDI_num_vci {
+    int n_vcis;
+    int n_total_vcis;
+} MPIDI_num_vci_t;
+
 #define HAVE_DEV_COMM_HOOK
 
 int MPIDI_check_for_failed_procs(void);

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -181,12 +181,11 @@ int MPID_Comm_commit_post_hook(MPIR_Comm * comm)
      * TODO: expose MPIX_Comm_set_vcis to allow vcis for arbitrary comm
      */
     if (comm == MPIR_Process.comm_world) {
-        int n_total_vcis = MPIR_CVAR_CH4_NUM_VCIS + MPIR_CVAR_CH4_RESERVE_VCIS;
         /* we always need call set_vcis even when n_total_vcis is 1 because -
          * 1. in case netmod need support multi-nics.
          * 2. remote processes may have multiple vcis.
          */
-        mpi_errno = MPIDI_Comm_set_vcis(comm, n_total_vcis);
+        mpi_errno = MPIDI_Comm_set_vcis(comm, MPIR_CVAR_CH4_NUM_VCIS, MPIR_CVAR_CH4_RESERVE_VCIS);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpid/ch4/src/ch4_types.h
+++ b/src/mpid/ch4/src/ch4_types.h
@@ -291,7 +291,7 @@ typedef struct MPIDI_CH4_Global_t {
     int n_reserved_vcis;        /* num of reserved vcis */
     int n_total_vcis;           /* total num of vcis, must > n_vcis + n_reserved_vcis */
     bool share_reserved_vcis;   /* default false, skip locking for explicit vcis */
-    int *all_num_vcis;          /* allgathered n_vcis, needed for implicit hashing */
+    MPIDI_num_vci_t *all_num_vcis;      /* allgathered num vcis, MPIDI_num_vci_t is {n_vcis, n_total_vcis} */
     MPIDI_per_vci_t per_vci[MPIDI_CH4_MAX_VCIS];
 
     MPIDI_CH4_configurations_t settings;

--- a/src/mpid/ch4/src/ch4_vci.h
+++ b/src/mpid/ch4/src/ch4_vci.h
@@ -73,7 +73,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_hash_remote_vci(int raw_vci, MPIR_Comm * comm
     } else {
         int grank = MPIDIU_get_grank(rank, comm_ptr);
         MPIR_Assert(grank >= 0);
-        return raw_vci % MPIDI_global.all_num_vcis[grank];
+        return raw_vci % MPIDI_global.all_num_vcis[grank].n_vcis;
     }
 }
 


### PR DESCRIPTION

## Pull Request Description
We need remote number of total vcis to do address exchanges. We need remote number of implicit vcis to hash consistently, ref. MPIDI_hash_remote_vci.

This fixes the `test/mpi/impls/mpich/cuda/stream_allred` test. However, the bug can be trigger when we simply set `MPIR_CVAR_CH4_RESERVE_VCIS=1`. It result a hang due to hashing against total number of vcis for remote rank rather than hashing against the number of *implicit* vcis (`MPIDI_global.n_vcis`).

Also, it is triggering in the `stream_allred` test accidentally because the "subcomm" is not inheriting the `stream_comm` fields, resulting `comm->node_comm` and `comm->node_roots_comm` being hashed implicitly rather than explicitly. 

*TODO* - fix subcomm not inheriting stream_comm. One solution is make all subcomm communicate in the context of parent comm. That can obviate the need for subcomm inheriting most of the fields from its parent comm.


[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
