### PR TITLE
ch4/ofi: Skip FI_INT128 support if not available

### DIFF
--- a/src/mpid/ch4/netmod/ofi/util.c
+++ b/src/mpid/ch4/netmod/ofi/util.c
@@ -363,10 +363,12 @@ static MPI_Datatype datatype_from_ofi(enum fi_datatype fi_dt)
             return MPIR_INT64;
         case FI_UINT64:
             return MPIR_UINT64;
+#ifdef FI_INT128
         case FI_INT128:
             return MPIR_INT128;
         case FI_UINT128:
             return MPIR_UINT128;
+#endif
         case FI_FLOAT:
             return MPIR_FLOAT32;
         case FI_DOUBLE:


### PR DESCRIPTION
## Pull Request Description

FI_[U]INT128 support was first introduced in libfabric 1.13.0 (ofiwg/libfabric#6813). Since older versions are still supported on many distributions, use preprocessor guards to avoid a compilation error.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
