### PR TITLE
mpir/pmix: fix PMIX_PREFIX info key

### DIFF
--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -25,11 +25,11 @@ static int pmix_add_to_info(MPIR_Info * info_ptr, const char *key, const char *p
                             MPIR_Info * target_ptr, int *key_found, size_t * counter, char **value);
 static int mpi_to_pmix_keyvals(MPIR_Info * info_ptr, int ninfo, pmix_info_t ** pmix_info);
 static int pmix_build_job_info(MPIR_Info * info_ptr, pmix_info_t ** pmix_job_info,
-                               size_t * njob_info, char **path);
+                               size_t * njob_info);
 static int pmix_build_app_info(MPIR_Info * info_ptr, pmix_info_t ** pmix_app_info,
                                size_t * napp_info);
 static int pmix_build_app_env(MPIR_Info * info_ptr, char ***env);
-static int pmix_build_app_cmd(char *path, char *command, char **app_cmd);
+static int pmix_build_app_cmd(MPIR_Info * info_ptr, char *command, char **app_cmd);
 static int pmix_prep_spawn(int count, char *commands[], char **argvs[], const int maxprocs[],
                            MPIR_Info * info_ptrs[], pmix_app_t * apps, pmix_info_t ** job_info,
                            size_t * njob_info);
@@ -677,8 +677,7 @@ int mpi_to_pmix_keyvals(MPIR_Info * info_ptr, int ninfo, pmix_info_t ** pmix_inf
 }
 
 static
-int pmix_build_job_info(MPIR_Info * info_ptr, pmix_info_t ** pmix_job_info, size_t * njob_info,
-                        char **path)
+int pmix_build_job_info(MPIR_Info * info_ptr, pmix_info_t ** pmix_job_info, size_t * njob_info)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Info *mpi_job_info;
@@ -689,10 +688,6 @@ int pmix_build_job_info(MPIR_Info * info_ptr, pmix_info_t ** pmix_job_info, size
     }
 
     mpi_errno = MPIR_Info_alloc(&mpi_job_info);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    /* path - standard key */
-    mpi_errno = pmix_add_to_info(info_ptr, "path", PMIX_PREFIX, mpi_job_info, NULL, &ninfo, path);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* FIXME: There is currently no mapping of the standard key `soft` to a
@@ -748,7 +743,7 @@ int pmix_build_app_info(MPIR_Info * info_ptr, pmix_info_t ** pmix_app_info, size
          * we should add the keys here */
     }
 
-    /* If no info provided where to look for executable, assume current working dir */
+    /* If no info provided for working directory of spawned processes, assume current working dir */
     if (!have_wdir) {
         char cwd[MAXPATHLEN];
         if (NULL == getcwd(cwd, MAXPATHLEN)) {
@@ -810,20 +805,34 @@ int pmix_build_app_env(MPIR_Info * info_ptr, char ***env)
 }
 
 static
-int pmix_build_app_cmd(char *path, char *command, char **app_cmd)
+int pmix_build_app_cmd(MPIR_Info * info_ptr, char *command, char **app_cmd)
 {
+    int mpi_errno = MPI_SUCCESS;
+    int has_path = 0;
+    char path[MPI_MAX_INFO_VAL];
+
+    /* Check if user provided standard key "path" */
+    if (info_ptr != NULL) {
+        mpi_errno = MPIR_Info_get_impl(info_ptr, "path", MPI_MAX_INFO_VAL, path, &has_path);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
     /* Either: User specified a path where to find the executable,
      * we have to include this path in addition to command.
      *
      * Or: No path specified by user, use command */
-    if (path) {
+    if (has_path) {
         int cmdlen = strlen(path) + strlen(command) + 1 + 1;    /* +1 for '/' and +1 for null terminator */
         *app_cmd = MPL_malloc(cmdlen, MPL_MEM_OTHER);
         snprintf(*app_cmd, cmdlen, "%s/%s", path, command);
     } else {
         *app_cmd = MPL_strdup(command);
     }
-    return MPI_SUCCESS;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 static
@@ -848,7 +857,7 @@ int pmix_prep_spawn(int count, char *commands[], char **argvs[], const int maxpr
         if ((info_ptrs != NULL) && (info_ptrs[i] != NULL)) {
             /* Build the job info based on the info provided to the first app */
             if (i == 0) {
-                mpi_errno = pmix_build_job_info(info_ptrs[i], job_info, njob_info, &path);
+                mpi_errno = pmix_build_job_info(info_ptrs[i], job_info, njob_info);
                 MPIR_ERR_CHECK(mpi_errno);
             }
 
@@ -862,7 +871,7 @@ int pmix_prep_spawn(int count, char *commands[], char **argvs[], const int maxpr
         }
 
         /* Build app cmd */
-        mpi_errno = pmix_build_app_cmd(path, commands[i], &(apps[i].cmd));
+        mpi_errno = pmix_build_app_cmd(info_ptrs[i], commands[i], &(apps[i].cmd));
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/test/mpi/maint/jenkins/xfail.conf
+++ b/test/mpi/maint/jenkins/xfail.conf
@@ -104,11 +104,6 @@ mpich-.*-arm.* * * * * /^reduce 10/           xfail=ticket0       coll/testlist.
 * * pmix ch3:.* *       /^darray_pack 72/       xfail=ticket0       datatype/testlist
 
 # myterious issues after upgrading to pmix-5.0.5
-* * pmix * *            /^spawninfo1/           xfail=issue7395         spawn/testlist
-* * pmix * *            /^spawnminfo1/          xfail=issue7395         spawn/testlist
-* * pmix * *            /^spaconacc/            xfail=issue7395         spawn/testlist
-* * pmix * *            /^spaconacc2/           xfail=issue7395         spawn/testlist
-* * pmix * *            /^disconnect_reconnect2/  xfail=issue7395       spawn/testlist
 * * pmix * *            /^session_re_init/      xfail=issue7396         session/testlist
 
 # MPI_Abort a sub group is not fully working


### PR DESCRIPTION
## Pull Request Description
PMIx client need to remove PMIX_PREFIX info key or the server may
complain on inconsistent number of info items, e.g. return
PMIX_ERR_EMPTY. This is fixed in OpenPMIx 5.0.7. But in-between the
upgrade, we need this patch to omit setting PMIX_PREFIX key.

Thanks Sonja Happ for the fix!

Fixes #7395 
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
