### PR TITLE
mpl/ze: fix the case when ZE_AFFINITY_MASK specifies whole device

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -462,7 +462,7 @@ static int init_device_mappings(affinity_mask_t * mask)
             } else {
                 for (int j = 0; j < known_subdev_count; ++j) {
                     int idx = GET_GLOBAL_DEV_INDEX(device, j + 1);
-                    global_to_local_map[idx + j] = 1;
+                    global_to_local_map[idx] = 1;
                 }
             }
         }


### PR DESCRIPTION
## Pull Request Description
In the case when a ZE_AFFINITY_MASK sets a whole device, we had a wrong
index calucation that results in a potential buffer over-run.

The logic in the code is complex and obscure. Add my current
understanding in comment.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
