### PR TITLE
ch4/ofi: fix when GPU_PIPELINE_THRESHOLD is too low

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -557,7 +557,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
         }
     }
 
-    if (MPIR_CVAR_CH4_OFI_ENABLE_INJECT && !syncflag && !is_init &&
+    if (MPIR_CVAR_CH4_OFI_ENABLE_INJECT && !syncflag && !is_init && !is_am && !do_gpu_pipelining &&
         (data_sz <= MPIDI_OFI_global.max_buffered_send)) {
         do_inject = true;
     }
@@ -604,8 +604,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
     uint64_t match_bits;
     match_bits = MPIDI_OFI_init_sendtag(comm->context_id + context_offset, comm->rank, tag);
 
-    if (MPIR_CVAR_CH4_OFI_ENABLE_INJECT && !syncflag && !is_am &&
-        (data_sz <= MPIDI_OFI_global.max_buffered_send)) {
+    if (do_inject) {
         /* inject path */
         void *pack_buf = NULL;
         if (need_pack) {


### PR DESCRIPTION
## Pull Request Description
When MPIR_CVAR_CH4_OFI_GPU_PIPELINE_THRESHOLD is set to below prov->tx_attr->inject_size, it selects the inject path but skips the packing due to previous do_gpu_pipelining logic.

Fix the inconsistency by properly setting and use do_inject.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
