### PR TITLE
windows/compiler-warning: GetCurrentThreadId() returns an unsigned long.

### DIFF
--- a/src/mpl/include/mpl_shm_win.h
+++ b/src/mpl/include/mpl_shm_win.h
@@ -45,7 +45,7 @@ static inline int MPL_shm_get_uniq_str(char *str, int strlen)
 {
     LARGE_INTEGER perfCnt;
     QueryPerformanceCounter(&perfCnt);
-    return (snprintf(str, strlen, "MPICH_NEM_%d_%I64d", GetCurrentThreadId(), (perfCnt.QuadPart)));
+    return (snprintf(str, strlen, "MPICH_NEM_%lu_%I64d", GetCurrentThreadId(), (perfCnt.QuadPart)));
 }
 #endif
 


### PR DESCRIPTION
## Pull Request Description
When compiling with Intel ICX compiler noticed the following warning for -Wformat. This produces around 7K+ lines of entry in the build log and slows down the build process.

Sample warning message:
_src\mpl\include\mpl_shm_win.h(54,26): : warning : format specifies type 'int' but the argument has type 'DWORD' (aka 'unsigned long') [-Wformat]
1>   53 |     return (MPL_snprintf(str, strlen, "MPICH_NEM_%d_%I64d",
1>      |                                                  ~~
1>      |                                                  %lu
1>   54 |                          GetCurrentThreadId(), (perfCnt.QuadPart)) < 0);
1>      |_                          ^~~~~~~~~~~~~~~~~~~~

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
