### PR TITLE
datatype: Expose Fortran logical globals

### DIFF
--- a/src/mpi/datatype/typeutil.c
+++ b/src/mpi/datatype/typeutil.c
@@ -471,12 +471,12 @@ void MPIR_Datatype_get_flattened(MPI_Datatype type, void **flattened, int *flatt
  */
 #if !defined(F77_TRUE_VALUE_SET)
 bool MPIR_fortran_booleans_is_set = false;
-int MPIR_fortran_true = 1;
-int MPIR_fortran_false = 0;
+MPICH_API_PUBLIC int MPIR_fortran_true = 1;
+MPICH_API_PUBLIC int MPIR_fortran_false = 0;
 #else
 bool MPIR_fortran_booleans_is_set = true;
-int MPIR_fortran_true = F77_TRUE_VALUE;
-int MPIR_fortran_false = F77_FALSE_VALUE;
+MPICH_API_PUBLIC int MPIR_fortran_true = F77_TRUE_VALUE;
+MPICH_API_PUBLIC int MPIR_fortran_false = F77_FALSE_VALUE;
 #endif
 
 int MPIR_Abi_set_fortran_booleans_impl(int logical_size, void *logical_true, void *logical_false)


### PR DESCRIPTION
## Pull Request Description

We are now setting Fortran logical values at runtime after pmodels/mpich#7455. Since the Fortran bindings depend on these variables, expose them. If we update the bindings to use the ABI functions for querying these values, we can remove these exposures.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
