### PR TITLE
ch4/xpmem: fix xpmem_init

### DIFF
--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -297,6 +297,7 @@ int MPIDI_POSIX_comm_bootstrap(MPIR_Comm * comm)
         if (!init_shm_initialized) {
             mpi_errno = MPIDU_Init_shm_init();
             MPIR_ERR_CHECK(mpi_errno);
+            init_shm_initialized = true;
         }
 
         mpi_errno = MPIDU_Init_shm_alloc(slab_size, (void *) &slab);

--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -1092,8 +1092,8 @@ dnl Check for shm
 PAC_ARG_SHARED_MEMORY
 
 dnl always check POSIX shared memory
-AC_CHECK_FUNC(shm_open)
-if test "$ac_cv_func_shm_open" = yes ; then
+AC_SEARCH_LIBS([shm_open], [rt], [have_shm_open=yes])
+if test "$have_shm_open" = yes ; then
     AC_DEFINE(HAVE_POSIX_SHM, 1, [Define if we have POSIX shared memory])
     AC_DEFINE(HAVE_INITSHM, 1, [Define if we have mpl_initshm_ facility])
 fi


### PR DESCRIPTION
## Pull Request Description
Fix errors due to skipping xpmem testing :( .
* compile error due to missing `int` in for-loop
* use `node_comm` in Allgather
* translate grank using `node_comm`

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
