### PR TITLE
mpl: Improve local host detection

### DIFF
--- a/src/mpl/src/sock/mpl_host.c
+++ b/src/mpl/src/sock/mpl_host.c
@@ -90,11 +90,19 @@ static void init_lhost_list(void)
 int MPL_host_is_local(const char *host)
 {
     int i;
+    char ip_str[INET_ADDRSTRLEN] = "";
 
     init_lhost_list();
 
+    /* we also try the IP address in case of inconsistent use of FQDN */
+    struct hostent *he = gethostbyname(host);
+    if (he && he->h_addr_list[0]) {
+        struct in_addr *addr = (struct in_addr *) he->h_addr_list[0];
+        inet_ntop(AF_INET, addr, ip_str, sizeof(ip_str));
+    }
+
     for (i = 0; i < lhost_count; i++)
-        if (!strcmp(lhost[i], host))
+        if (!strcmp(lhost[i], host) || !strcmp(lhost[i], ip_str))
             return 1;
 
     return 0;


### PR DESCRIPTION
## Pull Request Description

Lookup the IP address of the hostname when determining if it is the local host. Fixes an issue where the hostlist provided by the user or resource manager does not contain an exact match for the hostname returned by gethostname. For example, on LCRC Swing the PBS hostlist contains FQDNs like "gpu3.lcrc.anl.gov", while gethostname returns only "gpu3". Fixes pmodels/mpich#7186.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
