### PR TITLE
all: remove icomm_world

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -484,9 +484,6 @@ int MPII_Comm_check_hints(MPIR_Comm * comm_ptr);
 
 int MPIR_init_comm_self(void);
 int MPIR_init_comm_world(void);
-#ifdef MPID_NEEDS_ICOMM_WORLD
-int MPIR_init_icomm_world(void);
-#endif
 int MPIR_finalize_builtin_comms(void);
 
 void MPIR_Comm_set_session_ptr(MPIR_Comm * comm_ptr, MPIR_Session * session_ptr);

--- a/src/include/mpir_process.h
+++ b/src/include/mpir_process.h
@@ -45,9 +45,7 @@ typedef struct MPIR_Process_t {
                                          * error handler */
     struct MPIR_Comm *comm_self;        /* Easy access to comm_self */
     struct MPIR_Comm *comm_parent;      /* Easy access to comm_parent */
-    struct MPIR_Comm *icomm_world;      /* An internal version of comm_world
-                                         * that is separate from user's
-                                         * versions */
+
     PreDefined_attrs attrs;     /* Predefined attribute values */
     int tag_bits;               /* number of tag bits supported */
     char *memory_alloc_kinds;   /* memory kinds supported in the world model */

--- a/src/mpi/comm/contextid.c
+++ b/src/mpi/comm/contextid.c
@@ -159,14 +159,8 @@ void MPIR_context_id_init(void)
     for (i = 1; i < MPIR_MAX_CONTEXT_MASK; i++) {
         context_mask[i] = 0xFFFFFFFF;
     }
-    /* The first two values are already used (comm_world, comm_self).
-     * The third value is also used for the internal-only copy of
-     * comm_world, if needed by mpid. */
-#ifdef MPID_NEEDS_ICOMM_WORLD
-    context_mask[0] = 0xFFFFFFF8;
-#else
+    /* reserve the first two values for comm_world and comm_self */
     context_mask[0] = 0xFFFFFFFC;
-#endif
 
 #ifdef MPICH_DEBUG_HANDLEALLOC
     /* check for context ID leaks in MPI_Finalize.  Use (_PRIO-1) to make sure

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -287,12 +287,6 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
             mpi_errno = MPIR_init_comm_self();
             MPIR_ERR_CHECK(mpi_errno);
         }
-#ifdef MPID_NEEDS_ICOMM_WORLD
-        if (!MPIR_Process.icomm_world) {
-            mpi_errno = MPIR_init_icomm_world();
-            MPIR_ERR_CHECK(mpi_errno);
-        }
-#endif
     }
 
     /**********************************************************************/

--- a/src/mpid/ch3/include/mpidpre.h
+++ b/src/mpid/ch3/include/mpidpre.h
@@ -531,8 +531,6 @@ typedef struct {
     int gpid[2];
 } MPIDI_Gpid;
 
-/* Tell initthread to prepare a private comm_world */
-#define MPID_NEEDS_ICOMM_WORLD
 
 int MPID_Init(int required, int *provided);
 

--- a/src/mpid/ch3/src/ch3u_comm.c
+++ b/src/mpid/ch3/src/ch3u_comm.c
@@ -203,14 +203,6 @@ int MPIDI_CH3I_Comm_commit_pre_hook(MPIR_Comm *comm)
 
         MPIDI_VCR_Dup(&MPIDI_Process.my_pg->vct[MPIR_Process.rank], &comm->dev.vcrt->vcr_table[0]);
         goto done_vcrt;
-    } else if (comm == MPIR_Process.icomm_world) {
-        comm->rank        = MPIR_Process.rank;
-        comm->remote_size = MPIR_Process.size;
-        comm->local_size  = MPIR_Process.size;
-
-        MPIDI_VCRT_Add_ref(MPIR_Process.comm_world->dev.vcrt );
-        comm->dev.vcrt = MPIR_Process.comm_world->dev.vcrt;
-        goto done_vcrt;
     }
 
     if (comm->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
@@ -423,9 +415,9 @@ static int nonempty_intersection(MPIR_Comm *comm, MPIR_Group *group, int *flag)
     MPIR_FUNC_ENTER;
 
     /* handle common case fast */
-    if (comm == MPIR_Process.comm_world || comm == MPIR_Process.icomm_world) {
+    if (comm == MPIR_Process.comm_world) {
         *flag = TRUE;
-        MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER, VERBOSE, "comm is comm_world or icomm_world");
+        MPL_DBG_MSG(MPIDI_CH3_DBG_OTHER, VERBOSE, "comm is comm_world");
         goto fn_exit;
     }
     *flag = FALSE;


### PR DESCRIPTION
## Pull Request Description
Now that we no longer have a special world init stage, there is no need for the MPIR layer to initialize and finalize the potential internal icomm_world. If the device layer needs the internal comm, it can simply use dup the comm_world at the end of MPID_Comm_commit_pre_hook or MPID_Comm_commit_post_hook and maintain it inside the device layer.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
