### PR TITLE
pmix: hint pmix not to spawn threads

### DIFF
--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -50,7 +50,14 @@ static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
     static int pmix_init_count = 0;
     pmix_init_count++;
     if (pmix_init_count == 1) {
-        pmi_errno = PMIx_Init(&pmix_proc, NULL, 0);
+        pmix_info_t *info;
+        PMIX_INFO_CREATE(info, 1);
+        int flag = 1;
+        PMIx_Info_load(info, PMIX_EXTERNAL_PROGRESS, &flag, PMIX_BOOL);
+
+        pmi_errno = PMIx_Init(&pmix_proc, info, 0);
+        PMIX_INFO_FREE(info, 1);
+
         if (pmi_errno == PMIX_ERR_UNREACH) {
             /* Failed to connect to server. Throw an error if an
              * incompatible server is detected (e.g. hydra), otherwise


### PR DESCRIPTION
## Pull Request Description
PMIx launches background thread to support nonblocking operation, e.g. `PMIx_Fence_nb`, and event notification. MPICH always want to manage threads explicitly. Since currently we only use blocking operations, it should work without the background thread.




## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
