### PR TITLE
pmi: fix assertion on `PMIU_CS_ENTER` with `MPL_THREAD_PACKAGE_NONE`

### DIFF
--- a/src/mpl/include/mpl_thread.h
+++ b/src/mpl/include/mpl_thread.h
@@ -43,8 +43,8 @@ typedef void (*MPL_thread_func_t) (void *data);
 #define MPL_thread_mutex_destroy(mutex_ptr_, err_ptr_) { *((int*)err_ptr_) = 0;}
 #define MPL_thread_init(err_ptr_)      do { *((int*)err_ptr_) = 0;} while (0)
 #define MPL_thread_finalize(err_ptr_)  do { *((int*)err_ptr_) = 0;} while (0)
-#define MPL_thread_mutex_lock(mutex_ptr_, err_ptr_, prio_)   do { } while (0)
-#define MPL_thread_mutex_unlock(mutex_ptr_, err_ptr_)        do { } while (0)
+#define MPL_thread_mutex_lock(mutex_ptr_, err_ptr_, prio_)   do { *((int*)err_ptr_) = 0;} while (0)
+#define MPL_thread_mutex_unlock(mutex_ptr_, err_ptr_)        do { *((int*)err_ptr_) = 0;} while (0)
 #define MPL_thread_yield()             do { } while (0)
 #else
 #error "thread package (MPL_THREAD_PACKAGE_NAME) not defined or unknown"

--- a/src/pmi/src/pmi_util.c
+++ b/src/pmi/src/pmi_util.c
@@ -35,7 +35,7 @@
 #define MAXVALLEN 1024
 #define MAXKEYLEN   32
 
-int PMIU_is_threaded = 0;
+int PMIU_supports_threading = 0;
 MPL_thread_mutex_t PMIU_mutex;
 
 int PMIU_verbose = 0;           /* Set this to true to print PMI debugging info */

--- a/src/pmi/src/pmi_util.h
+++ b/src/pmi/src/pmi_util.h
@@ -215,13 +215,13 @@ extern int PMIU_verbose;        /* Set this to true to print PMI debugging info 
         (ptr_) = realloc_tmp_;                                                                  \
     } while (0)
 
-extern int PMIU_is_threaded;
+extern int PMIU_supports_threading;
 extern MPL_thread_mutex_t PMIU_mutex;
 
 void PMIU_thread_init(void);
 
 #define PMIU_CS_ENTER do { \
-    if (PMIU_is_threaded) { \
+    if (PMIU_supports_threading) { \
         int err; \
         MPL_thread_mutex_lock(&PMIU_mutex, &err, MPL_THREAD_PRIO_HIGH); \
         PMIU_Assert(err == 0); \
@@ -229,7 +229,7 @@ void PMIU_thread_init(void);
 } while (0)
 
 #define PMIU_CS_EXIT do { \
-    if (PMIU_is_threaded) { \
+    if (PMIU_supports_threading) { \
         int err; \
         MPL_thread_mutex_unlock(&PMIU_mutex, &err); \
         PMIU_Assert(err == 0); \

--- a/src/pmi/src/pmi_v1.c
+++ b/src/pmi/src/pmi_v1.c
@@ -169,7 +169,7 @@ PMI_API_PUBLIC int PMI_Init(int *spawned)
 
     if (PMI_server_version * 100 + PMI_server_subversion > 101) {
         /* enable PMIU_CS_{ENTER/EXIT} for PMI 1.2 and above */
-        PMIU_is_threaded = 1;
+        PMIU_supports_threading = 1;
         PMIU_thread_init();
     }
 
@@ -342,7 +342,7 @@ PMI_API_PUBLIC int PMI_Barrier_group(const int *group, int count, const char *ta
     }
 
     char *group_str;
-    if (group == PMI_GROUP_WORLD && !tag && !PMIU_is_threaded) {
+    if (group == PMI_GROUP_WORLD && !tag && !PMIU_supports_threading) {
         /* Backward-compatible PMI_Barrier */
         pmi_errno = PMI_Barrier();
         goto fn_exit;
@@ -370,7 +370,7 @@ PMI_API_PUBLIC int PMI_Barrier_group(const int *group, int count, const char *ta
 
     PMIU_msg_set_query_barrier(&pmicmd, USE_WIRE_VER, no_static, group_str);
 
-    if (!PMIU_is_threaded) {
+    if (!PMIU_supports_threading) {
         pmi_errno = PMIU_cmd_get_response(PMI_fd, &pmicmd);
         PMIU_ERR_POP(pmi_errno);
     } else {

--- a/src/pmi/src/pmi_wire.c
+++ b/src/pmi/src/pmi_wire.c
@@ -860,7 +860,7 @@ int PMIU_cmd_output(struct PMIU_cmd *pmicmd, char **buf_out, int *buflen_out)
         }
     } else {
         /* PMIU_WIRE_V2 */
-        if (PMIU_is_threaded) {
+        if (PMIU_supports_threading) {
             pmi_add_thrid(pmicmd);
         }
         pmi_errno = PMIU_cmd_output_v2(pmicmd, buf_out, buflen_out);
@@ -932,7 +932,7 @@ static int cmd_read_expect(int fd, struct PMIU_cmd *pmicmd, const char *expected
         PMIU_ERR_POP(pmi_errno);
 
         if (strcmp(expectedCmd, pmicmd->cmd) != 0) {
-            if (PMIU_is_threaded) {
+            if (PMIU_supports_threading) {
                 /* allow certain query/response to be nonblocking;
                  * enqueue and continue for such response when it not expected. */
                 if (strcmp("barrier_out", pmicmd->cmd) == 0) {


### PR DESCRIPTION
## Pull Request Description
With `MPL_THREAD_PACKAGE_NONE`, notably on `--enable-threads=single` builds, `PMIU_CS_ENTER` will always fail the `err` assertion when locking the stub mutex macro as `err != 0`.

https://jenkins-pmrs.cels.anl.gov/job/build-pulse/lastSuccessfulBuild/artifact/report.html#801

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.