### PR TITLE
cvar: add alias of MPIR_CVAR_PROGRESS_TIMEOUT

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -14,6 +14,7 @@
 cvars:
     - name        : MPIR_CVAR_PROGRESS_TIMEOUT
       category    : CH4
+      alt-env     : MPIR_CVAR_DEBUG_PROGRESS_TIMEOUT
       type        : int
       default     : 0
       class       : none


### PR DESCRIPTION
## Pull Request Description
Add alias MPIR_CVAR_DEBUG_PROGRESS_TIMEOUT to not break existing scripts.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
