### PR TITLE
ch3: ignore CONN_STATE_DISCARD in _handle_connect_event

### DIFF
--- a/src/mpid/ch3/util/sock/ch3u_connect_sock.c
+++ b/src/mpid/ch3/util/sock/ch3u_connect_sock.c
@@ -503,6 +503,11 @@ int MPIDI_CH3_Sockconn_handle_connect_event( MPIDI_CH3I_Connection_t *conn,
     int mpi_errno = MPI_SUCCESS;
 
     MPIR_FUNC_ENTER;
+
+    if (conn->state == CONN_STATE_DISCARD) {
+        /* this is a replaced CONN_STATE_CONNECTING. Just ignore. */
+        goto fn_exit;
+    }
     
     /* --BEGIN ERROR HANDLING-- */
     if (event_error != MPI_SUCCESS) {


### PR DESCRIPTION
## Pull Request Description
CONN_STATE_DISCARD is set for an asynchronous MPL_connect when the connection is already established by an accept event. There is no need to continue the discarded connect event and the errors should be ignored.


This should fix the sporadic osx jenkins test failures such as:
```
not ok 1453 - ./coll/exscan2 5
  ---
  Directory: ./coll
  File: exscan2
  Num-procs: 5
  Timeout: 180
  Date: "Wed Jun 11 20:27:42 2025"
  ...
## Test output (expected 'No Errors'):
##  No Errors
## Fatal error in internal_Finalize: Unknown error class, error stack:
## internal_Finalize(50).......................: MPI_Finalize failed
## MPII_Finalize(438)..........................: 
## MPID_Finalize(105)..........................: 
## MPIDI_CH3U_VC_WaitForClose(353).............: an error occurred while the device was waiting for all open connections to close
## MPIDI_CH3i_Progress_wait(187)...............: an error occurred while handling an event returned by MPIDI_CH3I_Sock_Wait()
## MPIDI_CH3I_Progress_handle_sock_event(572)..: 
## MPIDI_CH3_Sockconn_handle_connect_event(512): [ch3:sock] failed to connect to remote process
## MPIDI_CH3I_Socki_handle_connect(3787).......: connection failure (set=0,sock=2,errno=54:Connection reset by peer)
    
```

Not sure why we start to see these failures now and only on osx-sock jobs. It may be due to system update that makes the `connect` receive error when remote process exits.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
