### PR TITLE
mpir/pmi: fix bad static assertion

### DIFF
--- a/src/util/mpir_pmi1.inc
+++ b/src/util/mpir_pmi1.inc
@@ -136,10 +136,16 @@ static int pmi1_barrier_group(int *group, int count)
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
 
-    MPL_COMPILE_TIME_ASSERT(MPIR_PMI_GROUP_WORLD == PMI_GROUP_WORLD);
-    MPL_COMPILE_TIME_ASSERT(MPIR_PMI_GROUP_SELF == PMI_GROUP_SELF);
+    int *use_group;
+    if (group == MPIR_PMI_GROUP_WORLD) {
+        use_group = PMI_GROUP_WORLD;
+    } else if (group == MPIR_PMI_GROUP_SELF) {
+        use_group = PMI_GROUP_SELF;
+    } else {
+        use_group = group;
+    }
 
-    pmi_errno = PMI_Barrier_group(group, count);
+    pmi_errno = PMI_Barrier_group(use_group, count);
     MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                          "**pmi_barrier_group", "**pmi_barrier_group %d", pmi_errno);
 


### PR DESCRIPTION
## Pull Request Description
Clang does not allow pointer casted constants in static assertions. Replace it with runtime comparisons instead.

This fixes the current test failures using `clang`:
```
In file included from src/util/mpir_pmi.c:65:
./src/util/mpir_pmi1.inc:139:29: error: static_assert expression is not an integral constant expression
    MPL_COMPILE_TIME_ASSERT(MPIR_PMI_GROUP_WORLD == PMI_GROUP_WORLD);
    ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./src/include/mpir_pmi.h:48:35: note: expanded from macro 'MPIR_PMI_GROUP_WORLD'
#define MPIR_PMI_GROUP_WORLD      ((int *)0)
                                  ^
/scratch/jenkins-slave/workspace/mpich-main-ch4-ofi/compiler/clang/jenkins_configure/default/label/ubuntu22.04/mpich-main/src/mpl/include/mpl_base.h:100:58: note: expanded from macro 'MPL_COMPILE_TIME_ASSERT'
#define MPL_COMPILE_TIME_ASSERT(cond_) MPL_static_assert(cond_, "MPL_COMPILE_TIME_ASSERT failure")
                                       ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/scratch/jenkins-slave/workspace/mpich-main-ch4-ofi/compiler/clang/jenkins_configure/default/label/ubuntu22.04/mpich-main/src/mpl/include/mpl_base.h:89:54: note: expanded from macro 'MPL_static_assert'
#define MPL_static_assert(cond_,msg_) _Static_assert(cond_,msg_)
                                                     ^~~~~
In file included from src/util/mpir_pmi.c:65:
```

`gcc` was happy though.

[skip warnings]

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
