### PR TITLE
pmi: fallback to PMI_Barrier when applicable

### DIFF
--- a/src/pmi/src/pmi_v1.c
+++ b/src/pmi/src/pmi_v1.c
@@ -287,7 +287,23 @@ PMI_API_PUBLIC int PMI_Get_appnum(int *appnum)
 
 PMI_API_PUBLIC int PMI_Barrier(void)
 {
-    return PMI_Barrier_group(PMI_GROUP_WORLD, 0, NULL);
+    int pmi_errno = PMI_SUCCESS;
+
+    struct PMIU_cmd pmicmd;
+    PMIU_cmd_init_zero(&pmicmd);
+
+    if (PMI_initialized > SINGLETON_INIT_BUT_NO_PM) {
+        PMIU_msg_set_query_barrier(&pmicmd, USE_WIRE_VER, no_static, NULL);
+
+        pmi_errno = PMIU_cmd_get_response(PMI_fd, &pmicmd);
+        PMIU_ERR_POP(pmi_errno);
+    }
+
+  fn_exit:
+    PMIU_cmd_free_buf(&pmicmd);
+    return pmi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 PMI_API_PUBLIC int PMI_Barrier_group(const int *group, int count, const char *tag)
@@ -324,7 +340,11 @@ PMI_API_PUBLIC int PMI_Barrier_group(const int *group, int count, const char *ta
     }
 
     char *group_str;
-    if (group == PMI_GROUP_WORLD) {
+    if (group == PMI_GROUP_WORLD && !tag && !PMIU_is_threaded) {
+        /* Backward-compatible PMI_Barrier */
+        pmi_errno = PMI_Barrier();
+        goto fn_exit;
+    } else if (group == PMI_GROUP_WORLD) {
         group_str = MPL_malloc(20, MPL_MEM_OTHER);
         snprintf(group_str, 20, "WORLD:%d", inttag);
     } else if (group == PMI_GROUP_NODE) {


### PR DESCRIPTION
## Pull Request Description

This commit reverts the logic in b661404e8, rather than alias PMI_Barrier to PMI_Barrier_group, fallback to PMI_Barrier whenever it is applicable. At the wire protocol layer, PMI_Barrier should have the group attribute omitted for backward compatibility. This makes the older PMI servers such as gforker still work.

Fixes #7478
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
