### PR TITLE
ch4: use MPIR_pmi_allgather_group in address exchange

### DIFF
--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -45,6 +45,9 @@ typedef struct MPIR_PMI_KEYVAL {
     char *val;
 } MPIR_PMI_KEYVAL_t;
 
+#define MPIR_PMI_GROUP_WORLD      ((int *)0)
+#define MPIR_PMI_GROUP_SELF      ((int *)1)
+
 /* PMI init / finalize */
 int MPIR_pmi_init(void);
 void MPIR_pmi_finalize(void);
@@ -65,6 +68,8 @@ int MPIR_pmi_barrier(void);
 int MPIR_pmi_barrier_only(void);
 /* * barrier over local set. More efficient for PMIx. Same as MPIR_pmi_barrier for PMI1/2. */
 int MPIR_pmi_barrier_local(void);
+/* barrier over a group of processes. Supported with PMIx or PMI-1.2 */
+int MPIR_pmi_barrier_group(int *group, int count);
 /* * put, to global domain */
 int MPIR_pmi_kvs_put(const char *key, const char *val);
 /* * get. src in [0..size-1] or -1 for anysrc. val_size <= MPIR_pmi_max_val_size(). */
@@ -88,6 +93,14 @@ int MPIR_pmi_allgather(const void *sendbuf, int sendsize, void *recvbuf, int rec
  */
 int MPIR_pmi_allgather_shm(const void *sendbuf, int sendsize, void *shm_buf, int recvsize,
                            MPIR_PMI_DOMAIN domain);
+
+/* * allgather over a group of processes. Processes outside the group don't participate.
+ *   * recvsize <= MPIR_pmi_max_val_size().
+ *   * group is an array of process ids and count is the size of the array
+ *   * if count is 0, then group must be one of the special value PMI_GROUP_WORLD.
+ */
+int MPIR_pmi_allgather_group(const char *name, const void *sendbuf, int sendsize,
+                             void *recvbuf, int recvsize, int *group, int count);
 
 /* * bcast_local: all processes will participate.
  *   Each local leader bcast to each local proc (within a node).

--- a/src/mpid/ch4/netmod/ofi/init_addrxchg.c
+++ b/src/mpid/ch4/netmod/ofi/init_addrxchg.c
@@ -26,7 +26,7 @@ int MPIDI_OFI_comm_addr_exchange(MPIR_Comm * comm)
     MPIR_Assert(comm->attr & MPIR_COMM_ATTR__HIERARCHY);
 
     /* First, each get its own name */
-    char *addrname[FI_NAME_MAX];
+    char addrname[FI_NAME_MAX];
     size_t addrnamelen = FI_NAME_MAX;
     MPIDI_OFI_CALL(fi_getname((fid_t) MPIDI_OFI_global.ctx[0].ep, addrname, &addrnamelen), getname);
 
@@ -39,15 +39,16 @@ int MPIDI_OFI_comm_addr_exchange(MPIR_Comm * comm)
     }
 
     /* PMI allgather over node roots and av_insert to activate node_roots_comm */
+    char *roots_names = NULL;
     if (local_rank == 0) {
-        char *roots_names;
         MPIR_CHKLMEM_MALLOC(roots_names, external_size * addrnamelen);
+    }
 
-        MPIR_PMI_DOMAIN domain = MPIR_PMI_DOMAIN_NODE_ROOTS;
-        mpi_errno = MPIR_pmi_allgather(addrname, addrnamelen, roots_names, addrnamelen, domain);
-        MPIR_ERR_CHECK(mpi_errno);
+    mpi_errno = MPIDIU_bc_exchange_node_roots(comm, addrname, addrnamelen, roots_names);
+    MPIR_ERR_CHECK(mpi_errno);
 
-        /* insert av and activate node_roots_comm */
+    /* Node roots insert av and activate node_roots_comm */
+    if (local_rank == 0) {
         MPIR_Comm *node_roots_comm = MPIR_Comm_get_node_roots_comm(comm);
         for (int i = 0; i < external_size; i++) {
             MPIDI_av_entry_t *av = MPIDIU_comm_rank_to_av(node_roots_comm, i);
@@ -59,11 +60,6 @@ int MPIDI_OFI_comm_addr_exchange(MPIR_Comm * comm)
                 MPIR_Assert(MPIDI_OFI_AV_ADDR_ROOT(av) != FI_ADDR_NOTAVAIL);
             }
         }
-    } else {
-        /* just for the PMI_Barrier */
-        MPIR_PMI_DOMAIN domain = MPIR_PMI_DOMAIN_NODE_ROOTS;
-        mpi_errno = MPIR_pmi_allgather(addrname, addrnamelen, NULL, addrnamelen, domain);
-        MPIR_ERR_CHECK(mpi_errno);
     }
 
   all_addrexch:

--- a/src/mpid/ch4/src/ch4_proc.h
+++ b/src/mpid/ch4/src/ch4_proc.h
@@ -25,6 +25,8 @@ int MPIDIU_free_avt(int avtid);
 int MPIDIU_avt_init(void);
 int MPIDIU_avt_finalize(void);
 int MPIDIU_get_node_id(MPIR_Comm * comm, int rank, int *id_p);
+int MPIDIU_bc_exchange_node_roots(MPIR_Comm * comm, const char *addrname, int addrlen,
+                                  void *roots_names);
 
 #ifdef MPIDI_BUILD_CH4_UPID_HASH
 void MPIDIU_upidhash_add(const void *upid, int upid_len, MPIR_Lpid lpid);

--- a/src/pm/hydra/lib/hydra.h
+++ b/src/pm/hydra/lib/hydra.h
@@ -485,7 +485,7 @@ void HYDU_free_exec_list(struct HYD_exec *exec_list);
 HYD_status HYDU_create_proxy_list_singleton(struct HYD_node *node, int pgid,
                                             int *proxy_count_p, struct HYD_proxy **proxy_list_p);
 HYD_status HYDU_create_proxy_list(int count, struct HYD_exec *exec_list, struct HYD_node *node_list,
-                                  int pgid, int *rankmap,
+                                  int pgid, int *rankmap, int *min_node_id_p,
                                   int *proxy_count_p, struct HYD_proxy **proxy_list_p);
 HYD_status HYDU_correct_wdir(char **wdir);
 HYD_status HYDU_gen_rankmap(int process_count, struct HYD_node *node_list, int **rankmap);

--- a/src/pm/hydra/lib/hydra.h
+++ b/src/pm/hydra/lib/hydra.h
@@ -526,6 +526,23 @@ HYD_status HYDU_comma_list_to_env_list(char *str, struct HYD_env **env_list);
 HYD_status HYDU_create_process(char **client_arg, struct HYD_env *env_list,
                                int *in, int *out, int *err, int *pid, int idx);
 
+/* barrier */
+#define HYD_GROUP_ALL ((int *)0)
+
+struct HYD_barrier {
+    const char *name;           /* a string identifying process set. Support -
+                                 *   - WORLD, NODE, or
+                                 *   - 0,1,4,...   (CSV list of ranks)
+                                 */
+    int num_procs;
+    int barrier_count;
+
+    int *proc_list;             /* needed for sending "barrier_out". Accepts HYD_GROUP_ALL */
+    bool has_upstream;
+
+    UT_hash_handle hh;
+};
+
 /* others */
 int HYDU_dceil(int x, int y);
 HYD_status HYDU_add_to_node_list(const char *hostname, int num_procs, struct HYD_node **node_list);

--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -308,7 +308,7 @@ HYD_status HYDU_create_proxy_list_singleton(struct HYD_node *node, int pgid,
 }
 
 HYD_status HYDU_create_proxy_list(int count, struct HYD_exec *exec_list, struct HYD_node *node_list,
-                                  int pgid, int *rankmap,
+                                  int pgid, int *rankmap, int *min_node_id_p,
                                   int *proxy_count_p, struct HYD_proxy **proxy_list_p)
 {
     HYD_status status = HYD_SUCCESS;
@@ -382,6 +382,7 @@ HYD_status HYDU_create_proxy_list(int count, struct HYD_exec *exec_list, struct 
         }
     }
 
+    *min_node_id_p = min_node_id;
     *proxy_count_p = num_proxy;
     *proxy_list_p = MPL_malloc(num_proxy * sizeof(struct HYD_proxy), MPL_MEM_OTHER);
     HYDU_ASSERT(*proxy_list_p, status);

--- a/src/pm/hydra/mpiexec/hydra_server.h
+++ b/src/pm/hydra/mpiexec/hydra_server.h
@@ -26,11 +26,11 @@ struct HYD_pg {
     int proxy_count;
     int *rankmap;
     int pg_process_count;
-    int barrier_count;
     bool is_active;
-
     int spawner_pgid;
     int min_node_id;
+
+    struct HYD_barrier *barriers;
 
     /* user-specified node-list */
     struct HYD_node *user_node_list;

--- a/src/pm/hydra/mpiexec/hydra_server.h
+++ b/src/pm/hydra/mpiexec/hydra_server.h
@@ -30,6 +30,7 @@ struct HYD_pg {
     bool is_active;
 
     int spawner_pgid;
+    int min_node_id;
 
     /* user-specified node-list */
     struct HYD_node *user_node_list;

--- a/src/pm/hydra/mpiexec/mpiexec.c
+++ b/src/pm/hydra/mpiexec/mpiexec.c
@@ -177,6 +177,7 @@ int main(int argc, char **argv)
 
     if (HYD_server_info.is_singleton) {
         pg->pg_process_count = 1;
+        pg->min_node_id = 0;
 
         status = HYDU_gen_rankmap(1, HYD_server_info.node_list, &pg->rankmap);
         HYDU_ERR_POP(status, "error create rankmap\n");
@@ -217,7 +218,7 @@ int main(int argc, char **argv)
 
         status = HYDU_create_proxy_list(pg->pg_process_count, HYD_uii_mpx_exec_list,
                                         HYD_server_info.node_list, 0, pg->rankmap,
-                                        &pg->proxy_count, &pg->proxy_list);
+                                        &pg->min_node_id, &pg->proxy_count, &pg->proxy_list);
         HYDU_ERR_POP(status, "unable to create proxy list\n");
     }
 

--- a/src/pm/hydra/mpiexec/pmiserv_misc.c
+++ b/src/pm/hydra/mpiexec/pmiserv_misc.c
@@ -9,29 +9,123 @@
 #include "pmiserv_pmi.h"
 #include "pmiserv_utils.h"
 #include "bsci.h"
+#include "uthash.h"
+
+static struct HYD_barrier *barrier_group_create(struct HYD_pg *pg, const char *group)
+{
+    struct HYD_barrier *s;
+    s = MPL_malloc(sizeof(*s), MPL_MEM_OTHER);
+    if (!s) {
+        goto fn_exit;
+    }
+
+    s->name = MPL_strdup(group);
+    s->barrier_count = 0;
+    s->has_upstream = false;    /* not used */
+
+    if (strcmp(group, "WORLD") == 0) {
+        s->num_procs = pg->proxy_count;
+        s->proc_list = HYD_GROUP_ALL;
+    } else if (strcmp(group, "NODE") == 0) {
+        assert(0);
+    } else {
+        int *proxy_map = MPL_calloc(pg->proxy_count, sizeof(int), MPL_MEM_OTHER);
+        const char *str = group;
+        while (*str) {
+            int rank = atoi(str);
+            int proxy_id = pg->rankmap[rank] - pg->min_node_id;
+            proxy_map[proxy_id]++;
+            /* skip to next comma-separated id */
+            while (*str && *str != ',') {
+                str++;
+            }
+            if (*str == ',') {
+                str++;
+            }
+        }
+
+        /* populate barrier's proc_list (actually proxy list) */
+        s->proc_list = MPL_malloc(pg->proxy_count * sizeof(int), MPL_MEM_OTHER);
+        int num_proxy = 0;
+        for (int i = 0; i < pg->proxy_count; i++) {
+            if (proxy_map[i]) {
+                s->proc_list[num_proxy++] = i;
+            }
+        }
+        s->num_procs = num_proxy;
+    }
+
+  fn_exit:
+    return s;
+}
+
+static HYD_status barrier_group_finish(struct HYD_pg *pg, struct HYD_barrier *s,
+                                       int process_fd, struct PMIU_cmd *pmi)
+{
+    HYD_status status = HYD_SUCCESS;
+
+    /* barrier_out */
+    struct PMIU_cmd pmi_response;
+    PMIU_msg_set_response_barrier(pmi, &pmi_response, false /* is_static */ , s->name);
+
+    if (s->proc_list == HYD_GROUP_ALL) {
+        for (int i = 0; i < pg->proxy_count; i++) {
+            status = HYD_pmiserv_pmi_reply(&pg->proxy_list[i], process_fd, &pmi_response);
+            HYDU_ERR_POP(status, "error sending PMI response\n");
+        }
+    } else {
+        for (int i = 0; i < s->num_procs; i++) {
+            int j = s->proc_list[i];
+            status = HYD_pmiserv_pmi_reply(&pg->proxy_list[j], process_fd, &pmi_response);
+            HYDU_ERR_POP(status, "error sending PMI response\n");
+        }
+    }
+
+    HASH_DEL(pg->barriers, s);
+    MPL_free(s->name);
+    if (s->proc_list != HYD_GROUP_ALL) {
+        MPL_free(s->proc_list);
+    }
+    MPL_free(s);
+
+  fn_exit:
+    return status;
+  fn_fail:
+    goto fn_exit;
+}
+
 
 HYD_status HYD_pmiserv_barrier(struct HYD_proxy *proxy, int process_fd, int pgid,
                                struct PMIU_cmd *pmi)
 {
     HYD_status status = HYD_SUCCESS;
-
     HYDU_FUNC_ENTER();
+
+    const char *group;
+    int pmi_errno = PMIU_msg_get_query_barrier(pmi, &group);
+    HYDU_ASSERT(!pmi_errno, status);
+
+    if (!group) {
+        group = "WORLD";
+    }
 
     struct HYD_pg *pg;
     pg = PMISERV_pg_by_id(proxy->pgid);
 
-    pg->barrier_count++;
-    if (pg->barrier_count == pg->proxy_count) {
-        pg->barrier_count = 0;
+    struct HYD_barrier *s;
+    HASH_FIND_STR(pg->barriers, group, s);
+    if (!s) {
+        s = barrier_group_create(pg, group);
+        HYDU_ASSERT(s, status);
+        HASH_ADD_KEYPTR(hh, pg->barriers, s->name, strlen(s->name), s, MPL_MEM_OTHER);
+    }
 
+    s->barrier_count++;
+    if (s->barrier_count == s->num_procs) {
         HYD_pmiserv_bcast_keyvals(proxy, process_fd);
 
-        struct PMIU_cmd pmi_response;
-        PMIU_cmd_init_static(&pmi_response, 1, "barrier_out");
-        for (int i = 0; i < pg->proxy_count; i++) {
-            status = HYD_pmiserv_pmi_reply(&pg->proxy_list[i], process_fd, &pmi_response);
-            HYDU_ERR_POP(status, "error writing PMI line\n");
-        }
+        status = barrier_group_finish(pg, s, process_fd, pmi);
+        HYDU_ERR_POP(status, "error sending barrier_out to proxies\n");
     }
 
   fn_exit:

--- a/src/pm/hydra/mpiexec/pmiserv_spawn.c
+++ b/src/pm/hydra/mpiexec/pmiserv_spawn.c
@@ -257,7 +257,8 @@ static HYD_status do_spawn(void)
     HYDU_ERR_POP(status, "error create rankmap\n");
 
     status = HYDU_create_proxy_list(pg->pg_process_count, exec_list, node_list,
-                                    pg->pgid, pg->rankmap, &pg->proxy_count, &pg->proxy_list);
+                                    pg->pgid, pg->rankmap,
+                                    &pg->min_node_id, &pg->proxy_count, &pg->proxy_list);
     HYDU_ERR_POP(status, "error creating proxy list\n");
     HYDU_free_exec_list(exec_list);
 

--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -195,6 +195,12 @@ HYD_status HYD_pmcd_pmi_fill_in_exec_launch_info(struct HYD_pg *pg)
         mapping = NULL;
     }
 
+    /* FIXME: The following code is still assigning ranks according to round-robin PPN.
+     *        For now it works because we don't provide explicit rankmap option. The
+     *        rankmap is always generated from round-robin PPN. The code need be changed
+     *        if we ever offer user custom rankmap.
+     */
+
     total_core_count = 0;
     for (int i = 0; i < pg->proxy_count; i++) {
         total_core_count += pg->proxy_list[i].node->core_count;

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -139,6 +139,9 @@ HYD_status PMIP_foreach_pg_do(HYD_status(*callback) (struct pmip_pg * pg));
 HYD_status PMIP_pg_alloc_downstreams(struct pmip_pg *pg, int num_procs);
 struct pmip_pg *PMIP_find_pg(int pgid, int proxy_id);
 
+int PMIP_pg_local_to_global_id(struct pmip_pg *pg, int local_id);
+int PMIP_pg_global_to_local_id(struct pmip_pg *pg, int global_id);
+
 bool PMIP_pg_has_open_stdoe(struct pmip_pg *pg);
 
 int *PMIP_pg_get_pid_list(struct pmip_pg *pg);

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -107,7 +107,8 @@ struct pmip_pg {
      * server at barrier_in. */
     UT_array *kvs_batch;
 
-    /* for barrier_in */
+    /* for barrier_in. Use uthash to support group barriers */
+    struct HYD_barrier *barriers;
     int barrier_count;
 
     /* environment */

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -566,7 +566,6 @@ static HYD_status singleton_init(struct pmip_pg *pg, int singleton_pid, int sing
 static HYD_status launch_procs(struct pmip_pg *pg);
 static void init_pg_params(struct pmip_pg *pg);
 static HYD_status verify_pg_params(struct pmip_pg *pg);
-static int local_to_global_id(struct pmip_pg *pg, int local_id);
 
 static HYD_status handle_launch_procs(struct pmip_pg *pg)
 {
@@ -771,7 +770,7 @@ static HYD_status launch_procs(struct pmip_pg *pg)
          * PORT. */
         p->pmi_fd = HYD_FD_UNSET;
         p->pmi_fd_active = 0;
-        p->pmi_rank = local_to_global_id(pg, i);
+        p->pmi_rank = PMIP_pg_local_to_global_id(pg, i);
     }
 
     if (HYD_pmcd_pmip.user_global.pmi_port) {
@@ -1091,21 +1090,4 @@ static HYD_status verify_pg_params(struct pmip_pg *pg)
     return status;
   fn_fail:
     goto fn_exit;
-}
-
-static int local_to_global_id(struct pmip_pg *pg, int local_id)
-{
-    int rem1, rem2, layer, ret;
-
-    if (local_id < pg->global_core_map.local_filler)
-        ret = pg->pmi_id_map.filler_start + local_id;
-    else {
-        rem1 = local_id - pg->global_core_map.local_filler;
-        layer = rem1 / pg->global_core_map.local_count;
-        rem2 = rem1 - (layer * pg->global_core_map.local_count);
-
-        ret = pg->pmi_id_map.non_filler_start + (layer * pg->global_core_map.global_count) + rem2;
-    }
-
-    return ret;
 }

--- a/src/pm/hydra/proxy/pmip_pg.c
+++ b/src/pm/hydra/proxy/pmip_pg.c
@@ -69,6 +69,7 @@ struct pmip_pg *PMIP_new_pg(int pgid, int proxy_id)
     }
 
     pg->kvs = NULL;
+    pg->barriers = NULL;
 
     static UT_icd my_icd = { sizeof(char *), NULL, NULL, NULL };
     utarray_new(pg->kvs_batch, &my_icd, MPL_MEM_OTHER);

--- a/src/pm/hydra/proxy/pmip_pmi.c
+++ b/src/pm/hydra/proxy/pmip_pmi.c
@@ -215,8 +215,8 @@ HYD_status fn_init(struct pmip_downstream *p, struct PMIU_cmd *pmi)
     HYDU_ASSERT(!pmi_errno, status);
 
     struct PMIU_cmd pmi_response;
-    if (pmi_version == 1 && pmi_subversion <= 1) {
-        pmi_errno = PMIU_msg_set_response_init(pmi, &pmi_response, is_static, 1, 1);
+    if (pmi_version == 1 && pmi_subversion <= 2) {
+        pmi_errno = PMIU_msg_set_response_init(pmi, &pmi_response, is_static, 1, 2);
         HYDU_ASSERT(!pmi_errno, status);
     } else if (pmi_version == 2 && pmi_subversion == 0) {
         pmi_errno = PMIU_msg_set_response_init(pmi, &pmi_response, is_static, 2, 0);

--- a/src/pmi/errnames.txt
+++ b/src/pmi/errnames.txt
@@ -17,6 +17,8 @@
 **pmi_get_id %d:PMI_Get_id returned %d
 **pmi_barrier:PMI_Barrier failed
 **pmi_barrier %d:PMI_Barrier returned %d
+**pmi_barrier_group:PMI_Barrier_group failed
+**pmi_barrier_group %d:PMI_Barrier_group returned %d
 **pmi_kvs_get_my_name:PMI_KVS_Get_my_name failed
 **pmi_kvs_get_my_name %d:PMI_KVS_Get_my_name returned %d
 **pmi_kvs_get_name_length_max:PMI_KVS_Get_name_length_max failed
@@ -90,6 +92,8 @@
 **pmi_port %s: Unable to decide hostport from \"%s\"
 **pmi2_info_getjobattr: PMI2_Info_GetJobAttr failed
 **pmi2_info_getjobattr %d: PMI2_Info_GetJobAttr returned %d
+**pmi2_unsupport: PMI2 does not support this method
+**pmi2_unsupport %s: PMI2 does not support %s
 #
 # PMIx
 #

--- a/src/pmi/examples/barrier_group.c
+++ b/src/pmi/examples/barrier_group.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "pmi.h"
+
+/* example using PMI_Barrier_group from PMI 1.2 */
+
+int main(int argc, char **argv)
+{
+    char kvsname[1024];
+    int has_parent, rank, size;
+
+    PMI_Init(&has_parent);
+    PMI_Get_rank(&rank);
+    PMI_Get_size(&size);
+    if (size < 2) {
+        if (rank == 0) {
+            printf("Run this example with more than 2 processes.\n");
+        }
+    }
+
+    if (PMI_Barrier_group(PMI_GROUP_SELF, 0) != PMI_SUCCESS) {
+        if (rank == 0) {
+            printf("PMI_Barrier_group not supported by PMI server!\n");
+        }
+        goto fn_exit;
+    }
+
+    PMI_KVS_Get_my_name(kvsname, 1024);
+
+#define KEY_NAME "key0"
+#define KEY_VAL  "got-key0"
+    if (rank == 0) {
+        /* NOTE: PMI-v1 does not allow space in both key and value */
+        PMI_KVS_Put(kvsname, KEY_NAME, KEY_VAL);
+    }
+
+    if (rank == 0 || rank == 1) {
+        int procs[2] = { 0, 1 };
+        PMI_Barrier_group(procs, 2);
+    }
+
+    if (rank == 1) {
+        char buf[100];
+        PMI_KVS_Get(kvsname, KEY_NAME, buf, 100);
+        if (strcmp(buf, KEY_VAL) == 0) {
+            printf("No Errors\n");
+        } else {
+            printf("Test failed!\n");
+        }
+    }
+
+  fn_exit:
+    PMI_Finalize();
+    return 0;
+}

--- a/src/pmi/include/pmi.h
+++ b/src/pmi/include/pmi.h
@@ -7,7 +7,7 @@
 #define PMI_H_INCLUDED
 
 #define PMI_VERSION    1
-#define PMI_SUBVERSION 1
+#define PMI_SUBVERSION 2
 
 #define PMI_MAX_PORT_NAME 1024
 
@@ -57,6 +57,10 @@ D*/
 #define PMI_ERR_INVALID_NUM_PARSED  11
 #define PMI_ERR_INVALID_KEYVALP     12
 #define PMI_ERR_INVALID_SIZE        13
+
+#define PMI_GROUP_WORLD      ((int *)0)
+#define PMI_GROUP_SELF       ((int *)1)
+#define PMI_GROUP_NODE       ((int *)2)
 
 /* PMI Group functions */
 
@@ -240,6 +244,27 @@ have called 'PMI_Barrier()'. 'PMI_Barrier' automatically applies 'PMI_KVS_Commit
 
 @*/
     int PMI_Barrier(void);
+
+/*@
+PMI_Barrier_group - barrier across a subset of process group
+
+Return values:
++ PMI_SUCCESS - barrier successfully finished
+- PMI_FAIL - barrier failed
+
+Notes:
+This function is a collective call across all processes in the subset
+of process group specified by the function parameters. The parameters are
+an integer array of process world ranks and a count of the number of
+processes in the group. Special constants, including PMI_GROUP_WORLD,
+PMI_GROUP_NODE, can be used to represent commonly used special groups.
+When such constants are used, the count parameter is ignored.
+
+This function will not return until all the processes in the group have
+called. Upon return, previous KVS keys via PMI_Put will be available for
+subsequent PMI_Get for the processes within the group.
+@*/
+    int PMI_Barrier_group(const int *group, int count);
 
 /*@
 PMI_Abort - abort the process group associated with this process

--- a/src/pmi/maint/gen_pmi_msg.py
+++ b/src/pmi/maint/gen_pmi_msg.py
@@ -22,7 +22,7 @@ class RE:
 
 def main():
     # run from pmi top_srcdir
-    load_pmi_txt("maint/pmi-1.1.txt", "1.1")
+    load_pmi_txt("maint/pmi-1.2.txt", "1.2")
     load_pmi_txt("maint/pmi-2.0.txt", "2.0")
 
     dump_all()

--- a/src/pmi/maint/gen_pmi_msg.py
+++ b/src/pmi/maint/gen_pmi_msg.py
@@ -179,6 +179,22 @@ def dump_all():
                 print(t_if + " (pmi->version == %s) {" % ver, file=Out)
 
         def dump_attrs(spaces, is_set, is_query, attrs, attrs0):
+            def check_not_dflt(var, kind, dflt):
+                if kind == "int":
+                    return "%s != %s" % (var, dflt)
+                elif kind == "bool":
+                    if dflt == "true":
+                        return "!" + var
+                    else:
+                        return var
+                elif kind == "str":
+                    if dflt == "NULL":
+                        return var
+                    else:
+                        return "strcmp(%s, %s) == 0" % (var, dflt)
+                else:
+                    raise Exception("unexpected")
+
             non_optional = 0
             for i in range(len(attrs)):
                 a = attrs[i]
@@ -197,11 +213,21 @@ def dump_all():
                 else:
                     raise Exception("Unhandled kind: " + a[1])
 
+                dflt = None
+                if RE.match(r'.*optional=(\S+)', a[2]):
+                    dflt = RE.m.group(1)
+
                 if is_set:
+                    indent=spaces
+                    if dflt is not None:
+                        print(spaces + "if (%s) {" % check_not_dflt(var, kind, dflt), file=Out)
+                        indent += "    "
                     pmiu = "PMIU_cmd_add_" + kind
-                    print(spaces + "%s(%s, \"%s\", %s);" % (pmiu, pmi, a[0], var), file=Out)
+                    print(indent + "%s(%s, \"%s\", %s);" % (pmiu, pmi, a[0], var), file=Out)
+                    if dflt is not None:
+                        print(spaces + "}", file=Out)
                 else:
-                    if RE.match(r'.*optional=(\S+)', a[2]):
+                    if dflt is not None:
                         dflt = RE.m.group(1)
                         pmiu = "PMIU_CMD_GET_%sVAL_WITH_DEFAULT" % kind.upper()
                         print(spaces + "%s(pmi, \"%s\", *%s, %s);" % (pmiu, a[0], var, dflt), file=Out)

--- a/src/pmi/maint/pmi-1.2.txt
+++ b/src/pmi/maint/pmi-1.2.txt
@@ -1,0 +1,157 @@
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+#
+# PMI version 1.2 message protocol
+#
+# FORMAT:
+#     [Refer to the "INIT" message exchange below]
+#
+#     Each message exchange has a capitalized name, e.g. INIT. It is used to
+#     track Compatibilities between PMI versions. The exchange consists of a
+#     client query and a server reply. Each query or reply contains zero or
+#     more attributes. For example, INIT using PMI-1 wire protocol, client
+#     send query:
+#         cmd=init pmi_version=1 pmi_subversion=1
+#     , and the server reply:
+#         cmd=response_to_init version=1 pmi_subversion=1
+#          
+#     Each attribute specifies a type and zero or more annotations indicating
+#     e.g. when it is optional and the default value when it is missing. All
+#     optional attributes should be listed after any mandatory attributes.
+#
+#     The query or reply may also require specific wire protocol. For example,
+#     "Q: spawn, wire=v1-mcmd" indicate the query should be in the "v1-mcmd"
+#     wire format.
+#
+#     The server reply may include an "rc: INTEGER" and "msg: STRING"
+#     attributes to indicate an error. When a non-zero rc is returned, the
+#     normal attributes may not be included.
+#
+# Default wire protocol: v1
+#
+
+
+INIT:
+    Q: init
+        pmi_version: INTEGER
+        pmi_subversion: INTEGER
+    R: response_to_init
+        pmi_version: INTEGER
+        pmi_subversion: INTEGER
+
+FULLINIT:
+    Q: initack
+        pmiid: INTEGER
+    R: initack, wire=v1-initack
+        rank: INTEGER
+        size: INTEGER
+        appnum: INTEGER, optional=-1
+        spawner-jobid: STRING, optional=NULL
+        debug: INTEGER
+
+FINALIZE:
+    Q: finalize
+    R: finalize_ack
+
+ABORT:
+    Q: abort
+        exitcode: INTEGER, optional=1
+        message: STRING, optional=NULL
+
+MAXES:
+    Q: get_maxes
+    R: maxes
+        kvsname_max: INTEGER
+        keylen_max: INTEGER
+        vallen_max: INTEGER
+
+UNIVERSE:
+    Q: get_universe_size
+    R: universe_size
+        size: INTEGER
+
+APPNUM:
+    Q: get_appnum
+    R: appnum
+        appnum: INTEGER
+
+KVSNAME:
+    Q: get_my_kvsname
+    R: my_kvsname
+        kvsname: STRING
+
+PUT:
+    Q: put
+        kvsname: STRING, optional=NULL
+        key: STRING
+        value: STRING
+    R: put_result
+
+GET:
+    Q: get
+        kvsname: STRING, optional=NULL
+        key: STRING
+    R: get_result
+        found: BOOLEAN, optional=true
+        value: STRING
+
+BARRIER:
+    Q: barrier_in
+        group: STRING, optional=NULL
+    R: barrier_out
+        group: STRING, optional=NULL
+
+PUBLISH:
+    Q: publish_name
+        service: STRING
+        port: STRING
+    R: publish_result
+
+UNPUBLISH:
+    Q: unpublish_name
+        service: STRING
+    R: unpublish_result
+
+LOOKUP:
+    Q: lookup_name
+        service: STRING
+    R: lookup_result
+        port: STRING
+
+SPAWN:
+    Q: spawn, wire=v1-mcmd
+        totspawns: INTEGER
+        preput_num: INTEGER, optional=0
+        preput_key_#: STRING, count=preput_num, base=0
+        preput_val_#: STRING, count=preput_num, base=0
+        [
+        execname: STRING
+        nprocs: INTEGER
+        argcnt: INTEGER
+        infonum: INTEGER, optional=0
+        arg#: STRING, count=argcnt, base=1
+        info_key_#: STRING, count=infonum, base=0
+        info_val_#: STRING, count=infonum, base=0
+        ]
+    R: spawn_result
+
+SINGINIT:
+    Q: singinit
+        pmi_version: INTEGER
+        pmi_subversion: INTEGER
+        stdio: STRING, optional="yes"
+        authtype: STRING, optional="none"
+    R: singinit_info
+        versionok: STRING
+        stdio: STRING, optional="yes"
+        kvsname: STRING
+
+# server to proxy query
+MPUT:
+    Q: mput
+KVSCACHE:
+    Q: keyval_cache
+BARRIEROUT:
+    Q: barrier_out

--- a/src/pmi/src/pmi_v1.c
+++ b/src/pmi/src/pmi_v1.c
@@ -722,7 +722,11 @@ static int PMII_init(int *server_version_p, int *server_subversion_p)
     int pmi_errno = PMI_SUCCESS;
 
     struct PMIU_cmd pmicmd;
-    PMIU_msg_set_query_init(&pmicmd, USE_WIRE_VER, no_static, PMI_VERSION, PMI_SUBVERSION);
+    /* use version 1.1 for backward compatibility. Server should reply higher subversion
+     * if it supports extensions. Client should check server versions for graceful fallback
+     * on 1.2 and later features.
+     */
+    PMIU_msg_set_query_init(&pmicmd, USE_WIRE_VER, no_static, 1, 1);
 
     pmi_errno = PMIU_cmd_get_response(PMI_fd, &pmicmd);
     PMIU_ERR_POP(pmi_errno);

--- a/src/util/mpir_pmi1.inc
+++ b/src/util/mpir_pmi1.inc
@@ -129,6 +129,24 @@ static int pmi1_barrier_local(void)
     return pmi1_barrier();
 }
 
+static int pmi1_barrier_group(int *group, int count)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    MPL_COMPILE_TIME_ASSERT(MPIR_PMI_GROUP_WORLD == PMI_GROUP_WORLD);
+    MPL_COMPILE_TIME_ASSERT(MPIR_PMI_GROUP_SELF == PMI_GROUP_SELF);
+
+    pmi_errno = PMI_Barrier_group(group, count);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                         "**pmi_barrier_group", "**pmi_barrier_group %d", pmi_errno);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 static int pmi1_optimized_put(const char *key, const char *val, int is_local)
 {
     return pmi1_put(key, val);
@@ -305,6 +323,11 @@ static int pmi1_barrier(void)
 }
 
 static int pmi1_barrier_local(void)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi1_barrier_group(int *group, int count)
 {
     return MPI_ERR_INTERN;
 }

--- a/src/util/mpir_pmi2.inc
+++ b/src/util/mpir_pmi2.inc
@@ -122,6 +122,16 @@ static int pmi2_barrier_local(void)
     return pmi2_barrier();
 }
 
+static int pmi2_barrier_group(int *group, int count)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_ERR_SET1(mpi_errno, MPI_ERR_INTERN, "**pmi2_unsupport",
+                  "**pmi2_unsupport %s", "PMI_Barrier_group");
+
+    return mpi_errno;
+}
+
 static int pmi2_optimized_put(const char *key, const char *val, int is_local)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -338,6 +348,11 @@ static int pmi2_barrier(void)
 }
 
 static int pmi2_barrier_local(void)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmi2_barrier_group(int *group, int count)
 {
     return MPI_ERR_INTERN;
 }

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -327,6 +327,40 @@ static int pmix_barrier_local(void)
     goto fn_exit;
 }
 
+static int pmix_barrier_group(int *group, int count)
+{
+    int mpi_errno = MPI_SUCCESS;
+    int pmi_errno;
+
+    if (group == MPIR_PMI_GROUP_SELF) {
+        /* noop */
+        goto fn_exit;
+    }
+
+    pmix_proc_t *procs = NULL;
+    PMIX_PROC_CREATE(procs, count);
+    for (int i = 0; i < count; i++) {
+        PMIX_LOAD_PROCID(&(procs[i]), pmix_proc.nspace, group[i]);
+    }
+
+    pmix_info_t *info;
+    int flag = 1;
+    PMIX_INFO_CREATE(info, 1);
+    PMIx_Info_load(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
+
+    pmi_errno = PMIx_Fence(procs, count, info, 1);
+    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**pmix_fence",
+                         "**pmix_fence %d", pmi_errno);
+
+    PMIX_INFO_FREE(info, 1);
+    PMIX_PROC_FREE(procs, count);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 static int pmix_optimized_put(const char *key, const char *val, int is_local)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -984,6 +1018,11 @@ static int pmix_barrier_only(void)
 }
 
 static int pmix_barrier_local(void)
+{
+    return MPI_ERR_INTERN;
+}
+
+static int pmix_barrier_group(int *group, int count)
 {
     return MPI_ERR_INTERN;
 }


### PR DESCRIPTION
## Pull Request Description
True session requires address exchange within a group of processes. This PR supports it by -
* Add `PMI_Barrier_group` to PMI-1.2 API
* Support PMI-1.2 in hydra
* Add `MPIR_pmi_allgather_group`
    * PMI-1 uses `PMI_Barrier_group`
    * PMIx supports it with PMIx_Fence over an explicit set of procs
    * PMI-2 results in error
* Add `MPIDIU_bc_exchange_node_roots` to avoid duplicate code in each netmod
* Support group level address exchange in OFI and UCX

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
