### PR TITLE
Revert "env: Add --help and -h options for help text in wrappers"

### DIFF
--- a/src/env/mpicc.bash.in
+++ b/src/env/mpicc.bash.in
@@ -194,7 +194,7 @@ for arg in "$@" ; do
     mpi_abi=yes
     addarg=no
     ;;
-    --help|-help|-h)
+    -help)
     NC=`echo "$CC" | sed 's%\/% %g' | awk '{print $NF}' -`
     if [ -f "$sysconfdir/mpixxx_opts.conf" ] ; then
         . $sysconfdir/mpixxx_opts.conf

--- a/src/env/mpicc.sh.in
+++ b/src/env/mpicc.sh.in
@@ -194,7 +194,7 @@ for arg in "$@" ; do
     mpi_abi=yes
     addarg=no
     ;;
-    --help|-help|-h)
+    -help)
     NC=`echo "$CC" | sed 's%\/% %g' | awk '{print $NF}' -`
     if [ -f "$sysconfdir/mpixxx_opts.conf" ] ; then
         . $sysconfdir/mpixxx_opts.conf

--- a/src/env/mpicxx.bash.in
+++ b/src/env/mpicxx.bash.in
@@ -199,7 +199,7 @@ for arg in "$@" ; do
     mpi_abi=yes
     addarg=no
     ;;
-    --help|-help|-h)
+    -help)
     NC=`echo "$CXX" | sed 's%\/% %g' | awk '{print $NF}' -`
     if [ -f "$sysconfdir/mpixxx_opts.conf" ] ; then
         . $sysconfdir/mpixxx_opts.conf

--- a/src/env/mpicxx.sh.in
+++ b/src/env/mpicxx.sh.in
@@ -199,7 +199,7 @@ for arg in "$@" ; do
     mpi_abi=yes
     addarg=no
     ;;
-    --help|-help|-h)
+    -help)
     NC=`echo "$CXX" | sed 's%\/% %g' | awk '{print $NF}' -`
     if [ -f "$sysconfdir/mpixxx_opts.conf" ] ; then
         . $sysconfdir/mpixxx_opts.conf

--- a/src/env/mpifort.bash.in
+++ b/src/env/mpifort.bash.in
@@ -204,7 +204,7 @@ for arg in "$@" ; do
     nativelinking=yes
     addarg=no
     ;;
-    --help|-help|-h)
+    -help)
     NC=`echo "$FC" | sed 's%\/% %g' | awk '{print $NF}' -`
     if [ -f "$sysconfdir/mpixxx_opts.conf" ] ; then
         . $sysconfdir/mpixxx_opts.conf

--- a/src/env/mpifort.sh.in
+++ b/src/env/mpifort.sh.in
@@ -203,7 +203,7 @@ for arg in "$@" ; do
     nativelinking=yes
     addarg=no
     ;;
-    --help|-help|-h)
+    -help)
     NC=`echo "$FC" | sed 's%\/% %g' | awk '{print $NF}' -`
     if [ -f "$sysconfdir/mpixxx_opts.conf" ] ; then
         . $sysconfdir/mpixxx_opts.conf


### PR DESCRIPTION
## Pull Request Description

This reverts commit f1d88f8c59974f9ac313a86c41e8714a064f8388. Users have come to rely on the passthrough behavior of these options. Most other major MPI distributions behave the same way. See
https://gitlab.com/petsc/petsc/-/issues/1765#note_2524490760.

Fixes pmodels/mpich#7431.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
