### PR TITLE
ch4/ipc: Set locality of ipc rendezvous request

### DIFF
--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -264,6 +264,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_send_rndv(const void *buf, MPI_Aint coun
     MPIDIG_REQUEST(sreq, datatype) = datatype;
     MPIDIG_REQUEST(sreq, count) = count;
     MPIDIG_REQUEST(sreq, u.send.dest) = rank;
+    MPIDI_REQUEST_SET_LOCAL(sreq, 1, NULL);
     /* needed in case of IPC write */
     MPIDI_SHM_REQUEST(sreq, ipc.ipc_type) = MPIDI_IPCI_TYPE__NONE;
 


### PR DESCRIPTION
## Pull Request Description

Make sure ipc rendezvous requests are marked as local to ensure data is sent via the correct transport, instead of mistakenly via the network. Fixes performance regression for intranode transfers introduced in pmodels/mpich#7497.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
