### PR TITLE
pm/hydra: Add support for -report-bindings flag

### DIFF
--- a/src/pm/hydra/lib/hydra.h
+++ b/src/pm/hydra/lib/hydra.h
@@ -365,7 +365,7 @@ struct HYD_user_global {
     char *binding;
     char *mapping;
     char *membind;
-    int topo_debug;
+    int report_bindings;
 
     /* Demux engine */
     char *demux;

--- a/src/pm/hydra/lib/tools/topo/hwloc/topo_hwloc.c
+++ b/src/pm/hydra/lib/tools/topo/hwloc/topo_hwloc.c
@@ -675,7 +675,7 @@ HYD_status HYDT_topo_hwloc_bind(int idx)
     if (!HYDT_topo_hwloc_info.user_binding || (idx < HYDT_topo_hwloc_info.num_bitmaps)) {
         id = idx % HYDT_topo_hwloc_info.num_bitmaps;
 
-        if (HYDT_topo_info.debug) {
+        if (HYDT_topo_info.report_bindings) {
             /* Print the binding bitmaps for debugging. */
             int i;
             char *binding;

--- a/src/pm/hydra/lib/tools/topo/topo.c
+++ b/src/pm/hydra/lib/tools/topo/topo.c
@@ -14,7 +14,7 @@ struct HYDT_topo_info HYDT_topo_info;
 
 static int ignore_binding = 0;
 
-HYD_status HYDT_topo_init(char *user_topolib, int topo_debug)
+HYD_status HYDT_topo_init(char *user_topolib, int debug, int report_bindings)
 {
     const char *topolib = NULL;
     HYD_status status = HYD_SUCCESS;
@@ -33,7 +33,8 @@ HYD_status HYDT_topo_init(char *user_topolib, int topo_debug)
         HYDT_topo_info.topolib = NULL;
     }
 
-    HYDT_topo_info.debug = topo_debug;
+    HYDT_topo_info.debug = debug;
+    HYDT_topo_info.report_bindings = report_bindings;
 
     HYDU_FUNC_EXIT();
     return status;

--- a/src/pm/hydra/lib/tools/topo/topo.h
+++ b/src/pm/hydra/lib/tools/topo/topo.h
@@ -25,6 +25,8 @@ struct HYDT_topo_info {
     char *topolib;
     /** \brief Enable debugging output */
     int debug;
+    /** \brief Report process bindings */
+    int report_bindings;;
 };
 
 /*! \cond */
@@ -34,14 +36,15 @@ extern struct HYDT_topo_info HYDT_topo_info;
 /**
  * \brief HYDT_topo_init - Initialize the topology library
  *
- * \param[in]  topolib        Topology library to use
- * \param[in]  topo_debug     Enable debugging output
+ * \param[in]  topolib             Topology library to use
+ * \param[in]  debug               Enable debugging output
+ * \param[in]  report_bindings     Report process bindings
  *
  * This function initializes the topology library requested by the
  * user. It also queries for the support provided by the library and
  * stores it for future calls.
  */
-HYD_status HYDT_topo_init(char *topolib, int topo_debug);
+HYD_status HYDT_topo_init(char *topolib, int debug, int report_bindings);
 
 /**
  * \brief HYDT_topo_set - Set the topology bindings

--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -13,6 +13,7 @@ void HYDU_init_user_global(struct HYD_user_global *user_global)
 
     user_global->binding = NULL;
     user_global->topolib = NULL;
+    user_global->topo_debug = -1;
 
     user_global->demux = NULL;
     user_global->iface = NULL;

--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -13,7 +13,7 @@ void HYDU_init_user_global(struct HYD_user_global *user_global)
 
     user_global->binding = NULL;
     user_global->topolib = NULL;
-    user_global->topo_debug = -1;
+    user_global->report_bindings = -1;
 
     user_global->demux = NULL;
     user_global->iface = NULL;

--- a/src/pm/hydra/mpiexec/get_parameters.c
+++ b/src/pm/hydra/mpiexec/get_parameters.c
@@ -206,6 +206,9 @@ static void set_default_values(void)
 
     if (HYD_server_info.user_global.gpu_subdevs_per_proc == HYD_GPUS_PER_PROC_UNSET)
         HYD_server_info.user_global.gpu_subdevs_per_proc = HYD_GPUS_PER_PROC_AUTO;
+
+    if (HYD_server_info.user_global.topo_debug == -1)
+        HYD_server_info.user_global.topo_debug = 0;
 }
 
 /* In case a boolean environment value is unparsable (not 1|0|yes|no|true|false|on|off),
@@ -225,7 +228,7 @@ static HYD_status check_environment(void)
     if (!HYD_server_info.user_global.debug)
         ENV2BOOL("HYDRA_DEBUG", &HYD_server_info.user_global.debug);
 
-    if (!HYD_server_info.user_global.topo_debug)
+    if (HYD_server_info.user_global.topo_debug == -1)
         ENV2BOOL("HYDRA_TOPO_DEBUG", &HYD_server_info.user_global.topo_debug);
 
     /* don't clobber existing iface values from the command line */

--- a/src/pm/hydra/mpiexec/get_parameters.c
+++ b/src/pm/hydra/mpiexec/get_parameters.c
@@ -207,8 +207,8 @@ static void set_default_values(void)
     if (HYD_server_info.user_global.gpu_subdevs_per_proc == HYD_GPUS_PER_PROC_UNSET)
         HYD_server_info.user_global.gpu_subdevs_per_proc = HYD_GPUS_PER_PROC_AUTO;
 
-    if (HYD_server_info.user_global.topo_debug == -1)
-        HYD_server_info.user_global.topo_debug = 0;
+    if (HYD_server_info.user_global.report_bindings == -1)
+        HYD_server_info.user_global.report_bindings = 0;
 }
 
 /* In case a boolean environment value is unparsable (not 1|0|yes|no|true|false|on|off),
@@ -228,8 +228,8 @@ static HYD_status check_environment(void)
     if (!HYD_server_info.user_global.debug)
         ENV2BOOL("HYDRA_DEBUG", &HYD_server_info.user_global.debug);
 
-    if (HYD_server_info.user_global.topo_debug == -1)
-        ENV2BOOL("HYDRA_TOPO_DEBUG", &HYD_server_info.user_global.topo_debug);
+    if (HYD_server_info.user_global.report_bindings == -1)
+        ENV2BOOL("HYDRA_TOPO_DEBUG", &HYD_server_info.user_global.report_bindings);
 
     /* don't clobber existing iface values from the command line */
     if (HYD_server_info.user_global.iface == NULL) {

--- a/src/pm/hydra/mpiexec/options.c
+++ b/src/pm/hydra/mpiexec/options.c
@@ -1050,6 +1050,10 @@ static void bind_to_help_fn(void)
     printf("            nexttouch         -- closest to process that next touches memory\n");
     printf("            bind:<list>       -- bind to memory node list\n");
     printf("            interleave:<list> -- interleave among memory node list\n");
+
+    printf("\n\n");
+
+    printf("-report-bindings: Report bindings for each process\n\n");
 }
 
 static HYD_status bind_to_fn(char *arg, char ***argv)
@@ -1106,6 +1110,25 @@ static HYD_status membind_fn(char *arg, char ***argv)
 
   fn_exit:
     (*argv)++;
+    return status;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static HYD_status report_bindings_fn(char *arg, char ***argv)
+{
+    HYD_status status = HYD_SUCCESS;
+
+    if (HYD_ui_mpich_info.reading_config_file && HYD_server_info.user_global.topo_debug != -1) {
+        /* global variable already set; ignore */
+        goto fn_exit;
+    }
+
+    status = HYDU_set_int(arg, &HYD_server_info.user_global.topo_debug, 1);
+    HYDU_ERR_POP(status, "error setting topo debug");
+
+  fn_exit:
     return status;
 
   fn_fail:
@@ -1695,6 +1718,7 @@ struct HYD_arg_match_table HYD_mpiexec_match_table[] = {
     {"bind-to", bind_to_fn, bind_to_help_fn},
     {"map-by", map_by_fn, bind_to_help_fn},
     {"membind", membind_fn, bind_to_help_fn},
+    {"report-bindings", report_bindings_fn, bind_to_help_fn},
 
     /* Demux engine options */
     {"demux", demux_fn, demux_help_fn},

--- a/src/pm/hydra/mpiexec/options.c
+++ b/src/pm/hydra/mpiexec/options.c
@@ -1120,12 +1120,12 @@ static HYD_status report_bindings_fn(char *arg, char ***argv)
 {
     HYD_status status = HYD_SUCCESS;
 
-    if (HYD_ui_mpich_info.reading_config_file && HYD_server_info.user_global.topo_debug != -1) {
+    if (HYD_ui_mpich_info.reading_config_file && HYD_server_info.user_global.report_bindings != -1) {
         /* global variable already set; ignore */
         goto fn_exit;
     }
 
-    status = HYDU_set_int(arg, &HYD_server_info.user_global.topo_debug, 1);
+    status = HYDU_set_int(arg, &HYD_server_info.user_global.report_bindings, 1);
     HYDU_ERR_POP(status, "error setting topo debug");
 
   fn_exit:

--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -63,8 +63,8 @@ HYD_status HYD_pmcd_pmi_fill_in_proxy_args(struct HYD_string_stash *proxy_stash,
     if (HYD_server_info.user_global.debug)
         HYD_STRING_STASH(*proxy_stash, MPL_strdup("--debug"), status);
 
-    if (HYD_server_info.user_global.topo_debug)
-        HYD_STRING_STASH(*proxy_stash, MPL_strdup("--topo-debug"), status);
+    if (HYD_server_info.user_global.report_bindings)
+        HYD_STRING_STASH(*proxy_stash, MPL_strdup("--report-bindings"), status);
 
     if (HYDT_bsci_info.rmk) {
         HYD_STRING_STASH(*proxy_stash, MPL_strdup("--rmk"), status);

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -16,7 +16,7 @@ static HYD_status init_params(void)
     HYD_status status = HYD_SUCCESS;
 
     HYDU_init_user_global(&HYD_pmcd_pmip.user_global);
-    HYD_pmcd_pmip.user_global.topo_debug = 0;
+    HYD_pmcd_pmip.user_global.report_bindings = 0;
 
     HYD_pmcd_pmip.upstream.server_name = NULL;
     HYD_pmcd_pmip.upstream.server_port = -1;

--- a/src/pm/hydra/proxy/pmip.c
+++ b/src/pm/hydra/proxy/pmip.c
@@ -16,6 +16,7 @@ static HYD_status init_params(void)
     HYD_status status = HYD_SUCCESS;
 
     HYDU_init_user_global(&HYD_pmcd_pmip.user_global);
+    HYD_pmcd_pmip.user_global.topo_debug = 0;
 
     HYD_pmcd_pmip.upstream.server_name = NULL;
     HYD_pmcd_pmip.upstream.server_port = -1;

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -317,9 +317,9 @@ static HYD_status topolib_fn(char *arg, char ***argv)
     return status;
 }
 
-static HYD_status topo_debug_fn(char *arg, char ***argv)
+static HYD_status report_bindings_fn(char *arg, char ***argv)
 {
-    HYD_pmcd_pmip.user_global.topo_debug = 1;
+    HYD_pmcd_pmip.user_global.report_bindings = 1;
     return HYD_SUCCESS;
 }
 
@@ -625,7 +625,7 @@ struct HYD_arg_match_table HYD_pmip_args_match_table[] = {
     {"proxy-id", proxy_id_fn, NULL},
     {"pgid", pgid_fn, NULL},
     {"debug", debug_fn, NULL},
-    {"topo-debug", topo_debug_fn, NULL},
+    {"report-bindings", report_bindings_fn, NULL},
     {"usize", usize_fn, NULL},
     {"pmi-port", pmi_port_fn, NULL},
     {"gpus-per-proc", gpus_per_proc_fn, NULL},
@@ -709,7 +709,8 @@ HYD_status HYD_pmcd_pmip_get_params(char **t_argv)
     HYDU_ERR_POP(status, "proxy unable to initialize bootstrap server\n");
 
     status = HYDT_topo_init(HYD_pmcd_pmip.user_global.topolib,
-                            HYD_pmcd_pmip.user_global.topo_debug);
+                            HYD_pmcd_pmip.user_global.debug,
+                            HYD_pmcd_pmip.user_global.report_bindings);
     HYDU_ERR_POP(status, "proxy unable to initialize topology library\n");
 
     if (HYD_pmcd_pmip.local.id == -1) {


### PR DESCRIPTION
## Pull Request Description

Process binding information was previously only available via environment variable setting. Other implementations support a --report-bindings option to mpiexec, so add the same for Hydra. Anecdotally, Google's AI search summary already thinks MPICH supports such a flag.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
