### PR TITLE
config: Check for Python 3 if user sets PYTHON

### DIFF
--- a/confdb/aclocal_misc.m4
+++ b/confdb/aclocal_misc.m4
@@ -2,9 +2,9 @@ dnl PAC_CHECK_PYTHON check for python 3, sets PYTHON variable or abort
 dnl
 AC_DEFUN([PAC_CHECK_PYTHON],[
     AC_ARG_VAR([PYTHON], [set to Python 3])
+    python_one_liner="import sys; print(sys.version_info[[0]])"
     if test -z "$PYTHON" ; then
         PYTHON=
-        python_one_liner="import sys; print(sys.version_info[[0]])"
 
         dnl check command 'python'
         PYTHON_PATH=
@@ -30,6 +30,11 @@ AC_DEFUN([PAC_CHECK_PYTHON],[
             AC_MSG_WARN([Python version 3 not found! Bindings need to be generated before configure.])
         else
             AC_MSG_NOTICE([Python version 3 is $PYTHON])
+        fi
+    else
+        py_version=`$PYTHON -c "$python_one_liner"`
+        if test "x$py_version" != x3 ; then
+            AC_MSG_ERROR([PYTHON=$PYTHON is not a Python 3 interpreter])
         fi
     fi
 ])


### PR DESCRIPTION
## Pull Request Description

We were skipping the check for Python 3 if the configuration environment had a PYTHON variable set. If this variable pointed to something other than a Python 3 interpreter, it would result in broken Fortran bindings that could not be built. Add a sanity check to make sure PYTHON works and return an error if not. Fixes pmodels/mpich#7576.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
