### PR TITLE
test/config: Error out if Fortran requested but cannot be compiled

### DIFF
--- a/test/mpi/configure.ac
+++ b/test/mpi/configure.ac
@@ -103,7 +103,7 @@ AC_ARG_ENABLE(fortran,
 [  --enable-fortran=option - Control the level of Fortran support in the MPICH implementation.
         yes|all   - Enable all available Fortran implementations (F77, F90, F08)
         no|none   - No Fortran support
-],,[enable_fortran=all])
+],,[enable_fortran=auto])
 
 save_IFS="$IFS"
 IFS=","
@@ -112,7 +112,7 @@ enable_fc=no
 enable_f08=no
 for option in $enable_fortran ; do
     case "$option" in
-        yes|all)
+        auto|yes|all)
                 enable_f77=yes
                 enable_fc=yes
                 enable_f08=yes
@@ -1099,6 +1099,9 @@ if test "$enable_f77" = yes ; then
         buildingF77=yes
     ],[
         AC_MSG_RESULT(no)
+        if test $enable_fortran != "auto"; then
+            AC_MSG_ERROR([unable to build mpif.h program. consider using --disable-fortran or --enable-fortran=auto.])
+        fi
     ])
     AC_LANG_POP([Fortran 77])
 fi
@@ -1408,6 +1411,9 @@ if test "$enable_fc" = yes ; then
         f90dir=f90
     ],[
         AC_MSG_RESULT(no)
+        if test $enable_fortran != "auto"; then
+            AC_MSG_ERROR([unable to build "use mpi" program. consider using --disable-fortran or --enable-fortran=auto.])
+        fi
     ])
     AC_LANG_POP([Fortran])
 fi
@@ -1493,6 +1499,9 @@ if test "$enable_f08" = "yes" ; then
         f08dir=f08
     ],[
         AC_MSG_RESULT(no)
+        if test $enable_fortran != "auto"; then
+            AC_MSG_ERROR([unable to build "use mpi_f08" program. consider using --disable-fortran or --enable-fortran=auto.])
+        fi
     ])
     AC_LANG_POP([Fortran])
 fi


### PR DESCRIPTION
## Pull Request Description

The testsuite tries to compile a simple program with each of mpif.h, use mpi, and use mpi_f08 and will disable tests for any unsuccessful compile. It can be desirable, e.g. in CI builds, to force support for Fortran tests and thus return an error if programs cannot be compiled. By default, we still auto-detect the supported Fortran methods, but now passing --enable-fortran will cause configure to error if any of the three do not work. Fixes pmodels/mpich#7559.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
