### PR TITLE
genq: fix gpu register of shmem slab with wrong size

### DIFF
--- a/src/mpid/common/genq/mpidu_genq_shmem_pool.c
+++ b/src/mpid/common/genq/mpidu_genq_shmem_pool.c
@@ -128,6 +128,7 @@ int MPIDU_genq_shmem_pool_create(void *slab, int slab_size,
     pool_obj->rank = rank;
     pool_obj->gpu_registered = false;
     pool_obj->slab = slab;
+    pool_obj->slab_size = slab_size;
 
     /* the global_block_index is at the end of the slab to avoid extra need of alignment */
     int total_cells_size = num_proc * num_free_queue * cells_per_free_queue
@@ -184,12 +185,7 @@ int MPIDU_genqi_shmem_pool_register(MPIDU_genqi_shmem_pool_s * pool_obj)
 
     MPIR_FUNC_ENTER;
 
-    int total_cells_size =
-        pool_obj->num_proc * pool_obj->cells_per_free_queue * pool_obj->cell_alloc_size;
-    int free_queue_size = pool_obj->num_proc * sizeof(MPIDU_genq_shmem_queue_u);
-    uintptr_t slab_size = total_cells_size + free_queue_size;
-
-    rc = MPIR_gpu_register_host(pool_obj->slab, slab_size);
+    rc = MPIR_gpu_register_host(pool_obj->slab, pool_obj->slab_size);
     MPIR_ERR_CHECK(rc);
     pool_obj->gpu_registered = true;
 

--- a/src/mpid/common/genq/mpidu_genqi_shmem_types.h
+++ b/src/mpid/common/genq/mpidu_genqi_shmem_types.h
@@ -52,6 +52,7 @@ typedef struct MPIDU_genqi_shmem_pool {
     uintptr_t cells_per_free_queue;
     uintptr_t num_proc;
     uintptr_t num_free_queue;
+    uintptr_t slab_size;
     int rank;
 
     void *slab;


### PR DESCRIPTION
## Pull Request Description
The slab size calculated failed to account for `num_free_queues` > 1. This resulted in `cudaMemcpyAsync` "invalid argument" error because part of the slab (the 2nd half of the local ranks) is missing registration.

Store the slab_size to avoid potential inconsistency in re-calculating slab_size.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
