### PR TITLE
misc/ze: add thread-safety for ZE memcpy routines

### DIFF
--- a/src/mpi/init/mutex.c
+++ b/src/mpi/init/mutex.c
@@ -19,6 +19,7 @@ MPID_Thread_mutex_t MPIR_THREAD_VCI_CTX_MUTEX;
 MPID_Thread_mutex_t MPIR_THREAD_VCI_PMI_MUTEX;
 MPID_Thread_mutex_t MPIR_THREAD_VCI_BSEND_MUTEX;
 MPID_Thread_mutex_t MPIR_THREAD_VCI_REQUEST_POOL_MUTEXES[MPIR_REQUEST_NUM_POOLS];
+MPID_Thread_mutex_t MPIR_THREAD_VCI_GPU_MUTEX;
 #endif /* MPICH_THREAD_GRANULARITY */
 
 /* called the first thing in init so it can enter critical section immediately */
@@ -41,6 +42,9 @@ void MPII_thread_mutex_create(void)
     MPIR_Assert(err == 0);
 
     MPID_Thread_mutex_create(&MPIR_THREAD_VCI_BSEND_MUTEX, &err);
+    MPIR_Assert(err == 0);
+
+    MPID_Thread_mutex_create(&MPIR_THREAD_VCI_GPU_MUTEX, &err);
     MPIR_Assert(err == 0);
 
     for (int i = 0; i < MPIR_REQUEST_NUM_POOLS; i++) {
@@ -83,6 +87,9 @@ void MPII_thread_mutex_destroy(void)
     MPIR_Assert(err == 0);
 
     MPID_Thread_mutex_destroy(&MPIR_THREAD_VCI_BSEND_MUTEX, &err);
+    MPIR_Assert(err == 0);
+
+    MPID_Thread_mutex_destroy(&MPIR_THREAD_VCI_GPU_MUTEX, &err);
     MPIR_Assert(err == 0);
 
     for (int i = 0; i < MPIR_REQUEST_NUM_POOLS; i++) {

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -321,6 +321,7 @@ static int do_localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
             MPIR_ERR_CHKANDJUMP(dev_id == -1, mpi_errno, MPI_ERR_OTHER,
                                 "**mpl_gpu_get_dev_id_from_attr");
 
+            MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_BSEND_MUTEX);
             if (gpu_req == NULL) {
                 MPL_gpu_request req;
                 mpl_errno = MPL_gpu_imemcpy(recv_ptr, send_ptr, copy_sz, dev_id, dir, enginetype,
@@ -340,6 +341,7 @@ static int do_localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
                                     "**mpl_gpu_imemcpy");
                 gpu_req->type = MPIR_GPU_REQUEST;
             }
+            MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_BSEND_MUTEX);
         }
 #else /* !MPL_HAVE_ZE */
         goto fn_fallback;


### PR DESCRIPTION
## Pull Request Description
MPL_gpu_imemcpy for ZE requires thread-safety or segfaults.

[skip warnings]


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
