### PR TITLE
romio: fix quobyte build error

### DIFF
--- a/src/mpi/romio/adio/ad_quobytefs/ad_quobytefs.h
+++ b/src/mpi/romio/adio/ad_quobytefs/ad_quobytefs.h
@@ -58,7 +58,7 @@ int ADIOI_QUOBYTEFS_aio(ADIO_File fd, void *buf, MPI_Aint count, MPI_Datatype ty
                         ADIO_Offset offset, int wr, MPI_Request * request);
 int ADIOI_QUOBYTEFS_aio_free_fn(void *extra_state);
 int ADIOI_QUOBYTEFS_aio_poll_fn(void *extra_state, MPI_Status * status);
-int ADIOI_QUOBYTEFS_aio_wait_fn(MPI_Aint count, void **array_of_states, double timeout,
+int ADIOI_QUOBYTEFS_aio_wait_fn(int count, void **array_of_states, double timeout,
                                 MPI_Status * status);
 void ADIOI_QUOBYTEFS_IreadContig(ADIO_File fd, void *buf, MPI_Aint count, MPI_Datatype datatype,
                                  int file_ptr_type, ADIO_Offset offset, MPI_Request * request,


### PR DESCRIPTION
the async i/o routines don't take a Count but an int

Fixes: pmodels/mpich#7452

## Pull Request Description


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
