### PR TITLE
romio: Remove MPIO_ functions and objects from tests

### DIFF
--- a/src/mpi/romio/test/async.c
+++ b/src/mpi/romio/test/async.c
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
     int errs = 0, toterrs;
     MPI_File fh;
     MPI_Status status;
-    MPIO_Request request;
+    MPI_Request request;
     int errcode = 0;
 
     MPI_Init(&argc, &argv);
@@ -86,11 +86,7 @@ int main(int argc, char **argv)
     if (errcode != MPI_SUCCESS) {
         handle_error(errcode, "MPI_File_iwrite");
     }
-#ifdef MPIO_USES_MPI_REQUEST
     MPI_Wait(&request, &status);
-#else
-    MPIO_Wait(&request, &status);
-#endif
     MPI_File_close(&fh);
 
     /* reopen the file and read the data back */
@@ -111,11 +107,7 @@ int main(int argc, char **argv)
     if (errcode != MPI_SUCCESS) {
         handle_error(errcode, "MPI_File_open");
     }
-#ifdef MPIO_USES_MPI_REQUEST
     MPI_Wait(&request, &status);
-#else
-    MPIO_Wait(&request, &status);
-#endif
 
     MPI_File_close(&fh);
 

--- a/src/mpi/romio/test/i_noncontig.c
+++ b/src/mpi/romio/test/i_noncontig.c
@@ -37,7 +37,7 @@ int main(int argc, char **argv)
     MPI_Status status;
     char *filename;
     MPI_Datatype typevec, newtype, tmptype;
-    MPIO_Request req;
+    MPI_Request req;
 
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
@@ -112,11 +112,7 @@ int main(int argc, char **argv)
     for (i = 0; i < SIZE; i++)
         buf[i] = i + mynod * SIZE;
     MPI_CHECK(MPI_File_iwrite(fh, buf, 1, newtype, &req));
-#ifdef MPIO_USES_MPI_REQUEST
     MPI_Wait(&req, &status);
-#else
-    MPIO_Wait(&req, &status);
-#endif
 
     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -124,11 +120,7 @@ int main(int argc, char **argv)
         buf[i] = -1;
 
     MPI_CHECK(MPI_File_iread_at(fh, 0, buf, 1, newtype, &req));
-#ifdef MPIO_USES_MPI_REQUEST
     MPI_Wait(&req, &status);
-#else
-    MPIO_Wait(&req, &status);
-#endif
 
     for (i = 0; i < SIZE; i++) {
         if (!mynod) {
@@ -181,11 +173,7 @@ int main(int argc, char **argv)
     for (i = 0; i < SIZE; i++)
         buf[i] = i + mynod * SIZE;
     MPI_CHECK(MPI_File_iwrite_at(fh, mynod * (SIZE / 2) * sizeof(int), buf, 1, newtype, &req));
-#ifdef MPIO_USES_MPI_REQUEST
     MPI_Wait(&req, &status);
-#else
-    MPIO_Wait(&req, &status);
-#endif
 
     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -193,11 +181,7 @@ int main(int argc, char **argv)
         buf[i] = -1;
 
     MPI_CHECK(MPI_File_iread_at(fh, mynod * (SIZE / 2) * sizeof(int), buf, 1, newtype, &req));
-#ifdef MPIO_USES_MPI_REQUEST
     MPI_Wait(&req, &status);
-#else
-    MPIO_Wait(&req, &status);
-#endif
 
     for (i = 0; i < SIZE; i++) {
         if (!mynod) {
@@ -252,11 +236,7 @@ int main(int argc, char **argv)
     for (i = 0; i < SIZE; i++)
         buf[i] = i + mynod * SIZE;
     MPI_CHECK(MPI_File_iwrite(fh, buf, SIZE, MPI_INT, &req));
-#ifdef MPIO_USES_MPI_REQUEST
     MPI_Wait(&req, &status);
-#else
-    MPIO_Wait(&req, &status);
-#endif
 
     MPI_Barrier(MPI_COMM_WORLD);
 
@@ -264,11 +244,7 @@ int main(int argc, char **argv)
         buf[i] = -1;
 
     MPI_CHECK(MPI_File_iread_at(fh, 0, buf, SIZE, MPI_INT, &req));
-#ifdef MPIO_USES_MPI_REQUEST
     MPI_Wait(&req, &status);
-#else
-    MPIO_Wait(&req, &status);
-#endif
 
     for (i = 0; i < SIZE; i++) {
         if (!mynod) {


### PR DESCRIPTION
## Pull Request Description

This way of developing ROMIO programs is antiquated. Users should use
MPI_ namespace for standard functionality. Fixes https://github.com/pmodels/mpich/issues/7520.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
