### PR TITLE
ch4/xpmem: check MPIR_CVAR_CH4_XPMEM_ENABLE in comm_bootstrap

### DIFF
--- a/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
+++ b/src/mpid/ch4/shm/ipc/xpmem/xpmem_init.c
@@ -83,6 +83,10 @@ int MPIDI_XPMEM_comm_bootstrap(MPIR_Comm * comm)
     MPIR_FUNC_ENTER;
     MPIR_CHKLMEM_DECL();
 
+    if (!MPIR_CVAR_CH4_XPMEM_ENABLE) {
+        goto fn_exit;
+    }
+
     int local_size = comm->num_local;
     if (local_size > 1) {
         /* NOTE: always run Allgather in case some process disable XPMEM inconsistently */


### PR DESCRIPTION
## Pull Request Description
If `MPIR_CVAR_CH4_XPMEM_ENABLE` is disabled, make sure to skip it in `MPIDI_XPMEM_comm_bootstrap`.




## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
