### PR TITLE
ch4/gpu: suppress bogus warning on memset

### DIFF
--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -224,7 +224,7 @@ static int ipc_mapped_cache_insert(const void *remote_addr, int remote_rank, int
         entry->mapped_addrs[device_id] = mapped_base_addr;
     } else {
         /* create and add new entry */
-        size_t entry_size = sizeof(struct MPIDI_GPUI_map_cache_entry) +
+        int entry_size = sizeof(struct MPIDI_GPUI_map_cache_entry) +
             (MPIDI_GPUI_global.local_device_count * sizeof(void *));
         entry = MPL_malloc(entry_size, MPL_MEM_OTHER);
         memset(entry, 0, entry_size);


### PR DESCRIPTION
## Pull Request Description
Somehow gcc thinks the "entry_size" can overflow and issues warning -
```
   __builtin_memset’ specified bound between 9223372036854775808 and
18446744073709551608 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
```
Use int instead of size_t suppresses the warning.

[skip warnings]



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
