### PR TITLE
coll: More consistent rank, size, and pof2 calculations

### DIFF
--- a/maint/gen_coll.py
+++ b/maint/gen_coll.py
@@ -559,9 +559,9 @@ def dump_fallback(algo):
         elif a == "noinplace":
             cond_list.append("sendbuf != MPI_IN_PLACE")
         elif a == "power-of-two":
-            cond_list.append("comm_ptr->local_size == comm_ptr->coll.pof2")
+            cond_list.append("MPL_is_pof2(comm_ptr->local_size)")
         elif a == "size-ge-pof2":
-            cond_list.append("count >= comm_ptr->coll.pof2")
+            cond_list.append("count >= MPL_pof2(comm_ptr->local_size)")
         elif a == "commutative":
             cond_list.append("MPIR_Op_is_commutative(op)")
         elif a== "builtin-op":

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -407,6 +407,16 @@ int MPIR_Comm_commit(MPIR_Comm *);
 MPIR_Comm *MPIR_Comm_get_node_comm(MPIR_Comm * comm);
 MPIR_Comm *MPIR_Comm_get_node_roots_comm(MPIR_Comm * comm);
 
+#ifdef ENABLE_THREADCOMM
+#define MPIR_COMM_RANK_SIZE(comm, rank_, size_) MPIR_THREADCOMM_RANK_SIZE(comm, rank_, size_)
+#else
+#define MPIR_COMM_RANK_SIZE(comm, rank_, size_) do {            \
+        MPIR_Assert((comm)->threadcomm == NULL);                \
+        rank_ = (comm)->rank;                                   \
+        size_ = (comm)->local_size;                             \
+    } while (0)
+#endif
+
 #define MPIR_Comm_rank(comm_ptr) ((comm_ptr)->rank)
 #define MPIR_Comm_size(comm_ptr) ((comm_ptr)->local_size)
 

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -201,9 +201,6 @@ struct MPIR_Comm {
                                          * use int array for fast access */
 
     struct {
-        int pof2;               /* Nearest (smaller than or equal to) power of 2
-                                 * to the number of ranks in the communicator.
-                                 * To be used during collective communication */
         int pofk[MAX_RADIX - 1];
         int k[MAX_RADIX - 1];
         int step1_sendto[MAX_RADIX - 1];

--- a/src/include/mpir_threadcomm.h
+++ b/src/include/mpir_threadcomm.h
@@ -123,16 +123,6 @@ MPL_STATIC_INLINE_PREFIX
         } \
     } while (0)
 
-#else
-#define MPIR_THREADCOMM_RANK_SIZE(comm, rank_, size_) do { \
-        MPIR_Assert((comm)->threadcomm == NULL); \
-        rank_ = (comm)->rank; \
-        size_ = (comm)->local_size; \
-    } while (0)
-
-#endif
-
-#ifdef ENABLE_THREADCOMM
 typedef struct MPIR_threadcomm_tls_t {
     MPIR_Threadcomm *threadcomm;
     int tid;

--- a/src/mpi/coll/algorithms/treealgo/treeutil.c
+++ b/src/mpi/coll/algorithms/treealgo/treeutil.c
@@ -604,8 +604,9 @@ int MPII_Treeutil_tree_topology_aware_init(MPIR_Comm * comm, int k, int root, bo
                                            MPIR_Treealgo_tree_t * ct)
 {
     int mpi_errno = MPI_SUCCESS;
-    int rank = comm->rank;
-    int nranks = comm->local_size;
+    int rank;
+    int nranks;
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     UT_array hierarchy[MAX_HIERARCHY_DEPTH];
     int dim = MPIR_Process.coords_dims - 1;
@@ -699,8 +700,9 @@ int MPII_Treeutil_tree_topology_aware_k_init(MPIR_Comm * comm, int k, int root, 
                                              MPIR_Treealgo_tree_t * ct)
 {
     int mpi_errno = MPI_SUCCESS;
-    int rank = comm->rank;
-    int nranks = comm->local_size;
+    int rank;
+    int nranks;
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     /* fall back to MPII_Treeutil_tree_topology_aware_init if k is less or equal to 2 */
     if (k <= 2) {
@@ -1116,8 +1118,9 @@ int MPII_Treeutil_tree_topology_wave_init(MPIR_Comm * comm, int k, int root, boo
                                           int lat_same_switches, MPIR_Treealgo_tree_t * ct)
 {
     int mpi_errno = MPI_SUCCESS;
-    int rank = comm->rank;
-    int nranks = comm->local_size;
+    int rank;
+    int nranks;
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
     int root_gr_sorted_idx = 0;
     int root_sw_sorted_idx = 0;
     int group_offset = 0;

--- a/src/mpi/coll/allgather/allgather_intra_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_brucks.c
@@ -33,7 +33,7 @@ int MPIR_Allgather_intra_brucks(const void *sendbuf,
     if (((sendcount == 0) && (sendbuf != MPI_IN_PLACE)) || (recvcount == 0))
         goto fn_exit;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
     MPIR_Datatype_get_size_macro(recvtype, recvtype_sz);

--- a/src/mpi/coll/allgather/allgather_intra_k_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_k_brucks.c
@@ -30,8 +30,9 @@ MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
     int nphases = 0;
     int src, dst, p_of_k = 0;   /* Largest power of k that is smaller than 'size' */
 
-    int rank = MPIR_Comm_rank(comm);
-    int size = MPIR_Comm_size(comm);
+    int rank;
+    int size;
+    MPIR_COMM_RANK_SIZE(comm, rank, size);
     int is_inplace = (sendbuf == MPI_IN_PLACE);
     int max = size - 1;
     MPIR_Request **reqs;

--- a/src/mpi/coll/allgather/allgather_intra_recexch.c
+++ b/src/mpi/coll/allgather/allgather_intra_recexch.c
@@ -37,8 +37,7 @@ int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
     MPIR_Request **recv_reqs = NULL, **send_reqs = NULL;
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     MPIR_Datatype_get_extent_macro(recvtype, recv_extent);
     MPIR_Type_get_true_extent_impl(recvtype, &recv_lb, &true_extent);
@@ -74,7 +73,7 @@ int MPIR_Allgather_intra_recexch(const void *sendbuf, MPI_Aint sendcount,
             comm->coll.step1_nrecvs[index] = 0;
             comm->coll.step2_nphases[index] = 0;
             mpi_errno =
-                MPII_Recexchalgo_get_neighbors(comm->rank, comm->local_size, &comm->coll.k[index],
+                MPII_Recexchalgo_get_neighbors(rank, nranks, &comm->coll.k[index],
                                                &comm->coll.step1_sendto[index],
                                                &comm->coll.step1_recvfrom[index],
                                                &comm->coll.step1_nrecvs[index],

--- a/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
@@ -34,7 +34,7 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
     MPI_Status status;
     int mask, dst_tree_root, my_tree_root, nprocs_completed, k, tmp_mask, tree_root;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     /* Currently this algorithm can only handle power-of-2 comm_size.

--- a/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgather/allgather_intra_recursive_doubling.c
@@ -34,8 +34,7 @@ int MPIR_Allgather_intra_recursive_doubling(const void *sendbuf,
     MPI_Status status;
     int mask, dst_tree_root, my_tree_root, nprocs_completed, k, tmp_mask, tree_root;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     /* Currently this algorithm can only handle power-of-2 comm_size.

--- a/src/mpi/coll/allgather/allgather_intra_ring.c
+++ b/src/mpi/coll/allgather/allgather_intra_ring.c
@@ -33,8 +33,7 @@ int MPIR_Allgather_intra_ring(const void *sendbuf,
     int j, i;
     int left, right, jnext;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 

--- a/src/mpi/coll/allgather/allgather_intra_ring.c
+++ b/src/mpi/coll/allgather/allgather_intra_ring.c
@@ -33,7 +33,7 @@ int MPIR_Allgather_intra_ring(const void *sendbuf,
     int j, i;
     int left, right, jnext;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 

--- a/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_brucks.c
@@ -34,7 +34,7 @@ int MPIR_Allgatherv_intra_brucks(const void *sendbuf,
     void *tmp_buf;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     total_count = 0;
     for (i = 0; i < comm_size; i++)

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -38,7 +38,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
     MPI_Aint position, send_offset, recv_offset, offset;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     /* Currently this algorithm can only handle power-of-2 comm_size.

--- a/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_recursive_doubling.c
@@ -38,8 +38,7 @@ int MPIR_Allgatherv_intra_recursive_doubling(const void *sendbuf,
     MPI_Aint position, send_offset, recv_offset, offset;
     MPIR_CHKLMEM_DECL();
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     /* Currently this algorithm can only handle power-of-2 comm_size.

--- a/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
@@ -36,8 +36,7 @@ int MPIR_Allgatherv_intra_ring(const void *sendbuf,
     MPI_Aint recvtype_extent;
     MPI_Aint total_count;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     total_count = 0;
     for (i = 0; i < comm_size; i++)

--- a/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
+++ b/src/mpi/coll/allgatherv/allgatherv_intra_ring.c
@@ -36,7 +36,7 @@ int MPIR_Allgatherv_intra_ring(const void *sendbuf,
     MPI_Aint recvtype_extent;
     MPI_Aint total_count;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     total_count = 0;
     for (i = 0; i < comm_size; i++)

--- a/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_k_reduce_scatter_allgather.c
@@ -36,8 +36,7 @@ int MPIR_Allreduce_intra_k_reduce_scatter_allgather(const void *sendbuf,
 
     MPIR_Assert(k > 1);
 
-    rank = comm->rank;
-    nranks = comm->local_size;
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
     MPIR_Assert(MPIR_Op_is_commutative(op));
 
     /* need to allocate temporary buffer to store incoming data */

--- a/src/mpi/coll/allreduce/allreduce_intra_recexch.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recexch.c
@@ -34,8 +34,7 @@ int MPIR_Allreduce_intra_recexch(const void *sendbuf,
     MPIR_Request **send_reqs = NULL, **recv_reqs = NULL;
     int send_nreq = 0, recv_nreq = 0, total_phases = 0;
 
-    rank = comm->rank;
-    nranks = comm->local_size;
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
     is_commutative = MPIR_Op_is_commutative(op);
 
     bool is_float;

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
@@ -30,7 +30,7 @@ int MPIR_Allreduce_intra_recursive_doubling(const void *sendbuf,
     MPI_Aint true_extent, true_lb, extent;
     void *tmp_buf;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     is_commutative = MPIR_Op_is_commutative(op);
 

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_doubling.c
@@ -4,7 +4,6 @@
  */
 
 #include "mpiimpl.h"
-#include "mpir_threadcomm.h"
 
 /*
  * Algorithm: Recursive Doubling

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_multiplying.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_multiplying.c
@@ -31,7 +31,7 @@ int MPIR_Allreduce_intra_recursive_multiplying(const void *sendbuf,
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, rank, virt_rank;
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
     virt_rank = rank;
 
     /* get nearest power-of-two less than or equal to comm_size */

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_multiplying.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_multiplying.c
@@ -31,8 +31,7 @@ int MPIR_Allreduce_intra_recursive_multiplying(const void *sendbuf,
 {
     int mpi_errno = MPI_SUCCESS;
     int comm_size, rank, virt_rank;
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
     virt_rank = rank;
 
     /* get nearest power-of-two less than or equal to comm_size */

--- a/src/mpi/coll/allreduce/allreduce_intra_recursive_multiplying.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_recursive_multiplying.c
@@ -30,8 +30,6 @@ int MPIR_Allreduce_intra_recursive_multiplying(const void *sendbuf,
                                                const int k, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    /* Ensure the op is commutative */
-
     int comm_size, rank, virt_rank;
     comm_size = comm_ptr->local_size;
     rank = comm_ptr->rank;

--- a/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
@@ -4,6 +4,7 @@
  */
 
 #include "mpiimpl.h"
+#include "mpir_threadcomm.h"
 
 /* Algorithm: Rabenseifner's Algorithm
  *
@@ -52,8 +53,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
     MPI_Aint true_extent, true_lb, extent;
     void *tmp_buf;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* need to allocate temporary buffer to store incoming data */
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
@@ -71,7 +71,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
     }
 
     /* get nearest power-of-two less than or equal to comm_size */
-    pof2 = comm_ptr->coll.pof2;
+    pof2 = MPL_pof2(comm_size);
 
     rem = comm_size - pof2;
 

--- a/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_reduce_scatter_allgather.c
@@ -53,7 +53,7 @@ int MPIR_Allreduce_intra_reduce_scatter_allgather(const void *sendbuf,
     MPI_Aint true_extent, true_lb, extent;
     void *tmp_buf;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* need to allocate temporary buffer to store incoming data */
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/allreduce/allreduce_intra_ring.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_ring.c
@@ -25,8 +25,7 @@ int MPIR_Allreduce_intra_ring(const void *sendbuf, void *recvbuf, MPI_Aint count
     MPIR_Request *reqs[2];      /* one send and one recv per transfer */
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);

--- a/src/mpi/coll/allreduce/allreduce_intra_tree.c
+++ b/src/mpi/coll/allreduce/allreduce_intra_tree.c
@@ -37,8 +37,7 @@ int MPIR_Allreduce_intra_tree(const void *sendbuf,
     MPIR_Request **reqs;
     int num_reqs = 0;
 
-    comm_size = MPIR_Comm_size(comm_ptr);
-    rank = MPIR_Comm_rank(comm_ptr);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_size_macro(datatype, type_size);
     MPIR_Datatype_get_extent_macro(datatype, extent);

--- a/src/mpi/coll/alltoall/alltoall_intra_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_brucks.c
@@ -36,7 +36,7 @@ int MPIR_Alltoall_intra_brucks(const void *sendbuf,
     void *tmp_buf;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     MPIR_Assert(sendbuf != MPI_IN_PLACE);

--- a/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_k_brucks.c
@@ -133,8 +133,7 @@ int MPIR_Alltoall_intra_k_brucks(const void *sendbuf,
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
 
-    rank = MPIR_Comm_rank(comm);
-    size = MPIR_Comm_size(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, size);
 
     nphases = 0;
     max = size - 1;

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
@@ -35,7 +35,7 @@ int MPIR_Alltoall_intra_pairwise(const void *sendbuf,
     int mpi_errno = MPI_SUCCESS, src, dst, rank;
     MPI_Status status;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     MPIR_Assert(sendbuf != MPI_IN_PLACE);

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise.c
@@ -35,8 +35,7 @@ int MPIR_Alltoall_intra_pairwise(const void *sendbuf,
     int mpi_errno = MPI_SUCCESS, src, dst, rank;
     MPI_Status status;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     MPIR_Assert(sendbuf != MPI_IN_PLACE);

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
@@ -32,7 +32,7 @@ int MPIR_Alltoall_intra_pairwise_sendrecv_replace(const void *sendbuf,
     int mpi_errno = MPI_SUCCESS, rank;
     MPI_Status status;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Get extent of send and recv types */
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);

--- a/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_pairwise_sendrecv_replace.c
@@ -32,8 +32,7 @@ int MPIR_Alltoall_intra_pairwise_sendrecv_replace(const void *sendbuf,
     int mpi_errno = MPI_SUCCESS, rank;
     MPI_Status status;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Get extent of send and recv types */
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);

--- a/src/mpi/coll/alltoall/alltoall_intra_scattered.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_scattered.c
@@ -42,7 +42,7 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
     MPI_Status *starray;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     MPIR_Assert(sendbuf != MPI_IN_PLACE);

--- a/src/mpi/coll/alltoall/alltoall_intra_scattered.c
+++ b/src/mpi/coll/alltoall/alltoall_intra_scattered.c
@@ -42,8 +42,7 @@ int MPIR_Alltoall_intra_scattered(const void *sendbuf,
     MPI_Status *starray;
     MPIR_CHKLMEM_DECL();
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     MPIR_Assert(sendbuf != MPI_IN_PLACE);

--- a/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
@@ -30,7 +30,7 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
     MPI_Status status;
     int rank;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Get extent of recv type, but send type is only valid if (sendbuf!=MPI_IN_PLACE) */
     MPIR_Datatype_get_extent_macro(recvtype, recv_extent);

--- a/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_pairwise_sendrecv_replace.c
@@ -30,8 +30,7 @@ int MPIR_Alltoallv_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
     MPI_Status status;
     int rank;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Get extent of recv type, but send type is only valid if (sendbuf!=MPI_IN_PLACE) */
     MPIR_Datatype_get_extent_macro(recvtype, recv_extent);

--- a/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
+++ b/src/mpi/coll/alltoallv/alltoallv_intra_scattered.c
@@ -37,7 +37,7 @@ int MPIR_Alltoallv_intra_scattered(const void *sendbuf, const MPI_Aint * sendcou
 
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Get extent of recv type, but send type is only valid if (sendbuf!=MPI_IN_PLACE) */
     MPIR_Datatype_get_extent_macro(recvtype, recv_extent);

--- a/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
@@ -30,7 +30,7 @@ int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
     MPI_Status status;
     int rank;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     MPIR_Assert(sendbuf == MPI_IN_PLACE);

--- a/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_pairwise_sendrecv_replace.c
@@ -30,8 +30,7 @@ int MPIR_Alltoallw_intra_pairwise_sendrecv_replace(const void *sendbuf, const MP
     MPI_Status status;
     int rank;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     MPIR_Assert(sendbuf == MPI_IN_PLACE);

--- a/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
+++ b/src/mpi/coll/alltoallw/alltoallw_intra_scattered.c
@@ -35,7 +35,7 @@ int MPIR_Alltoallw_intra_scattered(const void *sendbuf, const MPI_Aint sendcount
     MPI_Aint type_size;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     /* When MPI_IN_PLACE, we use pair-wise sendrecv_replace in order to conserve memory usage,

--- a/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
+++ b/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
@@ -52,8 +52,7 @@ int MPIR_Barrier_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_Errflag_t e
     MPIR_Request *sreqs[MAX_RADIX], *rreqs[MAX_RADIX * 2];
     MPIR_Request **send_reqs = NULL, **recv_reqs = NULL;
 
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     if (nranks == 1)
         goto fn_exit;

--- a/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
+++ b/src/mpi/coll/barrier/barrier_intra_k_dissemination.c
@@ -20,7 +20,7 @@ int MPIR_Barrier_intra_dissemination(MPIR_Comm * comm_ptr, MPIR_Errflag_t errfla
 {
     int size, rank, src, dst, mask, mpi_errno = MPI_SUCCESS;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, size);
 
     mask = 0x1;
     while (mask < size) {

--- a/src/mpi/coll/bcast/bcast_intra_binomial.c
+++ b/src/mpi/coll/bcast/bcast_intra_binomial.c
@@ -32,7 +32,7 @@ int MPIR_Bcast_intra_binomial(void *buffer,
     void *tmp_buf = NULL;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     if (HANDLE_IS_BUILTIN(datatype))
         is_contig = 1;

--- a/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
@@ -31,8 +31,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
     MPIR_Treealgo_tree_t my_tree;
     MPIR_CHKLMEM_DECL();
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* If there is only one process, return */
     if (comm_size == 1)

--- a/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_pipelined_tree.c
@@ -31,7 +31,7 @@ int MPIR_Bcast_intra_pipelined_tree(void *buffer,
     MPIR_Treealgo_tree_t my_tree;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* If there is only one process, return */
     if (comm_size == 1)

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -45,8 +45,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
     MPI_Aint true_extent, true_lb;
     void *tmp_buf;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
     relative_rank = (rank >= root) ? rank - root : rank - root + comm_size;
 
     if (HANDLE_IS_BUILTIN(datatype))

--- a/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_recursive_doubling_allgather.c
@@ -45,7 +45,7 @@ int MPIR_Bcast_intra_scatter_recursive_doubling_allgather(void *buffer,
     MPI_Aint true_extent, true_lb;
     void *tmp_buf;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
     relative_rank = (rank >= root) ? rank - root : rank - root + comm_size;
 
     if (HANDLE_IS_BUILTIN(datatype))

--- a/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
@@ -38,8 +38,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
     MPI_Aint true_extent, true_lb;
     MPIR_CHKLMEM_DECL();
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     if (HANDLE_IS_BUILTIN(datatype))
         is_contig = 1;

--- a/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
+++ b/src/mpi/coll/bcast/bcast_intra_scatter_ring_allgather.c
@@ -38,7 +38,7 @@ int MPIR_Bcast_intra_scatter_ring_allgather(void *buffer,
     MPI_Aint true_extent, true_lb;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     if (HANDLE_IS_BUILTIN(datatype))
         is_contig = 1;

--- a/src/mpi/coll/bcast/bcast_intra_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_tree.c
@@ -29,8 +29,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
     MPIR_Treealgo_tree_t my_tree;
     MPIR_CHKLMEM_DECL();
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* If there is only one process, return */
     if (comm_size == 1)

--- a/src/mpi/coll/bcast/bcast_intra_tree.c
+++ b/src/mpi/coll/bcast/bcast_intra_tree.c
@@ -29,7 +29,7 @@ int MPIR_Bcast_intra_tree(void *buffer,
     MPIR_Treealgo_tree_t my_tree;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* If there is only one process, return */
     if (comm_size == 1)

--- a/src/mpi/coll/bcast/bcast_utils.c
+++ b/src/mpi/coll/bcast/bcast_utils.c
@@ -30,8 +30,7 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
     MPI_Aint scatter_size, recv_size = 0;
     MPI_Aint curr_size, send_size;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
     relative_rank = (rank >= root) ? rank - root : rank - root + comm_size;
 
     /* use long message algorithm: binomial tree scatter followed by an allgather */

--- a/src/mpi/coll/bcast/bcast_utils.c
+++ b/src/mpi/coll/bcast/bcast_utils.c
@@ -30,7 +30,7 @@ int MPII_Scatter_for_bcast(void *buffer ATTRIBUTE((unused)),
     MPI_Aint scatter_size, recv_size = 0;
     MPI_Aint curr_size, send_size;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
     relative_rank = (rank >= root) ? rank - root : rank - root + comm_size;
 
     /* use long message algorithm: binomial tree scatter followed by an allgather */

--- a/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
+++ b/src/mpi/coll/exscan/exscan_intra_recursive_doubling.c
@@ -58,7 +58,7 @@ int MPIR_Exscan_intra_recursive_doubling(const void *sendbuf,
     void *partial_scan, *tmp_buf;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     is_commutative = MPIR_Op_is_commutative(op);
 

--- a/src/mpi/coll/gather/gather_intra_binomial.c
+++ b/src/mpi/coll/gather/gather_intra_binomial.c
@@ -57,7 +57,7 @@ int MPIR_Gather_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Data
     MPIR_CHKLMEM_DECL();
 
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Use binomial tree algorithm. */
 

--- a/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
+++ b/src/mpi/coll/gatherv/gatherv_allcomm_linear.c
@@ -32,7 +32,7 @@ int MPIR_Gatherv_allcomm_linear(const void *sendbuf,
     MPI_Status *starray;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* If rank == root, then I recv lots, otherwise I send */
     if (((comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) && (root == rank)) ||

--- a/src/mpi/coll/iallgather/iallgather_intra_sched_brucks.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_sched_brucks.c
@@ -24,8 +24,7 @@ int MPIR_Iallgather_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
     MPI_Aint recvtype_extent, recvtype_sz;
     void *tmp_buf = NULL;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
     /* allocate a temporary buffer of the same size as recvbuf. */

--- a/src/mpi/coll/iallgather/iallgather_intra_sched_brucks.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_sched_brucks.c
@@ -24,7 +24,7 @@ int MPIR_Iallgather_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
     MPI_Aint recvtype_extent, recvtype_sz;
     void *tmp_buf = NULL;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
     /* allocate a temporary buffer of the same size as recvbuf. */

--- a/src/mpi/coll/iallgather/iallgather_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_sched_recursive_doubling.c
@@ -56,7 +56,7 @@ int MPIR_Iallgather_intra_sched_recursive_doubling(const void *sendbuf, MPI_Aint
     int dst_tree_root, my_tree_root, tree_root;
     MPI_Aint recvtype_extent;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     /* Currently this algorithm can only handle power-of-2 comm_size.

--- a/src/mpi/coll/iallgather/iallgather_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_sched_recursive_doubling.c
@@ -56,8 +56,7 @@ int MPIR_Iallgather_intra_sched_recursive_doubling(const void *sendbuf, MPI_Aint
     int dst_tree_root, my_tree_root, tree_root;
     MPI_Aint recvtype_extent;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     /* Currently this algorithm can only handle power-of-2 comm_size.

--- a/src/mpi/coll/iallgather/iallgather_intra_sched_ring.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_sched_ring.c
@@ -29,8 +29,7 @@ int MPIR_Iallgather_intra_sched_ring(const void *sendbuf, MPI_Aint sendcount, MP
     int i, j, jnext, left, right;
     MPI_Aint recvtype_extent;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 

--- a/src/mpi/coll/iallgather/iallgather_intra_sched_ring.c
+++ b/src/mpi/coll/iallgather/iallgather_intra_sched_ring.c
@@ -29,7 +29,7 @@ int MPIR_Iallgather_intra_sched_ring(const void *sendbuf, MPI_Aint sendcount, MP
     int i, j, jnext, left, right;
     MPI_Aint recvtype_extent;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 

--- a/src/mpi/coll/iallgather/iallgather_tsp_brucks.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_brucks.c
@@ -20,8 +20,9 @@ MPIR_TSP_Iallgather_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
     int src, dst, p_of_k = 0;   /* Largest power of k that is (strictly) smaller than 'size' */
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
-    int rank = MPIR_Comm_rank(comm);
-    int size = MPIR_Comm_size(comm);
+    int rank;
+    int size;
+    MPIR_COMM_RANK_SIZE(comm, rank, size);
     int is_inplace = (sendbuf == MPI_IN_PLACE);
     int max = size - 1;
     int vtx_id;

--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch.c
@@ -259,8 +259,7 @@ int MPIR_TSP_Iallgather_sched_intra_recexch(const void *sendbuf, MPI_Aint sendco
     MPIR_ERR_CHECK(mpi_errno);
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     MPIR_Datatype_get_extent_macro(recvtype, recv_extent);
     MPIR_Type_get_true_extent_impl(recvtype, &recv_lb, &true_extent);

--- a/src/mpi/coll/iallgather/iallgather_tsp_ring.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_ring.c
@@ -16,8 +16,9 @@ int MPIR_TSP_Iallgather_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount
     /* Temporary buffers to execute the ring algorithm */
     void *buf1, *buf2, *data_buf, *rbuf, *sbuf;
 
-    int size = MPIR_Comm_size(comm);
-    int rank = MPIR_Comm_rank(comm);
+    int size;
+    int rank;
+    MPIR_COMM_RANK_SIZE(comm, rank, size);
     int is_inplace = (sendbuf == MPI_IN_PLACE);
     int tag;
     int vtx_id;

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_brucks.c
@@ -16,8 +16,7 @@ int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
     int dst, pof2, src, rem;
     void *tmp_buf;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
     MPIR_Datatype_get_size_macro(recvtype, recvtype_sz);

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_brucks.c
@@ -16,7 +16,7 @@ int MPIR_Iallgatherv_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
     int dst, pof2, src, rem;
     void *tmp_buf;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
     MPIR_Datatype_get_size_macro(recvtype, recvtype_sz);

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_recursive_doubling.c
@@ -17,8 +17,7 @@ int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, MPI_Ain
     MPI_Aint recvtype_extent, recvtype_sz, position, offset;
     void *tmp_buf = NULL;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     /* Currently this algorithm can only handle power-of-2 comm_size.

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_recursive_doubling.c
@@ -17,7 +17,7 @@ int MPIR_Iallgatherv_intra_sched_recursive_doubling(const void *sendbuf, MPI_Ain
     MPI_Aint recvtype_extent, recvtype_sz, position, offset;
     void *tmp_buf = NULL;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     /* Currently this algorithm can only handle power-of-2 comm_size.

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_ring.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_ring.c
@@ -18,7 +18,7 @@ int MPIR_Iallgatherv_intra_sched_ring(const void *sendbuf, MPI_Aint sendcount,
     char *sbuf = NULL;
     char *rbuf = NULL;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     total_count = 0;

--- a/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_ring.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_intra_sched_ring.c
@@ -18,8 +18,7 @@ int MPIR_Iallgatherv_intra_sched_ring(const void *sendbuf, MPI_Aint sendcount,
     char *sbuf = NULL;
     char *rbuf = NULL;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
 
     total_count = 0;

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_brucks.c
@@ -68,8 +68,7 @@ MPIR_TSP_Iallgatherv_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
     MPIR_ERR_CHECK(mpi_errno);
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
-    rank = MPIR_Comm_rank(comm);
-    size = MPIR_Comm_size(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, size);
     max = size - 1;
 
     if (is_inplace) {

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
@@ -263,8 +263,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch(const void *sendbuf, MPI_Aint sendc
     MPIR_FUNC_ENTER;
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     MPIR_Datatype_get_extent_macro(recvtype, recv_extent);
     MPIR_Type_get_true_extent_impl(recvtype, &recv_lb, &true_extent);

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_ring.c
@@ -26,8 +26,7 @@ int MPIR_TSP_Iallgatherv_sched_intra_ring(const void *sendbuf, MPI_Aint sendcoun
     MPIR_FUNC_ENTER;
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     /* find out the buffer which has the send data and point data_buf to it */
     if (is_inplace) {

--- a/src/mpi/coll/iallreduce/iallreduce_intra_sched_naive.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_sched_naive.c
@@ -12,8 +12,9 @@ int MPIR_Iallreduce_intra_sched_naive(const void *sendbuf, void *recvbuf, MPI_Ai
 {
     int mpi_errno = MPI_SUCCESS;
     int rank;
+    int size ATTRIBUTE((unused));
 
-    rank = comm_ptr->rank;
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, size);
 
     if ((sendbuf == MPI_IN_PLACE) && (rank != 0)) {
         mpi_errno =

--- a/src/mpi/coll/iallreduce/iallreduce_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_sched_recursive_doubling.c
@@ -15,7 +15,7 @@ int MPIR_Iallreduce_intra_sched_recursive_doubling(const void *sendbuf, void *re
     MPI_Aint true_lb, true_extent, extent;
     void *tmp_buf = NULL;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     is_commutative = MPIR_Op_is_commutative(op);
 

--- a/src/mpi/coll/iallreduce/iallreduce_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_sched_recursive_doubling.c
@@ -15,8 +15,7 @@ int MPIR_Iallreduce_intra_sched_recursive_doubling(const void *sendbuf, void *re
     MPI_Aint true_lb, true_extent, extent;
     void *tmp_buf = NULL;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     is_commutative = MPIR_Op_is_commutative(op);
 

--- a/src/mpi/coll/iallreduce/iallreduce_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_sched_recursive_doubling.c
@@ -37,7 +37,7 @@ int MPIR_Iallreduce_intra_sched_recursive_doubling(const void *sendbuf, void *re
     }
 
     /* get nearest power-of-two less than or equal to comm_size */
-    pof2 = comm_ptr->coll.pof2;
+    pof2 = MPL_pof2(comm_size);
 
     rem = comm_size - pof2;
 

--- a/src/mpi/coll/iallreduce/iallreduce_intra_sched_reduce_scatter_allgather.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_sched_reduce_scatter_allgather.c
@@ -44,7 +44,7 @@ int MPIR_Iallreduce_intra_sched_reduce_scatter_allgather(const void *sendbuf, vo
     }
 
     /* get nearest power-of-two less than or equal to comm_size */
-    pof2 = comm_ptr->coll.pof2;
+    pof2 = MPL_pof2(comm_size);
 
     rem = comm_size - pof2;
 

--- a/src/mpi/coll/iallreduce/iallreduce_intra_sched_reduce_scatter_allgather.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_sched_reduce_scatter_allgather.c
@@ -24,7 +24,7 @@ int MPIR_Iallreduce_intra_sched_reduce_scatter_allgather(const void *sendbuf, vo
     MPIR_Assert(HANDLE_IS_BUILTIN(op));
 #endif
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* need to allocate temporary buffer to store incoming data */
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/iallreduce/iallreduce_intra_sched_reduce_scatter_allgather.c
+++ b/src/mpi/coll/iallreduce/iallreduce_intra_sched_reduce_scatter_allgather.c
@@ -24,8 +24,7 @@ int MPIR_Iallreduce_intra_sched_reduce_scatter_allgather(const void *sendbuf, vo
     MPIR_Assert(HANDLE_IS_BUILTIN(op));
 #endif
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* need to allocate temporary buffer to store incoming data */
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_auto.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_auto.c
@@ -14,7 +14,9 @@ int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf,
 {
     int mpi_errno = MPI_SUCCESS;
     int is_commutative = MPIR_Op_is_commutative(op);
-    int nranks = comm->local_size;
+    int nranks;
+    int rank;
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     MPIR_Assert(comm->comm_kind == MPIR_COMM_KIND__INTRACOMM);
 
@@ -50,7 +52,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf,
 
         case MPIR_CVAR_IALLREDUCE_INTRA_ALGORITHM_tsp_tree:
             /*Only knomial_1 tree supports non-commutative operations */
-            MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, is_commutative ||
+            MPII_COLLECTIVE_FALLBACK_CHECK(rank, is_commutative ||
                                            MPIR_Iallreduce_tree_type ==
                                            MPIR_TREE_TYPE_KNOMIAL_1, mpi_errno,
                                            "Iallreduce gentran_tree cannot be applied.\n");
@@ -64,7 +66,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf,
             break;
 
         case MPIR_CVAR_IALLREDUCE_INTRA_ALGORITHM_tsp_ring:
-            MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, is_commutative, mpi_errno,
+            MPII_COLLECTIVE_FALLBACK_CHECK(rank, is_commutative, mpi_errno,
                                            "Iallreduce gentran_ring cannot be applied.\n");
             mpi_errno =
                 MPIR_TSP_Iallreduce_sched_intra_ring(sendbuf, recvbuf, count, datatype,
@@ -76,7 +78,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tsp_auto(const void *sendbuf, void *recvbuf,
              * number of ranks. If it not commutative or if the
              * count < nranks, MPIR_Iallreduce_sched algorithm
              * will be run */
-            MPII_COLLECTIVE_FALLBACK_CHECK(comm->rank, is_commutative &&
+            MPII_COLLECTIVE_FALLBACK_CHECK(rank, is_commutative &&
                                            count >= nranks, mpi_errno,
                                            "Iallreduce gentran_recexch_reduce_scatter_recexch_allgatherv cannot be applied.\n");
             mpi_errno =

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch.c
@@ -39,8 +39,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch(const void *sendbuf, void *recvbuf, 
     MPIR_FUNC_ENTER;
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_recexch_reduce_scatter_recexch_allgatherv.c
@@ -45,8 +45,7 @@ int MPIR_TSP_Iallreduce_sched_intra_recexch_reduce_scatter_recexch_allgatherv(co
     MPIR_FUNC_ENTER;
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_ring.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_ring.c
@@ -30,8 +30,7 @@ int MPIR_TSP_Iallreduce_sched_intra_ring(const void *sendbuf, void *recvbuf, MPI
     MPIR_CHKLMEM_DECL();
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);

--- a/src/mpi/coll/iallreduce/iallreduce_tsp_tree.c
+++ b/src/mpi/coll/iallreduce/iallreduce_tsp_tree.c
@@ -37,8 +37,7 @@ int MPIR_TSP_Iallreduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI
 
     MPIR_FUNC_ENTER;
 
-    size = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, size);
 
     MPIR_Datatype_get_size_macro(datatype, type_size);
     MPIR_Datatype_get_extent_macro(datatype, extent);

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_brucks.c
@@ -37,8 +37,7 @@ int MPIR_Ialltoall_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
     MPIR_Assert(sendbuf != MPI_IN_PLACE);       /* we do not handle in-place */
 #endif
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_size_macro(recvtype, recvtype_sz);

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_brucks.c
@@ -37,7 +37,7 @@ int MPIR_Ialltoall_intra_sched_brucks(const void *sendbuf, MPI_Aint sendcount,
     MPIR_Assert(sendbuf != MPI_IN_PLACE);       /* we do not handle in-place */
 #endif
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_size_macro(recvtype, recvtype_sz);

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_inplace.c
@@ -33,8 +33,7 @@ int MPIR_Ialltoall_intra_sched_inplace(const void *sendbuf, MPI_Aint sendcount,
     MPIR_Assert(sendbuf == MPI_IN_PLACE);
 #endif
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
     MPIR_Datatype_get_size_macro(recvtype, recvtype_size);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
     nbytes = recvtype_size * recvcount;

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_inplace.c
@@ -33,7 +33,7 @@ int MPIR_Ialltoall_intra_sched_inplace(const void *sendbuf, MPI_Aint sendcount,
     MPIR_Assert(sendbuf == MPI_IN_PLACE);
 #endif
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
     MPIR_Datatype_get_size_macro(recvtype, recvtype_size);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);
     nbytes = recvtype_size * recvcount;

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_pairwise.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_pairwise.c
@@ -36,8 +36,7 @@ int MPIR_Ialltoall_intra_sched_pairwise(const void *sendbuf, MPI_Aint sendcount,
     MPIR_Assert(sendbuf != MPI_IN_PLACE);       /* we do not handle in-place */
 #endif
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_pairwise.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_pairwise.c
@@ -36,7 +36,7 @@ int MPIR_Ialltoall_intra_sched_pairwise(const void *sendbuf, MPI_Aint sendcount,
     MPIR_Assert(sendbuf != MPI_IN_PLACE);       /* we do not handle in-place */
 #endif
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_permuted_sendrecv.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_permuted_sendrecv.c
@@ -28,8 +28,7 @@ int MPIR_Ialltoall_intra_sched_permuted_sendrecv(const void *sendbuf, MPI_Aint s
     MPIR_Assert(sendbuf != MPI_IN_PLACE);       /* we do not handle in-place */
 #endif
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);

--- a/src/mpi/coll/ialltoall/ialltoall_intra_sched_permuted_sendrecv.c
+++ b/src/mpi/coll/ialltoall/ialltoall_intra_sched_permuted_sendrecv.c
@@ -28,7 +28,7 @@ int MPIR_Ialltoall_intra_sched_permuted_sendrecv(const void *sendbuf, MPI_Aint s
     MPIR_Assert(sendbuf != MPI_IN_PLACE);       /* we do not handle in-place */
 #endif
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(sendtype, sendtype_extent);
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_brucks.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_brucks.c
@@ -156,8 +156,7 @@ MPIR_TSP_Ialltoall_sched_intra_brucks(const void *sendbuf, MPI_Aint sendcount,
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
 
-    rank = MPIR_Comm_rank(comm);
-    size = MPIR_Comm_size(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, size);
 
     max = size - 1;
 

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_ring.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_ring.c
@@ -46,8 +46,9 @@ int MPIR_TSP_Ialltoall_sched_intra_ring(const void *sendbuf, MPI_Aint sendcount,
     void *buf1, *buf2, *data_buf, *sbuf, *rbuf;
     int tag, vtx_id;
 
-    int size = MPIR_Comm_size(comm);
-    int rank = MPIR_Comm_rank(comm);
+    int size;
+    int rank;
+    MPIR_COMM_RANK_SIZE(comm, rank, size);
     int is_inplace = (sendbuf == MPI_IN_PLACE);
 
     MPI_Aint recvtype_lb, recvtype_extent;

--- a/src/mpi/coll/ialltoall/ialltoall_tsp_scattered.c
+++ b/src/mpi/coll/ialltoall/ialltoall_tsp_scattered.c
@@ -61,8 +61,7 @@ int MPIR_TSP_Ialltoall_sched_intra_scattered(const void *sendbuf, MPI_Aint sendc
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
     MPIR_ERR_CHECK(mpi_errno);
 
-    size = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, size);
     is_inplace = (sendbuf == MPI_IN_PLACE);
 
     /* vtcs is twice the batch size to store both send and recv ids */

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_blocked.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_blocked.c
@@ -22,7 +22,7 @@ int MPIR_Ialltoallv_intra_sched_blocked(const void *sendbuf, const MPI_Aint send
     MPIR_Assert(sendbuf != MPI_IN_PLACE);
 #endif /* HAVE_ERROR_CHECKING */
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Get extent and size of recvtype, don't look at sendtype for MPI_IN_PLACE */
     MPIR_Datatype_get_extent_macro(recvtype, recv_extent);

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_blocked.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_blocked.c
@@ -22,8 +22,7 @@ int MPIR_Ialltoallv_intra_sched_blocked(const void *sendbuf, const MPI_Aint send
     MPIR_Assert(sendbuf != MPI_IN_PLACE);
 #endif /* HAVE_ERROR_CHECKING */
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Get extent and size of recvtype, don't look at sendtype for MPI_IN_PLACE */
     MPIR_Datatype_get_extent_macro(recvtype, recv_extent);

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_inplace.c
@@ -18,8 +18,7 @@ int MPIR_Ialltoallv_intra_sched_inplace(const void *sendbuf, const MPI_Aint send
     MPI_Aint recvtype_extent, recvtype_sz;
     int dst, rank;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Get extent and size of recvtype, don't look at sendtype for MPI_IN_PLACE */
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);

--- a/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_intra_sched_inplace.c
@@ -18,7 +18,7 @@ int MPIR_Ialltoallv_intra_sched_inplace(const void *sendbuf, const MPI_Aint send
     MPI_Aint recvtype_extent, recvtype_sz;
     int dst, rank;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Get extent and size of recvtype, don't look at sendtype for MPI_IN_PLACE */
     MPIR_Datatype_get_extent_macro(recvtype, recvtype_extent);

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_blocked.c
@@ -30,8 +30,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
     MPIR_ERR_CHECK(mpi_errno);
 
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     MPIR_Datatype_get_extent_macro(recvtype, recv_extent);
     MPIR_Type_get_true_extent_impl(recvtype, &recv_lb, &true_extent);

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_inplace.c
@@ -29,8 +29,7 @@ int MPIR_TSP_Ialltoallv_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
     MPIR_ERR_CHECK(mpi_errno);
 
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     MPIR_Datatype_get_extent_macro(recvtype, recv_extent);
     MPIR_Type_get_true_extent_impl(recvtype, &recv_lb, &true_extent);

--- a/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered.c
+++ b/src/mpi/coll/ialltoallv/ialltoallv_tsp_scattered.c
@@ -25,8 +25,9 @@ int MPIR_TSP_Ialltoallv_sched_intra_scattered(const void *sendbuf, const MPI_Ain
 
     MPIR_Assert(!(sendbuf == MPI_IN_PLACE));
 
-    int size = MPIR_Comm_size(comm);
-    int rank = MPIR_Comm_rank(comm);
+    int size;
+    int rank;
+    MPIR_COMM_RANK_SIZE(comm, rank, size);
 
     MPI_Aint recvtype_lb, recvtype_extent;
     MPI_Aint sendtype_lb, sendtype_extent;

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_blocked.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_blocked.c
@@ -34,8 +34,7 @@ int MPIR_Ialltoallw_intra_sched_blocked(const void *sendbuf, const MPI_Aint send
     MPIR_Assert(sendbuf != MPI_IN_PLACE);
 #endif /* HAVE_ERROR_CHECKING */
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     bblock = MPIR_CVAR_ALLTOALL_THROTTLE;
     if (bblock == 0)

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_blocked.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_blocked.c
@@ -34,7 +34,7 @@ int MPIR_Ialltoallw_intra_sched_blocked(const void *sendbuf, const MPI_Aint send
     MPIR_Assert(sendbuf != MPI_IN_PLACE);
 #endif /* HAVE_ERROR_CHECKING */
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     bblock = MPIR_CVAR_ALLTOALL_THROTTLE;
     if (bblock == 0)

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_inplace.c
@@ -29,8 +29,7 @@ int MPIR_Ialltoallw_intra_sched_inplace(const void *sendbuf, const MPI_Aint send
     MPI_Aint recvtype_sz;
     void *tmp_buf = NULL;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* The regular MPI_Alltoallw handles MPI_IN_PLACE using pairwise
      * sendrecv_replace calls.  We don't have a sendrecv_replace, so just

--- a/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_intra_sched_inplace.c
@@ -29,7 +29,7 @@ int MPIR_Ialltoallw_intra_sched_inplace(const void *sendbuf, const MPI_Aint send
     MPI_Aint recvtype_sz;
     void *tmp_buf = NULL;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* The regular MPI_Alltoallw handles MPI_IN_PLACE using pairwise
      * sendrecv_replace calls.  We don't have a sendrecv_replace, so just

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_blocked.c
@@ -25,8 +25,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_blocked(const void *sendbuf, const MPI_Aint 
 
     MPIR_Assert(sendbuf != MPI_IN_PLACE);
 
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     if (bblock == 0)
         bblock = nranks;

--- a/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace.c
+++ b/src/mpi/coll/ialltoallw/ialltoallw_tsp_inplace.c
@@ -27,8 +27,7 @@ int MPIR_TSP_Ialltoallw_sched_intra_inplace(const void *sendbuf, const MPI_Aint 
 
     MPIR_Assert(sendbuf == MPI_IN_PLACE);
 
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */

--- a/src/mpi/coll/ibarrier/ibarrier_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_sched_recursive_doubling.c
@@ -25,7 +25,7 @@ int MPIR_Ibarrier_intra_sched_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sche
 
     MPIR_Assert(comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM);
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, size);
 
     mask = 0x1;
     while (mask < size) {

--- a/src/mpi/coll/ibarrier/ibarrier_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_sched_recursive_doubling.c
@@ -25,8 +25,7 @@ int MPIR_Ibarrier_intra_sched_recursive_doubling(MPIR_Comm * comm_ptr, MPIR_Sche
 
     MPIR_Assert(comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM);
 
-    size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, size);
 
     mask = 0x1;
     while (mask < size) {

--- a/src/mpi/coll/ibarrier/ibarrier_intra_tsp_dissem.c
+++ b/src/mpi/coll/ibarrier/ibarrier_intra_tsp_dissem.c
@@ -19,8 +19,7 @@ int MPIR_TSP_Ibarrier_sched_intra_k_dissemination(MPIR_Comm * comm, int k, MPIR_
 
     MPIR_FUNC_ENTER;
 
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
     if (mpi_errno)

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_binomial.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_binomial.c
@@ -25,7 +25,7 @@ int MPIR_Ibcast_intra_sched_binomial(void *buffer, MPI_Aint count, MPI_Datatype 
     struct MPII_Ibcast_state *ibcast_state;
     void *tmp_buf = NULL;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_is_contig(datatype, &is_contig);
     MPIR_Datatype_get_size_macro(datatype, type_size);

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_binomial.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_binomial.c
@@ -25,8 +25,7 @@ int MPIR_Ibcast_intra_sched_binomial(void *buffer, MPI_Aint count, MPI_Datatype 
     struct MPII_Ibcast_state *ibcast_state;
     void *tmp_buf = NULL;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_is_contig(datatype, &is_contig);
     MPIR_Datatype_get_size_macro(datatype, type_size);

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_recursive_doubling_allgather.c
@@ -61,7 +61,7 @@ int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, M
     void *tmp_buf;
     struct MPII_Ibcast_state *ibcast_state;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
     relative_rank = (rank >= root) ? rank - root : rank - root + comm_size;
 
 #ifdef HAVE_ERROR_CHECKING

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_recursive_doubling_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_recursive_doubling_allgather.c
@@ -61,8 +61,7 @@ int MPIR_Ibcast_intra_sched_scatter_recursive_doubling_allgather(void *buffer, M
     void *tmp_buf;
     struct MPII_Ibcast_state *ibcast_state;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
     relative_rank = (rank >= root) ? rank - root : rank - root + comm_size;
 
 #ifdef HAVE_ERROR_CHECKING

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_ring_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_ring_allgather.c
@@ -37,7 +37,7 @@ int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
 
     struct MPII_Ibcast_state *ibcast_state;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     if (HANDLE_IS_BUILTIN(datatype))
         is_contig = 1;

--- a/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_ring_allgather.c
+++ b/src/mpi/coll/ibcast/ibcast_intra_sched_scatter_ring_allgather.c
@@ -37,8 +37,7 @@ int MPIR_Ibcast_intra_sched_scatter_ring_allgather(void *buffer, MPI_Aint count,
 
     struct MPII_Ibcast_state *ibcast_state;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     if (HANDLE_IS_BUILTIN(datatype))
         is_contig = 1;

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
@@ -37,14 +37,13 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
 
     MPIR_FUNC_ENTER;
 
+    MPIR_COMM_RANK_SIZE(comm, rank, size);
+    lrank = (rank - root + size) % size;        /* logical rank when root is non-zero */
+
     MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                     (MPL_DBG_FDEST,
                      "Scheduling scatter followed by recursive exchange allgather based broadcast on %d ranks, root=%d\n",
-                     MPIR_Comm_size(comm), root));
-
-    size = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
-    lrank = (rank - root + size) % size;        /* logical rank when root is non-zero */
+                     size, root));
 
     MPIR_Datatype_get_size_macro(datatype, type_size);
     MPIR_Datatype_get_extent_macro(datatype, extent);

--- a/src/mpi/coll/ibcast/ibcast_tsp_tree.c
+++ b/src/mpi/coll/ibcast/ibcast_tsp_tree.c
@@ -29,8 +29,7 @@ int MPIR_TSP_Ibcast_sched_intra_tree(void *buffer, MPI_Aint count, MPI_Datatype 
 
     MPIR_FUNC_ENTER;
 
-    size = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, size);
 
     MPIR_Datatype_get_size_macro(datatype, type_size);
     MPIR_Datatype_get_extent_macro(datatype, extent);

--- a/src/mpi/coll/ibcast/ibcast_utils.c
+++ b/src/mpi/coll/ibcast/ibcast_utils.c
@@ -76,8 +76,7 @@ int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr,
     int relative_rank, mask;
     MPI_Aint scatter_size, curr_size, recv_size, send_size;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
     relative_rank = (rank >= root) ? rank - root : rank - root + comm_size;
 
     /* The scatter algorithm divides the buffer into nprocs pieces and

--- a/src/mpi/coll/ibcast/ibcast_utils.c
+++ b/src/mpi/coll/ibcast/ibcast_utils.c
@@ -76,7 +76,7 @@ int MPII_Iscatter_for_bcast_sched(void *tmp_buf, int root, MPIR_Comm * comm_ptr,
     int relative_rank, mask;
     MPI_Aint scatter_size, curr_size, recv_size, send_size;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
     relative_rank = (rank >= root) ? rank - root : rank - root + comm_size;
 
     /* The scatter algorithm divides the buffer into nprocs pieces and

--- a/src/mpi/coll/iexscan/iexscan_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iexscan/iexscan_intra_sched_recursive_doubling.c
@@ -58,8 +58,7 @@ int MPIR_Iexscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvb
     MPI_Aint true_extent, true_lb, extent;
     void *partial_scan, *tmp_buf;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     is_commutative = MPIR_Op_is_commutative(op);
 

--- a/src/mpi/coll/iexscan/iexscan_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iexscan/iexscan_intra_sched_recursive_doubling.c
@@ -58,7 +58,7 @@ int MPIR_Iexscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvb
     MPI_Aint true_extent, true_lb, extent;
     void *partial_scan, *tmp_buf;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     is_commutative = MPIR_Op_is_commutative(op);
 

--- a/src/mpi/coll/igather/igather_inter_sched_short.c
+++ b/src/mpi/coll/igather/igather_inter_sched_short.c
@@ -23,7 +23,7 @@ int MPIR_Igather_inter_sched_short(const void *sendbuf, MPI_Aint sendcount, MPI_
     MPIR_Comm *newcomm_ptr = NULL;
 
     remote_size = comm_ptr->remote_size;
-    local_size = comm_ptr->local_size;
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, local_size);
 
     if (root == MPI_PROC_NULL) {
         /* local processes other than root do nothing */
@@ -38,8 +38,6 @@ int MPIR_Igather_inter_sched_short(const void *sendbuf, MPI_Aint sendcount, MPI_
          * to root. */
         MPI_Aint sendtype_sz;
         void *tmp_buf = NULL;
-
-        rank = comm_ptr->rank;
 
         if (rank == 0) {
             MPIR_Datatype_get_size_macro(sendtype, sendtype_sz);

--- a/src/mpi/coll/igather/igather_intra_sched_binomial.c
+++ b/src/mpi/coll/igather/igather_intra_sched_binomial.c
@@ -42,8 +42,7 @@ int MPIR_Igather_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
     int copy_offset = 0, copy_blks = 0;
     MPI_Datatype types[2], tmp_type;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Assert(comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM);
 

--- a/src/mpi/coll/igather/igather_intra_sched_binomial.c
+++ b/src/mpi/coll/igather/igather_intra_sched_binomial.c
@@ -42,7 +42,7 @@ int MPIR_Igather_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
     int copy_offset = 0, copy_blks = 0;
     MPI_Datatype types[2], tmp_type;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Assert(comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM);
 

--- a/src/mpi/coll/igather/igather_tsp_tree.c
+++ b/src/mpi/coll/igather/igather_tsp_tree.c
@@ -31,9 +31,7 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
 
     MPIR_FUNC_ENTER;
 
-
-    size = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, size);
     lrank = (rank - root + size) % size;        /* logical rank when root is non-zero */
 
     if (rank == root)

--- a/src/mpi/coll/igatherv/igatherv_allcomm_sched_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_allcomm_sched_linear.c
@@ -22,14 +22,12 @@ int MPIR_Igatherv_allcomm_sched_linear(const void *sendbuf, MPI_Aint sendcount,
     int comm_size, rank;
     MPI_Aint extent;
 
-    rank = comm_ptr->rank;
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* If rank == root, then I recv lots, otherwise I send */
     if (((comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) && (root == rank)) ||
         ((comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) && (root == MPI_ROOT))) {
-        if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM)
-            comm_size = comm_ptr->local_size;
-        else
+        if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM)
             comm_size = comm_ptr->remote_size;
 
         MPIR_Datatype_get_extent_macro(recvtype, extent);

--- a/src/mpi/coll/igatherv/igatherv_tsp_linear.c
+++ b/src/mpi/coll/igatherv/igatherv_tsp_linear.c
@@ -30,7 +30,7 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcou
     int tag;
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
 
-    rank = comm_ptr->rank;
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     mpi_errno = MPIR_Sched_next_tag(comm_ptr, &tag);
     MPIR_ERR_CHECK(mpi_errno);
@@ -38,9 +38,7 @@ int MPIR_TSP_Igatherv_sched_allcomm_linear(const void *sendbuf, MPI_Aint sendcou
     /* If rank == root, then I recv lots, otherwise I send */
     if (((comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) && (root == rank)) ||
         ((comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) && (root == MPI_ROOT))) {
-        if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM)
-            comm_size = comm_ptr->local_size;
-        else
+        if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM)
             comm_size = comm_ptr->remote_size;
 
         MPIR_Datatype_get_extent_macro(recvtype, extent);

--- a/src/mpi/coll/ireduce/ireduce_intra_sched_binomial.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_sched_binomial.c
@@ -17,7 +17,7 @@ int MPIR_Ireduce_intra_sched_binomial(const void *sendbuf, void *recvbuf, MPI_Ai
 
     MPIR_Assert(comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM);
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Create a temporary buffer */
 

--- a/src/mpi/coll/ireduce/ireduce_intra_sched_binomial.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_sched_binomial.c
@@ -17,8 +17,7 @@ int MPIR_Ireduce_intra_sched_binomial(const void *sendbuf, void *recvbuf, MPI_Ai
 
     MPIR_Assert(comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM);
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Create a temporary buffer */
 

--- a/src/mpi/coll/ireduce/ireduce_intra_sched_reduce_scatter_gather.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_sched_reduce_scatter_gather.c
@@ -63,7 +63,7 @@ int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *re
     tmp_buf = (void *) ((char *) tmp_buf - true_lb);
 
     /* get nearest power-of-two less than or equal to comm_size */
-    pof2 = comm_ptr->coll.pof2;
+    pof2 = MPL_pof2(comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     MPIR_Assert(HANDLE_IS_BUILTIN(op));

--- a/src/mpi/coll/ireduce/ireduce_intra_sched_reduce_scatter_gather.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_sched_reduce_scatter_gather.c
@@ -44,8 +44,7 @@ int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *re
     MPI_Aint true_lb, true_extent, extent;
     MPIR_CHKLMEM_DECL();
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* NOTE: this algorithm is currently only correct for commutative operations */
     is_commutative = MPIR_Op_is_commutative(op);

--- a/src/mpi/coll/ireduce/ireduce_intra_sched_reduce_scatter_gather.c
+++ b/src/mpi/coll/ireduce/ireduce_intra_sched_reduce_scatter_gather.c
@@ -44,7 +44,7 @@ int MPIR_Ireduce_intra_sched_reduce_scatter_gather(const void *sendbuf, void *re
     MPI_Aint true_lb, true_extent, extent;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* NOTE: this algorithm is currently only correct for commutative operations */
     is_commutative = MPIR_Op_is_commutative(op);

--- a/src/mpi/coll/ireduce/ireduce_tsp_tree.c
+++ b/src/mpi/coll/ireduce/ireduce_tsp_tree.c
@@ -42,8 +42,7 @@ int MPIR_TSP_Ireduce_sched_intra_tree(const void *sendbuf, void *recvbuf, MPI_Ai
 
     MPIR_FUNC_ENTER;
 
-    size = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, size);
     is_root = (rank == root);
 
     /* main algorithm */

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_noncommutative.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_noncommutative.c
@@ -26,8 +26,8 @@ int MPIR_Ireduce_scatter_intra_sched_noncommutative(const void *sendbuf, void *r
                                                     MPIR_Comm * comm_ptr, MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
-    int comm_size = comm_ptr->local_size;
-    int rank = comm_ptr->rank;
+    int comm_size;
+    int rank;
     int log2_comm_size;
     int i, k;
     MPI_Aint true_extent, true_lb;
@@ -35,6 +35,8 @@ int MPIR_Ireduce_scatter_intra_sched_noncommutative(const void *sendbuf, void *r
     void *tmp_buf0;
     void *tmp_buf1;
     void *result_ptr;
+
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_noncommutative.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_noncommutative.c
@@ -36,7 +36,7 @@ int MPIR_Ireduce_scatter_intra_sched_noncommutative(const void *sendbuf, void *r
     void *tmp_buf1;
     void *result_ptr;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_pairwise.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_pairwise.c
@@ -23,7 +23,7 @@ int MPIR_Ireduce_scatter_intra_sched_pairwise(const void *sendbuf, void *recvbuf
     void *tmp_recvbuf;
     int src, dst;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_pairwise.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_pairwise.c
@@ -23,8 +23,7 @@ int MPIR_Ireduce_scatter_intra_sched_pairwise(const void *sendbuf, void *recvbuf
     void *tmp_recvbuf;
     int src, dst;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_doubling.c
@@ -31,7 +31,7 @@ int MPIR_Ireduce_scatter_intra_sched_recursive_doubling(const void *sendbuf, voi
     MPI_Datatype sendtype, recvtype;
     int nprocs_completed, tmp_mask, tree_root, is_commutative;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_doubling.c
@@ -31,8 +31,7 @@ int MPIR_Ireduce_scatter_intra_sched_recursive_doubling(const void *sendbuf, voi
     MPI_Datatype sendtype, recvtype;
     int nprocs_completed, tmp_mask, tree_root, is_commutative;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_halving.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_halving.c
@@ -94,7 +94,7 @@ int MPIR_Ireduce_scatter_intra_sched_recursive_halving(const void *sendbuf, void
     MPIR_ERR_CHECK(mpi_errno);
     MPIR_SCHED_BARRIER(s);
 
-    pof2 = comm_ptr->coll.pof2;
+    pof2 = MPL_pof2(comm_size);
 
     rem = comm_size - pof2;
 

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_halving.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_halving.c
@@ -47,8 +47,7 @@ int MPIR_Ireduce_scatter_intra_sched_recursive_halving(const void *sendbuf, void
     int rem, newdst, send_idx, recv_idx, last_idx;
     int pof2, old_i, newrank;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_halving.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_intra_sched_recursive_halving.c
@@ -47,7 +47,7 @@ int MPIR_Ireduce_scatter_intra_sched_recursive_halving(const void *sendbuf, void
     int rem, newdst, send_idx, recv_idx, last_idx;
     int pof2, old_i, newrank;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
@@ -160,8 +160,7 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch(const void *sendbuf, void *recv
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_noncommutative.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_noncommutative.c
@@ -25,7 +25,7 @@ int MPIR_Ireduce_scatter_block_intra_sched_noncommutative(const void *sendbuf, v
     void *tmp_buf1;
     void *result_ptr;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_noncommutative.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_noncommutative.c
@@ -15,8 +15,8 @@ int MPIR_Ireduce_scatter_block_intra_sched_noncommutative(const void *sendbuf, v
                                                           MPIR_Sched_t s)
 {
     int mpi_errno = MPI_SUCCESS;
-    int comm_size = comm_ptr->local_size;
-    int rank = comm_ptr->rank;
+    int comm_size;
+    int rank;
     int log2_comm_size;
     int i, k;
     MPI_Aint true_extent, true_lb;
@@ -24,6 +24,8 @@ int MPIR_Ireduce_scatter_block_intra_sched_noncommutative(const void *sendbuf, v
     void *tmp_buf0;
     void *tmp_buf1;
     void *result_ptr;
+
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_pairwise.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_pairwise.c
@@ -19,8 +19,7 @@ int MPIR_Ireduce_scatter_block_intra_sched_pairwise(const void *sendbuf, void *r
     int src, dst;
     MPI_Aint total_count;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_pairwise.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_pairwise.c
@@ -19,7 +19,7 @@ int MPIR_Ireduce_scatter_block_intra_sched_pairwise(const void *sendbuf, void *r
     int src, dst;
     MPI_Aint total_count;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_doubling.c
@@ -22,8 +22,7 @@ int MPIR_Ireduce_scatter_block_intra_sched_recursive_doubling(const void *sendbu
     MPI_Datatype sendtype, recvtype;
     int nprocs_completed, tmp_mask, tree_root, is_commutative;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_doubling.c
@@ -22,7 +22,7 @@ int MPIR_Ireduce_scatter_block_intra_sched_recursive_doubling(const void *sendbu
     MPI_Datatype sendtype, recvtype;
     int nprocs_completed, tmp_mask, tree_root, is_commutative;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_halving.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_halving.c
@@ -21,8 +21,7 @@ int MPIR_Ireduce_scatter_block_intra_sched_recursive_halving(const void *sendbuf
     int rem, newdst, send_idx, recv_idx, last_idx, send_cnt, recv_cnt;
     int pof2, old_i, newrank;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_halving.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_intra_sched_recursive_halving.c
@@ -21,7 +21,7 @@ int MPIR_Ireduce_scatter_block_intra_sched_recursive_halving(const void *sendbuf
     int rem, newdst, send_idx, recv_idx, last_idx, send_cnt, recv_cnt;
     int pof2, old_i, newrank;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch.c
+++ b/src/mpi/coll/ireduce_scatter_block/ireduce_scatter_block_tsp_recexch.c
@@ -35,8 +35,7 @@ int MPIR_TSP_Ireduce_scatter_block_sched_intra_recexch(const void *sendbuf, void
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
 
     is_inplace = (sendbuf == MPI_IN_PLACE);
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &lb, &true_extent);

--- a/src/mpi/coll/iscan/iscan_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iscan/iscan_intra_sched_recursive_doubling.c
@@ -16,8 +16,7 @@ int MPIR_Iscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf
     void *partial_scan = NULL;
     void *tmp_buf = NULL;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     is_commutative = MPIR_Op_is_commutative(op);
 

--- a/src/mpi/coll/iscan/iscan_intra_sched_recursive_doubling.c
+++ b/src/mpi/coll/iscan/iscan_intra_sched_recursive_doubling.c
@@ -16,7 +16,7 @@ int MPIR_Iscan_intra_sched_recursive_doubling(const void *sendbuf, void *recvbuf
     void *partial_scan = NULL;
     void *tmp_buf = NULL;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     is_commutative = MPIR_Op_is_commutative(op);
 

--- a/src/mpi/coll/iscan/iscan_tsp_recursive_doubling.c
+++ b/src/mpi/coll/iscan/iscan_tsp_recursive_doubling.c
@@ -30,8 +30,7 @@ int MPIR_TSP_Iscan_sched_intra_recursive_doubling(const void *sendbuf, void *rec
     mpi_errno = MPIR_Sched_next_tag(comm, &tag);
     MPIR_ERR_CHECK(mpi_errno);
 
-    nranks = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, nranks);
 
     is_commutative = MPIR_Op_is_commutative(op);
 

--- a/src/mpi/coll/iscatter/iscatter_intra_sched_binomial.c
+++ b/src/mpi/coll/iscatter/iscatter_intra_sched_binomial.c
@@ -77,7 +77,7 @@ int MPIR_Iscatter_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
     void *tmp_buf = NULL;
     struct shared_state *ss = NULL;
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     ss = MPIR_Sched_alloc_state(s, sizeof(struct shared_state));
     MPIR_ERR_CHKANDJUMP(!ss, mpi_errno, MPI_ERR_OTHER, "**nomem");

--- a/src/mpi/coll/iscatter/iscatter_intra_sched_binomial.c
+++ b/src/mpi/coll/iscatter/iscatter_intra_sched_binomial.c
@@ -77,8 +77,7 @@ int MPIR_Iscatter_intra_sched_binomial(const void *sendbuf, MPI_Aint sendcount,
     void *tmp_buf = NULL;
     struct shared_state *ss = NULL;
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     ss = MPIR_Sched_alloc_state(s, sizeof(struct shared_state));
     MPIR_ERR_CHKANDJUMP(!ss, mpi_errno, MPI_ERR_OTHER, "**nomem");

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree.c
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree.c
@@ -34,8 +34,7 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
     MPIR_Errflag_t errflag ATTRIBUTE((unused)) = MPIR_ERR_NONE;
     MPIR_CHKLMEM_DECL();
 
-    size = MPIR_Comm_size(comm);
-    rank = MPIR_Comm_rank(comm);
+    MPIR_COMM_RANK_SIZE(comm, rank, size);
     lrank = (rank - root + size) % size;        /* logical rank when root is non-zero */
 
     if (rank == root)

--- a/src/mpi/coll/iscatterv/iscatterv_allcomm_sched_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_allcomm_sched_linear.c
@@ -25,14 +25,12 @@ int MPIR_Iscatterv_allcomm_sched_linear(const void *sendbuf, const MPI_Aint send
     MPI_Aint extent;
     int i;
 
-    rank = comm_ptr->rank;
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* If I'm the root, then scatter */
     if (((comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) && (root == rank)) ||
         ((comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) && (root == MPI_ROOT))) {
-        if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM)
-            comm_size = comm_ptr->local_size;
-        else
+        if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM)
             comm_size = comm_ptr->remote_size;
 
         MPIR_Datatype_get_extent_macro(sendtype, extent);

--- a/src/mpi/coll/iscatterv/iscatterv_tsp_linear.c
+++ b/src/mpi/coll/iscatterv/iscatterv_tsp_linear.c
@@ -22,7 +22,7 @@ int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const MPI_Aint 
 
     MPIR_FUNC_ENTER;
 
-    rank = comm_ptr->rank;
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* For correctness, transport based collectives need to get the
      * tag from the same pool as schedule based collectives */
@@ -32,9 +32,7 @@ int MPIR_TSP_Iscatterv_sched_allcomm_linear(const void *sendbuf, const MPI_Aint 
     /* If I'm the root, then scatter */
     if (((comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) && (root == rank)) ||
         ((comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM) && (root == MPI_ROOT))) {
-        if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM)
-            comm_size = comm_ptr->local_size;
-        else
+        if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTERCOMM)
             comm_size = comm_ptr->remote_size;
 
         MPIR_Datatype_get_extent_macro(sendtype, extent);

--- a/src/mpi/coll/mpir_coll_sched_auto.c
+++ b/src/mpi/coll/mpir_coll_sched_auto.c
@@ -538,7 +538,7 @@ int MPIR_Ireduce_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Aint c
     MPIR_Datatype_get_size_macro(datatype, type_size);
 
     /* get nearest power-of-two less than or equal to number of ranks in the communicator */
-    pof2 = comm_ptr->coll.pof2;
+    pof2 = MPL_pof2(comm_ptr->local_size);
 
     if ((count * type_size > MPIR_CVAR_REDUCE_SHORT_MSG_SIZE) &&
         (HANDLE_IS_BUILTIN(op)) && (count >= pof2)) {
@@ -595,7 +595,7 @@ int MPIR_Iallreduce_intra_sched_auto(const void *sendbuf, void *recvbuf, MPI_Ain
     MPIR_Datatype_get_size_macro(datatype, type_size);
 
     /* get nearest power-of-two less than or equal to number of ranks in the communicator */
-    pof2 = comm_ptr->coll.pof2;
+    pof2 = MPL_pof2(comm_ptr->local_size);
 
     /* If op is user-defined or count is less than pof2, use
      * recursive doubling algorithm. Otherwise do a reduce-scatter

--- a/src/mpi/coll/reduce/reduce_intra_binomial.c
+++ b/src/mpi/coll/reduce/reduce_intra_binomial.c
@@ -23,7 +23,7 @@ int MPIR_Reduce_intra_binomial(const void *sendbuf,
     void *tmp_buf;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Create a temporary buffer */
 

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -49,7 +49,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
 
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Create a temporary buffer */
 

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -73,7 +73,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
     }
 
     /* get nearest power-of-two less than or equal to comm_size */
-    pof2 = comm_ptr->coll.pof2;
+    pof2 = MPL_pof2(comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     MPIR_Assert(HANDLE_IS_BUILTIN(op));

--- a/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
+++ b/src/mpi/coll/reduce/reduce_intra_reduce_scatter_gather.c
@@ -49,8 +49,7 @@ int MPIR_Reduce_intra_reduce_scatter_gather(const void *sendbuf,
 
     MPIR_CHKLMEM_DECL();
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* Create a temporary buffer */
 

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
@@ -26,8 +26,8 @@ int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
                                              MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    int comm_size = comm_ptr->local_size;
-    int rank = comm_ptr->rank;
+    int comm_size;
+    int rank;
     int log2_comm_size;
     int i, k;
     MPI_Aint true_extent, true_lb;
@@ -36,6 +36,8 @@ int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
     void *tmp_buf1;
     void *result_ptr;
     MPIR_CHKLMEM_DECL();
+
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_noncommutative.c
@@ -37,7 +37,7 @@ int MPIR_Reduce_scatter_intra_noncommutative(const void *sendbuf, void *recvbuf,
     void *result_ptr;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
@@ -25,8 +25,7 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
     int src, dst;
     MPIR_CHKLMEM_DECL();
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_pairwise.c
@@ -25,7 +25,7 @@ int MPIR_Reduce_scatter_intra_pairwise(const void *sendbuf, void *recvbuf,
     int src, dst;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
@@ -34,8 +34,7 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
     int nprocs_completed, tmp_mask, tree_root, is_commutative;
     MPIR_CHKLMEM_DECL();
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_doubling.c
@@ -34,7 +34,7 @@ int MPIR_Reduce_scatter_intra_recursive_doubling(const void *sendbuf, void *recv
     int nprocs_completed, tmp_mask, tree_root, is_commutative;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter/reduce_scatter_intra_recursive_halving.c
@@ -50,7 +50,7 @@ int MPIR_Reduce_scatter_intra_recursive_halving(const void *sendbuf, void *recvb
     int pof2, old_i, newrank;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     {

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
@@ -28,8 +28,8 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
                                                    MPIR_Comm * comm_ptr, MPIR_Errflag_t errflag)
 {
     int mpi_errno = MPI_SUCCESS;
-    int comm_size = comm_ptr->local_size;
-    int rank = comm_ptr->rank;
+    int comm_size;
+    int rank;
     int log2_comm_size;
     int i, k;
     MPI_Aint true_extent, true_lb;
@@ -38,6 +38,8 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
     void *tmp_buf1;
     void *result_ptr;
     MPIR_CHKLMEM_DECL();
+
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_noncommutative.c
@@ -39,7 +39,7 @@ int MPIR_Reduce_scatter_block_intra_noncommutative(const void *sendbuf,
     void *result_ptr;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);
 

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
@@ -34,7 +34,7 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
     int src, dst;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_pairwise.c
@@ -34,8 +34,7 @@ int MPIR_Reduce_scatter_block_intra_pairwise(const void *sendbuf,
     int src, dst;
     MPIR_CHKLMEM_DECL();
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
@@ -38,7 +38,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
     int nprocs_completed, tmp_mask, tree_root, is_commutative;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_doubling.c
@@ -38,8 +38,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_doubling(const void *sendbuf,
     int nprocs_completed, tmp_mask, tree_root, is_commutative;
     MPIR_CHKLMEM_DECL();
 
-    comm_size = comm_ptr->local_size;
-    rank = comm_ptr->rank;
+    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     MPIR_Datatype_get_extent_macro(datatype, extent);
     MPIR_Type_get_true_extent_impl(datatype, &true_lb, &true_extent);

--- a/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
+++ b/src/mpi/coll/reduce_scatter_block/reduce_scatter_block_intra_recursive_halving.c
@@ -52,7 +52,7 @@ int MPIR_Reduce_scatter_block_intra_recursive_halving(const void *sendbuf,
     int pof2, old_i, newrank;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
 #ifdef HAVE_ERROR_CHECKING
     {

--- a/src/mpi/coll/scan/scan_intra_recursive_doubling.c
+++ b/src/mpi/coll/scan/scan_intra_recursive_doubling.c
@@ -54,7 +54,7 @@ int MPIR_Scan_intra_recursive_doubling(const void *sendbuf,
     void *partial_scan, *tmp_buf;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     is_commutative = MPIR_Op_is_commutative(op);
 

--- a/src/mpi/coll/scan/scan_intra_smp.c
+++ b/src/mpi/coll/scan/scan_intra_smp.c
@@ -12,7 +12,9 @@ int MPIR_Scan_intra_smp(const void *sendbuf, void *recvbuf, MPI_Aint count,
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_CHKLMEM_DECL();
-    int rank = comm_ptr->rank;
+    int rank;
+    int size ATTRIBUTE((unused));
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, size);
     MPI_Status status;
     void *tempbuf = NULL, *localfulldata = NULL, *prefulldata = NULL;
     MPI_Aint true_lb, true_extent, extent;

--- a/src/mpi/coll/scatter/scatter_intra_binomial.c
+++ b/src/mpi/coll/scatter/scatter_intra_binomial.c
@@ -41,7 +41,7 @@ int MPIR_Scatter_intra_binomial(const void *sendbuf, MPI_Aint sendcount, MPI_Dat
     int mpi_errno = MPI_SUCCESS;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     if (rank == root)
         MPIR_Datatype_get_extent_macro(sendtype, extent);

--- a/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
+++ b/src/mpi/coll/scatterv/scatterv_allcomm_linear.c
@@ -29,7 +29,7 @@ int MPIR_Scatterv_allcomm_linear(const void *sendbuf, const MPI_Aint * sendcount
     MPI_Status *starray;
     MPIR_CHKLMEM_DECL();
 
-    MPIR_THREADCOMM_RANK_SIZE(comm_ptr, rank, comm_size);
+    MPIR_COMM_RANK_SIZE(comm_ptr, rank, comm_size);
 
     /* If I'm the root, then scatter */
     if (((comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) && (root == rank)) ||

--- a/src/mpi/coll/src/coll_impl.c
+++ b/src/mpi/coll/src/coll_impl.c
@@ -237,8 +237,6 @@ int MPIR_Coll_comm_init(MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    comm->coll.pof2 = MPL_pof2(comm->local_size);
-
     /* initialize any stub algo related data structures */
     mpi_errno = MPII_Stubalgo_comm_init(comm);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpi/coll/src/csel.c
+++ b/src/mpi/coll/src/csel.c
@@ -1280,7 +1280,7 @@ void *MPIR_Csel_search(void *csel_, MPIR_Csel_coll_sig_s coll_info)
                 break;
 
             case CSEL_NODE_TYPE__OPERATOR__COUNT_LT_POW2:
-                if (get_count(coll_info) < coll_info.comm_ptr->coll.pof2)
+                if (get_count(coll_info) < MPL_pof2(coll_info.comm_ptr->local_size))
                     node = node->success;
                 else
                     node = node->failure;


### PR DESCRIPTION
## Pull Request Description

Stemming from a project to formally verify MPI collective algorithms in MPICH, there is a desire to eliminate some inconsistencies in the collective implementations. Namely:

1. Avoid getting rank and size information direct from the communicator struct. This also benefits threadcomm support in various algorithms.
2. Do pof2 calculations on-the-fly. We added optimized MPL utils in https://github.com/pmodels/mpich/pull/5778, so use it and remove the stored value from the comm struct.
3. Other minor cleanups like removing redundant header includes.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
