### PR TITLE
mpi_t: Remove invalid error check

### DIFF
--- a/maint/extractcvars
+++ b/maint/extractcvars
@@ -247,7 +247,7 @@ print OUTPUT_C <<EOT;
 int ${fn_ns}_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
-    int rc, got_rc;
+    int rc, is_set;
     const char *tmp_str;
     MPIR_T_cvar_value_t defaultval;
 
@@ -327,33 +327,33 @@ foreach my $p (@cvars) {
     push @env_names, "${alt_ns}_" . $p->{name};
     push @env_names, "${uc_ns}_" . $p->{name};
 
-    print OUTPUT_C "    got_rc = 0;\n";
+    print OUTPUT_C "    is_set = 0;\n";
     foreach my $env_name (@env_names) {
         # assumes rc is defined
         if ($p->{type} eq 'range') {
 print OUTPUT_C <<EOT;
     rc = MPL_env2${env_fn}("$env_name", &($var_name.low), &($var_name.high));
     MPIR_ERR_CHKANDJUMP1((-1 == rc),mpi_errno,MPI_ERR_OTHER,"**envvarparse","**envvarparse %s","$env_name");
-    got_rc += rc;
+    is_set += rc;
 EOT
         }
         elsif ($p->{type} eq 'string' or $p->{type} eq 'enum') {
 print OUTPUT_C <<EOT;
     rc = MPL_env2${env_fn}("$env_name", &tmp_str);
-    got_rc += rc;
+    is_set += rc;
 EOT
         }
         else {
 print OUTPUT_C <<EOT;
     rc = MPL_env2${env_fn}("$env_name", &($var_name));
     MPIR_ERR_CHKANDJUMP1((-1 == rc),mpi_errno,MPI_ERR_OTHER,"**envvarparse","**envvarparse %s","$env_name");
-    got_rc += rc;
+    is_set += rc;
 EOT
         }
     }
 
     # debugging
-    print OUTPUT_C "    if (got_rc && debug) {\n";
+    print OUTPUT_C "    if (is_set && debug) {\n";
     if ($p->{type} eq 'string' or $p->{type} eq 'enum') {
         print OUTPUT_C "        printf(\"CVAR: $var_name = %s\\n\", tmp_str);\n";
     } elsif ($p->{type} eq "range") {


### PR DESCRIPTION
## Pull Request Description

MPL_env2str is used to check for CVARs with string or enum type. It returns only 0 or 1 based on whether the environment variable is found. It never returns -1, so we can safely remove the error check.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
