### PR TITLE
mpir/pmi: fix a bug in getting fabric coordinates

### DIFF
--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -118,7 +118,7 @@ static int pmix_init(int *has_parent, int *rank, int *size, int *appnum)
     for (int i = 0; i < *size; i++) {
         proc.rank = i;
         pmi_errno = PMIx_Get(&proc, PMIX_FABRIC_COORDINATES, NULL, 0, &val);
-        if (pmi_errno != PMIX_SUCCESS) {
+        if (pmi_errno != PMIX_SUCCESS || PMIX_COORD != val->type) {
             MPIR_Process.coords = NULL;
             break;
         }


### PR DESCRIPTION
MPICH only supports PMIX_COORD type of the coordinate format. When it is other type (ARRAY type), it is not supported. In that case, the dims can be a garbage value for unsupported coordinate type, which may results in a random size malloc. This could happen if --hosts mpiexec option (to specify a subset of nodes) is used to launch MPI applications. 

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
