### PR TITLE
gpu: Fix initialization when no devices are present

### DIFF
--- a/src/mpi/datatype/typerep/yaksa/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/mpi/datatype/typerep/yaksa/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -170,6 +170,10 @@ int yaksuri_cuda_init_hook(yaksur_gpudriver_hooks_s ** hooks)
     cudaError_t cerr;
 
     cerr = cudaGetDeviceCount(&yaksuri_cudai_global.ndevices);
+    if (cerr == cudaErrorNoDevice || cerr == cudaErrorInsufficientDriver) {
+        /* both codes can indicate no devices available on the system */
+        goto fn_exit;
+    }
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
     if (getenv("CUDA_VISIBLE_DEVICES") == NULL) {

--- a/src/mpi/datatype/typerep/yaksa/src/backend/hip/hooks/yaksuri_hip_init_hooks.c
+++ b/src/mpi/datatype/typerep/yaksa/src/backend/hip/hooks/yaksuri_hip_init_hooks.c
@@ -108,6 +108,9 @@ int yaksuri_hip_init_hook(yaksur_gpudriver_hooks_s ** hooks)
     hipError_t cerr;
 
     cerr = hipGetDeviceCount(&yaksuri_hipi_global.ndevices);
+    if (cerr == hipErrorNoDevice) {
+        goto fn_exit;
+    }
     YAKSURI_HIPI_HIP_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
     if (getenv("HIP_VISIBLE_DEVICES") == NULL) {

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -41,13 +41,17 @@ int MPIDI_GPU_init_local(void)
     int my_max_subdev_id;
 
     MPIDI_GPUI_global.initialized = 0;
-    int mpl_err = MPL_gpu_get_dev_count(&device_count, &my_max_dev_id, &my_max_subdev_id);
-    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**gpu_get_dev_count");
 
-    MPIDI_GPUI_global.local_device_count = device_count;
-    MPL_gpu_free_hook_register(ipc_handle_free_hook);
+    if (MPIR_CVAR_ENABLE_GPU) {
+        int mpl_err = MPL_gpu_get_dev_count(&device_count, &my_max_dev_id, &my_max_subdev_id);
+        MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                            "**gpu_get_dev_count");
 
-    MPIDI_GPUI_global.initialized = 1;
+        MPIDI_GPUI_global.local_device_count = device_count;
+        MPL_gpu_free_hook_register(ipc_handle_free_hook);
+
+        MPIDI_GPUI_global.initialized = 1;
+    }
 
   fn_exit:
     return mpi_errno;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -325,6 +325,9 @@ int MPL_gpu_init(int debug_summary)
 {
     int mpl_err = MPL_SUCCESS;
     hipError_t ret = hipGetDeviceCount(&device_count);
+    if (ret == hipErrorNoDevice) {
+        goto fn_exit;
+    }
     HIP_ERR_CHECK(ret);
 
     MPL_gpu_info.debug_summary = debug_summary;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -973,6 +973,9 @@ static int gpu_ze_init_driver(void)
 
     ze_init_flag_t flags = ZE_INIT_FLAG_GPU_ONLY;
     ret = zeInit(flags);
+    if (ret == ZE_RESULT_ERROR_UNINITIALIZED) {
+        goto fn_exit;
+    }
     ZE_ERR_CHECK(ret);
 
     ret = zeDriverGet(&driver_count, NULL);


### PR DESCRIPTION
## Pull Request Description

If MPICH is configured for GPU support but no devices are present, do not throw an error. Fixes pmodels/mpich#7399.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
