### PR TITLE
mpl/ze: Print error information when failure is detected

### DIFF
--- a/src/mpi/datatype/typerep/yaksa/src/backend/ze/include/yaksuri_zei.h
+++ b/src/mpi/datatype/typerep/yaksa/src/backend/ze/include/yaksuri_zei.h
@@ -42,14 +42,17 @@ extern "C" {
 #define YAKSURI_ZEI_ZE_ERR_CHECK(zerr)                                  \
     do {                                                                \
         if (zerr != ZE_RESULT_SUCCESS) {                                \
-            fprintf(stderr, "ZE Error (%s:%s,%d): %d\n", __func__, __FILE__, __LINE__, zerr); \
+            const char *ppString;                                       \
+            zeDriverGetLastErrorDescription(yaksuri_zei_global.driver, &ppString); \
+            fprintf(stderr, "ZE Error (%s:%s,%d): %#x:%s\n", __func__, __FILE__, __LINE__, zerr, ppString); \
         }                                                               \
     } while (0)
 
 #define YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail)                \
     do {                                                                \
         if (zerr != ZE_RESULT_SUCCESS) {                                \
-            fprintf(stderr, "ZE Error (%s:%s,%d): %d\n", __func__, __FILE__, __LINE__, zerr); \
+            zeDriverGetLastErrorDescription(yaksuri_zei_global.driver, &ppString); \
+            fprintf(stderr, "ZE Error (%s:%s,%d): %#x:%s\n", __func__, __FILE__, __LINE__, zerr, ppString); \
             rc = YAKSA_ERR__INTERNAL;                                   \
             goto fn_fail;                                               \
         }                                                               \

--- a/src/mpid/ch4/shm/ipc/src/ipc_fd.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_fd.c
@@ -46,8 +46,8 @@ int MPIDI_FD_comm_bootstrap(MPIR_Comm * comm)
     }
 
     int already_initialized;
-    mpi_errno = MPIR_Allreduce(&ipc_fd_initialized, &already_initialized, 1, MPIR_INT_INTERNAL,
-                               MPI_MAX, node_comm, MPIR_ERR_NONE);
+    mpi_errno = MPIR_Allreduce_impl(&ipc_fd_initialized, &already_initialized, 1, MPIR_INT_INTERNAL,
+                                    MPI_MAX, node_comm, MPIR_ERR_NONE);
     MPIR_ERR_CHECK(mpi_errno);
 
     if (already_initialized) {

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -283,8 +283,12 @@ static ze_result_t ZE_APICALL(*sys_zeMemFree) (ze_context_handle_t hContext, voi
 
 #define ZE_ERR_CHECK(ret) \
     do { \
-        if (unlikely((ret) != ZE_RESULT_SUCCESS)) \
+        if (unlikely((ret) != ZE_RESULT_SUCCESS)) { \
+            const char *ppString; \
+            zeDriverGetLastErrorDescription(ze_driver_handle, &ppString); \
+            MPL_internal_error_printf("ZE Error: (%s:%s,%d): %#x:%s\n", __func__, __FILE__, __LINE__, ret, ppString); \
             goto fn_fail; \
+        } \
     } while (0)
 
 int MPL_gpu_get_dev_count(int *dev_cnt, int *max_dev_id, int *max_subdev_id)


### PR DESCRIPTION
## Pull Request Description

Failures in Level Zero calls previously were masked by the MPL abstraction and returned to the user as general MPICH internal errors. Output the error description from the Level Zero runtime to give the user more clues as to what failed. Fixes pmodels/mpich#7439.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
