### PR TITLE
ch4/ofi: fix leak of critical sections in flush_send_queue

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -879,8 +879,10 @@ int MPIDI_OFI_flush_send_queue(void)
 
     /* Apparently by sending self messages can flush the send queue */
     int rank = MPIR_Process.rank;
+    int in_vci_cs = -1;
     for (int vci = 0; vci < num_vcis; vci++) {
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
+        in_vci_cs = vci;
 
         MPIDI_OFI_dynamic_process_request_t reqs[2];
         mpi_errno = flush_send(rank, 0, vci, &reqs[0]);
@@ -899,6 +901,9 @@ int MPIDI_OFI_flush_send_queue(void)
   fn_exit:
     return mpi_errno;
   fn_fail:
+    if (in_vci_cs != -1) {
+        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(in_vci_cs));
+    }
     goto fn_exit;
 }
 


### PR DESCRIPTION
## Pull Request Description
In case of error, MPIR_ERR_CHECK will jump out within a vci critical section. Make sure we catch that in fn_fail.

Thanks @dalcinl  - https://github.com/pmodels/mpich/pull/7503/files#r2213188984

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
