### PR TITLE
test/gpu: remove setting MPIR_CVAR_ENABLE_GPU

### DIFF
--- a/src/mpid/ch4/shm/ipc/src/ipc_control.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_control.c
@@ -57,6 +57,12 @@ int MPIDI_IPC_write_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
 
     MPIR_Request *sreq = hdr->sreq;
     MPIDIG_REQUEST(sreq, u.ipc.peer_req) = hdr->rreq;
+    if (MPIDI_SHM_REQUEST(sreq, ipc.ipc_type) == MPIDI_IPCI_TYPE__NONE) {
+        /* convert the request for ipc */
+        MPIDIG_REQUEST(sreq, u.ipc.peer_rank) = MPIDIG_REQUEST(sreq, u.send.dest);
+        MPIDIG_REQUEST(sreq, u.ipc.peer_req) = hdr->rreq;
+        MPIDIG_REQUEST(sreq, u.ipc.src_dt_ptr) = NULL;
+    }
     /* ipc write only for gpu, for now */
     MPIR_Assert(hdr->ipc_type == MPIDI_IPCI_TYPE__GPU);
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -264,6 +264,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_rndv(const void *buf, MPI_Aint coun
     MPIDIG_REQUEST(sreq, datatype) = datatype;
     MPIDIG_REQUEST(sreq, count) = count;
     MPIDIG_REQUEST(sreq, u.send.dest) = rank;
+    /* needed in case of IPC write */
+    MPIDI_SHM_REQUEST(sreq, ipc.ipc_type) = MPIDI_IPCI_TYPE__NONE;
 
     /* Fill am hdr */
     MPIDIG_hdr_t hdr;

--- a/test/mpi/datatype/testlist.in
+++ b/test/mpi/datatype/testlist.in
@@ -12,8 +12,8 @@ transpose_pack_oldapi 1 strict=FALSE
 slice_pack 1
 struct_pack 1
 structpack2 1
-struct_pack_mpi_bottom 1 gpu=yes
-struct_unpack_mpi_bottom 1 gpu=yes
+struct_pack_mpi_bottom 1
+struct_unpack_mpi_bottom 1
 typecommit 1
 typename 1
 typename_oldapi 1 strict=FALSE

--- a/test/mpi/impls/mpich/info/memory_alloc_kinds.c
+++ b/test/mpi/impls/mpich/info/memory_alloc_kinds.c
@@ -68,7 +68,8 @@ int main(int argc, char *argv[])
         errs += check_value(value, "mpi,system,mpi:win_allocate:alloc_mem");
     } else {
         errs++;
-        printf("Key mpi_memory_alloc_kinds was not found in info from MPI_Session_init with info.\n");
+        printf
+            ("Key mpi_memory_alloc_kinds was not found in info from MPI_Session_init with info.\n");
     }
     MPI_Info_free(&info_in);
     MPI_Info_free(&sinfo);
@@ -80,11 +81,18 @@ int main(int argc, char *argv[])
 
 static int check_value(const char *value, const char *expected)
 {
-    /* MPICH may add GPU kinds after the mpi,system related kinds, which we ignore here */
-    if (strncmp(value, expected, strlen(expected))) {
-        printf("mpi_memory_alloc_kinds value is \"%s\", expected \"%s\"\n", value, expected);
-        return 1;
+    MTestPrintfMsg(1, "Checking \"%s\" in \"%s\"\n", expected, value);
+    char *tok;
+    char *expected_copy = strdup(expected);
+    tok = strtok(expected_copy, ",");
+    while (tok != NULL) {
+        char *s = strstr(value, tok);
+        if (!s) {
+            printf("\"%s\" is not found in mpi_memory_alloc_kinds \"%s\"\n", tok, value);
+        }
+        tok = strtok(NULL, ",");
     }
+    free(expected_copy);
 
     return 0;
 }

--- a/test/mpi/runtests
+++ b/test/mpi/runtests
@@ -444,7 +444,7 @@ sub LoadTests {
                 if ($args[$i] =~ /([^=]+)=(.*)/) {
                     my $key = $1;
                     my $value = $2;
-                    if ($key =~ /^(resultTest|init|timeLimit|xfail|lock|mem|gpu)$/) {
+                    if ($key =~ /^(resultTest|init|timeLimit|xfail|lock|mem)$/) {
                         $test_opt->{$key} = $value;
                     }
                     elsif ($key eq "arg") {

--- a/test/mpi/runtests
+++ b/test/mpi/runtests
@@ -73,7 +73,6 @@ $g_opt{memory_total} = 4;       # Total memory in GB
 $g_opt{memory_multiplier} = 1;  # No of simultaneous jobs
 $g_opt{cleanup} = 1;            # Whether to remove the compiled programs
 $g_opt{start_time} = time();    # So we can track accumulative test duration
-$g_opt{has_gpu_test} = 0;       # will set MPIR_CVAR_ENABLE_GPU for optimizations
 $g_opt{strict} = 0;             # will skip tests marked as "strict=false"
 $g_opt{runxfail} = 0;           # will run xfailed tests
 $g_opt{exeext} = "";
@@ -302,10 +301,6 @@ OpenOutputs();
 #
 # Process any files
 
-if ($g_opt{listfiles} =~ /testlist\.gpu/) {
-    $g_opt{has_gpu_test} = 1;
-}
-
 my @all_tests;
 if ($g_opt{listfiles} eq "") {
     if ($g_opt{batchRun}) {
@@ -443,17 +438,6 @@ sub LoadTests {
             my $requiresStrict = "";
 
             if ($#args >= 1) { $np = $args[1]; }
-
-            # global env for GPU feature, can be overridden by per-test envs
-            if ($g_opt{has_gpu_test}) {
-                if ($test_opt->{gpu}) {
-                    push @{$test_opt->{envs}}, "MPIR_CVAR_ENABLE_GPU=1";
-                } elsif ($_f eq "testlist.gpu" or $curdir =~ /\bcuda$/) {
-                    push @{$test_opt->{envs}}, "MPIR_CVAR_ENABLE_GPU=1";
-                } else {
-                    push @{$test_opt->{envs}}, "MPIR_CVAR_ENABLE_GPU=0";
-                }
-            }
 
             # Process the key=value arguments
             for (my $i=2; $i <= $#args; $i++) {


### PR DESCRIPTION

## Pull Request Description
We set MPIR_CVAR_ENABLE_GPU=0 for non-gpu tests to expedite the tests. However, today there is little penalty, thanks to delayed gpu optimization, to leave GPU enabled for non-gpu tests. Therefore, let's remove the extra setting.

This fixes the test datatype/struct_pack_mpi_bottom since it checks for gpu during the configure/compile time.


[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
