### PR TITLE
binding/abi: fix declaration for HAVE_WEAK_ATTRIBUTE

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -2997,7 +2997,7 @@ def get_C_return(func, mapping, is_abi=False):
         ret = mapping[func['return']]
         if func['return'] == 'EXTRA_STATE':
             ret = 'void *'
-        if is_abi:
+        if is_abi and func['dir'] != 'io':
             re_Handle = get_abi_re_Handle()
             ret = re.sub(re_Handle, r'ABI_\1', ret)
     return ret
@@ -3007,7 +3007,7 @@ def get_C_params(func, mapping, is_abi=False):
     re_Handle = get_abi_re_Handle()
     for p in func['c_parameters']:
         param = get_C_param(p, func, mapping)
-        if is_abi:
+        if is_abi and func['dir'] != 'io':
             param = re.sub(re_Handle, r'ABI_\1', param)
         param_list.append(param)
     if not len(param_list):


### PR DESCRIPTION
## Pull Request Description
Only handle types need use ABI types (e.g. ABI_Comm) in declarations. For example, MPI_Comm_copy_attr_function should not be replaced as ABI_Comm_copy_attr_function. Clang uses weak attributes.

Fixes #7486 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
