### PR TITLE
maint/python: Fix info_hints.py if files are processed in batches

### DIFF
--- a/maint/local_python/info_hints.py
+++ b/maint/local_python/info_hints.py
@@ -10,7 +10,12 @@ def collect_info_hint_blocks(root_dir):
     """Collect INFO_HINT_BLOCKS from source files and return a function-name-keyed dictionary"""
     infos_by_funcname = {}
 
-    files = subprocess.check_output("find %s -name '*.[ch]' |xargs grep -l BEGIN_INFO_HINT_BLOCK" % root_dir, shell=True).splitlines()
+    # xargs may process files in batches and return a non-zero exit code if grep comes up empty
+    # use "|| true" to avoid terminating the script in those instances
+    # https://stackoverflow.com/questions/26540813/got-exit-code-123-in-find-xargs-grep
+    files = subprocess.check_output(
+        "find %s -name '*.[ch]' |xargs grep -l BEGIN_INFO_HINT_BLOCK || true" % root_dir,
+        shell=True).splitlines()
     for f in files:
         infos = parse_info_block(f)
         for info in infos:


### PR DESCRIPTION
## Pull Request Description

Using xargs + grep to find info hint comment blocks could result in files getting processed in batches. If any of the batches do not have any info comment blocks, then the command with return a non-zero exit code and cause the script to fail. Append "|| true" to prevent this failure mode.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
