### PR TITLE
pmi/v1: close stdin before exec mpiexec in singleton

### DIFF
--- a/src/pmi/src/pmi_v1.c
+++ b/src/pmi/src/pmi_v1.c
@@ -954,6 +954,10 @@ static int PMII_singinit(void)
         newargv[i++] = charpid;
         newargv[i++] = NULL;
         PMIU_Assert(i <= 8);
+
+        /* close stdin to avoid confusions */
+        close(0);
+
         rc = execvp(newargv[0], (char **) newargv);
 
         /* never should return unless failed */


### PR DESCRIPTION
## Pull Request Description
When singleton launches mpiexec, it is unclear which process should take stdin. Since normally mpiexec (or its proxies) do not take stdin and will forward stdin to the first process anyway, let's simply close stdin in the singleton case to avoid confusion.

This fixes `run_mpitests` in the singleton tests. run_mpitests communicates with the mpi process via stdin, thus it is crucial for mpiexec not to grab the stdin away.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
