### PR TITLE
binding/f08: MPIX_Request_is_complete returns bool

### DIFF
--- a/maint/local_python/binding_f08.py
+++ b/maint/local_python/binding_f08.py
@@ -862,7 +862,12 @@ def dump_interface_function(func, name, c_name, is_large):
         decl_list.append("INTEGER(c_int) :: ierror")
     else:
         ret = "res"
-        decl_list.append("%s :: res" % f08_mapping[func['return']])
+        if func['return'] == 'LOGICAL':
+            # MPIX_Request_is_complete
+            decl_list.append("LOGICAL(c_bool) :: res")
+            uses['c_bool'] = 1
+        else:
+            decl_list.append("%s :: res" % f08_mapping[func['return']])
 
     # ----
     G.out.append("")


### PR DESCRIPTION
## Pull Request Description
Usually MPI functions return an int (error code),
`MPIX_Request_is_complete` returns bool. It needs to be mapped to LOGICAL(c_bool) in bind(C) interface.

Fixes #7346


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
