### PR TITLE
pm/gforker: set MAXVALLEN to 1024

### DIFF
--- a/src/pm/util/pmiserv.h
+++ b/src/pm/util/pmiserv.h
@@ -58,7 +58,7 @@ typedef struct PMIGroup {
  * sockets and for sockets+shared memory can exceed 128 characters.
  */
 #define MAXKEYLEN    64 /* max length of key in keyval space */
-#define MAXVALLEN  4096 /* max length of value in keyval space */
+#define MAXVALLEN  1024 /* max length of value in keyval space */
 #define MAXNAMELEN  256 /* max length of various names */
 #define MAXKVSNAME  MAXNAMELEN  /* max length of a kvsname */
 typedef struct PMIKVPair {


### PR DESCRIPTION
## Pull Request Description
MAXVALLEN need to be smaller than PMIU_MAXLINE or it may over flow the line buffer.

Fixes #7417 

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
