### PR TITLE
hydra: fix singleton init

### DIFF
--- a/src/pm/hydra/mpiexec/mpiexec.c
+++ b/src/pm/hydra/mpiexec/mpiexec.c
@@ -56,7 +56,7 @@ int main(int argc, char **argv)
         }
     }
 
-    if (!HYD_uii_mpx_exec_list) {
+    if (!HYD_uii_mpx_exec_list && !HYD_server_info.is_singleton) {
         HYDU_ERR_SETANDJUMP(status, HYD_INVALID_PARAM,
                             "No executable provided. Try -h for usages.\n");
     }


### PR DESCRIPTION
## Pull Request Description
The previous fix 7e87562555 broke the singleton init. Singleton init is allowed to proceed without executables in the command line.

Reference https://github.com/pmodels/mpich/issues/7381#issuecomment-2844782783
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
