### PR TITLE
ch4/release_gather: Check for shm buffer before free

### DIFF
--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.c
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.c
@@ -504,8 +504,10 @@ int MPIDI_POSIX_mpi_release_gather_comm_free(MPIR_Comm * comm_ptr)
                                     RELEASE_GATHER_FIELD(comm_ptr, flags_shm_size));
 
     /* destroy and detach shared memory used for flags */
-    mpi_errno = MPIDU_shm_free(RELEASE_GATHER_FIELD(comm_ptr, flags_addr));
-    MPIR_ERR_CHECK(mpi_errno);
+    if (RELEASE_GATHER_FIELD(comm_ptr, flags_addr) != NULL) {
+        mpi_errno = MPIDU_shm_free(RELEASE_GATHER_FIELD(comm_ptr, flags_addr));
+        MPIR_ERR_CHECK(mpi_errno);
+    }
 
     if (RELEASE_GATHER_FIELD(comm_ptr, bcast_buf_addr) != NULL) {
         if (comm_ptr->rank == 0)


### PR DESCRIPTION
## Pull Request Description

If an error occurs during release_gather initialization, we try to cleanup any allocated resources and let communication proceed. We need to first check if the buffer allocated for flags is actually allocated before freeing, otherwise the user will see a fatal assertion error. See pmodels/mpich#7456.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
