### PR TITLE
confdb: add __int128 in get_c_int_type

### DIFF
--- a/confdb/aclocal_datatype.m4
+++ b/confdb/aclocal_datatype.m4
@@ -32,7 +32,7 @@ to_dec() {
 get_c_int_type() {
     len=$[]1
     pac_retval=
-    for c_type in char short int long "long_long" ; do
+    for c_type in char short int long "long_long" __int128 ; do
         eval ctypelen=\$"ac_cv_sizeof_$c_type"
         if test "$len" = "$ctypelen" -a "$ctypelen" -gt 0 ; then
             if test "$c_type" = "long_long" ; then

--- a/confdb/aclocal_datatype.m4
+++ b/confdb/aclocal_datatype.m4
@@ -2,32 +2,6 @@ dnl Utilities in shell functions - reduces size in configure script
 dnl These functions sets $pac_retval
 dnl
 AC_DEFUN([PAC_DATATYPE_UTILS], [
-# Take decimal and turn it into two hex digits
-to_hex() {
-    len=$[]1
-    if test -z $len ; then
-        pac_retval="00"
-    elif test $len -le 9 ; then
-        dnl avoid subshell for speed
-        pac_retval="0${len}"
-    elif test $len -eq 16 ; then
-        pac_retval="10"
-    elif test $len -eq 32 ; then
-        pac_retval="20"
-    else
-        dnl printf is portable enough
-        pac_retval=`printf "%02x" $len`
-    fi
-}
-
-# Convert hex values in the form of 0x######## to decimal for
-# datatype constants in Fortran.
-to_dec() {
-    orig_value=$[]1
-    dnl printf is portable enough
-    pac_retval=`printf "%d" $orig_value`
-}
-
 # return the C type matching integer of size
 get_c_int_type() {
     len=$[]1

--- a/configure.ac
+++ b/configure.ac
@@ -2831,7 +2831,7 @@ AS_IF([test "X$pac_cv_have_long_double" = "Xyes"],[
   AC_CHECK_TYPES([long double _Complex])
 ])
 
-dnl define shell functions e.g. to_hex, to_dec, get_c_int_type, get_c_float_type
+dnl define shell functions e.g. get_c_int_type, get_c_float_type, get_c_bool_type
 PAC_DATATYPE_UTILS()
 
 # Generate a hex version of the size of each type


### PR DESCRIPTION
## Pull Request Description
We use get_c_int_type in configure to match a basic C type to internal
types with a fixed type size. Add __128 to its match pool to enable
16-byte integers when compiler supports it.

After we switch to internal datatypes, external MPI builtin-types are
true constants and we no longer need to compute them in configure.
Remove unused function to_hex and to_dec

Fixes #7390
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
