### PR TITLE
mpir/pmi1: use stub error_msg in MPIR_pmi_abort

### DIFF
--- a/src/pmi/maint/pmi-1.1.txt
+++ b/src/pmi/maint/pmi-1.1.txt
@@ -57,7 +57,7 @@ FINALIZE:
 
 ABORT:
     Q: abort
-        exitcode: INTEGER, optional=1
+        exitcode: INTEGER
         message: STRING, optional=NULL
 
 MAXES:

--- a/src/pmi/maint/pmi-1.2.txt
+++ b/src/pmi/maint/pmi-1.2.txt
@@ -57,7 +57,7 @@ FINALIZE:
 
 ABORT:
     Q: abort
-        exitcode: INTEGER, optional=1
+        exitcode: INTEGER
         message: STRING, optional=NULL
 
 MAXES:

--- a/src/util/mpir_pmi1.inc
+++ b/src/util/mpir_pmi1.inc
@@ -54,7 +54,9 @@ static void pmi1_exit(void)
 
 static void pmi1_abort(int exit_code, const char *error_msg)
 {
-    PMI_Abort(exit_code, error_msg);
+    /* abort messages may contain spaces. Since there is no specific use case for error_msg,
+     * simplify it with a stub message. */
+    PMI_Abort(exit_code, "abort");
 }
 
 static int pmi1_put(const char *key, const char *val)


### PR DESCRIPTION

## Pull Request Description
The error_msg passed to MPIR_pmi_abort may contain characters that PMI-1 wire protocol cannot handle. Since there is no real usage for this error message, simplify it with a stub message.

NOTE: we could strengthen the PMI-1 protocols using escape sequence, then we need ensure all implementations including gforker to handle escape sequence. Let's keep it simple for now.

Fixes #7415 
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
