### PR TITLE
RFC: bindings_f08: Use normal MPI C binding to allow profiling by C code

### DIFF
--- a/maint/local_python/binding_f08.py
+++ b/maint/local_python/binding_f08.py
@@ -810,8 +810,8 @@ def dump_mpi_c_interface_nobuf(func, is_large):
         # defined in src/binding/fortran/mpif_h/user_proxy.c
         c_name = "MPII_op_create"
     else:
-        # uses PMPI c binding directly
-        c_name = 'P' + get_function_name(func, is_large)
+        # uses MPI c binding directly
+        c_name = get_function_name(func, is_large)
     dump_interface_function(func, name, c_name, is_large)
 
 def dump_interface_function(func, name, c_name, is_large):

--- a/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_c.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_c.c
@@ -22,7 +22,7 @@ int MPIR_Comm_spawn_c(const char *command, char *argv_f, int maxprocs, MPI_Info 
     }
 
     mpi_errno =
-        PMPI_Comm_spawn(command, argv_c, maxprocs, info, root, comm, intercomm, array_of_errcodes);
+        MPI_Comm_spawn(command, argv_c, maxprocs, info, root, comm, intercomm, array_of_errcodes);
 
     if (argv_c != MPI_ARGV_NULL) {
         free(argv_c);

--- a/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_multiple_c.c
+++ b/src/binding/fortran/use_mpi_f08/wrappers_c/comm_spawn_multiple_c.c
@@ -110,9 +110,9 @@ int MPIR_Comm_spawn_multiple_c(int count, char *array_of_commands_f,
         free(buf);
     }
 
-    mpi_errno = PMPI_Comm_spawn_multiple(count, array_of_commands_c, array_of_argv_c,
-                                         array_of_maxprocs, array_of_info, root, comm, intercomm,
-                                         array_of_errcodes);
+    mpi_errno = MPI_Comm_spawn_multiple(count, array_of_commands_c, array_of_argv_c,
+                                        array_of_maxprocs, array_of_info, root, comm, intercomm,
+                                        array_of_errcodes);
 
     free(array_of_commands_c);
 


### PR DESCRIPTION
## Pull Request Description

This PR changes some of the generated bindings for the mpi_f08 module to use the standard C MPI functions internally, allowing profiling tools to intercept them.
This matches the behavior of the Fortran 90 module, and the rest of the Fortran 2008 bindings, which already allowed for this (Fortran Interface -> Fortran \_f08 Impl -> MPIR\_ cdesc -> MPI C call).

I rely on this behavior to allow PnMPI and MUST [1] to run on Fortran 2008 code.
Without these changes, some interceptions work, while others do not.

I understand this may not be a supported workflow, but I find it useful nonetheless.
Pull Request is an RFC, feel free to reject if this change is unwanted.

[1] https://www.i12.rwth-aachen.de/cms/i12/forschung/forschungsschwerpunkte/lehrstuhl-fuer-hochleistungsrechnen/~nrbe/must/

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
