### PR TITLE
ch4/ofi: fix missing thread CS in `MPIDI_OFI_flush_send_queue`

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -873,42 +873,28 @@ int MPIDI_OFI_flush_send_queue(void)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    MPIDI_OFI_dynamic_process_request_t *reqs;
     /* TODO - Iterate over each NIC in addition to each VNI when multi-NIC within the same
      * process is implemented. */
     int num_vcis = MPIDI_OFI_global.num_vcis;
-    int num_reqs = num_vcis * 2;
-    reqs = MPL_malloc(sizeof(MPIDI_OFI_dynamic_process_request_t) * num_reqs, MPL_MEM_OTHER);
 
     /* Apparently by sending self messages can flush the send queue */
     int rank = MPIR_Process.rank;
     for (int vci = 0; vci < num_vcis; vci++) {
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
-        mpi_errno = flush_send(rank, 0, vci, &reqs[vci * 2]);
-        MPIR_ERR_CHECK(mpi_errno);
-        mpi_errno = flush_recv(rank, 0, vci, &reqs[vci * 2 + 1]);
-        MPIR_ERR_CHECK(mpi_errno);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
-    }
 
-    bool all_done = false;
-    while (!all_done) {
-        int made_progress;
-        for (int vci = 0; vci < num_vcis; vci++) {
-            MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
+        MPIDI_OFI_dynamic_process_request_t reqs[2];
+        mpi_errno = flush_send(rank, 0, vci, &reqs[0]);
+        MPIR_ERR_CHECK(mpi_errno);
+        mpi_errno = flush_recv(rank, 0, vci, &reqs[1]);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        while (!reqs[0].done || !reqs[1].done) {
+            int made_progress;
             mpi_errno = MPIDI_NM_progress(vci, &made_progress);
             MPIR_ERR_CHECK(mpi_errno);
-            MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         }
-        all_done = true;
-        for (int i = 0; i < num_reqs; i++) {
-            if (!reqs[i].done) {
-                all_done = false;
-                break;
-            }
-        }
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     }
-    MPL_free(reqs);
 
   fn_exit:
     return mpi_errno;


### PR DESCRIPTION
## Pull Request Description
Now that we call flush_send_queue at MPID_Comm_free_hook, we need add
thread protections.

This is only checked when thread multiple is enabled and the `socket` provider is used, such as the `xpmem-vci` test.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
