### PR TITLE
comm: fix memleak due to uninitialized collective structure

### DIFF
--- a/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
+++ b/src/mpi/coll/algorithms/recexchalgo/recexchalgo.c
@@ -26,19 +26,6 @@ int MPII_Recexchalgo_comm_init(MPIR_Comm * comm)
     }
     comm->coll.recexch_allreduce_nbr_buffer = NULL;
 
-    comm->coll.topo_aware_tree_root = -1;
-    comm->coll.topo_aware_tree_k = 0;
-    comm->coll.topo_aware_tree = NULL;
-    comm->coll.topo_aware_k_tree_root = -1;
-    comm->coll.topo_aware_k_tree_k = 0;
-    comm->coll.topo_aware_k_tree = NULL;
-    comm->coll.topo_wave_tree_root = -1;
-    comm->coll.topo_wave_tree = NULL;
-    comm->coll.topo_wave_tree_overhead = 0;
-    comm->coll.topo_wave_tree_lat_diff_groups = 0;
-    comm->coll.topo_wave_tree_lat_diff_switches = 0;
-    comm->coll.topo_wave_tree_lat_same_switches = 0;
-
     return mpi_errno;
 }
 
@@ -64,24 +51,6 @@ int MPII_Recexchalgo_comm_cleanup(MPIR_Comm * comm)
         for (j = 0; j < 2 * (MAX_RADIX - 1); j++)
             MPL_free(comm->coll.recexch_allreduce_nbr_buffer[j]);
         MPL_free(comm->coll.recexch_allreduce_nbr_buffer);
-    }
-
-    if (comm->coll.topo_aware_tree) {
-        MPIR_Treealgo_tree_free(comm->coll.topo_aware_tree);
-        MPL_free(comm->coll.topo_aware_tree);
-        comm->coll.topo_aware_tree = NULL;
-    }
-
-    if (comm->coll.topo_aware_k_tree) {
-        MPIR_Treealgo_tree_free(comm->coll.topo_aware_k_tree);
-        MPL_free(comm->coll.topo_aware_k_tree);
-        comm->coll.topo_aware_k_tree = NULL;
-    }
-
-    if (comm->coll.topo_wave_tree) {
-        MPIR_Treealgo_tree_free(comm->coll.topo_wave_tree);
-        MPL_free(comm->coll.topo_wave_tree);
-        comm->coll.topo_wave_tree = NULL;
     }
 
     return mpi_errno;

--- a/src/mpi/coll/algorithms/treealgo/treealgo.c
+++ b/src/mpi/coll/algorithms/treealgo/treealgo.c
@@ -22,6 +22,19 @@ int MPII_Treealgo_comm_init(MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    comm->coll.topo_aware_tree_root = -1;
+    comm->coll.topo_aware_tree_k = 0;
+    comm->coll.topo_aware_tree = NULL;
+    comm->coll.topo_aware_k_tree_root = -1;
+    comm->coll.topo_aware_k_tree_k = 0;
+    comm->coll.topo_aware_k_tree = NULL;
+    comm->coll.topo_wave_tree_root = -1;
+    comm->coll.topo_wave_tree = NULL;
+    comm->coll.topo_wave_tree_overhead = 0;
+    comm->coll.topo_wave_tree_lat_diff_groups = 0;
+    comm->coll.topo_wave_tree_lat_diff_switches = 0;
+    comm->coll.topo_wave_tree_lat_same_switches = 0;
+
     return mpi_errno;
 }
 
@@ -30,6 +43,23 @@ int MPII_Treealgo_comm_cleanup(MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;
 
+    if (comm->coll.topo_aware_tree) {
+        MPIR_Treealgo_tree_free(comm->coll.topo_aware_tree);
+        MPL_free(comm->coll.topo_aware_tree);
+        comm->coll.topo_aware_tree = NULL;
+    }
+
+    if (comm->coll.topo_aware_k_tree) {
+        MPIR_Treealgo_tree_free(comm->coll.topo_aware_k_tree);
+        MPL_free(comm->coll.topo_aware_k_tree);
+        comm->coll.topo_aware_k_tree = NULL;
+    }
+
+    if (comm->coll.topo_wave_tree) {
+        MPIR_Treealgo_tree_free(comm->coll.topo_wave_tree);
+        MPL_free(comm->coll.topo_wave_tree);
+        comm->coll.topo_wave_tree = NULL;
+    }
     return mpi_errno;
 }
 

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -609,12 +609,13 @@ int MPIR_Subcomm_create(MPIR_Comm * comm, int sub_size, int sub_rank, int *procs
     mpi_errno = MPIR_Group_incl_impl(parent_group, sub_size, procs, &subcomm->local_group);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* Notify device of communicator creation */
-    mpi_errno = MPID_Comm_commit_pre_hook(subcomm);
+    /* Create collectives-specific infrastructure.
+     * Need to be done before device init because addr exchange uses collective. */
+    mpi_errno = MPIR_Coll_comm_init(subcomm);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* Create collectives-specific infrastructure */
-    mpi_errno = MPIR_Coll_comm_init(subcomm);
+    /* Notify device of communicator creation */
+    mpi_errno = MPID_Comm_commit_pre_hook(subcomm);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* call post commit hooks */
@@ -808,12 +809,13 @@ int MPIR_Comm_commit(MPIR_Comm * comm)
         MPIR_ERR_CHECK(mpi_errno);
     }
 
-    /* Notify device of communicator creation */
-    mpi_errno = MPID_Comm_commit_pre_hook(comm);
+    /* Create collectives-specific infrastructure.
+     * Need to be done before device init because addr exchange uses collective. */
+    mpi_errno = MPIR_Coll_comm_init(comm);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* Create collectives-specific infrastructure */
-    mpi_errno = MPIR_Coll_comm_init(comm);
+    /* Notify device of communicator creation */
+    mpi_errno = MPID_Comm_commit_pre_hook(comm);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* call post commit hooks */


### PR DESCRIPTION
## Pull Request Description

The address exchange during init uses collective. This cause memory leak because the collective related data structure in comm is initialized after the device hook using the collective. This causing trees being allocated and later overwritten to NULL by the collective init logic. Therefore, the allocated trees were never freed.

Moving collective init before device hook solves the problem.

For reference, this is the ASAN report.

```
[9] =================================================================
[9] ==45965==ERROR: LeakSanitizer: detected memory leaks
[9]
[9] Direct leak of 24 byte(s) in 1 object(s) allocated from:
[9]     #0 0x7f144e4dc110 in malloc (/usr/lib64/libasan.so.4+0xdc110)
[9]     #1 0x7f144d283ba9 in MPL_malloc /home/yguo/jlse-proj/mpich-dev/mpich-shm/src/mpl/include/mpl_trmem.h:284
[9]     #2 0x7f144d283ba9 in MPIR_Treealgo_tree_create_topo_aware src/mpi/coll/algorithms/treealgo/treealgo.c:123
[9]     #3 0x7f144d1bd8ab in MPIR_Bcast_intra_tree src/mpi/coll/bcast/bcast_intra_tree.c:78
[9]     #4 0x7f144d2b7e9b in MPIR_Bcast_impl src/mpi/coll/mpir_coll.c:410
[9]     #5 0x7f144d18e7ca in MPIR_Allgather_intra_smp_no_order src/mpi/coll/allgather/allgather_intra_smp.c:90
[9]     #6 0x7f144d78f460 in MPIDI_OFI_comm_addr_exchange src/mpid/ch4/netmod/ofi/init_addrxchg.c:90
[9]     #7 0x7f144d717b97 in MPIDI_OFI_mpi_comm_commit_pre_hook src/mpid/ch4/netmod/ofi/ofi_comm.c:141
[9]     #8 0x7f144d60ff2b in MPID_Comm_commit_pre_hook src/mpid/ch4/src/ch4_comm.c:144
[9]     #9 0x7f144d39cc52 in MPIR_Comm_commit src/mpi/comm/commutil.c:812
[9]     #10 0x7f144d39064a in MPIR_init_comm_world src/mpi/comm/builtin_comms.c:34
[9]     #11 0x7f144d43360a in MPII_Init_thread src/mpi/init/mpir_init.c:283
[9]     #12 0x7f144d43398a in MPIR_Init_impl src/mpi/init/mpir_init.c:146
[9]     #13 0x7f144caebd29 in internal_Init src/binding/c/init/init.c:57
[9]     #14 0x7f144caebd29 in PMPI_Init src/binding/c/init/init.c:108
[9]     #15 0x4016f0 in main /vast/users/yguo/mpich-dev/mpich-shm/test/mpi/util/run_mpitests.c:50
[9]     #16 0x7f144c440e6b in __libc_start_call_main (/lib64/libc.so.6+0x40e6b)
[9]
[9] Indirect leak of 64 byte(s) in 1 object(s) allocated from:
[9]     #0 0x7f144e4dc4c0 in realloc (/usr/lib64/libasan.so.4+0xdc4c0)
[9]     #1 0x7f144d285cca in MPL_realloc /home/yguo/jlse-proj/mpich-dev/mpich-shm/src/mpl/include/mpl_trmem.h:302
[9]     #2 0x7f144d285cca in tree_add_child src/mpi/coll/algorithms/treealgo/treeutil.c:21
[9]     #3 0x7f144d28b5b3 in MPII_Treeutil_tree_topology_aware_init src/mpi/coll/algorithms/treealgo/treeutil.c:658
[9]     #4 0x7f144d2835bf in MPIR_Treealgo_tree_create_topo_aware src/mpi/coll/algorithms/treealgo/treealgo.c:126
[9]     #5 0x7f144d1bd8ab in MPIR_Bcast_intra_tree src/mpi/coll/bcast/bcast_intra_tree.c:78
[9]     #6 0x7f144d2b7e9b in MPIR_Bcast_impl src/mpi/coll/mpir_coll.c:410
[9]     #7 0x7f144d18e7ca in MPIR_Allgather_intra_smp_no_order src/mpi/coll/allgather/allgather_intra_smp.c:90
[9]     #8 0x7f144d78f460 in MPIDI_OFI_comm_addr_exchange src/mpid/ch4/netmod/ofi/init_addrxchg.c:90
[9]     #9 0x7f144d717b97 in MPIDI_OFI_mpi_comm_commit_pre_hook src/mpid/ch4/netmod/ofi/ofi_comm.c:141
[9]     #10 0x7f144d60ff2b in MPID_Comm_commit_pre_hook src/mpid/ch4/src/ch4_comm.c:144
[9]     #11 0x7f144d39cc52 in MPIR_Comm_commit src/mpi/comm/commutil.c:812
[9]     #12 0x7f144d39064a in MPIR_init_comm_world src/mpi/comm/builtin_comms.c:34
[9]     #13 0x7f144d43360a in MPII_Init_thread src/mpi/init/mpir_init.c:283
[9]     #14 0x7f144d43398a in MPIR_Init_impl src/mpi/init/mpir_init.c:146
[9]     #15 0x7f144caebd29 in internal_Init src/binding/c/init/init.c:57
[9]     #16 0x7f144caebd29 in PMPI_Init src/binding/c/init/init.c:108
[9]     #17 0x4016f0 in main /vast/users/yguo/mpich-dev/mpich-shm/test/mpi/util/run_mpitests.c:50
[9]     #18 0x7f144c440e6b in __libc_start_call_main (/lib64/libc.so.6+0x40e6b)
[9]
[9] Indirect leak of 24 byte(s) in 1 object(s) allocated from:
[9]     #0 0x7f144e4dc2e8 in __interceptor_calloc (/usr/lib64/libasan.so.4+0xdc2e8)
[9]     #1 0x7f144d28b0f6 in MPL_malloc /home/yguo/jlse-proj/mpich-dev/mpich-shm/src/mpl/include/mpl_trmem.h:284
[9]     #2 0x7f144d28b0f6 in MPII_Treeutil_tree_topology_aware_init src/mpi/coll/algorithms/treealgo/treeutil.c:623
[9]     #3 0x7f144d2835bf in MPIR_Treealgo_tree_create_topo_aware src/mpi/coll/algorithms/treealgo/treealgo.c:126
[9]     #4 0x7f144d1bd8ab in MPIR_Bcast_intra_tree src/mpi/coll/bcast/bcast_intra_tree.c:78
[9]     #5 0x7f144d2b7e9b in MPIR_Bcast_impl src/mpi/coll/mpir_coll.c:410
[9]     #6 0x7f144d18e7ca in MPIR_Allgather_intra_smp_no_order src/mpi/coll/allgather/allgather_intra_smp.c:90
[9]     #7 0x7f144d78f460 in MPIDI_OFI_comm_addr_exchange src/mpid/ch4/netmod/ofi/init_addrxchg.c:90
[9]     #8 0x7f144d717b97 in MPIDI_OFI_mpi_comm_commit_pre_hook src/mpid/ch4/netmod/ofi/ofi_comm.c:141
[9]     #9 0x7f144d60ff2b in MPID_Comm_commit_pre_hook src/mpid/ch4/src/ch4_comm.c:144
[9]     #10 0x7f144d39cc52 in MPIR_Comm_commit src/mpi/comm/commutil.c:812
[9]     #11 0x7f144d39064a in MPIR_init_comm_world src/mpi/comm/builtin_comms.c:34
[9]     #12 0x7f144d43360a in MPII_Init_thread src/mpi/init/mpir_init.c:283
[9]     #13 0x7f144d43398a in MPIR_Init_impl src/mpi/init/mpir_init.c:146
[9]     #14 0x7f144caebd29 in internal_Init src/binding/c/init/init.c:57
[9]     #15 0x7f144caebd29 in PMPI_Init src/binding/c/init/init.c:108
[9]     #16 0x4016f0 in main /vast/users/yguo/mpich-dev/mpich-shm/test/mpi/util/run_mpitests.c:50
[9]     #17 0x7f144c440e6b in __libc_start_call_main (/lib64/libc.so.6+0x40e6b)
[9]
[9] SUMMARY: AddressSanitizer: 112 byte(s) leaked in 3 allocation(s).
```

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
