### PR TITLE
misc/ze: missing declaration MPIR_THREAD_VCI_GPU_MUTEX

### DIFF
--- a/src/include/mpir_thread.h
+++ b/src/include/mpir_thread.h
@@ -84,6 +84,7 @@ extern MPID_Thread_mutex_t MPIR_THREAD_VCI_HANDLE_MUTEX;
 extern MPID_Thread_mutex_t MPIR_THREAD_VCI_CTX_MUTEX;
 extern MPID_Thread_mutex_t MPIR_THREAD_VCI_PMI_MUTEX;
 extern MPID_Thread_mutex_t MPIR_THREAD_VCI_BSEND_MUTEX;
+extern MPID_Thread_mutex_t MPIR_THREAD_VCI_GPU_MUTEX;
 extern MPID_Thread_mutex_t MPIR_THREAD_VCI_REQUEST_POOL_MUTEXES[];
 #endif /* MPICH_THREAD_GRANULARITY */
 #endif /* MPICH_IS_THREADED */


### PR DESCRIPTION

## Pull Request Description
Neglected adding declaratio for MPIR_THREAD_VCI_GPU_MUTEX.



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
