### PR TITLE
ch4/ofi: Initialize provider score to INT_MIN

### DIFF
--- a/src/mpid/ch4/netmod/ofi/init_provider.c
+++ b/src/mpid/ch4/netmod/ofi/init_provider.c
@@ -299,7 +299,7 @@ static struct fi_info *pick_provider_from_list(struct fi_info *list)
     MPIDI_OFI_init_settings(&optimal_settings, MPIDI_OFI_SET_NAME_DEFAULT);
     MPIDI_OFI_init_settings(&minimal_settings, MPIDI_OFI_SET_NAME_MINIMAL);
 
-    int best_score = 0;
+    int best_score = INT_MIN;
     struct fi_info *best_prov = NULL;
     for (struct fi_info * prov = list; prov; prov = prov->next) {
         /* Confirm the NIC backed by the provider is actually up. */


### PR DESCRIPTION
## Pull Request Description

In some edge cases, e.g. a single node job on a Slingshot system with FI_HMEM enabled, the only provider available might have a negative preference score. Rather than error out, we can still select the best provider available and let the application run. See pmodels/mpich#7467.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
