### PR TITLE
ch4: use fallback collectives during init or bootstrap

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_vci.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_vci.c
@@ -55,9 +55,9 @@ int MPIDI_OFI_comm_set_vcis(MPIR_Comm * comm, int num_implicit, int num_reserved
     /* gather the number of remote vcis */
     all_num_vcis[comm->rank].n_vcis = MPL_MIN(num_implicit, num_vcis_actual);
     all_num_vcis[comm->rank].n_total_vcis = num_vcis_actual;
-    mpi_errno = MPIR_Allgather_impl(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
-                                    all_num_vcis, sizeof(MPIDI_num_vci_t), MPIR_BYTE_INTERNAL,
-                                    comm, MPIR_COLL_ATTR_SYNC);
+    mpi_errno = MPIR_Allgather_fallback(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
+                                        all_num_vcis, sizeof(MPIDI_num_vci_t), MPIR_BYTE_INTERNAL,
+                                        comm, MPIR_COLL_ATTR_SYNC);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* Since we allow different process to have different num_vcis, we always need run exchange. */
@@ -124,8 +124,8 @@ static int check_num_nics(MPIR_Comm * comm)
     /* Confirm that all processes have the same number of NICs, if not, all can change to minimum */
     int my_nums[2] = { MPIDI_OFI_global.num_nics, can_change_nics };
     int min_nums[2];
-    mpi_errno = MPIR_Allreduce_impl(my_nums, &min_nums, 2, MPIR_INT_INTERNAL,
-                                    MPI_MIN, comm, MPIR_COLL_ATTR_SYNC);
+    mpi_errno = MPIR_Allreduce_fallback(my_nums, &min_nums, 2, MPIR_INT_INTERNAL,
+                                        MPI_MIN, comm, MPIR_COLL_ATTR_SYNC);
     MPIR_ERR_CHECK(mpi_errno);
 
     /* If num_nics disagree, fallback to fewer NICs if we can, otherwise throw an error */

--- a/src/mpid/ch4/netmod/ucx/ucx_vci.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_vci.c
@@ -25,9 +25,9 @@ int MPIDI_UCX_comm_set_vcis(MPIR_Comm * comm, int num_implicit, int num_reserved
 
     all_num_vcis[comm->rank].n_vcis = num_implicit;
     all_num_vcis[comm->rank].n_total_vcis = num_implicit + num_reserved;;
-    mpi_errno = MPIR_Allgather_impl(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
-                                    all_num_vcis, sizeof(MPIDI_num_vci_t), MPIR_BYTE_INTERNAL,
-                                    comm, MPIR_COLL_ATTR_SYNC);
+    mpi_errno = MPIR_Allgather_fallback(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
+                                        all_num_vcis, sizeof(MPIDI_num_vci_t), MPIR_BYTE_INTERNAL,
+                                        comm, MPIR_COLL_ATTR_SYNC);
     MPIR_ERR_CHECK(mpi_errno);
 
     for (int i = 1; i < MPIDI_UCX_global.num_vcis; i++) {


### PR DESCRIPTION
## Pull Request Description
Use fixed fallback algorithms during init or bootstrapping for better stability. This avoids triggering test failures for some collective cvar tests.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
