### PR TITLE
ch4/ofi: fix MPIDI_OFI_rndv_need_pack for reg_host 

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -568,9 +568,8 @@ int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret)
                             MPIR_STATUS_SET_CANCEL_BIT(req->status, TRUE);
                             MPIR_STATUS_SET_COUNT(req->status, 0);
                             MPIR_Datatype_release_if_not_builtin(MPIDI_OFI_REQUEST(req, datatype));
-                            if ((event_id == MPIDI_OFI_EVENT_RECV_PACK) &&
-                                MPIDI_OFI_REQUEST(req, noncontig.pack.pack_buffer)) {
-                                MPL_free(MPIDI_OFI_REQUEST(req, noncontig.pack.pack_buffer));
+                            if (event_id == MPIDI_OFI_EVENT_RECV_PACK) {
+                                MPIDI_OFI_free_pack_buffer(req);
                             } else if (event_id == MPIDI_OFI_EVENT_RECV_NOPACK) {
                                 MPL_free(MPIDI_OFI_REQUEST(req, noncontig.nopack.iovs));
                             }

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -46,9 +46,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_event(int vci,
     MPIR_FUNC_ENTER;
 
     /* free the packing buffers and datatype */
-    if ((event_id == MPIDI_OFI_EVENT_SEND_PACK) &&
-        (MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer))) {
-        MPL_free(MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer));
+    if (event_id == MPIDI_OFI_EVENT_SEND_PACK) {
+        MPIDI_OFI_free_pack_buffer(sreq);
     } else if (MPIDI_OFI_ENABLE_PT2PT_NOPACK && (event_id == MPIDI_OFI_EVENT_SEND_NOPACK)) {
         MPL_free(MPIDI_OFI_REQUEST(sreq, noncontig.nopack.iovs));
     }
@@ -97,7 +96,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_complete(MPIR_Request * rreq, int ev
         if (mpi_errno) {
             MPIR_ERR_SET(rreq->status.MPI_ERROR, MPI_ERR_TYPE, "**dtypemismatch");
         }
-        MPL_free(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer));
+        MPIDI_OFI_free_pack_buffer(rreq);
     } else if (event_id == MPIDI_OFI_EVENT_RECV_NOPACK) {
 #ifdef HAVE_ERROR_CHECKING
         MPI_Count elements;

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -302,6 +302,7 @@ typedef struct {
     enum MPIDI_OFI_req_kind kind;
     union {
         struct {
+            bool is_genq;
             char *pack_buffer;
         } pack;
         struct {

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -224,11 +224,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
 
         /* Unpack */
         MPIDI_OFI_REQUEST(rreq, event_id) = MPIDI_OFI_EVENT_RECV_PACK;
-        MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer) =
-            MPL_aligned_alloc(64, data_sz, MPL_MEM_OTHER);
+        recv_buf = MPIDI_OFI_malloc_pack_buffer(rreq, data_sz);
         MPIR_ERR_CHKANDJUMP1(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer) == NULL, mpi_errno,
                              MPI_ERR_OTHER, "**nomem", "**nomem %s", "Recv Pack Buffer alloc");
-        recv_buf = MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer);
     } else {
         MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer) = NULL;
     }

--- a/src/mpid/ch4/netmod/ofi/ofi_rndv.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rndv.c
@@ -91,7 +91,7 @@ int MPIDI_OFI_recv_rndv_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Reque
     /* if we were expecting an eager send, free the unneeded pack_buffer or iovs array */
     switch (MPIDI_OFI_REQUEST(rreq, event_id)) {
         case MPIDI_OFI_EVENT_RECV_PACK:
-            MPL_free(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer));
+            MPIDI_OFI_free_pack_buffer(rreq);
             break;
         case MPIDI_OFI_EVENT_RECV_NOPACK:
             MPL_free(MPIDI_OFI_REQUEST(rreq, noncontig.nopack.iovs));

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -464,7 +464,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
 
         void *data = NULL;
         if (need_pack) {
-            void *pack_buf = MPL_aligned_alloc(64, data_sz, MPL_MEM_OTHER);
+            void *pack_buf = MPIDI_OFI_malloc_pack_buffer(sreq, data_sz);
             MPIR_ERR_CHKANDJUMP1(pack_buf == NULL, mpi_errno,
                                  MPI_ERR_OTHER, "**nomem", "**nomem %s", "Send Pack buffer alloc");
 
@@ -475,7 +475,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
             MPIR_ERR_CHECK(mpi_errno);
 
             data = pack_buf;
-            MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer) = pack_buf;
         } else {
             data = MPIR_get_contig_ptr(buf, dt_true_lb);
             MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer) = NULL;


### PR DESCRIPTION
## Pull Request Description
When we use malloc for pack buffer and when it is used for copying from
and to GPU, we potentially can incur expensive registration cost every
time. This is the case with ZE. Use pipeline_pool allows re-usage of pack
buffers.


[skip warnings]
## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
