### PR TITLE
romio/gpfs: fix a datatype to avoid integer overflow

### DIFF
--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c
@@ -1072,7 +1072,7 @@ static void ADIOI_R_Exchange_data_alltoallv(ADIO_File fd, void *buf, ADIOI_Flatl
     char **recv_buf = NULL;
     MPI_Request *requests = NULL;
     MPI_Status *statuses = NULL;
-    int rtail, stail;
+    MPI_Count rtail, stail;
     char *sbuf_ptr, *from_ptr;
     size_t len;                 /* for memcpy: must be size_t */
     MPI_Aint *sdispls, *rdispls;
@@ -1163,7 +1163,7 @@ static void ADIOI_R_Exchange_data_alltoallv(ADIO_File fd, void *buf, ADIOI_Flatl
         if (rdispls[i - 1] != rdispls[i]) {
             DBG_FPRINTF(stderr, "\t\t[%d]%2ld,", i, rdispls[i]);
         }
-    DBG_FPRINTF(stderr, "\ttails = %4d, %4d\n", stail, rtail);
+    DBG_FPRINTF(stderr, "\ttails = %4lld, %4lld\n", (long long) stail, (long long) rtail);
     if (nprocs_send) {
         DBG_FPRINTF(stderr, "\tall_send_buf =  [%d]%2d,", 0, all_send_buf[0]);
         /* someone at some point found it useful to look at the 128th kilobyte of data from each processor, but this segfaults in many situations if "all debugging" enabled */


### PR DESCRIPTION
## Pull Request Description

This PR changes an `int` to `MPI_Count` in the GPFS part of ROMIO (`ad_gpfs_rdcoll.c`) to avoid overflows with large data sets. The counterpart in `ad_gpfs_wrcoll.c` already uses `MPI_Count` instead of `int`, see [here](https://github.com/pmodels/mpich/blob/main/src/mpi/romio/adio/ad_gpfs/ad_gpfs_wrcoll.c#L1300).

We got a user error report (out of memory error [here](https://github.com/pmodels/mpich/blob/main/src/mpi/romio/adio/ad_gpfs/ad_gpfs_rdcoll.c#L1123)) for romio/gpfs with ParaStation MPI on a production system and our analysis leads us to the conclusion that  this potential integer overflow is at least part of the root source.

I'm just the messenger, @carsten-clauss deserves the credits for the analysis and fix. ;-)



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
