### PR TITLE
ch4/ofi: move flush_send_queue back to finalize

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -200,17 +200,8 @@ int MPIDI_OFI_mpi_comm_free_hook(MPIR_Comm * comm)
 
     MPL_free(MPIDI_OFI_COMM(comm).pref_nic);
 
-    if (strcmp("sockets", MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name) == 0) {
-        /* sockets provider need flush any last lightweight send. */
-        mpi_errno = MPIDI_OFI_flush_send_queue();
-        MPIR_ERR_CHECK(mpi_errno);
-    }
-
-  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 int MPIDI_OFI_comm_set_hints(MPIR_Comm * comm, MPIR_Info * info)

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -60,7 +60,6 @@ ATTRIBUTE((unused));
 
 int MPIDI_OFI_progress_uninlined(int vci);
 int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret);
-int MPIDI_OFI_flush_send_queue(void);
 
 /*
  * Helper routines and macros for request completion

--- a/test/mpi/spawn/spawn_rootargs.c
+++ b/test/mpi/spawn/spawn_rootargs.c
@@ -25,8 +25,13 @@ int main(int argc, char *argv[])
 
     if (parent == MPI_COMM_NULL) {
         MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-        MPI_Comm_spawn("./spawn_rootargs", args,        /*MPI_ARGV_NULL, */
-                       5, MPI_INFO_NULL, 0, MPI_COMM_SELF, &child, MPI_ERRCODES_IGNORE);
+        if (rank == 0) {
+            MPI_Comm_spawn("./spawn_rootargs", args,
+                           5, MPI_INFO_NULL, 0, MPI_COMM_WORLD, &child, MPI_ERRCODES_IGNORE);
+        } else {
+            MPI_Comm_spawn(NULL, NULL,
+                           -1, MPI_INFO_NULL, 0, MPI_COMM_WORLD, &child, MPI_ERRCODES_IGNORE);
+        }
         MPI_Barrier(child);
         MPI_Comm_disconnect(&child);
         if (!rank)


### PR DESCRIPTION
## Pull Request Description
This reverts the previous changes that moved flush_send_queue from finalize_hook to comm_free_hook. The comm_free_hook currently can be invoked both inside and outside critical sections. The flush_send_queue need thread protections for all vcis and this is difficult to manage due to ambiguous caller critical sections.

Move the flush_send_queue back to ofi_finalize_hook for now.

Fixes #7522
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
