### PR TITLE
misc: remove copy dir from localcopy_gpu

### DIFF
--- a/src/include/mpir_gpu_util.h
+++ b/src/include/mpir_gpu_util.h
@@ -85,8 +85,7 @@ MPL_STATIC_INLINE_PREFIX void MPIR_gpu_host_swap_gpu(const void *buf, MPI_Aint c
 {
     if (host_buf) {
         MPIR_Localcopy_gpu(buf, count, datatype, 0, &attr, host_buf, count, datatype, 0, NULL,
-                           MPL_GPU_COPY_DIRECTION_NONE, MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH,
-                           true);
+                           MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH, true);
     }
 }
 
@@ -101,7 +100,7 @@ MPL_STATIC_INLINE_PREFIX void MPIR_gpu_swap_back_gpu(void *host_buf, void *gpu_b
                                                      MPI_Datatype datatype, MPL_pointer_attr_t attr)
 {
     MPIR_Localcopy_gpu(host_buf, count, datatype, 0, NULL, gpu_buf, count, datatype, 0, &attr,
-                       MPL_GPU_COPY_DIRECTION_NONE, MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH, true);
+                       MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH, true);
 }
 
 #endif /* MPIR_GPU_UTIL_H_INCLUDED */

--- a/src/include/mpir_misc.h
+++ b/src/include/mpir_misc.h
@@ -104,12 +104,12 @@ int MPIR_Localcopy_stream(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype 
 int MPIR_Localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                        MPI_Aint sendoffset, MPL_pointer_attr_t * sendattr, void *recvbuf,
                        MPI_Aint recvcount, MPI_Datatype recvtype, MPI_Aint recvoffset,
-                       MPL_pointer_attr_t * recvattr, MPL_gpu_copy_direction_t dir,
+                       MPL_pointer_attr_t * recvattr,
                        MPL_gpu_engine_type_t enginetype, bool commit);
 int MPIR_Ilocalcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                         MPI_Aint sendoffset, MPL_pointer_attr_t * sendattr, void *recvbuf,
                         MPI_Aint recvcount, MPI_Datatype recvtype, MPI_Aint recvoffset,
-                        MPL_pointer_attr_t * recvattr, MPL_gpu_copy_direction_t dir,
+                        MPL_pointer_attr_t * recvattr,
                         MPL_gpu_engine_type_t enginetype, bool commit, MPIR_gpu_req * req);
 
 /* Contiguous datatype calculates buffer address with `(char *) buf + dt_true_lb`.

--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -238,7 +238,7 @@ static int do_localcopy(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
 static int do_localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                             MPI_Aint sendoffset, MPL_pointer_attr_t * send_attr, void *recvbuf,
                             MPI_Aint recvcount, MPI_Datatype recvtype, MPI_Aint recvoffset,
-                            MPL_pointer_attr_t * recv_attr, MPL_gpu_copy_direction_t dir,
+                            MPL_pointer_attr_t * recv_attr,
                             MPL_gpu_engine_type_t enginetype, bool commit, MPIR_gpu_req * gpu_req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -303,6 +303,7 @@ static int do_localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatyp
             goto fn_exit;
         }
 
+        MPL_gpu_copy_direction_t dir;
         if (send_attr->type == MPL_GPU_POINTER_DEV) {
             if (recv_attr->type == MPL_GPU_POINTER_DEV) {
                 dir = MPL_GPU_COPY_D2D_OUTGOING;
@@ -477,8 +478,7 @@ int MPIR_Localcopy_stream(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype 
 int MPIR_Localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                        MPI_Aint sendoffset, MPL_pointer_attr_t * sendattr, void *recvbuf,
                        MPI_Aint recvcount, MPI_Datatype recvtype, MPI_Aint recvoffset,
-                       MPL_pointer_attr_t * recvattr, MPL_gpu_copy_direction_t dir,
-                       MPL_gpu_engine_type_t enginetype, bool commit)
+                       MPL_pointer_attr_t * recvattr, MPL_gpu_engine_type_t enginetype, bool commit)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -490,7 +490,7 @@ int MPIR_Localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sen
 #ifdef MPL_HAVE_GPU
     mpi_errno =
         do_localcopy_gpu(sendbuf, sendcount, sendtype, sendoffset, sendattr, recvbuf, recvcount,
-                         recvtype, recvoffset, recvattr, dir, enginetype, commit, NULL);
+                         recvtype, recvoffset, recvattr, enginetype, commit, NULL);
     MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno =
@@ -509,7 +509,7 @@ int MPIR_Localcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sen
 int MPIR_Ilocalcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype sendtype,
                         MPI_Aint sendoffset, MPL_pointer_attr_t * sendattr, void *recvbuf,
                         MPI_Aint recvcount, MPI_Datatype recvtype, MPI_Aint recvoffset,
-                        MPL_pointer_attr_t * recvattr, MPL_gpu_copy_direction_t dir,
+                        MPL_pointer_attr_t * recvattr,
                         MPL_gpu_engine_type_t enginetype, bool commit, MPIR_gpu_req * req)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -522,7 +522,7 @@ int MPIR_Ilocalcopy_gpu(const void *sendbuf, MPI_Aint sendcount, MPI_Datatype se
 #ifdef MPL_HAVE_GPU
     mpi_errno =
         do_localcopy_gpu(sendbuf, sendcount, sendtype, sendoffset, sendattr, recvbuf, recvcount,
-                         recvtype, recvoffset, recvattr, dir, enginetype, commit, req);
+                         recvtype, recvoffset, recvattr, enginetype, commit, req);
     MPIR_ERR_CHECK(mpi_errno);
 #else
     mpi_errno =

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -92,7 +92,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_complete(MPIR_Request * rreq, int ev
                                        MPIDI_OFI_REQUEST(rreq, buf),
                                        MPIDI_OFI_REQUEST(rreq, count),
                                        MPIDI_OFI_REQUEST(rreq, datatype), 0, NULL,
-                                       MPL_GPU_COPY_H2D,
                                        MPIDI_OFI_gpu_get_recv_engine_type(), true);
         if (mpi_errno) {
             MPIR_ERR_SET(rreq->status.MPI_ERROR, MPI_ERR_TYPE, "**dtypemismatch");

--- a/src/mpid/ch4/netmod/ofi/ofi_pipeline.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_pipeline.c
@@ -207,11 +207,9 @@ static int pipeline_send_poll(MPIX_Async_thing thing)
         MPIR_gpu_req async_req;
         int mpi_errno;
         int engine_type = MPIDI_OFI_gpu_get_send_engine_type();
-        int copy_dir = MPL_GPU_COPY_DIRECTION_NONE;
         mpi_errno = MPIR_Ilocalcopy_gpu(p->buf, p->count, p->datatype,
                                         p->u.send.copy_offset, &p->attr, chunk_buf, chunk_sz,
-                                        MPIR_BYTE_INTERNAL, 0, NULL, copy_dir, engine_type,
-                                        1, &async_req);
+                                        MPIR_BYTE_INTERNAL, 0, NULL, engine_type, 1, &async_req);
         MPIR_Assertp(mpi_errno == MPI_SUCCESS);
         struct send_chunk *chunk = spawn_send_copy(thing, sreq, &async_req,
                                                    p->chunk_index, chunk_buf, chunk_sz);
@@ -420,10 +418,9 @@ static void recv_chunk_copy(MPIR_Request * rreq, void *chunk_buf, MPI_Aint chunk
 
     MPIR_gpu_req async_req;
     int engine_type = MPIDI_OFI_gpu_get_recv_engine_type();
-    int copy_dir = MPL_GPU_COPY_DIRECTION_NONE;
     mpi_errno = MPIR_Ilocalcopy_gpu(chunk_buf, chunk_sz, MPIR_BYTE_INTERNAL, 0, NULL,
                                     (void *) p->buf, p->count, p->datatype, offset, &p->attr,
-                                    copy_dir, engine_type, 1, &async_req);
+                                    engine_type, 1, &async_req);
     MPIR_Assertp(mpi_errno == MPI_SUCCESS);
 
     add_recv_copy(rreq, &async_req, chunk_buf, chunk_sz);

--- a/src/mpid/ch4/netmod/ofi/ofi_rndv_read.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rndv_read.c
@@ -294,10 +294,8 @@ static int async_recv_copy(MPIR_Request * rreq, void *chunk_buf, MPI_Aint chunk_
 
     MPIR_gpu_req async_req;
     int engine_type = MPIDI_OFI_gpu_get_recv_engine_type();
-    int copy_dir = MPL_GPU_COPY_DIRECTION_NONE;
     mpi_errno = MPIR_Ilocalcopy_gpu(chunk_buf, chunk_sz, MPIR_BYTE_INTERNAL, 0, NULL,
-                                    buf, count, datatype, offset, attr,
-                                    copy_dir, engine_type, 1, &async_req);
+                                    buf, count, datatype, offset, attr, engine_type, 1, &async_req);
     MPIR_ERR_CHECK(mpi_errno);
 
     struct recv_copy *p = MPL_malloc(sizeof(struct recv_copy), MPL_MEM_OTHER);

--- a/src/mpid/ch4/netmod/ofi/ofi_rndv_write.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rndv_write.c
@@ -177,10 +177,9 @@ static int async_send_copy(MPIX_Async_thing thing, MPIR_Request * sreq, int nic,
 
     MPIR_gpu_req async_req;
     int engine_type = MPIDI_OFI_gpu_get_send_engine_type();
-    int copy_dir = MPL_GPU_COPY_DIRECTION_NONE;
     mpi_errno = MPIR_Ilocalcopy_gpu((void *) buf, count, datatype, offset, attr,
                                     chunk_buf, chunk_sz, MPIR_BYTE_INTERNAL, 0, NULL,
-                                    copy_dir, engine_type, 1, &async_req);
+                                    engine_type, 1, &async_req);
     MPIR_ERR_CHECK(mpi_errno);
 
     struct send_copy *p = MPL_malloc(sizeof(struct send_copy), MPL_MEM_OTHER);

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -393,7 +393,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
             pack_buf = MPL_aligned_alloc(64, data_sz, MPL_MEM_OTHER);
             mpi_errno = MPIR_Localcopy_gpu(buf, count, datatype, 0, &attr,
                                            pack_buf, data_sz, MPIR_BYTE_INTERNAL, 0,
-                                           MPIR_GPU_ATTR_HOST, MPL_GPU_COPY_D2H,
+                                           MPIR_GPU_ATTR_HOST,
                                            MPIDI_OFI_gpu_get_send_engine_type(), true);
             MPIR_ERR_CHECK(mpi_errno);
             send_buf = pack_buf;
@@ -470,7 +470,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
 
             mpi_errno = MPIR_Localcopy_gpu(buf, count, datatype, 0, &attr,
                                            pack_buf, data_sz, MPIR_BYTE_INTERNAL, 0,
-                                           MPIR_GPU_ATTR_HOST, MPL_GPU_COPY_D2H,
+                                           MPIR_GPU_ATTR_HOST,
                                            MPIDI_OFI_gpu_get_send_engine_type(), true);
             MPIR_ERR_CHECK(mpi_errno);
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -686,8 +686,7 @@ int MPIDI_GPU_copy_data_async(MPIDI_IPC_hdr * ipc_hdr, MPIR_Request * req, MPI_A
         MPIDI_IPCI_choose_engine(ipc_hdr->ipc_handle.gpu.global_dev_id, dev_id);
     mpi_errno = MPIR_Ilocalcopy_gpu(src_buf, src_count, src_dt, 0, NULL,
                                     MPIDIG_REQUEST(req, buffer), MPIDIG_REQUEST(req, count),
-                                    MPIDIG_REQUEST(req, datatype), 0, &attr,
-                                    MPL_GPU_COPY_DIRECTION_NONE, engine, true, &yreq);
+                                    MPIDIG_REQUEST(req, datatype), 0, &attr, engine, true, &yreq);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = gpu_ipc_async_start(req, &yreq, src_buf, ipc_hdr->ipc_handle.gpu);
@@ -749,8 +748,7 @@ int MPIDI_GPU_write_data_async(MPIDI_IPC_hdr * ipc_hdr, MPIR_Request * sreq)
     MPL_gpu_engine_type_t engine =
         MPIDI_IPCI_choose_engine(ipc_hdr->ipc_handle.gpu.global_dev_id, dev_id);
     mpi_errno = MPIR_Ilocalcopy_gpu(src_buf, src_count, src_datatype, 0, &attr,
-                                    dst_buf, dst_count, dst_datatype, 0, NULL,
-                                    MPL_GPU_COPY_DIRECTION_NONE, engine, true, &yreq);
+                                    dst_buf, dst_count, dst_datatype, 0, NULL, engine, true, &yreq);
     MPIR_ERR_CHECK(mpi_errno);
 
     mpi_errno = gpu_ipc_async_start(sreq, &yreq, dst_buf, ipc_hdr->ipc_handle.gpu);

--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -167,14 +167,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
             mpi_errno =
                 MPIR_Ilocalcopy_gpu(origin_addr, origin_count, origin_datatype, 0, &origin_attr,
                                     target_addr, target_count, target_datatype, 0, &target_attr,
-                                    MPL_GPU_COPY_DIRECTION_NONE, engine_type, 1, &yreq);
+                                    engine_type, 1, &yreq);
             if (yreq.type != MPIR_NULL_REQUEST)
                 MPIDI_POSIX_rma_outstanding_req_enqueu(yreq, &win->dev.shm.posix);
         } else {
             mpi_errno =
                 MPIR_Localcopy_gpu(origin_addr, origin_count, origin_datatype, 0, &origin_attr,
                                    target_addr, target_count, target_datatype, 0, &target_attr,
-                                   MPL_GPU_COPY_DIRECTION_NONE, engine_type, 1);
+                                   engine_type, 1);
         }
         goto fn_exit;
     }
@@ -257,14 +257,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
             mpi_errno = MPIR_Ilocalcopy_gpu(target_addr, target_count,
                                             target_datatype, 0, NULL, origin_addr,
                                             origin_count, origin_datatype, 0, NULL,
-                                            MPL_GPU_COPY_DIRECTION_NONE, engine_type, 1, &yreq);
+                                            engine_type, 1, &yreq);
             if (yreq.type != MPIR_NULL_REQUEST)
                 MPIDI_POSIX_rma_outstanding_req_enqueu(yreq, &win->dev.shm.posix);
         } else {
             mpi_errno = MPIR_Localcopy_gpu(target_addr, target_count,
                                            target_datatype, 0, NULL, origin_addr,
-                                           origin_count, origin_datatype, 0, NULL,
-                                           MPL_GPU_COPY_DIRECTION_NONE, engine_type, 1);
+                                           origin_count, origin_datatype, 0, NULL, engine_type, 1);
         }
         goto fn_exit;
     }

--- a/src/mpid/ch4/src/ch4_coll_impl.h
+++ b/src/mpid/ch4/src/ch4_coll_impl.h
@@ -613,7 +613,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_alpha(const void 
         recvbuf = in_recvbuf;
         mpi_errno = MPIR_Localcopy_gpu(host_recvbuf, count, datatype, 0, NULL,
                                        recvbuf, count, datatype, 0, &recv_attr,
-                                       MPL_GPU_COPY_DIRECTION_NONE,
                                        MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH, true);
         MPIR_ERR_CHECK(mpi_errno);
         MPIDI_Coll_host_buffer_genq_free(host_sendbuf, host_recvbuf, shift);
@@ -661,7 +660,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_beta(const void *
         recvbuf = in_recvbuf;
         mpi_errno = MPIR_Localcopy_gpu(host_recvbuf, count, datatype, 0, NULL,
                                        recvbuf, count, datatype, 0, &recv_attr,
-                                       MPL_GPU_COPY_DIRECTION_NONE,
                                        MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH, true);
         MPIR_ERR_CHECK(mpi_errno);
         MPIDI_Coll_host_buffer_genq_free(host_sendbuf, host_recvbuf, shift);
@@ -713,7 +711,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_Allreduce_intra_composition_gamma(const void 
         recvbuf = in_recvbuf;
         mpi_errno = MPIR_Localcopy_gpu(host_recvbuf, count, datatype, 0, NULL,
                                        recvbuf, count, datatype, 0, &recv_attr,
-                                       MPL_GPU_COPY_DIRECTION_NONE,
                                        MPL_GPU_ENGINE_TYPE_COPY_HIGH_BANDWIDTH, true);
         MPIR_ERR_CHECK(mpi_errno);
         MPIDI_Coll_host_buffer_genq_free(host_sendbuf, host_recvbuf, shift);


### PR DESCRIPTION
## Pull Request Description
Let the localcopy routine determin copy direction based on buffer
attributes. I guess we can't tell MPL_GPU_COPY_D2D_OUTGOING from
MPL_GPU_COPY_D2D_INCOMING, but both are not in use anyway. We should
extend MPL_pointer_attr_t if we need to tell remotely mapped gpu
pointers.


[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
