### PR TITLE
mpir_pmi: add auto-detection of PMI version 1,2,x at runtime

### DIFF
--- a/src/pmi/errnames.txt
+++ b/src/pmi/errnames.txt
@@ -46,6 +46,10 @@
 **pmi_job_getid %d:PMI2_Job_GetId returned %d
 **pmi_kvs_get_parent_port:PMI_KVS_Get parent port failed
 **pmi_kvs_get_parent_port %d:PMI_KVS_Get parent port failed %d
+**pmi_version_auto_failure: Auto-detection of PMI version failed. Env var PMI_SIZE or PMIX_NAMESPACE not found. There is likely something wrong with the runtime environment! Aborting.
+**pmi_version_auto_ambiguous: Auto-detection of PMI version failed. Found both env vars PMI_SIZE and PMIX_NAMESPACE. There is likely something wrong with the runtime environment! Aborting.
+**pmi_version_auto_not_supported: Runtime environment uses unsupported PMI version. Aborting.
+**pmi_version_auto_not_supported %s: Runtime environment uses unsupported PMI version %s. Aborting.
 #
 # pmi2
 #

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -18,7 +18,7 @@ cvars:
     - name        : MPIR_CVAR_PMI_VERSION
       category    : PMI
       type        : enum
-      default     : 1
+      default     : auto
       class       : none
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_ALL_EQ
@@ -27,6 +27,7 @@ cvars:
         1        - PMI (default)
         2        - PMI2
         x        - PMIx
+        auto     - Auto-detect PMI version
 
     - name        : MPIR_CVAR_PMI_DISABLE_GROUP
       category    : PMI
@@ -99,34 +100,80 @@ static char *hwloc_topology_xmlfile;
 
 static int check_MPIR_CVAR_PMI_VERSION(void)
 {
-    /* Adjust MPIR_CVAR_PMI_VERSION if the default is disabled */
-#ifndef ENABLE_PMI1
-    if (MPIR_CVAR_PMI_VERSION == MPIR_CVAR_PMI_VERSION_1) {
-#if defined(ENABLE_PMI2)
-        MPIR_CVAR_PMI_VERSION = MPIR_CVAR_PMI_VERSION_2;
-#elif defined(ENABLE_PMIX)
-        MPIR_CVAR_PMI_VERSION = MPIR_CVAR_PMI_VERSION_x;
+    int mpi_errno = MPI_SUCCESS;
+
+    if (MPIR_CVAR_PMI_VERSION == MPIR_CVAR_PMI_VERSION_auto) {
+        /* Auto-detection of PMI version */
+        int have_pmi, have_pmix, job_size;
+        const char *nspace = NULL;
+
+        /* Env var PMI_SIZE is used for both PMI-1 and PMI-2. If enabled, PMI-1
+         * has precedence over PMI-2 in the auto-detection. */
+        if ((have_pmi = MPL_env2int("PMI_SIZE", &job_size)) < 0) {
+            return MPI_ERR_INTERN;
+        }
+        have_pmix = MPL_env2str("PMIX_NAMESPACE", &nspace);
+
+        if (have_pmi && have_pmix) {
+            /* There is something wrong with the runtime environment.
+             * Multiple PMI versions are detected. */
+            MPIR_ERR_SET(mpi_errno, MPI_ERR_INTERN, "**pmi_version_auto_ambiguous");
+        } else if (!have_pmi && !have_pmix) {
+            /* There is something wrong with the runtime environment.
+             * No PMI version could be detected. */
+            MPIR_ERR_SET(mpi_errno, MPI_ERR_INTERN, "**pmi_version_auto_failure");
+        } else if (have_pmi) {
+#ifdef ENABLE_PMI1
+            MPIR_CVAR_PMI_VERSION = MPIR_CVAR_PMI_VERSION_1;
+#elif defined(ENABLE_PMI2)
+            MPIR_CVAR_PMI_VERSION = MPIR_CVAR_PMI_VERSION_2;
 #else
-        return MPI_ERR_INTERN;
-#endif
-    }
+            /* Runtime environment uses PMI-1 or PMI-2 but none of the two
+             * is enabled in the MPI lib. We cannot proceed. */
+            MPIR_ERR_SET1(mpi_errno, MPI_ERR_INTERN, "**pmi_version_auto_not_supported",
+                          "**pmi_version_auto_not_supported %s", "PMI-1 or PMI-2");
 #endif
 
-    /* Error if user select PMI2 but it is disabled */
+        } else if (have_pmix) {
+#ifdef ENABLE_PMIX
+            MPIR_CVAR_PMI_VERSION = MPIR_CVAR_PMI_VERSION_x;
+#else
+            /* Runtime environment uses PMIx but this is not enabled in the
+             * MPI lib. We cannot proceed. */
+            MPIR_ERR_SET1(mpi_errno, MPI_ERR_INTERN, "**pmi_version_auto_not_supported",
+                          "**pmi_version_auto_not_supported %s", "PMIx");
+#endif
+        }
+    } else {
+        /* Adjust MPIR_CVAR_PMI_VERSION if the default is disabled */
+#ifndef ENABLE_PMI1
+        if (MPIR_CVAR_PMI_VERSION == MPIR_CVAR_PMI_VERSION_1) {
+#if defined(ENABLE_PMI2)
+            MPIR_CVAR_PMI_VERSION = MPIR_CVAR_PMI_VERSION_2;
+#elif defined(ENABLE_PMIX)
+            MPIR_CVAR_PMI_VERSION = MPIR_CVAR_PMI_VERSION_x;
+#else
+            return MPI_ERR_INTERN;
+#endif
+        }
+#endif
+
+        /* Error if user select PMI2 but it is disabled */
 #ifndef ENABLE_PMI2
-    if (MPIR_CVAR_PMI_VERSION == MPIR_CVAR_PMI_VERSION_2) {
-        return MPI_ERR_INTERN;
-    }
+        if (MPIR_CVAR_PMI_VERSION == MPIR_CVAR_PMI_VERSION_2) {
+            return MPI_ERR_INTERN;
+        }
 #endif
 
-    /* Error if user select PMI2 but it is disabled */
+        /* Error if user select PMIx but it is disabled */
 #ifndef ENABLE_PMIX
-    if (MPIR_CVAR_PMI_VERSION == MPIR_CVAR_PMI_VERSION_x) {
-        return MPI_ERR_INTERN;
-    }
+        if (MPIR_CVAR_PMI_VERSION == MPIR_CVAR_PMI_VERSION_x) {
+            return MPI_ERR_INTERN;
+        }
 #endif
+    }
 
-    return MPI_SUCCESS;
+    return mpi_errno;
 }
 
 /* When user call MPIR_pmi_finalize, we will postpone the actual PMI_Finalize


### PR DESCRIPTION
## Pull Request Description
This PR adds a new default value for `MPIR_CVAR_PMI_VERSION=auto` to auto-detect if a process is running in a PMI1, PMI2 or PMIx environment.

The env var `PMI_SIZE` is used for auto-detection of PMI1 and PMI2. The env var `PMIX_NAMESPACE` is used to auto-detect PMIx.

If both or none of these env vars are found a respective error is returned and startup is aborted. If a PMI version is detected at runtime which is not supported by the MPI library an error is returned and startup is aborted.

We have added this to ParaStation MPI a while ago and made positive experience with this mechanism in practice. It is tested with hydra, PRRTE and our ParaStation runtime environment. It helps to prevent errors due to mismatch of PMI version used by the runtime and PMI version set for the MPI lib early on. Hence we are wondering if you want to add it to MPICH!

CC @spickartz 

## Author Checklist
* [X] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [X] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [X] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
