### PR TITLE
hydra/mpiexec: fix segfaults when no executable provided

### DIFF
--- a/src/pm/hydra/mpiexec/mpiexec.c
+++ b/src/pm/hydra/mpiexec/mpiexec.c
@@ -44,11 +44,6 @@ int main(int argc, char **argv)
 
     PMISERV_pg_init();
 
-    if (argc == 1) {
-        HYDU_ERR_SETANDJUMP(status, HYD_INVALID_PARAM,
-                            "No executable provided. Try -h for usages.\n");
-    }
-
     /* Get user preferences */
     status = HYD_uii_mpx_get_parameters(argv);
     HYDU_ERR_POP(status, "error parsing parameters\n");
@@ -59,6 +54,11 @@ int main(int argc, char **argv)
             HYDU_ERR_SETANDJUMP(status, HYD_INVALID_PARAM,
                                 "Missing executable. Try -h for usages.\n");
         }
+    }
+
+    if (!HYD_uii_mpx_exec_list) {
+        HYDU_ERR_SETANDJUMP(status, HYD_INVALID_PARAM,
+                            "No executable provided. Try -h for usages.\n");
     }
 
     /* The demux engine should be initialized before any sockets are


### PR DESCRIPTION
## Pull Request Description
We need more robust check when no executables are provided. This fixes the segfault when user do things like `mpiexec -v` without executables.


Fixes #7403 

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
