### PR TITLE
mpir/pmix: do not call explicit PMIx_Progress

### DIFF
--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -363,7 +363,10 @@ static int pmix_barrier_group(int *group, int count, const char *stringtag)
     MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**pmix_fence_nb",
                          "**pmix_fence_nb %d", pmi_errno);
     while (MPL_atomic_load_int(&done_flag) == 0) {
+        /* NOTE: PMIx_Progress not needed unless progress threads are disabled */
+#if 0
         PMIx_Progress();
+#endif
     }
 
     PMIX_INFO_FREE(info, 1);


### PR DESCRIPTION
## Pull Request Description
Explicit PMIx_Progress is not needed unless pmix background threads are disabled. Reference PMIX_EXTERNAL_PROGRESS.

Otherwise it emits tons of following warnings:
```
[warn] event_base_loop: reentrant invocation.  Only one event_base_loop can run on each event_base at once.
[warn] event_base_loop: reentrant invocation.  Only one event_base_loop can run on each event_base at once.
...
```

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
