### PR TITLE
pm/gforker: fix gforker singleton init

### DIFF
--- a/src/pm/gforker/mpiexec.c
+++ b/src/pm/gforker/mpiexec.c
@@ -301,7 +301,7 @@ int mypreamble(void *data, ProcessState * pState)
     /* Add clique information */
     {
         int i, size = pState->app->nProcess;
-        char digits[10], ranks[1024];
+        char digits[20], ranks[1024];
         char key[256];
 
         /* Create the string of ranks.  These are ranks in comm_world */

--- a/src/pm/util/cmnargs.c
+++ b/src/pm/util/cmnargs.c
@@ -216,6 +216,9 @@ int MPIE_Args(int argc, char *argv[], ProcessUniverse * mypUniv,
         } else if (strcmp(argv[i], "-l") == 0) {
             IOLabelSetDefault(1);
             optionArgs = 1;
+        } else if (strcmp(argv[i], "-v") == 0) {
+            /* TODO: add a verbose option */
+            optionArgs = 1;
         } else if (strcmp(argv[i], "-maxtime") == 0) {
             mypUniv->timeout = getInt(i + 1, argc, argv);
             optionArgs = 1;

--- a/src/pm/util/pmiserv.c
+++ b/src/pm/util/pmiserv.c
@@ -793,7 +793,8 @@ static int fPMI_Handle_init(PMIProcess * pentry)
     /* check version compatibility with PMI client library */
     PMIU_getval("pmi_version", version, PMIU_MAXLINE);
     PMIU_getval("pmi_subversion", subversion, PMIU_MAXLINE);
-    if (PMI_VERSION == atoi(version) && PMI_SUBVERSION >= atoi(subversion))
+    /* Only check major version. This allows client to gracefully fallback if they request higher subversion */
+    if (PMI_VERSION == atoi(version))
         rc = 0;
     else
         rc = -1;
@@ -1274,7 +1275,8 @@ int PMI_InitSingletonConnection(int fd, PMIProcess * pmiprocess)
     /* check version compatibility with PMI client library */
     PMIU_getval("pmi_version", version, PMIU_MAXLINE);
     PMIU_getval("pmi_subversion", subversion, PMIU_MAXLINE);
-    if (PMI_VERSION == atoi(version) && PMI_SUBVERSION >= atoi(subversion))
+    /* NOTE: we only require major version match. */
+    if (PMI_VERSION == atoi(version))
         rc = 0;
     else
         rc = -1;


### PR DESCRIPTION
## Pull Request Description

Let server omit PMI subversion check when respond to init. This allows client to decide whether they want gracefully fallback or abort in case of subversion mismatch.




Fixes https://github.com/pmodels/mpich/pull/7406#issuecomment-2845770598
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
