### PR TITLE
Add support for Unified Collective Communication (UCC)

### DIFF
--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -14,6 +14,14 @@
 #include "hcoll/api/hcoll_dte.h"
 #endif
 
+#ifdef HAVE_UCC
+#include "../../common/ucc/mpid_ucc_pre.h"
+#define MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+#else
+/* Define `MPIDI_DEV_COMM_DECL_UCC` as "nothing" */
+#define MPIDI_DEV_COMM_DECL_UCC
+#endif
+
 #include "mpid_thread.h"
 #include "mpid_sched.h"
 #include "netmodpre.h"
@@ -615,7 +623,8 @@ typedef struct {
 
 #define MPID_DEV_REQUEST_DECL    MPIDI_Devreq_t  dev;
 #define MPID_DEV_WIN_DECL        MPIDI_Devwin_t  dev;
-#define MPID_DEV_COMM_DECL       MPIDI_Devcomm_t dev;
+#define MPID_DEV_COMM_DECL       MPIDI_Devcomm_t dev;	\
+    MPIDI_DEV_COMM_DECL_UCC;
 #define MPID_DEV_OP_DECL         MPIDI_Devop_t   dev;
 #define MPID_DEV_STREAM_DECL     MPIDI_Devstream_t dev;
 

--- a/src/mpid/ch4/netmod/ucx/ucx_coll.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_coll.h
@@ -16,6 +16,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, int coll
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+#ifdef HAVE_UCC
+    MPIDI_COMMOM_UCC_CHECK_AND_FALLBACK(MPIDI_common_ucc_barrier(comm_ptr), (void) 0, (void) 0,
+                                        (void) 0);
+#endif
 #ifdef HAVE_HCOLL
     mpi_errno = hcoll_Barrier(comm_ptr, coll_attr);
     if (mpi_errno != MPI_SUCCESS)
@@ -24,8 +28,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_barrier(MPIR_Comm * comm_ptr, int coll
         mpi_errno = MPIR_Barrier_impl(comm_ptr, coll_attr);
     }
 
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MPI_Datatype datatype,
@@ -34,6 +41,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MP
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+#ifdef HAVE_UCC
+    MPIDI_COMMOM_UCC_CHECK_AND_FALLBACK(MPIDI_common_ucc_bcast
+                                        (buffer, count, datatype, root, comm_ptr), (void) 0,
+                                        (void) 0, (void) 0);
+#endif
 #ifdef HAVE_HCOLL
     mpi_errno = hcoll_Bcast(buffer, count, datatype, root, comm_ptr, coll_attr);
     if (mpi_errno != MPI_SUCCESS)
@@ -42,8 +54,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_bcast(void *buffer, MPI_Aint count, MP
         mpi_errno = MPIR_Bcast_impl(buffer, count, datatype, root, comm_ptr, coll_attr);
     }
 
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *recvbuf,
@@ -53,6 +68,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+#ifdef HAVE_UCC
+    MPIDI_COMMOM_UCC_CHECK_AND_FALLBACK(MPIDI_common_ucc_allreduce
+                                        (sendbuf, recvbuf, count, datatype, op, comm_ptr),
+                                        (void) 0, (void) 0, (void) 0);
+#endif
 #ifdef HAVE_HCOLL
     mpi_errno = hcoll_Allreduce(sendbuf, recvbuf, count, datatype, op, comm_ptr, coll_attr);
     if (mpi_errno != MPI_SUCCESS)
@@ -61,8 +81,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allreduce(const void *sendbuf, void *r
         mpi_errno = MPIR_Allreduce_impl(sendbuf, recvbuf, count, datatype, op, comm_ptr, coll_attr);
     }
 
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Aint sendcount,
@@ -73,6 +96,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Ain
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+#ifdef HAVE_UCC
+    MPIDI_COMMOM_UCC_CHECK_AND_FALLBACK(MPIDI_common_ucc_allgather
+                                        (sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
+                                         comm_ptr), (void) 0, (void) 0, (void) 0);
+#endif
 #ifdef HAVE_HCOLL
     mpi_errno = hcoll_Allgather(sendbuf, sendcount, sendtype, recvbuf,
                                 recvcount, recvtype, comm_ptr, coll_attr);
@@ -83,8 +111,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgather(const void *sendbuf, MPI_Ain
                                         recvcount, recvtype, comm_ptr, coll_attr);
     }
 
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Aint sendcount,
@@ -96,11 +127,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_allgatherv(const void *sendbuf, MPI_Ai
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+#ifdef HAVE_UCC
+    MPIDI_COMMOM_UCC_CHECK_AND_FALLBACK(MPIDI_common_ucc_allgatherv
+                                        (sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
+                                         recvtype, comm_ptr), (void) 0, (void) 0, (void) 0);
+#endif
     mpi_errno = MPIR_Allgatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                                      recvcounts, displs, recvtype, comm_ptr, coll_attr);
 
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint sendcount,
@@ -111,11 +150,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gather(const void *sendbuf, MPI_Aint s
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+#ifdef HAVE_UCC
+    MPIDI_COMMOM_UCC_CHECK_AND_FALLBACK(MPIDI_common_ucc_gather
+                                        (sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
+                                         root, comm_ptr), (void) 0, (void) 0, (void) 0);
+#endif
     mpi_errno = MPIR_Gather_impl(sendbuf, sendcount, sendtype, recvbuf,
                                  recvcount, recvtype, root, comm_ptr, coll_attr);
 
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint sendcount,
@@ -127,11 +174,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_gatherv(const void *sendbuf, MPI_Aint 
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+#ifdef HAVE_UCC
+    MPIDI_COMMOM_UCC_CHECK_AND_FALLBACK(MPIDI_common_ucc_gatherv
+                                        (sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs,
+                                         recvtype, root, comm_ptr), (void) 0, (void) 0, (void) 0);
+#endif
     mpi_errno = MPIR_Gatherv_impl(sendbuf, sendcount, sendtype, recvbuf,
                                   recvcounts, displs, recvtype, root, comm_ptr, coll_attr);
 
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint sendcount,
@@ -142,11 +197,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatter(const void *sendbuf, MPI_Aint 
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+#ifdef HAVE_UCC
+    MPIDI_COMMOM_UCC_CHECK_AND_FALLBACK(MPIDI_common_ucc_scatter
+                                        (sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
+                                         root, comm_ptr), (void) 0, (void) 0, (void) 0);
+#endif
     mpi_errno = MPIR_Scatter_impl(sendbuf, sendcount, sendtype, recvbuf,
                                   recvcount, recvtype, root, comm_ptr, coll_attr);
 
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MPI_Aint * sendcounts,
@@ -158,11 +221,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scatterv(const void *sendbuf, const MP
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+#ifdef HAVE_UCC
+    MPIDI_COMMOM_UCC_CHECK_AND_FALLBACK(MPIDI_common_ucc_scatterv
+                                        (sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount,
+                                         recvtype, root, comm_ptr), (void) 0, (void) 0, (void) 0);
+#endif
     mpi_errno = MPIR_Scatterv_impl(sendbuf, sendcounts, displs, sendtype,
                                    recvbuf, recvcount, recvtype, root, comm_ptr, coll_attr);
 
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint sendcount,
@@ -173,6 +244,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+#ifdef HAVE_UCC
+    MPIDI_COMMOM_UCC_CHECK_AND_FALLBACK(MPIDI_common_ucc_alltoall
+                                        (sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype,
+                                         comm_ptr), (void) 0, (void) 0, (void) 0);
+#endif
 #ifdef HAVE_HCOLL
     mpi_errno = hcoll_Alltoall(sendbuf, sendcount, sendtype, recvbuf,
                                recvcount, recvtype, comm_ptr, coll_attr);
@@ -182,8 +258,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoall(const void *sendbuf, MPI_Aint
         mpi_errno = MPIR_Alltoall_impl(sendbuf, sendcount, sendtype, recvbuf,
                                        recvcount, recvtype, comm_ptr, coll_attr);
     }
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
@@ -196,6 +275,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+#ifdef HAVE_UCC
+    MPIDI_COMMOM_UCC_CHECK_AND_FALLBACK(MPIDI_common_ucc_alltoallv
+                                        (sendbuf, sendcounts, sdispls, sendtype, recvbuf,
+                                         recvcounts, rdispls, recvtype, comm_ptr), (void) 0,
+                                        (void) 0, (void) 0);
+#endif
 #ifdef HAVE_HCOLL
     mpi_errno = hcoll_Alltoallv(sendbuf, sendcounts, sdispls, sendtype, recvbuf,
                                 recvcounts, rdispls, recvtype, comm_ptr, coll_attr);
@@ -206,8 +291,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallv(const void *sendbuf,
                                         recvbuf, recvcounts, rdispls, recvtype, comm_ptr,
                                         coll_attr);
     }
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_alltoallw(const void *sendbuf,
@@ -236,6 +324,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+#ifdef HAVE_UCC
+    MPIDI_COMMOM_UCC_CHECK_AND_FALLBACK(MPIDI_common_ucc_reduce
+                                        (sendbuf, recvbuf, count, datatype, op, root, comm_ptr),
+                                        (void) 0, (void) 0, (void) 0);
+#endif
 #ifdef HAVE_HCOLL
     mpi_errno = hcoll_Reduce(sendbuf, recvbuf, count, datatype, op, root, comm_ptr, coll_attr);
     if (mpi_errno != MPI_SUCCESS)
@@ -244,8 +337,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce(const void *sendbuf, void *recv
         mpi_errno = MPIR_Reduce_impl(sendbuf, recvbuf, count, datatype, op, root, comm_ptr,
                                      coll_attr);
     }
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, void *recvbuf,
@@ -256,11 +352,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter(const void *sendbuf, vo
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+#ifdef HAVE_UCC
+    MPIDI_COMMOM_UCC_CHECK_AND_FALLBACK(MPIDI_common_ucc_reduce_scatter
+                                        (sendbuf, recvbuf, recvcounts, datatype, op, comm_ptr),
+                                        (void) 0, (void) 0, (void) 0);
+#endif
     mpi_errno = MPIR_Reduce_scatter_impl(sendbuf, recvbuf, recvcounts,
                                          datatype, op, comm_ptr, coll_attr);
 
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendbuf, void *recvbuf,
@@ -271,11 +375,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_reduce_scatter_block(const void *sendb
     int mpi_errno;
     MPIR_FUNC_ENTER;
 
+#ifdef HAVE_UCC
+    MPIDI_COMMOM_UCC_CHECK_AND_FALLBACK(MPIDI_common_ucc_reduce_scatter_block
+                                        (sendbuf, recvbuf, recvcount, datatype, op, comm_ptr),
+                                        (void) 0, (void) 0, (void) 0);
+#endif
     mpi_errno = MPIR_Reduce_scatter_block_impl(sendbuf, recvbuf, recvcount,
                                                datatype, op, comm_ptr, coll_attr);
 
+  fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_scan(const void *sendbuf, void *recvbuf, MPI_Aint count,

--- a/src/mpid/ch4/netmod/ucx/ucx_comm.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_comm.c
@@ -35,6 +35,10 @@ int MPIDI_UCX_mpi_comm_commit_post_hook(MPIR_Comm * comm)
 
     MPIR_FUNC_ENTER;
 
+#ifdef HAVE_UCC
+    MPIDI_common_ucc_comm_create_hook(comm);
+#endif
+
     MPIR_FUNC_EXIT;
     return mpi_errno;
 }
@@ -47,6 +51,10 @@ int MPIDI_UCX_mpi_comm_free_hook(MPIR_Comm * comm)
 #ifdef HAVE_HCOLL
     hcoll_comm_destroy(comm, NULL);
 #endif
+#ifdef HAVE_UCC
+    MPIDI_common_ucc_comm_destroy_hook(comm);
+#endif
+
     MPIR_FUNC_EXIT;
     return mpi_errno;
 }

--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -12,7 +12,41 @@
 
 categories :
     - name : CH4_UCX
-      description : A category for CH4 OFI netmod variables
+      description : A category for CH4 UCX netmod variables
+
+cvars:
+    - name        : MPIR_CVAR_CH4_UCX_ENABLE_UCC
+      category    : DEVELOPER
+      alt-env     : MPIR_CVAR_CH4_UCC_ENABLE
+      type        : boolean
+      default     : false
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        Enable UCC support.
+
+    - name        : MPIR_CVAR_CH4_UCX_UCC_ENABLE_DEBUG
+      category    : DEVELOPER
+      alt-env     : MPIR_CVAR_CH4_UCC_ENABLE_DEBUG
+      type        : boolean
+      default     : false
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        Enable additional debug output for UCC wrappers.
+
+    - name        : MPIR_CVAR_CH4_UCX_UCC_VERBOSITY_LEVEL
+      category    : CH4_UCX
+      alt-env     : MPIR_CVAR_CH4_UCC_VERBOSITY_LEVEL
+      type        : string
+      default     : 0
+      class       : device
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        Set verbosity output level for UCC wrappers.
 
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
@@ -198,6 +232,14 @@ int MPIDI_UCX_init_local(int *tag_bits)
     /* initialize worker for vci 0 */
     mpi_errno = MPIDI_UCX_init_worker(0);
     MPIR_ERR_CHECK(mpi_errno);
+
+#ifdef HAVE_UCC
+    if (MPIR_CVAR_CH4_UCX_ENABLE_UCC) {
+        int verbose_level = atoi(MPIR_CVAR_CH4_UCX_UCC_VERBOSITY_LEVEL);
+        MPIDI_common_ucc_enable(verbose_level, MPIR_CVAR_CH4_UCX_UCC_VERBOSITY_LEVEL,
+                                MPIR_CVAR_CH4_UCX_UCC_ENABLE_DEBUG);
+    }
+#endif
 
     /* insert self address */
     MPIR_Lpid lpid = MPIR_Process.rank;

--- a/src/mpid/ch4/netmod/ucx/ucx_progress.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_progress.h
@@ -22,6 +22,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_progress(int vci, int *made_progress)
 
     ucp_worker_progress(MPIDI_UCX_global.ctx[vci].worker);
 
+#ifdef HAVE_UCC
+    MPIDI_common_ucc_progress(made_progress);
+#endif
+
     MPIR_FUNC_EXIT;
     return mpi_errno;
 }

--- a/src/mpid/common/Makefile.mk
+++ b/src/mpid/common/Makefile.mk
@@ -10,3 +10,4 @@ include $(top_srcdir)/src/mpid/common/timers/Makefile.mk
 include $(top_srcdir)/src/mpid/common/shm/Makefile.mk
 include $(top_srcdir)/src/mpid/common/genq/Makefile.mk
 include $(top_srcdir)/src/mpid/common/stream_workq/Makefile.mk
+include $(top_srcdir)/src/mpid/common/ucc/Makefile.mk

--- a/src/mpid/common/ucc/Makefile.mk
+++ b/src/mpid/common/ucc/Makefile.mk
@@ -1,0 +1,32 @@
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+if BUILD_UCC
+
+mpi_core_sources +=  \
+    src/mpid/common/ucc/mpid_ucc.c  \
+    src/mpid/common/ucc/mpid_ucc_barrier.c \
+    src/mpid/common/ucc/mpid_ucc_bcast.c \
+    src/mpid/common/ucc/mpid_ucc_gather.c \
+    src/mpid/common/ucc/mpid_ucc_gatherv.c \
+    src/mpid/common/ucc/mpid_ucc_scatter.c \
+    src/mpid/common/ucc/mpid_ucc_scatterv.c \
+    src/mpid/common/ucc/mpid_ucc_reduce.c \
+    src/mpid/common/ucc/mpid_ucc_reduce_scatter.c \
+    src/mpid/common/ucc/mpid_ucc_reduce_scatter_block.c \
+    src/mpid/common/ucc/mpid_ucc_allgather.c \
+    src/mpid/common/ucc/mpid_ucc_allgatherv.c \
+    src/mpid/common/ucc/mpid_ucc_allreduce.c \
+    src/mpid/common/ucc/mpid_ucc_alltoall.c \
+    src/mpid/common/ucc/mpid_ucc_alltoallv.c
+
+noinst_HEADERS += \
+    src/mpid/common/ucc/mpid_ucc.h \
+    src/mpid/common/ucc/mpid_ucc_pre.h \
+    src/mpid/common/ucc/mpid_ucc_collops.h \
+    src/mpid/common/ucc/mpid_ucc_dtypes.h \
+    src/mpid/common/ucc/mpid_ucc_debug.h
+
+endif BUILD_UCC

--- a/src/mpid/common/ucc/errnames.txt
+++ b/src/mpid/common/ucc/errnames.txt
@@ -1,0 +1,4 @@
+#
+# UCC errors
+#
+**ucc_collop_failed:Error in UCC collective operation: Fallback not possible.

--- a/src/mpid/common/ucc/mpid_ucc.c
+++ b/src/mpid/common/ucc/mpid_ucc.c
@@ -1,0 +1,494 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpid_ucc.h"
+
+#ifdef MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+
+#ifndef NDEBUG
+/* include this file and set `verbose_debug` flag in `MPIDI_common_ucc_enable()` to get more output */
+#include "mpid_ucc_debug.h"
+#endif
+
+MPIDI_common_ucc_priv_t MPIDI_common_ucc_priv = { 0 };
+
+#define MPIDI_COMMON_UCC_VERBOSE_STRING(STRING) #STRING,
+const char *MPIDI_COMMON_UCC_VERBOSE_LEVEL_TO_STRING[] = {
+    MPIDI_COMMON_UCC_VERBOSE_LEVELS(MPIDI_COMMON_UCC_VERBOSE_STRING)
+};
+
+#define MPIDI_COMMON_UCC_VERBOSE_COMM_WORLD \
+    comm_ptr == MPIR_Process.comm_world ? " (world)" : ""
+
+static int mpidi_ucc_finalize(void *param ATTRIBUTE((unused)))
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    MPIR_FUNC_ENTER;
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC, "entering mpidi ucc finalize");
+
+    if (!MPIDI_common_ucc_priv.ucc_enabled || !MPIDI_common_ucc_priv.ucc_initialized) {
+        goto fn_exit;
+    }
+
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC, "finalizing ucc library");
+
+    MPIR_Progress_hook_deactivate(MPIDI_common_ucc_priv.progress_hook_id);
+    MPIR_Progress_hook_deregister(MPIDI_common_ucc_priv.progress_hook_id);
+
+    ucc_context_destroy(MPIDI_common_ucc_priv.ucc_context);
+    if (ucc_finalize(MPIDI_common_ucc_priv.ucc_lib) != UCC_OK) {
+        MPIDI_COMMON_UCC_ERROR("ucc finalize failed");
+        goto fn_fail;
+    }
+
+    MPIDI_common_ucc_priv.ucc_initialized = 0;
+
+  fn_exit:
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC, "leaving mpidi ucc finalize");
+    MPIR_FUNC_EXIT;
+    return mpidi_ucc_err;
+  fn_fail:
+    MPIDI_COMMON_UCC_WARNING("mpidi ucc finalize failed");
+    goto fn_exit;
+}
+
+int MPIDI_common_ucc_enable(int verbose_level, const char *verbose_level_str, int debug_flag)
+{
+    /* Only initialize the basic flags here, as the actual UCC initialization happens
+     * later when `MPIDI_common_ucc_comm_create_hook()` is called for the first time.
+     */
+
+    if (verbose_level) {
+        MPIDI_common_ucc_priv.verbose_level = (MPIDI_common_ucc_verbose_levels_t) verbose_level;
+    } else if (verbose_level_str) {
+        MPIDI_COMMON_UCC_VERBOSE_STRING_TO_LEVEL(verbose_level_str,
+                                                 MPIDI_common_ucc_priv.verbose_level);
+    } else {
+        MPIDI_common_ucc_priv.verbose_level = MPIDI_COMMON_UCC_VERBOSE_LEVEL_NONE;
+    }
+
+    MPIDI_common_ucc_priv.verbose_debug = debug_flag;
+
+    if (!MPIDI_common_ucc_priv.ucc_enabled) {
+        MPIR_Add_finalize(mpidi_ucc_finalize, NULL, MPIR_FINALIZE_CALLBACK_PRIO + 1);
+        MPIDI_common_ucc_priv.ucc_enabled = 1;
+    }
+
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC, "use of ucc generally enabled");
+    return MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+}
+
+static ucc_status_t mpidi_ucc_oob_allgather_test(void *req)
+{
+    MPIR_Request *request = (MPIR_Request *) req;
+    int completed = 0;
+
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC, "entering oob allgather test");
+
+    int mpi_errno = MPIR_Test(request, &completed, MPI_STATUS_IGNORE);
+
+    if (mpi_errno != MPI_SUCCESS) {
+        MPIDI_COMMON_UCC_WARNING("MPIR_Test() for oob allgather failed");
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    if (!completed) {
+        MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC,
+                               "leaving oob allgather test (in progress)");
+        return UCC_INPROGRESS;
+    }
+
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC,
+                           "leaving oob allgather test (completed)");
+    return UCC_OK;
+}
+
+static ucc_status_t mpidi_ucc_oob_allgather_free(void *req)
+{
+    MPIR_Request *request = (MPIR_Request *) req;
+
+    MPIR_Request_free(request);
+
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC, "oob allgather free called");
+    return UCC_OK;
+}
+
+static ucc_status_t mpidi_ucc_oob_allgather(void *sbuf, void *rbuf, size_t msglen,
+                                            void *oob_coll_ctx, void **req)
+{
+    MPIR_Comm *comm = (MPIR_Comm *) oob_coll_ctx;
+    MPIR_Request *request = NULL;
+
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC, "entering oob allgather");
+
+    int mpi_errno =
+        MPIR_Iallgather_impl(sbuf, msglen, MPIR_BYTE_INTERNAL, rbuf, msglen, MPIR_BYTE_INTERNAL,
+                             comm, &request);
+
+    if (mpi_errno != MPI_SUCCESS) {
+        MPIDI_COMMON_UCC_WARNING("MPIR_Iallgather_impl() for oob allgather failed");
+        return UCC_ERR_NO_MESSAGE;
+    }
+
+    if (!request) {
+        request = MPIR_Request_create_complete(MPIR_REQUEST_KIND__COLL);
+    }
+
+    *req = request;
+
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC, "oob allgather called");
+    return UCC_OK;
+}
+
+static int mpidi_ucc_progress(int vci, int *made_progress)
+{
+    ucc_context_progress(MPIDI_common_ucc_priv.ucc_context);
+    return MPI_SUCCESS;
+}
+
+int MPIDI_common_ucc_progress(int *made_progress)
+{
+    if (!MPIDI_common_ucc_priv.ucc_enabled || !MPIDI_common_ucc_priv.ucc_initialized)
+        return MPI_SUCCESS;
+
+    return mpidi_ucc_progress(-1, made_progress);
+}
+
+static int mpidi_ucc_setup_lib(void)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    char str_buf[256];
+    ucc_lib_config_h lib_config;
+    ucc_context_config_h ctx_config;
+    ucc_lib_params_t lib_params;
+    ucc_context_params_t ctx_params;
+
+    ucc_lib_h *lib_ptr = NULL;
+    ucc_lib_attr_t *lib_attr_ptr = NULL;
+    ucc_lib_config_h *lib_config_ptr = NULL;
+    ucc_lib_params_t *lib_params_ptr = NULL;
+    ucc_context_params_t *ctx_params_ptr = NULL;
+    ucc_context_config_h *ctx_config_ptr = NULL;
+
+    MPIR_FUNC_ENTER;
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC, "entering mpidi setup lib");
+
+    if (!MPIDI_common_ucc_priv.ucc_enabled) {
+        MPIDI_COMMON_UCC_ERROR("ucc is disabled explicitly");
+        goto fn_fail;
+    }
+
+    if (ucc_lib_config_read(NULL, NULL, &lib_config) != UCC_OK) {
+        MPIDI_COMMON_UCC_ERROR("ucc lib config read failed");
+        goto fn_fail;
+    }
+
+    lib_config_ptr = &lib_config;
+    lib_params_ptr = &lib_params;
+
+#ifdef MPICH_IS_THREADED
+    lib_params_ptr->thread_mode =
+        MPIR_ThreadInfo.isThreaded ? UCC_THREAD_MULTIPLE : UCC_THREAD_SINGLE;
+    lib_params_ptr->mask = UCC_LIB_PARAM_FIELD_THREAD_MODE;
+#else
+    lib_params_ptr->mask = 0;
+#endif
+
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC, "initializing ucc library");
+    if (ucc_init(lib_params_ptr, *lib_config_ptr, &MPIDI_common_ucc_priv.ucc_lib) != UCC_OK) {
+        MPIDI_COMMON_UCC_ERROR("ucc lib init failed");
+        goto fn_fail;
+    }
+
+    lib_ptr = &MPIDI_common_ucc_priv.ucc_lib;
+    lib_attr_ptr = &MPIDI_common_ucc_priv.ucc_lib_attr;
+    lib_attr_ptr->mask = UCC_LIB_ATTR_FIELD_THREAD_MODE | UCC_LIB_ATTR_FIELD_COLL_TYPES;
+
+    if (ucc_lib_get_attr(*lib_ptr, lib_attr_ptr)) {
+        MPIDI_COMMON_UCC_ERROR("ucc get lib attr failed");
+        goto fn_fail;
+    }
+#ifdef MPICH_IS_THREADED
+    if (lib_attr_ptr->thread_mode < lib_params_ptr->thread_mode) {
+        MPIDI_COMMON_UCC_ERROR("ucc library doesn't support MPI_THREAD_MULTIPLE");
+        goto fn_fail;
+    }
+#endif
+
+    ctx_params_ptr = &ctx_params;
+    ctx_params_ptr->mask = UCC_CONTEXT_PARAM_FIELD_OOB;
+    ctx_params_ptr->oob.allgather = mpidi_ucc_oob_allgather;
+    ctx_params_ptr->oob.req_test = mpidi_ucc_oob_allgather_test;
+    ctx_params_ptr->oob.req_free = mpidi_ucc_oob_allgather_free;
+
+    /* TODO: For the time being, we rely on MPI_COMM_WORLD as the "substrate" for
+     * all the out-of-band communication. For the future, we have to think about
+     * how to realize this also for the pure session model.
+     */
+    ctx_params_ptr->oob.coll_info = MPIR_Process.comm_world;
+    ctx_params_ptr->oob.n_oob_eps = MPIR_Process.size;
+    ctx_params_ptr->oob.oob_ep = MPIR_Process.rank;
+
+    if (ucc_context_config_read(*lib_ptr, NULL, &ctx_config) != UCC_OK) {
+        MPIDI_COMMON_UCC_ERROR("ucc context config read failed");
+        goto fn_fail;
+    }
+
+    ctx_config_ptr = &ctx_config;
+
+    snprintf(str_buf, sizeof(str_buf), "%d", MPIR_Process.size);
+
+    if (ucc_context_config_modify(*ctx_config_ptr, NULL, "ESTIMATED_NUM_EPS", str_buf) != UCC_OK) {
+        MPIDI_COMMON_UCC_ERROR("ucc context config modify failed for estimated_num_eps");
+        goto fn_fail;
+    }
+
+    snprintf(str_buf, sizeof(str_buf), "%d", MPIR_Process.local_size);
+
+    if (ucc_context_config_modify(*ctx_config_ptr, NULL, "ESTIMATED_NUM_PPN", str_buf) != UCC_OK) {
+        MPIDI_COMMON_UCC_ERROR("ucc context config modify failed for estimated_num_eps");
+        goto fn_fail;
+    }
+
+    if (ucc_context_create(*lib_ptr, ctx_params_ptr,
+                           *ctx_config_ptr, &MPIDI_common_ucc_priv.ucc_context) != UCC_OK) {
+        MPIDI_COMMON_UCC_ERROR("ucc context create failed");
+        goto fn_fail;
+    }
+
+    int mpi_errno = MPIR_Progress_hook_register(-1, mpidi_ucc_progress,
+                                                &MPIDI_common_ucc_priv.progress_hook_id);
+
+    if (mpi_errno != MPI_SUCCESS) {
+        MPIDI_COMMON_UCC_ERROR("mpir progress hook register failed");
+        goto fn_fail;
+    }
+
+    MPIR_Progress_hook_activate(MPIDI_common_ucc_priv.progress_hook_id);
+
+    MPIDI_common_ucc_priv.ucc_initialized = 1;
+
+  fn_exit:
+    if (lib_config_ptr)
+        ucc_lib_config_release(*lib_config_ptr);
+    if (ctx_config_ptr)
+        ucc_context_config_release(*ctx_config_ptr);
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC, "leaving mpidi setup lib");
+    MPIR_FUNC_EXIT;
+    return mpidi_ucc_err;
+  fn_fail:
+    if (lib_ptr)
+        ucc_finalize(*lib_ptr);
+    MPIDI_common_ucc_priv.ucc_initialized = 0;
+    MPIDI_COMMON_UCC_WARNING("mpidi setup lib failed");
+    goto fn_exit;
+}
+
+static uint64_t mpidi_ucc_rank_map_cb(uint64_t ep, void *cb_ctx)
+{
+    MPIR_Comm *comm_ptr = cb_ctx;
+    MPIR_Lpid lpid;
+    int rank = (int) ep;
+
+    lpid = MPIR_comm_rank_to_lpid(comm_ptr, rank);
+
+    return (uint64_t) lpid;
+}
+
+static int mpidi_ucc_setup_comm_team(MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_status_t status;
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COMM, "entering mpidi setup comm team");
+
+    ucc_team_params_t team_params = {
+        .mask = UCC_TEAM_PARAM_FIELD_EP_MAP |
+            UCC_TEAM_PARAM_FIELD_EP | UCC_TEAM_PARAM_FIELD_EP_RANGE | UCC_TEAM_PARAM_FIELD_ID,
+        .ep_map = {
+                   .type = (comm_ptr == MPIR_Process.comm_world) ? UCC_EP_MAP_FULL : UCC_EP_MAP_CB,
+                   .ep_num = MPIR_Comm_size(comm_ptr),
+                   .cb.cb = mpidi_ucc_rank_map_cb,
+                   .cb.cb_ctx = (void *) comm_ptr},
+        .ep = MPIR_Comm_rank(comm_ptr),
+        .ep_range = UCC_COLLECTIVE_EP_RANGE_CONTIG,
+        .id = comm_ptr->context_id
+    };
+
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COMM,
+                             "creating ucc_team for comm %p, comm_id %llu, comm_size %d",
+                             (void *) comm_ptr, (long long unsigned) team_params.id,
+                             MPIR_Comm_size(comm_ptr));
+
+    if (ucc_team_create_post
+        (&MPIDI_common_ucc_priv.ucc_context, 1, &team_params,
+         &comm_ptr->ucc_priv.ucc_team) != UCC_OK) {
+        MPIDI_COMMON_UCC_ERROR("ucc team create post failed");
+        goto fn_fail;
+    }
+    while ((status = ucc_team_create_test(comm_ptr->ucc_priv.ucc_team)) == UCC_INPROGRESS) {
+        MPID_Progress_test(NULL);
+    }
+    if (status != UCC_OK) {
+        MPIDI_COMMON_UCC_ERROR("ucc team create test failed");
+        goto fn_fail;
+    }
+
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COMM,
+                             "team created for comm %p, comm_id %llu, comm_size %d",
+                             (void *) comm_ptr, (long long unsigned) team_params.id,
+                             MPIR_Comm_size(comm_ptr));
+
+  fn_exit:
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COMM, "leaving mpidi setup comm team");
+    return mpidi_ucc_err;
+  fn_fail:
+    comm_ptr->ucc_priv.ucc_team = NULL;
+    comm_ptr->ucc_priv.ucc_initialized = 0;
+    MPIDI_COMMON_UCC_WARNING("mpidi setup comm team failed");
+    goto fn_exit;
+}
+
+static int mpidi_ucc_setup_comm_collops(MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COMM,
+                           "entering mpidi setup comm collops");
+
+    /* TODO */
+
+    if (mpidi_ucc_err != MPIDI_COMMON_UCC_RETVAL_SUCCESS) {
+        goto fn_fail;
+    }
+
+  fn_exit:
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COMM, "leaving mpidi setup comm collops");
+    return mpidi_ucc_err;
+  fn_fail:
+    MPIDI_COMMON_UCC_WARNING("mpidi setup comm collops failed");
+    goto fn_exit;
+}
+
+int MPIDI_common_ucc_comm_create_hook(MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    MPIR_FUNC_ENTER;
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COMM,
+                           "entering mpidi comm create hook for comm_id %d", comm_ptr->context_id);
+
+    /* TODO: Later, this could be decided on a per comm basis (e.g., based on an Info key) */
+    comm_ptr->ucc_priv.ucc_enabled = MPIDI_common_ucc_priv.ucc_enabled;
+
+    comm_ptr->ucc_priv.ucc_initialized = 0;
+
+    if (!MPIDI_common_ucc_priv.ucc_enabled || !comm_ptr->ucc_priv.ucc_enabled) {
+        goto fn_exit;
+    }
+
+    if (!MPIDI_common_ucc_priv.comm_world_initialized && (comm_ptr != MPIR_Process.comm_world)) {
+        /* TODO: In the case of the pure session model (i.e., without MPI_COMM_WORLD), we always
+         * get here and fall back. Therefore, as a task for future improvements, we will need to
+         * consider something else for this case, not relying on MPI_COMM_WORLD and its ranks
+         * for the out-of-band communication. (See also mpidi_ucc_setup_lib() above.)
+         */
+        goto fn_exit;
+    }
+
+    if ((MPIDI_COMMON_UCC_COMM_EXCL_COND_TYPE) || (MPIDI_COMMON_UCC_COMM_EXCL_COND_SIZE) ||
+        (MPIDI_COMMON_UCC_COMM_EXCL_COND_DEV)) {
+#ifdef MPIDI_COMMON_UCC_OUTPUT_COMM_EXCL_COND
+        MPIDI_COMMON_UCC_OUTPUT_COMM_EXCL_COND;
+#endif
+        goto disabled;
+    }
+
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COMM,
+                             "create hook for comm %p, comm_id %d%s", (void *) comm_ptr,
+                             comm_ptr->context_id, MPIDI_COMMON_UCC_VERBOSE_COMM_WORLD);
+
+    if (!MPIDI_common_ucc_priv.ucc_initialized) {
+        mpidi_ucc_err = mpidi_ucc_setup_lib();
+        if (mpidi_ucc_err != MPIDI_COMMON_UCC_RETVAL_SUCCESS)
+            goto fn_fail;
+    }
+
+    MPIR_Assert(MPIDI_common_ucc_priv.ucc_initialized);
+
+    mpidi_ucc_err = mpidi_ucc_setup_comm_team(comm_ptr);
+    if (mpidi_ucc_err != MPIDI_COMMON_UCC_RETVAL_SUCCESS)
+        goto fn_fail;
+
+    mpidi_ucc_err = mpidi_ucc_setup_comm_collops(comm_ptr);
+    if (mpidi_ucc_err != MPIDI_COMMON_UCC_RETVAL_SUCCESS)
+        goto fn_fail;
+
+    if (comm_ptr == MPIR_Process.comm_world) {
+        MPIDI_common_ucc_priv.comm_world_initialized = 1;
+    }
+
+    comm_ptr->ucc_priv.ucc_initialized = 1;
+
+  fn_exit:
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC, "leaving mpidi comm create hook");
+    MPIR_FUNC_EXIT;
+    return mpidi_ucc_err;
+  fn_fail:
+    MPIDI_COMMON_UCC_WARNING("comm create hook failed");
+    goto fn_exit;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COMM,
+                             "create hook for comm %p, comm_id %d%s is disabled",
+                             (void *) comm_ptr, comm_ptr->context_id,
+                             MPIDI_COMMON_UCC_VERBOSE_COMM_WORLD);
+    goto fn_exit;
+}
+
+int MPIDI_common_ucc_comm_destroy_hook(MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_status_t status;
+    MPIR_FUNC_ENTER;
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC,
+                           "entering mpidi comm destroy hook");
+
+    if (!MPIDI_common_ucc_priv.ucc_enabled || !MPIDI_common_ucc_priv.ucc_initialized) {
+        goto fn_exit;
+    }
+
+    if (!comm_ptr->ucc_priv.ucc_initialized || (comm_ptr->comm_kind != MPIR_COMM_KIND__INTRACOMM)) {
+        goto disabled;
+    }
+
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COMM,
+                             "destroy hook for comm %p, comm_id %d%s", (void *) comm_ptr,
+                             comm_ptr->context_id, MPIDI_COMMON_UCC_VERBOSE_COMM_WORLD);
+
+    while ((status = ucc_team_destroy(comm_ptr->ucc_priv.ucc_team)) == UCC_INPROGRESS) {
+        /* Wait until the team has been destroyed (or there is an error) */
+        MPID_Progress_test(NULL);
+    }
+
+    if (status != UCC_OK) {
+        MPIDI_COMMON_UCC_ERROR("ucc team destroy failed");
+        goto fn_fail;
+    }
+
+    comm_ptr->ucc_priv.ucc_initialized = 0;
+
+  fn_exit:
+    MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_BASIC, "leaving mpidi comm destroy hook");
+    MPIR_FUNC_EXIT;
+    return mpidi_ucc_err;
+  fn_fail:
+    MPIDI_COMMON_UCC_WARNING("comm destroy hook failed");
+    goto fn_exit;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COMM,
+                             "destroy hook for comm %p, comm_id %d%s is disabled",
+                             (void *) comm_ptr, comm_ptr->context_id,
+                             MPIDI_COMMON_UCC_VERBOSE_COMM_WORLD);
+    goto fn_exit;
+}
+
+#endif /* MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC */

--- a/src/mpid/common/ucc/mpid_ucc.h
+++ b/src/mpid/common/ucc/mpid_ucc.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef _MPID_UCC_H_
+#define _MPID_UCC_H_
+
+#include "mpidimpl.h"
+#include "mpid_ucc_pre.h"
+
+#ifndef MPIDI_COMMON_UCC_COMM_MIN_SIZE
+#define MPIDI_COMMON_UCC_COMM_MIN_SIZE 2
+#endif
+
+/* Condition statement for excluding communicators due to their type: */
+#define MPIDI_COMMON_UCC_COMM_EXCL_COND_TYPE (comm_ptr->comm_kind != MPIR_COMM_KIND__INTRACOMM)
+/* Condition statement for excluding communicators due to their size: */
+#define MPIDI_COMMON_UCC_COMM_EXCL_COND_SIZE (comm_ptr->local_size < MPIDI_COMMON_UCC_COMM_MIN_SIZE)
+
+/* Additional exclusion statement given by the device? */
+#ifndef MPIDI_COMMON_UCC_COMM_EXCL_COND_DEV
+/* If not, set this condition statement to false: */
+#define MPIDI_COMMON_UCC_COMM_EXCL_COND_DEV (0)
+#endif
+
+#define MPIDI_COMMON_UCC_OUTPUT_FORMAT "%s: (%s:%d)"
+#define MPIDI_COMMON_UCC_OUTPUT_PARAMS __FILE__, __FUNCTION__, __LINE__
+#define MPIDI_COMMON_UCC_OUTPUT_STRINGIFY(_x) #_x
+
+#define MPIDI_COMMON_UCC_VERBOSE_LEVELS(LEVEL) \
+    LEVEL(NONE)                                \
+    LEVEL(ERROR)                               \
+    LEVEL(WARNING)                             \
+    LEVEL(BASIC)                               \
+    LEVEL(COMM)                                \
+    LEVEL(DTYPE)                               \
+    LEVEL(COLLOP)                              \
+    LEVEL(FNCALL)                              \
+    LEVEL(ALL)
+
+#define MPIDI_COMMON_UCC_VERBOSE_ENUM(ENUM) MPIDI_COMMON_UCC_VERBOSE_LEVEL_ ## ENUM,
+typedef enum {
+    MPIDI_COMMON_UCC_VERBOSE_LEVELS(MPIDI_COMMON_UCC_VERBOSE_ENUM)
+} MPIDI_common_ucc_verbose_levels_t;
+
+extern const char *MPIDI_COMMON_UCC_VERBOSE_LEVEL_TO_STRING[];
+
+#define MPIDI_COMMON_UCC_VERBOSE_STRING_TO_LEVEL(_str, _num) do {       \
+        int __len = strlen(_str);                                       \
+        int __exm = 0;                                                  \
+        if (_str[__len ? __len - 1 : 0] == '!') {                       \
+            __exm = 1;                                                  \
+            __len--;                                                    \
+        }                                                               \
+        for (int __idx = 0; __idx <= MPIDI_COMMON_UCC_VERBOSE_LEVEL_ALL;\
+             __idx++) {                                                 \
+            if (strncasecmp(_str,                                       \
+                       MPIDI_COMMON_UCC_VERBOSE_LEVEL_TO_STRING[__idx], \
+                       __len) == 0) {                                   \
+                _num = __exm ? (-1) * __idx : __idx;                    \
+                break;                                                  \
+            }                                                           \
+        }                                                               \
+    } while (0)
+
+#define MPIDI_COMMON_UCC_ERROR(_format, ...) do {                       \
+        mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_ERROR;                  \
+        if (abs(MPIDI_common_ucc_priv.verbose_level) >=                 \
+            MPIDI_COMMON_UCC_VERBOSE_LEVEL_ERROR) {                     \
+            fprintf(stderr, "==%u== UCC ERROR in "                      \
+                    MPIDI_COMMON_UCC_OUTPUT_FORMAT " | "                \
+                    _format "\n", getpid(),                             \
+                    MPIDI_COMMON_UCC_OUTPUT_PARAMS, ## __VA_ARGS__);    \
+            mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_ERROR;              \
+            (void)mpidi_ucc_err;                                        \
+        }                                                               \
+    } while (0)
+
+#define MPIDI_COMMON_UCC_WARNING(_format, ...) do {                     \
+        if (abs(MPIDI_common_ucc_priv.verbose_level) >=                 \
+            MPIDI_COMMON_UCC_VERBOSE_LEVEL_WARNING) {                   \
+            fprintf(stderr, "==%u== UCC WARNING in "                    \
+                    MPIDI_COMMON_UCC_OUTPUT_FORMAT " | "                \
+                    _format "\n", getpid(),                             \
+                    MPIDI_COMMON_UCC_OUTPUT_PARAMS, ## __VA_ARGS__);    \
+        }                                                               \
+    } while (0)
+
+#define MPIDI_COMMON_UCC_VERBOSE(_level, _format, ...) do {             \
+        if ((MPIDI_common_ucc_priv.verbose_level >= _level) ||          \
+            (MPIDI_common_ucc_priv.verbose_level == _level * (-1))) {   \
+            fprintf(stderr, "==%u== UCC INFO %s in "                    \
+                    MPIDI_COMMON_UCC_OUTPUT_FORMAT " | "                \
+                    _format "\n", getpid(),                             \
+                    MPIDI_COMMON_UCC_VERBOSE_LEVEL_TO_STRING[_level],   \
+                    MPIDI_COMMON_UCC_OUTPUT_PARAMS, ## __VA_ARGS__);    \
+        }                                                               \
+    } while (0)
+
+#ifndef MPIDI_COMMON_UCC_DEBUG
+#define MPIDI_COMMON_UCC_DEBUG(...)
+#endif
+
+typedef struct {
+
+    int ucc_enabled;            /* flag set during `MPIDI_common_ucc_enable()` to activate the UCC support in general */
+    int ucc_initialized;        /* flag set when the UCC library has been initialized successfully */
+    int verbose_level;          /* verbosity level of the UCC wrappers; set during `MPIDI_common_ucc_enable()` */
+    int verbose_debug;          /* flag for activating the very verbose debugging mode; set during `MPIDI_common_ucc_enable()` */
+    int progress_hook_id;       /* id as set by `MPIR_Progress_hook_register()` and needed for deregistering it again later */
+    int comm_world_initialized; /* flag indicating whether UCC support has been initialized already for MPI_COMM_WORLD */
+
+    ucc_lib_h ucc_lib;          /* handle for the UCC library itself after its initialization */
+    ucc_lib_attr_t ucc_lib_attr;        /* handle for the attributes used when initializing the UCC library */
+    ucc_context_h ucc_context;  /* handle for the single UCC context that we're currently using for all MPI communicators */
+
+} MPIDI_common_ucc_priv_t;
+
+extern MPIDI_common_ucc_priv_t MPIDI_common_ucc_priv;
+
+#endif /*_MPID_UCC_H_*/

--- a/src/mpid/common/ucc/mpid_ucc_allgather.c
+++ b/src/mpid/common/ucc/mpid_ucc_allgather.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpid_ucc.h"
+#include "mpid_ucc_collops.h"
+#include "mpid_ucc_dtypes.h"
+
+#ifdef MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+
+static inline ucc_status_t mpidi_ucc_allgather_init(const void *sbuf, MPI_Aint scount,
+                                                    MPI_Datatype sdtype, void *rbuf,
+                                                    MPI_Aint rcount, MPI_Datatype rdtype,
+                                                    MPIR_Comm * comm_ptr, ucc_coll_req_h * req,
+                                                    MPIR_Request * coll_req)
+{
+
+    bool is_inplace = (sbuf == MPI_IN_PLACE);
+    int comm_size = MPIR_Comm_size(comm_ptr);
+
+    ucc_datatype_t ucc_sdt = MPIDI_COMMON_UCC_DTYPE_NULL;
+    ucc_datatype_t ucc_rdt = mpidi_mpi_dtype_to_ucc_dtype(rdtype);
+
+    if (!is_inplace) {
+        ucc_sdt = mpidi_mpi_dtype_to_ucc_dtype(sdtype);
+    }
+
+    if ((ucc_sdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED) ||
+        (ucc_rdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED)) {
+        MPIDI_COMMON_UCC_VERBOSE_DTYPE_UNSUPPORTED(allgather);
+        goto fallback;
+    }
+
+    ucc_coll_args_t coll = {
+        .mask = 0,
+        .flags = 0,
+        .coll_type = UCC_COLL_TYPE_ALLGATHER,
+        .src.info = {
+                     .buffer = (void *) sbuf,
+                     .count = scount,
+                     .datatype = ucc_sdt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+        ,
+        .dst.info = {
+                     .buffer = rbuf,
+                     .count = rcount * comm_size,
+                     .datatype = ucc_rdt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+    };
+
+    if (is_inplace) {
+
+        coll.mask = UCC_COLL_ARGS_FIELD_FLAGS;
+        coll.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
+
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(allgather, "comm %p, comm_id %u, comm_size %d"
+                                                 ", INPLACE, rcount %zu, rdtype %s",
+                                                 (void *) comm_ptr, comm_ptr->context_id,
+                                                 comm_size, rcount,
+                                                 mpidi_ucc_dtype_to_str(ucc_rdt));
+    } else {
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(allgather, "comm %p, comm_id %u, comm_size %d"
+                                                 ", scount %zu, sdtype %s, rcount %zu, rdtype %s",
+                                                 (void *) comm_ptr, comm_ptr->context_id,
+                                                 comm_size, scount, mpidi_ucc_dtype_to_str(ucc_sdt),
+                                                 rcount, mpidi_ucc_dtype_to_str(ucc_rdt));
+    }
+
+    MPIDI_COMMON_UCC_REQ_INIT(coll_req, req, coll, comm_ptr);
+    return UCC_OK;
+  fallback:
+    return UCC_ERR_NOT_SUPPORTED;
+}
+
+int MPIDI_common_ucc_allgather(const void *sbuf, MPI_Aint scount, MPI_Datatype sdtype,
+                               void *rbuf, MPI_Aint rcount, MPI_Datatype rdtype,
+                               MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_coll_req_h req;
+
+    MPIDI_COMMON_UCC_CHECK_ENABLED(comm_ptr, allgather);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_TRY_TO_RUN(allgather);
+
+    MPIDI_COMMON_UCC_CALL_AND_CHECK(mpidi_ucc_allgather_init
+                                    (sbuf, scount, sdtype, rbuf, rcount, rdtype,
+                                     comm_ptr, &req, NULL));
+    MPIDI_COMMON_UCC_POST_AND_CHECK(req);
+    MPIDI_COMMON_UCC_WAIT_AND_CHECK(req);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DONE_SUCCESS(allgather);
+
+    return MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+
+  fallback:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_FALLBACK(allgather);
+    return MPIDI_COMMON_UCC_RETVAL_FALLBACK;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DISABLED(allgather);
+    goto fallback;
+}
+
+#endif /* MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC */

--- a/src/mpid/common/ucc/mpid_ucc_allgatherv.c
+++ b/src/mpid/common/ucc/mpid_ucc_allgatherv.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpid_ucc.h"
+#include "mpid_ucc_collops.h"
+#include "mpid_ucc_dtypes.h"
+
+#ifdef MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+
+static inline ucc_status_t mpidi_ucc_allgatherv_init(const void *sbuf, MPI_Aint scount,
+                                                     MPI_Datatype sdtype, void *rbuf,
+                                                     const MPI_Aint rcounts[],
+                                                     const MPI_Aint rdispls[], MPI_Datatype rdtype,
+                                                     MPIR_Comm * comm_ptr, ucc_coll_req_h * req,
+                                                     MPIR_Request * coll_req)
+{
+
+    bool is_inplace = (sbuf == MPI_IN_PLACE);
+    int comm_size = MPIR_Comm_size(comm_ptr);
+    bool is_large_counts = (sizeof(MPI_Aint) * 8 == 64);
+
+    ucc_datatype_t ucc_sdt = MPIDI_COMMON_UCC_DTYPE_NULL;
+    ucc_datatype_t ucc_rdt = mpidi_mpi_dtype_to_ucc_dtype(rdtype);
+
+    uint64_t flags = 0;
+
+    if (!is_inplace) {
+        ucc_sdt = mpidi_mpi_dtype_to_ucc_dtype(sdtype);
+    }
+
+    if ((ucc_sdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED) ||
+        (ucc_rdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED)) {
+        MPIDI_COMMON_UCC_VERBOSE_DTYPE_UNSUPPORTED(allgatherv);
+        goto fallback;
+    }
+
+    if (is_inplace) {
+        flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
+    }
+
+    if (is_large_counts) {
+        flags |= UCC_COLL_ARGS_FLAG_COUNT_64BIT;
+        flags |= UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT;
+    }
+
+    ucc_coll_args_t coll = {
+        .mask = flags ? UCC_COLL_ARGS_FIELD_FLAGS : 0,
+        .flags = flags,
+        .coll_type = UCC_COLL_TYPE_ALLGATHERV,
+        .src.info = {
+                     .buffer = (void *) sbuf,
+                     .count = scount,
+                     .datatype = ucc_sdt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+        ,
+        .dst.info_v = {
+                       .buffer = rbuf,
+                       .counts = (ucc_count_t *) rcounts,
+                       .displacements = (ucc_aint_t *) rdispls,
+                       .datatype = ucc_rdt,
+                       .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                       }
+    };
+
+    if (is_inplace) {
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(allgatherv, "comm %p, comm_id %u, comm_size %d"
+                                                 ", INPLACE, rdtype %s",
+                                                 (void *) comm_ptr, comm_ptr->context_id,
+                                                 comm_size, mpidi_ucc_dtype_to_str(ucc_rdt));
+    } else {
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(allgatherv, "comm %p, comm_id %u, comm_size %d"
+                                                 ", scount %zu, sdtype %s, rdtype %s",
+                                                 (void *) comm_ptr, comm_ptr->context_id,
+                                                 comm_size, scount,
+                                                 mpidi_ucc_dtype_to_str(ucc_sdt),
+                                                 mpidi_ucc_dtype_to_str(ucc_rdt));
+    }
+
+    MPIDI_COMMON_UCC_REQ_INIT(coll_req, req, coll, comm_ptr);
+    return UCC_OK;
+  fallback:
+    return UCC_ERR_NOT_SUPPORTED;
+}
+
+int MPIDI_common_ucc_allgatherv(const void *sbuf, MPI_Aint scount, MPI_Datatype sdtype,
+                                void *rbuf, const MPI_Aint rcounts[],
+                                const MPI_Aint rdispls[], MPI_Datatype rdtype, MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_coll_req_h req;
+
+    MPIDI_COMMON_UCC_CHECK_ENABLED(comm_ptr, allgatherv);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_TRY_TO_RUN(allgatherv);
+
+    MPIDI_COMMON_UCC_CALL_AND_CHECK(mpidi_ucc_allgatherv_init
+                                    (sbuf, scount, sdtype, rbuf, rcounts, rdispls, rdtype,
+                                     comm_ptr, &req, NULL));
+    MPIDI_COMMON_UCC_POST_AND_CHECK(req);
+    MPIDI_COMMON_UCC_WAIT_AND_CHECK(req);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DONE_SUCCESS(allgatherv);
+
+    return MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+
+  fallback:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_FALLBACK(allgatherv);
+    return MPIDI_COMMON_UCC_RETVAL_FALLBACK;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DISABLED(allgatherv);
+    goto fallback;
+}
+
+#endif /* MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC */

--- a/src/mpid/common/ucc/mpid_ucc_allreduce.c
+++ b/src/mpid/common/ucc/mpid_ucc_allreduce.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpid_ucc.h"
+#include "mpid_ucc_collops.h"
+#include "mpid_ucc_dtypes.h"
+
+#ifdef MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+
+static inline ucc_status_t mpidi_ucc_allreduce_init(const void *sbuf, void *rbuf, MPI_Aint count,
+                                                    MPI_Datatype dtype, MPI_Op op,
+                                                    MPIR_Comm * comm_ptr, ucc_coll_req_h * req,
+                                                    MPIR_Request * coll_req)
+{
+
+    bool is_inplace = (sbuf == MPI_IN_PLACE);
+    int comm_size = MPIR_Comm_size(comm_ptr);
+
+    ucc_datatype_t ucc_dt = mpidi_mpi_dtype_to_ucc_dtype(dtype);
+    ucc_reduction_op_t ucc_op = mpidi_mpi_op_to_ucc_reduction_op(op);
+
+    if (ucc_dt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED) {
+        MPIDI_COMMON_UCC_VERBOSE_DTYPE_UNSUPPORTED(allreduce);
+        goto fallback;
+    }
+
+    if (ucc_op == MPIDI_COMMON_UCC_REDUCTION_OP_UNSUPPORTED) {
+        MPIDI_COMMON_UCC_VERBOSE_REDUCTION_OP_UNSUPPORTED(allreduce);
+        goto fallback;
+    }
+
+    ucc_coll_args_t coll = {
+        .mask = 0,
+        .flags = 0,
+        .coll_type = UCC_COLL_TYPE_ALLREDUCE,
+        .src.info = {
+                     .buffer = (void *) sbuf,
+                     .count = count,
+                     .datatype = ucc_dt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+        ,
+        .dst.info = {
+                     .buffer = rbuf,
+                     .count = count,
+                     .datatype = ucc_dt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     },
+        .op = ucc_op,
+    };
+
+    if (is_inplace) {
+
+        coll.mask = UCC_COLL_ARGS_FIELD_FLAGS;
+        coll.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
+
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(allreduce, "comm %p, comm_id %u, comm_size %d"
+                                                 ", INPLACE, count %zu, dtype %s, op %s",
+                                                 (void *) comm_ptr, comm_ptr->context_id,
+                                                 comm_size, count, mpidi_ucc_dtype_to_str(ucc_dt),
+                                                 mpidi_ucc_reduction_op_to_str(ucc_op));
+    } else {
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(allreduce, "comm %p, comm_id %u, comm_size %d"
+                                                 ", count %zu, dtype %s, op %s",
+                                                 (void *) comm_ptr, comm_ptr->context_id,
+                                                 comm_size, count, mpidi_ucc_dtype_to_str(ucc_dt),
+                                                 mpidi_ucc_reduction_op_to_str(ucc_op));
+    }
+
+    MPIDI_COMMON_UCC_REQ_INIT(coll_req, req, coll, comm_ptr);
+    return UCC_OK;
+  fallback:
+    return UCC_ERR_NOT_SUPPORTED;
+}
+
+int MPIDI_common_ucc_allreduce(const void *sbuf, void *rbuf, MPI_Aint count,
+                               MPI_Datatype dtype, MPI_Op op, MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_coll_req_h req;
+
+    MPIDI_COMMON_UCC_CHECK_ENABLED(comm_ptr, allreduce);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_TRY_TO_RUN(allreduce);
+
+    MPIDI_COMMON_UCC_CALL_AND_CHECK(mpidi_ucc_allreduce_init
+                                    (sbuf, rbuf, count, dtype, op, comm_ptr, &req, NULL));
+    MPIDI_COMMON_UCC_POST_AND_CHECK(req);
+    MPIDI_COMMON_UCC_WAIT_AND_CHECK(req);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DONE_SUCCESS(allreduce);
+
+    return MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+
+  fallback:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_FALLBACK(allreduce);
+    return MPIDI_COMMON_UCC_RETVAL_FALLBACK;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DISABLED(allreduce);
+    goto fallback;
+}
+
+#endif /* MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC */

--- a/src/mpid/common/ucc/mpid_ucc_alltoall.c
+++ b/src/mpid/common/ucc/mpid_ucc_alltoall.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpid_ucc.h"
+#include "mpid_ucc_collops.h"
+#include "mpid_ucc_dtypes.h"
+
+#ifdef MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+
+static inline ucc_status_t mpidi_ucc_alltoall_init(const void *sbuf, MPI_Aint scount,
+                                                   MPI_Datatype sdtype, void *rbuf, MPI_Aint rcount,
+                                                   MPI_Datatype rdtype, MPIR_Comm * comm_ptr,
+                                                   ucc_coll_req_h * req, MPIR_Request * coll_req)
+{
+
+    bool is_inplace = (sbuf == MPI_IN_PLACE);
+    int comm_size = MPIR_Comm_size(comm_ptr);
+
+    ucc_datatype_t ucc_sdt = MPIDI_COMMON_UCC_DTYPE_NULL;
+    ucc_datatype_t ucc_rdt = MPIDI_COMMON_UCC_DTYPE_NULL;
+
+    ucc_rdt = mpidi_mpi_dtype_to_ucc_dtype(rdtype);
+    if (!is_inplace) {
+        ucc_sdt = mpidi_mpi_dtype_to_ucc_dtype(sdtype);
+    }
+
+    if ((ucc_sdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED) ||
+        (ucc_rdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED)) {
+        MPIDI_COMMON_UCC_VERBOSE_DTYPE_UNSUPPORTED(alltoall);
+        goto fallback;
+    }
+
+    ucc_coll_args_t coll = {
+        .mask = 0,
+        .flags = 0,
+        .coll_type = UCC_COLL_TYPE_ALLTOALL,
+        .src.info = {
+                     .buffer = (void *) sbuf,
+                     .count = scount * comm_size,
+                     .datatype = ucc_sdt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+        ,
+        .dst.info = {
+                     .buffer = rbuf,
+                     .count = rcount * comm_size,
+                     .datatype = ucc_rdt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+    };
+
+    if (is_inplace) {
+
+        coll.mask = UCC_COLL_ARGS_FIELD_FLAGS;
+        coll.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
+
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(alltoall, "comm %p, comm_id %u, comm_size %d"
+                                                 ", INPLACE, rcount %zu, rdtype %s",
+                                                 (void *) comm_ptr, comm_ptr->context_id,
+                                                 comm_size, rcount,
+                                                 mpidi_ucc_dtype_to_str(ucc_rdt));
+    } else {
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(alltoall, "comm %p, comm_id %u, comm_size %d"
+                                                 ", scount %zu, sdtype %s, rcount %zu, rdtype %s",
+                                                 (void *) comm_ptr, comm_ptr->context_id, comm_size,
+                                                 scount, mpidi_ucc_dtype_to_str(ucc_sdt),
+                                                 rcount, mpidi_ucc_dtype_to_str(ucc_rdt));
+    }
+
+    MPIDI_COMMON_UCC_REQ_INIT(coll_req, req, coll, comm_ptr);
+    return UCC_OK;
+  fallback:
+    return UCC_ERR_NOT_SUPPORTED;
+}
+
+int MPIDI_common_ucc_alltoall(const void *sbuf, MPI_Aint scount, MPI_Datatype sdtype, void *rbuf,
+                              MPI_Aint rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_coll_req_h req;
+
+    MPIDI_COMMON_UCC_CHECK_ENABLED(comm_ptr, alltoall);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_TRY_TO_RUN(alltoall);
+
+    MPIDI_COMMON_UCC_CALL_AND_CHECK(mpidi_ucc_alltoall_init
+                                    (sbuf, scount, sdtype, rbuf, rcount, rdtype,
+                                     comm_ptr, &req, NULL));
+    MPIDI_COMMON_UCC_POST_AND_CHECK(req);
+    MPIDI_COMMON_UCC_WAIT_AND_CHECK(req);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DONE_SUCCESS(alltoall);
+
+    return MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+
+  fallback:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_FALLBACK(alltoall);
+    return MPIDI_COMMON_UCC_RETVAL_FALLBACK;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DISABLED(alltoall);
+    goto fallback;
+}
+
+#endif /* MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC */

--- a/src/mpid/common/ucc/mpid_ucc_alltoallv.c
+++ b/src/mpid/common/ucc/mpid_ucc_alltoallv.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpid_ucc.h"
+#include "mpid_ucc_collops.h"
+#include "mpid_ucc_dtypes.h"
+
+#ifdef MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+
+static inline ucc_status_t mpidi_ucc_alltoallv_init(const void *sbuf, const MPI_Aint scounts[],
+                                                    const MPI_Aint sdispls[], MPI_Datatype sdtype,
+                                                    void *rbuf, const MPI_Aint rcounts[],
+                                                    const MPI_Aint rdispls[], MPI_Datatype rdtype,
+                                                    MPIR_Comm * comm_ptr, ucc_coll_req_h * req,
+                                                    MPIR_Request * coll_req)
+{
+
+    bool is_inplace = (sbuf == MPI_IN_PLACE);
+    int comm_size = MPIR_Comm_size(comm_ptr);
+    bool is_large_counts = (sizeof(MPI_Aint) * 8 == 64);
+
+    ucc_datatype_t ucc_sdt = MPIDI_COMMON_UCC_DTYPE_NULL;
+    ucc_datatype_t ucc_rdt = MPIDI_COMMON_UCC_DTYPE_NULL;;
+
+    uint64_t flags = 0;
+
+    ucc_rdt = mpidi_mpi_dtype_to_ucc_dtype(rdtype);
+    if (!is_inplace) {
+        ucc_sdt = mpidi_mpi_dtype_to_ucc_dtype(sdtype);
+    }
+
+    if ((ucc_sdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED) ||
+        (ucc_rdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED)) {
+        MPIDI_COMMON_UCC_VERBOSE_DTYPE_UNSUPPORTED(alltoallv);
+        goto fallback;
+    }
+
+    if (is_inplace) {
+        flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
+    }
+
+    if (is_large_counts) {
+        flags |= UCC_COLL_ARGS_FLAG_COUNT_64BIT;
+        flags |= UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT;
+    }
+
+    ucc_coll_args_t coll = {
+        .mask = flags ? UCC_COLL_ARGS_FIELD_FLAGS : 0,
+        .flags = flags,
+        .coll_type = UCC_COLL_TYPE_ALLTOALLV,
+        .src.info_v = {
+                       .buffer = (void *) sbuf,
+                       .counts = (ucc_count_t *) scounts,
+                       .displacements = (ucc_aint_t *) sdispls,
+                       .datatype = ucc_sdt,
+                       .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                       }
+        ,
+        .dst.info_v = {
+                       .buffer = rbuf,
+                       .counts = (ucc_count_t *) rcounts,
+                       .displacements = (ucc_aint_t *) rdispls,
+                       .datatype = ucc_rdt,
+                       .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                       }
+    };
+
+    if (is_inplace) {
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(alltoallv, "comm %p, comm_id %u, comm_size %d"
+                                                 ", INPLACE, rdtype %s",
+                                                 (void *) comm_ptr, comm_ptr->context_id,
+                                                 comm_size, mpidi_ucc_dtype_to_str(ucc_rdt));
+    } else {
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(alltoallv, "comm %p, comm_id %u, comm_size %d"
+                                                 ", sdtype %s, rdtype %s",
+                                                 (void *) comm_ptr, comm_ptr->context_id,
+                                                 comm_size,
+                                                 mpidi_ucc_dtype_to_str(ucc_sdt),
+                                                 mpidi_ucc_dtype_to_str(ucc_rdt));
+    }
+
+    MPIDI_COMMON_UCC_REQ_INIT(coll_req, req, coll, comm_ptr);
+    return UCC_OK;
+  fallback:
+    return UCC_ERR_NOT_SUPPORTED;
+}
+
+int MPIDI_common_ucc_alltoallv(const void *sbuf, const MPI_Aint scounts[], const MPI_Aint sdispls[],
+                               MPI_Datatype sdtype, void *rbuf, const MPI_Aint rcounts[],
+                               const MPI_Aint rdispls[], MPI_Datatype rdtype, MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_coll_req_h req;
+
+    MPIDI_COMMON_UCC_CHECK_ENABLED(comm_ptr, alltoallv);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_TRY_TO_RUN(alltoallv);
+
+    MPIDI_COMMON_UCC_CALL_AND_CHECK(mpidi_ucc_alltoallv_init
+                                    (sbuf, scounts, sdispls, sdtype, rbuf, rcounts, rdispls, rdtype,
+                                     comm_ptr, &req, NULL));
+    MPIDI_COMMON_UCC_POST_AND_CHECK(req);
+    MPIDI_COMMON_UCC_WAIT_AND_CHECK(req);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DONE_SUCCESS(alltoallv);
+
+    return MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+
+  fallback:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_FALLBACK(alltoallv);
+    return MPIDI_COMMON_UCC_RETVAL_FALLBACK;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DISABLED(alltoallv);
+    goto fallback;
+}
+
+#endif /* MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC */

--- a/src/mpid/common/ucc/mpid_ucc_barrier.c
+++ b/src/mpid/common/ucc/mpid_ucc_barrier.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpid_ucc.h"
+#include "mpid_ucc_collops.h"
+#include "mpid_ucc_dtypes.h"
+
+#ifdef MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+
+static inline ucc_status_t mpidi_ucc_barrier_init(MPIR_Comm * comm_ptr, ucc_coll_req_h * req,
+                                                  MPIR_Request * coll_req)
+{
+    ucc_coll_args_t coll = {
+        .mask = 0,
+        .flags = 0,
+        .coll_type = UCC_COLL_TYPE_BARRIER
+    };
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(barrier, "comm %p, comm_id %u, comm_size %d",
+                                             (void *) comm_ptr, comm_ptr->context_id,
+                                             MPIR_Comm_size(comm_ptr));
+
+    MPIDI_COMMON_UCC_REQ_INIT(coll_req, req, coll, comm_ptr);
+    return UCC_OK;
+  fallback:
+    return UCC_ERR_NOT_SUPPORTED;
+}
+
+int MPIDI_common_ucc_barrier(MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_coll_req_h req;
+
+    MPIDI_COMMON_UCC_CHECK_ENABLED(comm_ptr, BARRIER);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_TRY_TO_RUN(barrier);
+
+    MPIDI_COMMON_UCC_CALL_AND_CHECK(mpidi_ucc_barrier_init(comm_ptr, &req, NULL));
+    MPIDI_COMMON_UCC_POST_AND_CHECK(req);
+    MPIDI_COMMON_UCC_WAIT_AND_CHECK(req);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DONE_SUCCESS(barrier);
+
+    return MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+
+  fallback:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_FALLBACK(barrier);
+    return MPIDI_COMMON_UCC_RETVAL_FALLBACK;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DISABLED(barrier);
+    goto fallback;
+}
+
+#endif /* MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC */

--- a/src/mpid/common/ucc/mpid_ucc_bcast.c
+++ b/src/mpid/common/ucc/mpid_ucc_bcast.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpid_ucc.h"
+#include "mpid_ucc_collops.h"
+#include "mpid_ucc_dtypes.h"
+
+#ifdef MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+
+static inline ucc_status_t mpidi_ucc_bcast_init(void *buf, MPI_Aint count,
+                                                MPI_Datatype dtype, int root,
+                                                MPIR_Comm * comm_ptr, ucc_coll_req_h * req,
+                                                MPIR_Request * coll_req)
+{
+
+    ucc_datatype_t ucc_dt = mpidi_mpi_dtype_to_ucc_dtype(dtype);
+
+    if (ucc_dt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED) {
+        MPIDI_COMMON_UCC_VERBOSE_DTYPE_UNSUPPORTED(bcast);
+        goto fallback;
+    }
+
+    ucc_coll_args_t coll = {
+        .mask = 0,
+        .flags = 0,
+        .coll_type = UCC_COLL_TYPE_BCAST,
+        .root = root,
+        .src.info = {
+                     .buffer = buf,
+                     .count = count,
+                     .datatype = ucc_dt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+    };
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(bcast, "comm %p, comm_id %u, comm_size %d"
+                                             ", count %zu, dtype %s",
+                                             (void *) comm_ptr, comm_ptr->context_id,
+                                             MPIR_Comm_size(comm_ptr), count,
+                                             mpidi_ucc_dtype_to_str(ucc_dt));
+
+    MPIDI_COMMON_UCC_REQ_INIT(coll_req, req, coll, comm_ptr);
+    return UCC_OK;
+  fallback:
+    return UCC_ERR_NOT_SUPPORTED;
+}
+
+int MPIDI_common_ucc_bcast(void *buf, MPI_Aint count, MPI_Datatype dtype, int root,
+                           MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_coll_req_h req;
+
+    MPIDI_COMMON_UCC_CHECK_ENABLED(comm_ptr, bcast);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_TRY_TO_RUN(bcast);
+
+    MPIDI_COMMON_UCC_CALL_AND_CHECK(mpidi_ucc_bcast_init
+                                    (buf, count, dtype, root, comm_ptr, &req, NULL));
+    MPIDI_COMMON_UCC_POST_AND_CHECK(req);
+    MPIDI_COMMON_UCC_WAIT_AND_CHECK(req);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DONE_SUCCESS(bcast);
+
+    return MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+
+  fallback:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_FALLBACK(bcast);
+    return MPIDI_COMMON_UCC_RETVAL_FALLBACK;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DISABLED(bcast);
+    goto fallback;
+}
+
+#endif /* MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC */

--- a/src/mpid/common/ucc/mpid_ucc_collops.h
+++ b/src/mpid/common/ucc/mpid_ucc_collops.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef _MPID_UCC_COLLOPS_H_
+#define _MPID_UCC_COLLOPS_H_
+
+#include "mpid_ucc.h"
+
+#define MPIDI_COMMON_UCC_VERBOSE_INPLACE_UNSUPPORTED(_collop)           \
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_DTYPE,      \
+                             "MPI_INPLACE is not supported (" #_collop  \
+                             ")");
+
+#define MPIDI_COMMON_UCC_VERBOSE_DTYPE_UNSUPPORTED(_collop)             \
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_DTYPE,      \
+                             "MPI datatype is not supported (" #_collop \
+                             ")");
+
+#define MPIDI_COMMON_UCC_VERBOSE_REDUCTION_OP_UNSUPPORTED(_collop)      \
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_DTYPE,      \
+                             "MPI reduction operation is not supported" \
+                             "(" #_collop ")");
+
+#define MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(_collop, _format, ...) \
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COLLOP,     \
+                             "posting ucc " #_collop " req | " _format, \
+                             __VA_ARGS__);
+
+#define MPIDI_COMMON_UCC_VERBOSE_COLLOP_TRY_TO_RUN(_collop)             \
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COLLOP,     \
+                             "trying to run ucc " #_collop);
+
+#define MPIDI_COMMON_UCC_VERBOSE_COLLOP_DONE_SUCCESS(_collop)           \
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COLLOP,     \
+                             "ucc " #_collop " done successfully");
+
+#define MPIDI_COMMON_UCC_VERBOSE_COLLOP_FALLBACK(_collop)               \
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COLLOP,     \
+                             "running fallback " #_collop);
+
+#define MPIDI_COMMON_UCC_VERBOSE_COLLOP_DISABLED(_collop)               \
+    MPIDI_COMMON_UCC_VERBOSE(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COLLOP,     \
+                             "ucc " #_collop " disabled");
+
+
+#define MPIDI_COMMON_UCC_CHECK_ENABLED(_comm, _collop) do {             \
+        if (!MPIDI_common_ucc_priv.ucc_enabled ||                       \
+            !MPIDI_common_ucc_priv.ucc_initialized ||                   \
+            !comm_ptr->ucc_priv.ucc_initialized) {                      \
+            goto disabled;                                              \
+        }                                                               \
+    } while (0)
+
+#define MPIDI_COMMON_UCC_CALL_AND_CHECK(_call) do {                     \
+        ucc_status_t __status = (_call);                                \
+        if (UCC_OK != __status) {                                       \
+            MPIDI_COMMON_UCC_WARNING("Calling " #_call " failed: "      \
+                                     "%s. Goto fallback.",              \
+                                     ucc_status_string(__status));      \
+            goto fallback;                                              \
+        }                                                               \
+    } while (0)
+
+#define MPIDI_COMMON_UCC_POST_AND_CHECK(_req) do {                      \
+        ucc_status_t __status = ucc_collective_post(_req);              \
+        if (UCC_OK != __status) {                                       \
+            ucc_collective_finalize(_req);                              \
+            MPIDI_COMMON_UCC_WARNING("ucc_collective_post() failed: "   \
+                                     "%s. Goto fallback.",              \
+                                     ucc_status_string(__status));      \
+            goto fallback;                                              \
+        }                                                               \
+    } while (0)
+
+#define MPIDI_COMMON_UCC_REQ_INIT(_coll_req, _req, _coll, _comm) do {   \
+        if (_coll_req) {                                                \
+            MPIR_Assert(0); /* not yet supported */                     \
+            _coll.mask   |= UCC_COLL_ARGS_FIELD_CB;                     \
+            _coll.cb.cb   = NULL;                                       \
+            _coll.cb.data = (void*)_coll_req;                           \
+        } else {                                                        \
+            _coll.mask  |= UCC_COLL_ARGS_FIELD_FLAGS;                   \
+            _coll.flags |= UCC_COLL_ARGS_HINT_OPTIMIZE_LATENCY;         \
+        }                                                               \
+        MPIDI_COMMON_UCC_CALL_AND_CHECK(ucc_collective_init(\
+                              &_coll, _req, _comm->ucc_priv.ucc_team)); \
+        if (_coll_req) {                                                \
+            /* _coll_req->ucc_req = *(_req); TODO*/                     \
+            MPIR_Assert(0); /* not yet supported */                     \
+        }                                                               \
+    } while (0)
+
+#define MPIDI_COMMON_UCC_WAIT_AND_CHECK(_req) do {                      \
+        ucc_status_t status;                                            \
+        while ((status = ucc_collective_test(req)) != UCC_OK) {         \
+            if (status < 0) {                                           \
+                MPIDI_COMMON_UCC_ERROR("ucc_collective_test failed:"    \
+                    " %s", ucc_status_string(status));                  \
+                MPIDI_COMMON_UCC_CALL_AND_CHECK(ucc_collective_finalize(\
+                    req));                                              \
+                goto fallback;                                          \
+            }                                                           \
+            MPIDI_COMMON_UCC_CALL_AND_CHECK(ucc_context_progress(\
+                                   MPIDI_common_ucc_priv.ucc_context)); \
+            MPID_Progress_test(NULL);                                   \
+        }                                                               \
+        MPIDI_COMMON_UCC_CALL_AND_CHECK(ucc_collective_finalize(req));  \
+    } while (0)
+
+#endif /*_MPID_UCC_COLLOPS_H_*/

--- a/src/mpid/common/ucc/mpid_ucc_debug.h
+++ b/src/mpid/common/ucc/mpid_ucc_debug.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef _MPID_UCC_DEBUG_H_
+#define _MPID_UCC_DEBUG_H_
+
+#include "mpid_ucc.h"
+
+#define __MPIDI_COMMON_UCC_DEBUG(_level, _format, _file, _func, _line, ...) \
+    do {                                                                    \
+        if (MPIDI_common_ucc_priv.verbose_debug &&                          \
+            ((MPIDI_common_ucc_priv.verbose_level == _level * (-1)) ||      \
+             (MPIDI_common_ucc_priv.verbose_level > _level))) {             \
+            fprintf(stderr, "==%u== UCC DEBUG %s in %s: (%s:%d) | "         \
+                    _format "\n", getpid(),                                 \
+                    MPIDI_COMMON_UCC_VERBOSE_LEVEL_TO_STRING[_level],       \
+                    _file, _func, _line,                                    \
+                    ## __VA_ARGS__);                                        \
+        }                                                                   \
+    } while (0)
+
+#ifdef MPIDI_COMMON_UCC_DEBUG
+#undef MPIDI_COMMON_UCC_DEBUG
+#endif
+#define MPIDI_COMMON_UCC_DEBUG(_level, _format, ...)            \
+    __MPIDI_COMMON_UCC_DEBUG(_level, _format,                   \
+                            __FILE__, __FUNCTION__, __LINE__,   \
+                            ## __VA_ARGS__)
+
+#define MPIDI_COMMON_UCC_DEBUG_WRAPPER(_level, _format, ...)    \
+    __MPIDI_COMMON_UCC_DEBUG(_level, _format,                   \
+                             _file, _func, _line,               \
+                             ## __VA_ARGS__)
+
+#define MPIDI_COMMON_UCC_DEBUG_FNCALL(_fn_name)	\
+    MPIDI_COMMON_UCC_DEBUG_WRAPPER(MPIDI_COMMON_UCC_VERBOSE_LEVEL_FNCALL, "calling %s() ...", _fn_name);
+
+#define MPIDI_COMMON_UCC_DEBUG_FNDONE(_fn_name) \
+    MPIDI_COMMON_UCC_DEBUG_WRAPPER(MPIDI_COMMON_UCC_VERBOSE_LEVEL_FNCALL, "call of %s() DONE", _fn_name);
+
+#define MPIDI_COMMON_UCC_DEBUG_WRAPPER_CALL(_fn_name, ...) MPIDI_COMMON_UCC_DEBUG_WRAPPER_ \
+    ## _fn_name (__FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+#define MPIDI_COMMON_UCC_DEBUG_WRAPPER_IMPL(_ret_type, _fn_name, _arglist, ...) \
+    static _ret_type MPIDI_COMMON_UCC_DEBUG_WRAPPER_ ## _fn_name                \
+        (const char * _file, const char * _func, int _line, __VA_ARGS__)        \
+    {                                                                           \
+        _ret_type ret_val;                                                      \
+        MPIDI_COMMON_UCC_DEBUG_FNCALL(# _fn_name);                              \
+        ret_val = _fn_name _arglist ;                                           \
+        MPIDI_COMMON_UCC_DEBUG_FNDONE(# _fn_name);                              \
+        return ret_val;                                                         \
+    }
+
+
+MPIDI_COMMON_UCC_DEBUG_WRAPPER_IMPL(ucc_status_t, ucc_init,
+                                    (params, config, lib_p),
+                                    const ucc_lib_params_t * params, const ucc_lib_config_h config,
+                                    ucc_lib_h * lib_p);
+#define ucc_init(...) MPIDI_COMMON_UCC_DEBUG_WRAPPER_CALL(ucc_init, __VA_ARGS__)
+
+MPIDI_COMMON_UCC_DEBUG_WRAPPER_IMPL(ucc_status_t, ucc_lib_config_read,
+                                    (env_prefix, filename, config),
+                                    const char *env_prefix, const char *filename,
+                                    ucc_lib_config_h * config);
+#define ucc_lib_config_read(...) MPIDI_COMMON_UCC_DEBUG_WRAPPER_CALL(ucc_lib_config_read, __VA_ARGS__)
+
+MPIDI_COMMON_UCC_DEBUG_WRAPPER_IMPL(ucc_status_t, ucc_context_config_read,
+                                    (lib_handle, filename, config),
+                                    ucc_lib_h lib_handle, const char *filename,
+                                    ucc_context_config_h * config);
+#define ucc_context_config_read(...) MPIDI_COMMON_UCC_DEBUG_WRAPPER_CALL(ucc_context_config_read, __VA_ARGS__)
+
+MPIDI_COMMON_UCC_DEBUG_WRAPPER_IMPL(ucc_status_t, ucc_context_config_modify,
+                                    (config, component, name, value),
+                                    ucc_context_config_h config, const char *component,
+                                    const char *name, const char *value);
+#define ucc_context_config_modify(...) MPIDI_COMMON_UCC_DEBUG_WRAPPER_CALL(ucc_context_config_modify, __VA_ARGS__)
+
+MPIDI_COMMON_UCC_DEBUG_WRAPPER_IMPL(ucc_status_t, ucc_context_create,
+                                    (lib_handle, params, config, context),
+                                    ucc_lib_h lib_handle, const ucc_context_params_t * params,
+                                    const ucc_context_config_h config, ucc_context_h * context);
+#define ucc_context_create(...) MPIDI_COMMON_UCC_DEBUG_WRAPPER_CALL(ucc_context_create, __VA_ARGS__)
+
+MPIDI_COMMON_UCC_DEBUG_WRAPPER_IMPL(ucc_status_t, ucc_context_destroy,
+                                    (context), ucc_context_h context);
+#define ucc_context_destroy(...) MPIDI_COMMON_UCC_DEBUG_WRAPPER_CALL(ucc_context_destroy, __VA_ARGS__);
+
+MPIDI_COMMON_UCC_DEBUG_WRAPPER_IMPL(ucc_status_t, ucc_finalize, (lib_p), ucc_lib_h lib_p);
+#define ucc_finalize(...) MPIDI_COMMON_UCC_DEBUG_WRAPPER_CALL(ucc_finalize, __VA_ARGS__)
+
+
+#define MPIDI_COMMON_UCC_OUTPUT_COND_CONCAT_STR(_str, _cond) do {      \
+       if (_cond) {                                                    \
+           if (strlen(_str)) strcat(_str, " + ");                      \
+           strcat(_str , MPIDI_COMMON_UCC_OUTPUT_STRINGIFY(_cond));    \
+       }                                                               \
+   } while (0);
+#define MPIDI_COMMON_UCC_OUTPUT_COND_CREATE_STR(_str) do {             \
+       MPIDI_COMMON_UCC_OUTPUT_COND_CONCAT_STR(_str,                   \
+                      MPIDI_COMMON_UCC_COMM_EXCL_COND_TYPE);           \
+       MPIDI_COMMON_UCC_OUTPUT_COND_CONCAT_STR(_str,                   \
+                      MPIDI_COMMON_UCC_COMM_EXCL_COND_SIZE);           \
+       MPIDI_COMMON_UCC_OUTPUT_COND_CONCAT_STR(_str,                   \
+                      MPIDI_COMMON_UCC_COMM_EXCL_COND_DEV);            \
+    } while (0);
+#define MPIDI_COMMON_UCC_OUTPUT_COMM_EXCL_COND do {                    \
+       char reason_str[512] = {0};                                     \
+       MPIDI_COMMON_UCC_OUTPUT_COND_CREATE_STR(reason_str);            \
+       MPIDI_COMMON_UCC_DEBUG(MPIDI_COMMON_UCC_VERBOSE_LEVEL_COMM,     \
+                              "excluded comm %p, comm_id %d from ucc " \
+                              "use with reason \"%s\"",                \
+                              (void *) comm_ptr, comm_ptr->context_id, \
+                              reason_str);                             \
+    } while (0);
+
+#endif /*_MPID_UCC_DEBUG_H_*/

--- a/src/mpid/common/ucc/mpid_ucc_dtypes.h
+++ b/src/mpid/common/ucc/mpid_ucc_dtypes.h
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef _MPID_UCC_DTYPES_H_
+#define _MPID_UCC_DTYPES_H_
+
+#define MPIDI_COMMON_UCC_DTYPE_NULL ((ucc_datatype_t)-1)
+#define MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED ((ucc_datatype_t)-2)
+
+#define MPIDI_COMMON_UCC_DTYPE_MAP_SIGNED(_ctype)   \
+    do {                                            \
+        switch (sizeof(signed _ctype)) {            \
+        case 1:                                     \
+            return UCC_DT_INT8;                     \
+        case 2:                                     \
+            return UCC_DT_INT16;                    \
+        case 4:                                     \
+            return UCC_DT_INT32;                    \
+        case 8:                                     \
+            return UCC_DT_INT64;                    \
+        case 16:                                    \
+            return UCC_DT_INT128;                   \
+        }                                           \
+    } while (0)
+#define MPIDI_COMMON_UCC_DTYPE_MAP_UNSIGNED(_ctype) \
+    do {                                            \
+        switch (sizeof(unsigned _ctype)) {          \
+        case 1:                                     \
+            return UCC_DT_UINT8;                    \
+        case 2:                                     \
+            return UCC_DT_UINT16;                   \
+        case 4:                                     \
+            return UCC_DT_UINT32;                   \
+        case 8:                                     \
+            return UCC_DT_UINT64;                   \
+        case 16:                                    \
+            return UCC_DT_UINT128;                  \
+        }                                           \
+    } while (0)
+#define MPIDI_COMMON_UCC_DTYPE_MAP_FLOAT(_ctype)    \
+    do {                                            \
+        switch (sizeof(_ctype)) {                   \
+        case 4:                                     \
+            return UCC_DT_FLOAT32;                  \
+        case 8:                                     \
+            return UCC_DT_FLOAT64;                  \
+        case 16:                                    \
+            return UCC_DT_FLOAT128;                 \
+        }                                           \
+    } while (0)
+
+static inline ucc_datatype_t mpidi_mpi_dtype_to_ucc_dtype(MPI_Datatype datatype)
+{
+    if (HANDLE_IS_BUILTIN(datatype) && ((datatype) & 0xff)) {
+        switch (MPIR_Internal_types[(datatype) & 0xff].dtype) {
+            case MPI_CHAR:
+            case MPI_INT8_T:
+            case MPI_SIGNED_CHAR:
+                return UCC_DT_INT8;
+            case MPI_BYTE:
+            case MPI_UINT8_T:
+            case MPI_UNSIGNED_CHAR:
+                return UCC_DT_UINT8;
+            case MPI_INT16_T:
+                return UCC_DT_INT16;
+            case MPI_UINT16_T:
+                return UCC_DT_UINT16;
+            case MPI_INT32_T:
+                return UCC_DT_INT32;
+            case MPI_UINT32_T:
+                return UCC_DT_UINT32;
+            case MPI_INT64_T:
+                return UCC_DT_INT64;
+            case MPI_UINT64_T:
+                return UCC_DT_UINT64;
+            case MPI_SHORT:
+                MPIDI_COMMON_UCC_DTYPE_MAP_SIGNED(short int);
+                break;
+            case MPI_INT:
+                MPIDI_COMMON_UCC_DTYPE_MAP_SIGNED(int);
+                break;
+            case MPI_LONG:
+                MPIDI_COMMON_UCC_DTYPE_MAP_SIGNED(long int);
+                break;
+            case MPI_LONG_LONG:
+                MPIDI_COMMON_UCC_DTYPE_MAP_SIGNED(long long int);
+                break;
+            case MPI_UNSIGNED_SHORT:
+                MPIDI_COMMON_UCC_DTYPE_MAP_UNSIGNED(short int);
+                break;
+            case MPI_UNSIGNED:
+                MPIDI_COMMON_UCC_DTYPE_MAP_UNSIGNED(int);
+                break;
+            case MPI_UNSIGNED_LONG:
+                MPIDI_COMMON_UCC_DTYPE_MAP_UNSIGNED(long);
+                break;
+            case MPI_UNSIGNED_LONG_LONG:
+                MPIDI_COMMON_UCC_DTYPE_MAP_UNSIGNED(long long);
+                break;
+            case MPI_FLOAT:
+                MPIDI_COMMON_UCC_DTYPE_MAP_FLOAT(float);
+                break;
+            case MPI_DOUBLE:
+                MPIDI_COMMON_UCC_DTYPE_MAP_FLOAT(double);
+                break;
+            case MPI_LONG_DOUBLE:
+                MPIDI_COMMON_UCC_DTYPE_MAP_FLOAT(long double);
+                break;
+        }
+    }
+    return MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED;
+}
+
+static inline const char *mpidi_ucc_dtype_to_str(ucc_datatype_t datatype)
+{
+#ifndef NDEBUG
+    switch (datatype) {
+        case UCC_DT_INT8:
+            return "UCC_DT_INT8";
+        case UCC_DT_INT16:
+            return "UCC_DT_INT16";
+        case UCC_DT_INT32:
+            return "UCC_DT_INT32";
+        case UCC_DT_INT64:
+            return "UCC_DT_INT64";
+        case UCC_DT_INT128:
+            return "UCC_DT_INT128";
+        case UCC_DT_UINT8:
+            return "UCC_DT_UINT8";
+        case UCC_DT_UINT16:
+            return "UCC_DT_UINT16";
+        case UCC_DT_UINT32:
+            return "UCC_DT_UINT32";
+        case UCC_DT_UINT64:
+            return "UCC_DT_UINT64";
+        case UCC_DT_UINT128:
+            return "UCC_DT_UINT128";
+        case UCC_DT_FLOAT32:
+            return "UCC_DT_FLOAT32";
+        case UCC_DT_FLOAT64:
+            return "UCC_DT_FLOAT64";
+        case UCC_DT_FLOAT128:
+            return "UCC_DT_FLOAT128";
+        default:
+            return "unknown";
+    }
+#else
+    static char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%" PRId64, datatype);
+    return buffer;
+#endif
+}
+
+
+#define MPIDI_COMMON_UCC_REDUCTION_OP_NULL ((ucc_reduction_op_t)-1)
+#define MPIDI_COMMON_UCC_REDUCTION_OP_UNSUPPORTED ((ucc_reduction_op_t)-2)
+
+static inline ucc_reduction_op_t mpidi_mpi_op_to_ucc_reduction_op(MPI_Op operation)
+{
+    switch (operation) {
+        case MPI_MAX:
+            return UCC_OP_MAX;
+        case MPI_MIN:
+            return UCC_OP_MIN;
+        case MPI_SUM:
+            return UCC_OP_SUM;
+        case MPI_PROD:
+            return UCC_OP_PROD;
+        case MPI_LAND:
+            return UCC_OP_LAND;
+        case MPI_BAND:
+            return UCC_OP_BAND;
+        case MPI_LOR:
+            return UCC_OP_LOR;
+        case MPI_BOR:
+            return UCC_OP_BOR;
+        case MPI_LXOR:
+            return UCC_OP_LXOR;
+        case MPI_BXOR:
+            return UCC_OP_BXOR;
+        default:
+            return MPIDI_COMMON_UCC_REDUCTION_OP_UNSUPPORTED;
+    }
+}
+
+static inline const char *mpidi_ucc_reduction_op_to_str(ucc_reduction_op_t operation)
+{
+#ifndef NDEBUG
+    switch (operation) {
+        case UCC_OP_MAX:
+            return "UCC_OP_MAX";
+        case UCC_OP_MIN:
+            return "UCC_OP_MIN";
+        case UCC_OP_SUM:
+            return "UCC_OP_SUM";
+        case UCC_OP_PROD:
+            return "UCC_OP_PROD";
+        case UCC_OP_LAND:
+            return "UCC_OP_LAND";
+        case UCC_OP_BAND:
+            return "UCC_OP_BAND";
+        case UCC_OP_LOR:
+            return "UCC_OP_LOR";
+        case UCC_OP_BOR:
+            return "UCC_OP_BOR";
+        case UCC_OP_LXOR:
+            return "UCC_OP_LXOR";
+        case UCC_OP_BXOR:
+            return "UCC_OP_BXOR";
+        default:
+            return "unknown";
+    }
+#else
+    static char buffer[32];
+    snprintf(buffer, sizeof(buffer), "%d", operation);
+    return buffer;
+#endif
+}
+
+#endif /*_MPID_UCC_DTYPES_H_*/

--- a/src/mpid/common/ucc/mpid_ucc_gather.c
+++ b/src/mpid/common/ucc/mpid_ucc_gather.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpid_ucc.h"
+#include "mpid_ucc_collops.h"
+#include "mpid_ucc_dtypes.h"
+
+#ifdef MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+
+static inline ucc_status_t mpidi_ucc_gather_init(const void *sbuf, MPI_Aint scount,
+                                                 MPI_Datatype sdtype, void *rbuf, MPI_Aint rcount,
+                                                 MPI_Datatype rdtype, int root,
+                                                 MPIR_Comm * comm_ptr, ucc_coll_req_h * req,
+                                                 MPIR_Request * coll_req)
+{
+
+    bool is_inplace = (sbuf == MPI_IN_PLACE);
+    int comm_rank = MPIR_Comm_rank(comm_ptr);
+    int comm_size = MPIR_Comm_size(comm_ptr);
+
+    ucc_datatype_t ucc_sdt = MPIDI_COMMON_UCC_DTYPE_NULL;
+    ucc_datatype_t ucc_rdt = MPIDI_COMMON_UCC_DTYPE_NULL;
+
+    if (comm_rank == root) {
+        ucc_rdt = mpidi_mpi_dtype_to_ucc_dtype(rdtype);
+        if (!is_inplace) {
+            ucc_sdt = mpidi_mpi_dtype_to_ucc_dtype(sdtype);
+        }
+    } else {
+        ucc_sdt = mpidi_mpi_dtype_to_ucc_dtype(sdtype);
+    }
+
+    if ((ucc_sdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED) ||
+        (ucc_rdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED)) {
+        MPIDI_COMMON_UCC_VERBOSE_DTYPE_UNSUPPORTED(gather);
+        goto fallback;
+    }
+
+    ucc_coll_args_t coll = {
+        .mask = 0,
+        .flags = 0,
+        .coll_type = UCC_COLL_TYPE_GATHER,
+        .root = root,
+        .src.info = {
+                     .buffer = (void *) sbuf,
+                     .count = scount,
+                     .datatype = ucc_sdt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+        ,
+        .dst.info = {
+                     .buffer = rbuf,
+                     .count = rcount * comm_size,
+                     .datatype = ucc_rdt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+    };
+
+    if (comm_rank == root) {
+
+        if (is_inplace) {
+
+            coll.mask = UCC_COLL_ARGS_FIELD_FLAGS;
+            coll.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
+
+            MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(gather, "comm %p, comm_id %u, comm_size %d"
+                                                     ", INPLACE, rcount %zu, rdtype %s, root %d (me)",
+                                                     (void *) comm_ptr, comm_ptr->context_id,
+                                                     comm_size, rcount,
+                                                     mpidi_ucc_dtype_to_str(ucc_rdt), root);
+        } else {
+            MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(gather, "comm %p, comm_id %u, comm_size %d"
+                                                     ", scount %zu, sdtype %s, rcount %zu, rdtype %s"
+                                                     ", root %d (me)",
+                                                     (void *) comm_ptr, comm_ptr->context_id,
+                                                     comm_size, scount,
+                                                     mpidi_ucc_dtype_to_str(ucc_sdt), rcount,
+                                                     mpidi_ucc_dtype_to_str(ucc_rdt), root);
+        }
+    } else {
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(gather, "comm %p, comm_id %u, comm_size %d"
+                                                 ", scount %zu, sdtype %s, root %d",
+                                                 (void *) comm_ptr, comm_ptr->context_id,
+                                                 comm_size, scount,
+                                                 mpidi_ucc_dtype_to_str(ucc_sdt), root);
+    }
+
+    MPIDI_COMMON_UCC_REQ_INIT(coll_req, req, coll, comm_ptr);
+    return UCC_OK;
+  fallback:
+    return UCC_ERR_NOT_SUPPORTED;
+}
+
+int MPIDI_common_ucc_gather(const void *sbuf, MPI_Aint scount, MPI_Datatype sdtype, void *rbuf,
+                            MPI_Aint rcount, MPI_Datatype rdtype, int root, MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_coll_req_h req;
+
+    MPIDI_COMMON_UCC_CHECK_ENABLED(comm_ptr, gather);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_TRY_TO_RUN(gather);
+
+    MPIDI_COMMON_UCC_CALL_AND_CHECK(mpidi_ucc_gather_init
+                                    (sbuf, scount, sdtype, rbuf, rcount, rdtype, root,
+                                     comm_ptr, &req, NULL));
+    MPIDI_COMMON_UCC_POST_AND_CHECK(req);
+    MPIDI_COMMON_UCC_WAIT_AND_CHECK(req);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DONE_SUCCESS(gather);
+
+    return MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+
+  fallback:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_FALLBACK(gather);
+    return MPIDI_COMMON_UCC_RETVAL_FALLBACK;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DISABLED(gather);
+    goto fallback;
+}
+
+#endif /* MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC */

--- a/src/mpid/common/ucc/mpid_ucc_gatherv.c
+++ b/src/mpid/common/ucc/mpid_ucc_gatherv.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpid_ucc.h"
+#include "mpid_ucc_collops.h"
+#include "mpid_ucc_dtypes.h"
+
+#ifdef MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+
+static inline ucc_status_t mpidi_ucc_gatherv_init(const void *sbuf, MPI_Aint scount,
+                                                  MPI_Datatype sdtype, void *rbuf,
+                                                  const MPI_Aint rcounts[],
+                                                  const MPI_Aint rdispls[], MPI_Datatype rdtype,
+                                                  int root, MPIR_Comm * comm_ptr,
+                                                  ucc_coll_req_h * req, MPIR_Request * coll_req)
+{
+
+    bool is_inplace = (sbuf == MPI_IN_PLACE);
+    int comm_rank = MPIR_Comm_rank(comm_ptr);
+    int comm_size = MPIR_Comm_size(comm_ptr);
+    bool is_large_counts = (sizeof(MPI_Aint) * 8 == 64);
+
+    ucc_datatype_t ucc_sdt = MPIDI_COMMON_UCC_DTYPE_NULL;
+    ucc_datatype_t ucc_rdt = MPIDI_COMMON_UCC_DTYPE_NULL;
+
+    uint64_t flags = 0;
+
+    if (comm_rank == root) {
+        ucc_rdt = mpidi_mpi_dtype_to_ucc_dtype(rdtype);
+        if (!is_inplace) {
+            ucc_sdt = mpidi_mpi_dtype_to_ucc_dtype(sdtype);
+        }
+    } else {
+        ucc_sdt = mpidi_mpi_dtype_to_ucc_dtype(sdtype);
+    }
+
+    if ((ucc_sdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED) ||
+        (ucc_rdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED)) {
+        MPIDI_COMMON_UCC_VERBOSE_DTYPE_UNSUPPORTED(gatherv);
+        goto fallback;
+    }
+
+    if (is_inplace) {
+        flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
+    }
+
+    if (is_large_counts) {
+        flags |= UCC_COLL_ARGS_FLAG_COUNT_64BIT;
+        flags |= UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT;
+    }
+
+    ucc_coll_args_t coll = {
+        .mask = flags ? UCC_COLL_ARGS_FIELD_FLAGS : 0,
+        .flags = flags,
+        .coll_type = UCC_COLL_TYPE_GATHERV,
+        .root = root,
+        .src.info = {
+                     .buffer = (void *) sbuf,
+                     .count = scount,
+                     .datatype = ucc_sdt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+        ,
+        .dst.info_v = {
+                       .buffer = rbuf,
+                       .counts = (ucc_count_t *) rcounts,
+                       .displacements = (ucc_aint_t *) rdispls,
+                       .datatype = ucc_rdt,
+                       .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                       }
+    };
+
+    if (comm_rank == root) {
+        if (is_inplace) {
+            MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(gatherv, "comm %p, comm_id %u, comm_size %d"
+                                                     ", INPLACE, rdtype %s, root %d (me)",
+                                                     (void *) comm_ptr, comm_ptr->context_id,
+                                                     comm_size, mpidi_ucc_dtype_to_str(ucc_rdt),
+                                                     root);
+        } else {
+            MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(gatherv, "comm %p, comm_id %u, comm_size %d"
+                                                     ", scount %zu, sdtype %s, rdtype %s, "
+                                                     ", root %d (me)",
+                                                     (void *) comm_ptr, comm_ptr->context_id,
+                                                     comm_size, scount,
+                                                     mpidi_ucc_dtype_to_str(ucc_sdt),
+                                                     mpidi_ucc_dtype_to_str(ucc_rdt), root);
+        }
+    } else {
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(gatherv, "comm %p, comm_id %u, comm_size %d"
+                                                 ", scount %zu, sdtype %s, root %d",
+                                                 (void *) comm_ptr, comm_ptr->context_id,
+                                                 comm_size, scount,
+                                                 mpidi_ucc_dtype_to_str(ucc_sdt), root);
+    }
+
+    MPIDI_COMMON_UCC_REQ_INIT(coll_req, req, coll, comm_ptr);
+    return UCC_OK;
+  fallback:
+    return UCC_ERR_NOT_SUPPORTED;
+}
+
+int MPIDI_common_ucc_gatherv(const void *sbuf, MPI_Aint scount, MPI_Datatype sdtype, void *rbuf,
+                             const MPI_Aint rcounts[], const MPI_Aint rdispls[],
+                             MPI_Datatype rdtype, int root, MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_coll_req_h req;
+    MPIDI_COMMON_UCC_CHECK_ENABLED(comm_ptr, gatherv);
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_TRY_TO_RUN(gatherv);
+    MPIDI_COMMON_UCC_CALL_AND_CHECK(mpidi_ucc_gatherv_init
+                                    (sbuf, scount, sdtype, rbuf, rcounts, rdispls, rdtype, root,
+                                     comm_ptr, &req, NULL));
+    MPIDI_COMMON_UCC_POST_AND_CHECK(req);
+    MPIDI_COMMON_UCC_WAIT_AND_CHECK(req);
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DONE_SUCCESS(gatherv);
+    return MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+  fallback:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_FALLBACK(gatherv);
+    return MPIDI_COMMON_UCC_RETVAL_FALLBACK;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DISABLED(gatherv);
+    goto fallback;
+}
+
+#endif /* MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC */

--- a/src/mpid/common/ucc/mpid_ucc_pre.h
+++ b/src/mpid/common/ucc/mpid_ucc_pre.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef _MPID_UCC_PRE_H_
+#define _MPID_UCC_PRE_H_
+
+#include <ucc/api/ucc.h>
+
+int MPIDI_common_ucc_enable(int verbose_level, const char *verbose_level_str, int debug_flag);
+int MPIDI_common_ucc_progress(int *made_progress);
+int MPIDI_common_ucc_comm_create_hook(MPIR_Comm * comm_ptr);
+int MPIDI_common_ucc_comm_destroy_hook(MPIR_Comm * comm_ptr);
+int MPIDI_common_ucc_barrier(MPIR_Comm * comm_ptr);
+int MPIDI_common_ucc_bcast(void *buf, MPI_Aint count, MPI_Datatype dtype, int root,
+                           MPIR_Comm * comm_ptr);
+int MPIDI_common_ucc_gather(const void *sbuf, MPI_Aint scount, MPI_Datatype sdtype, void *rbuf,
+                            MPI_Aint rcount, MPI_Datatype rdtype, int root, MPIR_Comm * comm_ptr);
+int MPIDI_common_ucc_gatherv(const void *sbuf, MPI_Aint scount, MPI_Datatype sdtype, void *rbuf,
+                             const MPI_Aint rcounts[], const MPI_Aint rdispls[],
+                             MPI_Datatype rdtype, int root, MPIR_Comm * comm_ptr);
+int MPIDI_common_ucc_scatter(const void *sbuf, MPI_Aint scount, MPI_Datatype sdtype, void *rbuf,
+                             MPI_Aint rcount, MPI_Datatype rdtype, int root, MPIR_Comm * comm_ptr);
+int MPIDI_common_ucc_scatterv(const void *sbuf, const MPI_Aint scounts[], const MPI_Aint rdispls[],
+                              MPI_Datatype sdtype, void *rbuf, MPI_Aint rcount, MPI_Datatype rdtype,
+                              int root, MPIR_Comm * comm_ptr);
+int MPIDI_common_ucc_reduce(const void *sbuf, void *rbuf, MPI_Aint count, MPI_Datatype dtype,
+                            MPI_Op op, int root, MPIR_Comm * comm_ptr);
+int MPIDI_common_ucc_reduce_scatter(const void *sbuf, void *rbuf, const MPI_Aint rcounts[],
+                                    MPI_Datatype dtype, MPI_Op op, MPIR_Comm * comm_ptr);
+int MPIDI_common_ucc_reduce_scatter_block(const void *sbuf, void *rbuf, MPI_Aint rcount,
+                                          MPI_Datatype dtype, MPI_Op op, MPIR_Comm * comm_ptr);
+int MPIDI_common_ucc_allgather(const void *sbuf, MPI_Aint scount, MPI_Datatype sdtype, void *rbuf,
+                               MPI_Aint rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr);
+int MPIDI_common_ucc_allgatherv(const void *sbuf, MPI_Aint scount, MPI_Datatype sdtype, void *rbuf,
+                                const MPI_Aint rcounts[], const MPI_Aint rdispls[],
+                                MPI_Datatype rdtype, MPIR_Comm * comm_ptr);
+int MPIDI_common_ucc_allreduce(const void *sbuf, void *rbuf, MPI_Aint count, MPI_Datatype dtype,
+                               MPI_Op op, MPIR_Comm * comm_ptr);
+int MPIDI_common_ucc_alltoall(const void *sbuf, MPI_Aint scount, MPI_Datatype sdtype, void *rbuf,
+                              MPI_Aint rcount, MPI_Datatype rdtype, MPIR_Comm * comm_ptr);
+int MPIDI_common_ucc_alltoallv(const void *sbuf, const MPI_Aint scounts[], const MPI_Aint sdispls[],
+                               MPI_Datatype sdtype, void *rbuf, const MPI_Aint rcounts[],
+                               const MPI_Aint rdispls[], MPI_Datatype rdtype, MPIR_Comm * comm_ptr);
+
+#define MPIDI_DEV_COMM_DECL_UCC MPIDI_common_ucc_comm_t ucc_priv;
+
+typedef struct {
+
+    int ucc_enabled;            /* flag indicating whether UCC should be initialized for this communicator (for future use) */
+    int ucc_initialized;        /* flag indicating whether UCC has been initialized successfully for this communicator */
+    ucc_team_h ucc_team;        /* handle for the UCC team created for this communicator */
+
+} MPIDI_common_ucc_comm_t;
+
+typedef enum {
+    MPIDI_COMMON_UCC_RETVAL_ERROR = -1,
+    MPIDI_COMMON_UCC_RETVAL_SUCCESS = 0,
+    MPIDI_COMMON_UCC_RETVAL_FALLBACK = 1,
+} MPIDI_common_ucc_error_t;
+
+/* Macro for ADI3 devices to encapsulate calls to the UCC wrappers for the
+ * collective functions. Use is optional, but improves consistency due to
+ * the differing return semantics of the UCC wrappers in comparison to the
+ * usual error handling scheme for covering also the fallback case.
+ * - Caller defines the labels `fn_exit`, `fn_fail`, and `int mpi_errno`.
+ * - On success: `_success_stmt` is executed, then jump to `fn_exit`.
+ * - On fatal error: `_error_stmt` is executed, error "ucc_collop_failed"
+ *   is pushed, then jump to `fn_fail`.
+ * - Fallback case: `_fallback_stmt` is executed and macro falls through
+ *   for alternative handling of the collective.
+ * - Otherwise: Same as fallback case, but w/o executing `_fallback_stmt`.
+ * The statement parameters can be used for counting the different cases,
+ * for example. If not needed, `(void)0` can be passed instead.
+ */
+#define MPIDI_COMMOM_UCC_CHECK_AND_FALLBACK(_collop_fn,                 \
+                                            _success_stmt,              \
+                                            _error_stmt,                \
+                                            _fallback_stmt)             \
+    do {                                                                \
+        MPIDI_common_ucc_error_t mpidi_ucc_err = _collop_fn;            \
+        switch (mpidi_ucc_err) {                                        \
+        case MPIDI_COMMON_UCC_RETVAL_SUCCESS:                           \
+            _success_stmt;                                              \
+            mpi_errno = MPI_SUCCESS;                                    \
+            goto fn_exit;                                               \
+        case MPIDI_COMMON_UCC_RETVAL_ERROR:                             \
+            _error_stmt;                                                \
+            MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER,               \
+                                "**ucc_collop_failed");                 \
+        case MPIDI_COMMON_UCC_RETVAL_FALLBACK:                          \
+            _fallback_stmt;                                             \
+            break;                                                      \
+        }                                                               \
+    } while (0)
+
+#endif /*_MPID_UCC_PRE_H_*/

--- a/src/mpid/common/ucc/mpid_ucc_reduce.c
+++ b/src/mpid/common/ucc/mpid_ucc_reduce.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpid_ucc.h"
+#include "mpid_ucc_collops.h"
+#include "mpid_ucc_dtypes.h"
+
+#ifdef MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+
+static inline ucc_status_t mpidi_ucc_reduce_init(const void *sbuf, void *rbuf, MPI_Aint count,
+                                                 MPI_Datatype dtype, MPI_Op op, int root,
+                                                 MPIR_Comm * comm_ptr, ucc_coll_req_h * req,
+                                                 MPIR_Request * coll_req)
+{
+
+    bool is_inplace = (sbuf == MPI_IN_PLACE);
+    int comm_size = MPIR_Comm_size(comm_ptr);
+
+    ucc_datatype_t ucc_dt = mpidi_mpi_dtype_to_ucc_dtype(dtype);
+    ucc_reduction_op_t ucc_op = mpidi_mpi_op_to_ucc_reduction_op(op);
+
+    if (ucc_dt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED) {
+        MPIDI_COMMON_UCC_VERBOSE_DTYPE_UNSUPPORTED(reduce);
+        goto fallback;
+    }
+
+    if (ucc_op == MPIDI_COMMON_UCC_REDUCTION_OP_UNSUPPORTED) {
+        MPIDI_COMMON_UCC_VERBOSE_REDUCTION_OP_UNSUPPORTED(reduce);
+        goto fallback;
+    }
+
+    ucc_coll_args_t coll = {
+        .mask = 0,
+        .flags = 0,
+        .coll_type = UCC_COLL_TYPE_REDUCE,
+        .root = root,
+        .src.info = {
+                     .buffer = (void *) sbuf,
+                     .count = count,
+                     .datatype = ucc_dt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+        ,
+        .dst.info = {
+                     .buffer = rbuf,
+                     .count = count,
+                     .datatype = ucc_dt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     },
+        .op = ucc_op,
+    };
+
+    if (is_inplace) {
+
+        coll.mask = UCC_COLL_ARGS_FIELD_FLAGS;
+        coll.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
+
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(reduce, "comm %p, comm_id %u, comm_size %d"
+                                                 ", INPLACE, count %zu, dtype %s, op %s, root %d",
+                                                 (void *) comm_ptr, comm_ptr->context_id,
+                                                 comm_size, count, mpidi_ucc_dtype_to_str(ucc_dt),
+                                                 mpidi_ucc_reduction_op_to_str(ucc_op), root);
+    } else {
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(reduce, "comm %p, comm_id %u, comm_size %d"
+                                                 ", count %zu, dtype %s, op %s, root %d",
+                                                 (void *) comm_ptr, comm_ptr->context_id,
+                                                 comm_size, count, mpidi_ucc_dtype_to_str(ucc_dt),
+                                                 mpidi_ucc_reduction_op_to_str(ucc_op), root);
+    }
+
+    MPIDI_COMMON_UCC_REQ_INIT(coll_req, req, coll, comm_ptr);
+    return UCC_OK;
+  fallback:
+    return UCC_ERR_NOT_SUPPORTED;
+}
+
+int MPIDI_common_ucc_reduce(const void *sbuf, void *rbuf, MPI_Aint count,
+                            MPI_Datatype dtype, MPI_Op op, int root, MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_coll_req_h req;
+
+    MPIDI_COMMON_UCC_CHECK_ENABLED(comm_ptr, reduce);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_TRY_TO_RUN(reduce);
+
+    MPIDI_COMMON_UCC_CALL_AND_CHECK(mpidi_ucc_reduce_init
+                                    (sbuf, rbuf, count, dtype, op, root, comm_ptr, &req, NULL));
+    MPIDI_COMMON_UCC_POST_AND_CHECK(req);
+    MPIDI_COMMON_UCC_WAIT_AND_CHECK(req);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DONE_SUCCESS(reduce);
+
+    return MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+
+  fallback:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_FALLBACK(reduce);
+    return MPIDI_COMMON_UCC_RETVAL_FALLBACK;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DISABLED(reduce);
+    goto fallback;
+}
+
+#endif /* MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC */

--- a/src/mpid/common/ucc/mpid_ucc_reduce_scatter.c
+++ b/src/mpid/common/ucc/mpid_ucc_reduce_scatter.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpid_ucc.h"
+#include "mpid_ucc_collops.h"
+#include "mpid_ucc_dtypes.h"
+
+#ifdef MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+
+static inline ucc_status_t mpidi_ucc_reduce_scatter_init(const void *sbuf, void *rbuf,
+                                                         const MPI_Aint rcounts[],
+                                                         MPI_Datatype dtype, MPI_Op op,
+                                                         MPIR_Comm * comm_ptr, ucc_coll_req_h * req,
+                                                         MPIR_Request * coll_req)
+{
+
+    bool is_inplace = (sbuf == MPI_IN_PLACE);
+    int comm_size = MPIR_Comm_size(comm_ptr);
+    bool is_large_counts = (sizeof(MPI_Aint) * 8 == 64);
+    size_t total_count = 0;
+
+    ucc_datatype_t ucc_dt = mpidi_mpi_dtype_to_ucc_dtype(dtype);
+    ucc_reduction_op_t ucc_op = mpidi_mpi_op_to_ucc_reduction_op(op);
+
+    uint64_t flags = 0;
+
+    if (is_inplace) {
+        MPIDI_COMMON_UCC_VERBOSE_INPLACE_UNSUPPORTED(reduce_scatter);
+        goto fallback;
+    }
+
+    if (ucc_dt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED) {
+        MPIDI_COMMON_UCC_VERBOSE_DTYPE_UNSUPPORTED(reduce_scatter);
+        goto fallback;
+    }
+
+    if (ucc_op == MPIDI_COMMON_UCC_REDUCTION_OP_UNSUPPORTED) {
+        MPIDI_COMMON_UCC_VERBOSE_REDUCTION_OP_UNSUPPORTED(reduce_scatter);
+        goto fallback;
+    }
+
+    for (int i = 0; i < comm_size; i++) {
+        total_count += rcounts[i];
+    }
+
+    if (is_large_counts) {
+        flags |= UCC_COLL_ARGS_FLAG_COUNT_64BIT;
+    }
+
+    ucc_coll_args_t coll = {
+        .mask = flags ? UCC_COLL_ARGS_FIELD_FLAGS : 0,
+        .flags = flags,
+        .coll_type = UCC_COLL_TYPE_REDUCE_SCATTERV,
+        .src.info = {
+                     .buffer = (void *) sbuf,
+                     .count = total_count,
+                     .datatype = ucc_dt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+        ,
+        .dst.info_v = {
+                       .buffer = rbuf,
+                       .counts = (ucc_count_t *) rcounts,
+                       .datatype = ucc_dt,
+                       .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                       },
+        .op = ucc_op,
+    };
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(reduce_scatter, "comm %p, comm_id %u, comm_size %d"
+                                             ", total_count %zu, dtype %s, op %s",
+                                             (void *) comm_ptr, comm_ptr->context_id,
+                                             comm_size, total_count, mpidi_ucc_dtype_to_str(ucc_dt),
+                                             mpidi_ucc_reduction_op_to_str(ucc_op));
+
+    MPIDI_COMMON_UCC_REQ_INIT(coll_req, req, coll, comm_ptr);
+    return UCC_OK;
+  fallback:
+    return UCC_ERR_NOT_SUPPORTED;
+}
+
+int MPIDI_common_ucc_reduce_scatter(const void *sbuf, void *rbuf, const MPI_Aint rcounts[],
+                                    MPI_Datatype dtype, MPI_Op op, MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_coll_req_h req;
+
+    MPIDI_COMMON_UCC_CHECK_ENABLED(comm_ptr, reduce_scatter);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_TRY_TO_RUN(reduce_scatter);
+
+    MPIDI_COMMON_UCC_CALL_AND_CHECK(mpidi_ucc_reduce_scatter_init
+                                    (sbuf, rbuf, rcounts, dtype, op, comm_ptr, &req, NULL));
+    MPIDI_COMMON_UCC_POST_AND_CHECK(req);
+    MPIDI_COMMON_UCC_WAIT_AND_CHECK(req);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DONE_SUCCESS(reduce_scatter);
+
+    return MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+
+  fallback:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_FALLBACK(reduce_scatter);
+    return MPIDI_COMMON_UCC_RETVAL_FALLBACK;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DISABLED(reduce_scatter);
+    goto fallback;
+}
+
+#endif /* MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC */

--- a/src/mpid/common/ucc/mpid_ucc_reduce_scatter_block.c
+++ b/src/mpid/common/ucc/mpid_ucc_reduce_scatter_block.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpid_ucc.h"
+#include "mpid_ucc_collops.h"
+#include "mpid_ucc_dtypes.h"
+
+#ifdef MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+
+static inline ucc_status_t mpidi_ucc_reduce_scatter_block_init(const void *sbuf, void *rbuf,
+                                                               MPI_Aint rcount, MPI_Datatype dtype,
+                                                               MPI_Op op, MPIR_Comm * comm_ptr,
+                                                               ucc_coll_req_h * req,
+                                                               MPIR_Request * coll_req)
+{
+
+    bool is_inplace = (sbuf == MPI_IN_PLACE);
+    int comm_size = MPIR_Comm_size(comm_ptr);
+
+    ucc_datatype_t ucc_dt = mpidi_mpi_dtype_to_ucc_dtype(dtype);
+    ucc_reduction_op_t ucc_op = mpidi_mpi_op_to_ucc_reduction_op(op);
+
+    if (is_inplace) {
+        MPIDI_COMMON_UCC_VERBOSE_INPLACE_UNSUPPORTED(reduce_scatter_block);
+        goto fallback;
+    }
+
+    if (ucc_dt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED) {
+        MPIDI_COMMON_UCC_VERBOSE_DTYPE_UNSUPPORTED(reduce_scatter_block);
+        goto fallback;
+    }
+
+    if (ucc_op == MPIDI_COMMON_UCC_REDUCTION_OP_UNSUPPORTED) {
+        MPIDI_COMMON_UCC_VERBOSE_REDUCTION_OP_UNSUPPORTED(reduce_scatter_block);
+        goto fallback;
+    }
+
+    ucc_coll_args_t coll = {
+        .mask = 0,
+        .flags = 0,
+        .coll_type = UCC_COLL_TYPE_REDUCE_SCATTER,
+        .src.info = {
+                     .buffer = (void *) sbuf,
+                     .count = rcount * comm_size,
+                     .datatype = ucc_dt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+        ,
+        .dst.info = {
+                     .buffer = rbuf,
+                     .count = rcount,
+                     .datatype = ucc_dt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     },
+        .op = ucc_op,
+    };
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(reduce_scatter_block,
+                                             "comm %p, comm_id %u, comm_size %d"
+                                             ", rcount %zu, dtype %s, op %s", (void *) comm_ptr,
+                                             comm_ptr->context_id, comm_size, rcount,
+                                             mpidi_ucc_dtype_to_str(ucc_dt),
+                                             mpidi_ucc_reduction_op_to_str(ucc_op));
+
+    MPIDI_COMMON_UCC_REQ_INIT(coll_req, req, coll, comm_ptr);
+    return UCC_OK;
+  fallback:
+    return UCC_ERR_NOT_SUPPORTED;
+}
+
+int MPIDI_common_ucc_reduce_scatter_block(const void *sbuf, void *rbuf, MPI_Aint rcount,
+                                          MPI_Datatype dtype, MPI_Op op, MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_coll_req_h req;
+
+    MPIDI_COMMON_UCC_CHECK_ENABLED(comm_ptr, reduce_scatter_block);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_TRY_TO_RUN(reduce_scatter_block);
+
+    MPIDI_COMMON_UCC_CALL_AND_CHECK(mpidi_ucc_reduce_scatter_block_init
+                                    (sbuf, rbuf, rcount, dtype, op, comm_ptr, &req, NULL));
+    MPIDI_COMMON_UCC_POST_AND_CHECK(req);
+    MPIDI_COMMON_UCC_WAIT_AND_CHECK(req);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DONE_SUCCESS(reduce_scatter_block);
+
+    return MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+
+  fallback:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_FALLBACK(reduce_scatter_block);
+    return MPIDI_COMMON_UCC_RETVAL_FALLBACK;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DISABLED(reduce_scatter_block);
+    goto fallback;
+}
+
+#endif /* MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC */

--- a/src/mpid/common/ucc/mpid_ucc_scatter.c
+++ b/src/mpid/common/ucc/mpid_ucc_scatter.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpid_ucc.h"
+#include "mpid_ucc_collops.h"
+#include "mpid_ucc_dtypes.h"
+
+#ifdef MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+
+static inline ucc_status_t mpidi_ucc_scatter_init(const void *sbuf, MPI_Aint scount,
+                                                  MPI_Datatype sdtype, void *rbuf, MPI_Aint rcount,
+                                                  MPI_Datatype rdtype, int root,
+                                                  MPIR_Comm * comm_ptr, ucc_coll_req_h * req,
+                                                  MPIR_Request * coll_req)
+{
+
+    bool is_inplace = (rbuf == MPI_IN_PLACE);
+    int comm_rank = MPIR_Comm_rank(comm_ptr);
+    int comm_size = MPIR_Comm_size(comm_ptr);
+
+    ucc_datatype_t ucc_sdt = MPIDI_COMMON_UCC_DTYPE_NULL;
+    ucc_datatype_t ucc_rdt = MPIDI_COMMON_UCC_DTYPE_NULL;
+
+    if (comm_rank == root) {
+        ucc_sdt = mpidi_mpi_dtype_to_ucc_dtype(sdtype);
+        if (!is_inplace) {
+            ucc_rdt = mpidi_mpi_dtype_to_ucc_dtype(rdtype);
+        }
+    } else {
+        ucc_rdt = mpidi_mpi_dtype_to_ucc_dtype(rdtype);
+    }
+
+    if ((ucc_sdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED) ||
+        (ucc_rdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED)) {
+        MPIDI_COMMON_UCC_VERBOSE_DTYPE_UNSUPPORTED(scatter);
+        goto fallback;
+    }
+
+    ucc_coll_args_t coll = {
+        .mask = 0,
+        .flags = 0,
+        .coll_type = UCC_COLL_TYPE_SCATTER,
+        .root = root,
+        .src.info = {
+                     .buffer = (void *) sbuf,
+                     .count = scount * comm_size,
+                     .datatype = ucc_sdt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+        ,
+        .dst.info = {
+                     .buffer = rbuf,
+                     .count = rcount,
+                     .datatype = ucc_rdt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+    };
+
+    if (comm_rank == root) {
+
+        if (is_inplace) {
+
+            coll.mask = UCC_COLL_ARGS_FIELD_FLAGS;
+            coll.flags = UCC_COLL_ARGS_FLAG_IN_PLACE;
+
+            MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(scatter, "comm %p, comm_id %u, comm_size %d"
+                                                     ", INPLACE, rcount %zu, rdtype %s, root %d (me)",
+                                                     (void *) comm_ptr, comm_ptr->context_id,
+                                                     comm_size, rcount,
+                                                     mpidi_ucc_dtype_to_str(ucc_rdt), root);
+        } else {
+            MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(scatter, "comm %p, comm_id %u, comm_size %d"
+                                                     ", scount %zu, sdtype %s, rcount %zu, rdtype %s"
+                                                     ", root %d (me)",
+                                                     (void *) comm_ptr, comm_ptr->context_id,
+                                                     comm_size, scount,
+                                                     mpidi_ucc_dtype_to_str(ucc_sdt), rcount,
+                                                     mpidi_ucc_dtype_to_str(ucc_rdt), root);
+        }
+    } else {
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(scatter, "comm %p, comm_id %u, comm_size %d"
+                                                 ", rcount %zu, rdtype %s, root %d",
+                                                 (void *) comm_ptr, comm_ptr->context_id,
+                                                 comm_size, rcount,
+                                                 mpidi_ucc_dtype_to_str(ucc_rdt), root);
+    }
+
+    MPIDI_COMMON_UCC_REQ_INIT(coll_req, req, coll, comm_ptr);
+    return UCC_OK;
+  fallback:
+    return UCC_ERR_NOT_SUPPORTED;
+}
+
+int MPIDI_common_ucc_scatter(const void *sbuf, MPI_Aint scount, MPI_Datatype sdtype, void *rbuf,
+                             MPI_Aint rcount, MPI_Datatype rdtype, int root, MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_coll_req_h req;
+
+    MPIDI_COMMON_UCC_CHECK_ENABLED(comm_ptr, scatter);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_TRY_TO_RUN(scatter);
+
+    MPIDI_COMMON_UCC_CALL_AND_CHECK(mpidi_ucc_scatter_init
+                                    (sbuf, scount, sdtype, rbuf, rcount, rdtype, root,
+                                     comm_ptr, &req, NULL));
+    MPIDI_COMMON_UCC_POST_AND_CHECK(req);
+    MPIDI_COMMON_UCC_WAIT_AND_CHECK(req);
+
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DONE_SUCCESS(scatter);
+
+    return MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+
+  fallback:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_FALLBACK(scatter);
+    return MPIDI_COMMON_UCC_RETVAL_FALLBACK;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DISABLED(scatter);
+    goto fallback;
+}
+
+#endif /* MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC */

--- a/src/mpid/common/ucc/mpid_ucc_scatterv.c
+++ b/src/mpid/common/ucc/mpid_ucc_scatterv.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "mpid_ucc.h"
+#include "mpid_ucc_collops.h"
+#include "mpid_ucc_dtypes.h"
+
+#ifdef MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC
+
+static inline ucc_status_t mpidi_ucc_scatterv_init(const void *sbuf, const MPI_Aint scounts[],
+                                                   const MPI_Aint sdispls[], MPI_Datatype sdtype,
+                                                   void *rbuf, MPI_Aint rcount, MPI_Datatype rdtype,
+                                                   int root, MPIR_Comm * comm_ptr,
+                                                   ucc_coll_req_h * req, MPIR_Request * coll_req)
+{
+
+    bool is_inplace = (rbuf == MPI_IN_PLACE);
+    int comm_rank = MPIR_Comm_rank(comm_ptr);
+    int comm_size = MPIR_Comm_size(comm_ptr);
+    bool is_large_counts = (sizeof(MPI_Aint) * 8 == 64);
+
+    ucc_datatype_t ucc_sdt = MPIDI_COMMON_UCC_DTYPE_NULL;
+    ucc_datatype_t ucc_rdt = MPIDI_COMMON_UCC_DTYPE_NULL;
+
+    uint64_t flags = 0;
+
+    if (comm_rank == root) {
+        ucc_sdt = mpidi_mpi_dtype_to_ucc_dtype(sdtype);
+        if (!is_inplace) {
+            ucc_rdt = mpidi_mpi_dtype_to_ucc_dtype(rdtype);
+        }
+    } else {
+        ucc_rdt = mpidi_mpi_dtype_to_ucc_dtype(rdtype);
+    }
+
+    if ((ucc_sdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED) ||
+        (ucc_rdt == MPIDI_COMMON_UCC_DTYPE_UNSUPPORTED)) {
+        MPIDI_COMMON_UCC_VERBOSE_DTYPE_UNSUPPORTED(scatterv);
+        goto fallback;
+    }
+
+    if (is_inplace) {
+        flags |= UCC_COLL_ARGS_FLAG_IN_PLACE;
+    }
+
+    if (is_large_counts) {
+        flags |= UCC_COLL_ARGS_FLAG_COUNT_64BIT;
+        flags |= UCC_COLL_ARGS_FLAG_DISPLACEMENTS_64BIT;
+    }
+
+    ucc_coll_args_t coll = {
+        .mask = flags ? UCC_COLL_ARGS_FIELD_FLAGS : 0,
+        .flags = flags,
+        .coll_type = UCC_COLL_TYPE_SCATTERV,
+        .root = root,
+        .src.info_v = {
+                       .buffer = (void *) sbuf,
+                       .counts = (ucc_count_t *) scounts,
+                       .displacements = (ucc_aint_t *) sdispls,
+                       .datatype = ucc_sdt,
+                       .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                       }
+        ,
+        .dst.info = {
+                     .buffer = rbuf,
+                     .count = rcount,
+                     .datatype = ucc_rdt,
+                     .mem_type = UCC_MEMORY_TYPE_UNKNOWN,
+                     }
+    };
+
+    if (comm_rank == root) {
+        if (is_inplace) {
+            MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(scatterv, "comm %p, comm_id %u, comm_size %d"
+                                                     ", INPLACE, sdtype %s, root %d (me)",
+                                                     (void *) comm_ptr, comm_ptr->context_id,
+                                                     comm_size, mpidi_ucc_dtype_to_str(ucc_sdt),
+                                                     root);
+        } else {
+            MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(scatterv, "comm %p, comm_id %u, comm_size %d"
+                                                     ", sdtype %s, rcount %zu, rdtype %s"
+                                                     ", root %d (me)",
+                                                     (void *) comm_ptr, comm_ptr->context_id,
+                                                     comm_size,
+                                                     mpidi_ucc_dtype_to_str(ucc_sdt), rcount,
+                                                     mpidi_ucc_dtype_to_str(ucc_rdt), root);
+        }
+    } else {
+        MPIDI_COMMON_UCC_VERBOSE_COLLOP_POST_REQ(scatterv, "comm %p, comm_id %u, comm_size %d"
+                                                 ", rcount %zu, rdtype %s, root %d",
+                                                 (void *) comm_ptr, comm_ptr->context_id,
+                                                 comm_size, rcount,
+                                                 mpidi_ucc_dtype_to_str(ucc_rdt), root);
+    }
+
+    MPIDI_COMMON_UCC_REQ_INIT(coll_req, req, coll, comm_ptr);
+    return UCC_OK;
+  fallback:
+    return UCC_ERR_NOT_SUPPORTED;
+}
+
+int MPIDI_common_ucc_scatterv(const void *sbuf, const MPI_Aint scounts[], const MPI_Aint sdispls[],
+                              MPI_Datatype sdtype, void *rbuf, MPI_Aint rcount, MPI_Datatype rdtype,
+                              int root, MPIR_Comm * comm_ptr)
+{
+    int mpidi_ucc_err = MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+    ucc_coll_req_h req;
+    MPIDI_COMMON_UCC_CHECK_ENABLED(comm_ptr, scatterv);
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_TRY_TO_RUN(scatterv);
+    MPIDI_COMMON_UCC_CALL_AND_CHECK(mpidi_ucc_scatterv_init
+                                    (sbuf, scounts, sdispls, sdtype, rbuf,
+                                     rcount, rdtype, root, comm_ptr, &req, NULL));
+    MPIDI_COMMON_UCC_POST_AND_CHECK(req);
+    MPIDI_COMMON_UCC_WAIT_AND_CHECK(req);
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DONE_SUCCESS(scatterv);
+    return MPIDI_COMMON_UCC_RETVAL_SUCCESS;
+  fallback:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_FALLBACK(scatterv);
+    return MPIDI_COMMON_UCC_RETVAL_FALLBACK;
+  disabled:
+    MPIDI_COMMON_UCC_VERBOSE_COLLOP_DISABLED(scatterv);
+    goto fallback;
+}
+
+#endif /* MPIDI_DEV_IMPLEMENTS_COMM_DECL_UCC */

--- a/src/mpid/common/ucc/subconfigure.m4
+++ b/src/mpid/common/ucc/subconfigure.m4
@@ -1,0 +1,52 @@
+[#] start of __file__
+
+AC_DEFUN([PAC_SUBCFG_PREREQ_]PAC_SUBCFG_AUTO_SUFFIX,[
+    if test "${with_ucc}" = "no" ; then
+        pac_have_ucc=no;
+    else
+        PAC_CHECK_HEADER_LIB_OPTIONAL(ucc,[ucc/api/ucc.h],[ucc],[ucc_init_version])
+        if test "$pac_have_ucc" = "yes" ; then
+            AC_DEFINE([HAVE_UCC],1,[Define if building ucc])
+        fi
+    fi
+    AM_CONDITIONAL([BUILD_UCC],[test "$pac_have_ucc" = "yes"])
+])dnl end PREREQ
+
+AC_DEFUN([PAC_SUBCFG_BODY_]PAC_SUBCFG_AUTO_SUFFIX,[
+
+# Check if CUDA awareness is enabled, and if so, whether UCC is also CUDA-aware
+AS_IF([test -n "${GPU_SUPPORT}" -a "x${GPU_SUPPORT}" = "xCUDA" && test -n "${with_ucc}" -a "x${with_ucc}" != "xno"],
+[
+    AC_PATH_PROG([ucc_info_path], [ucc_info], [no], [${with_ucc}/bin])
+    AS_IF([test "x${ucc_info_path}" != "xno"],
+    [
+        AC_MSG_CHECKING([if UCC is CUDA-aware (HAVE_CUDA)])
+        ucc_info_defs=$(${ucc_info_path} -b)
+        AC_LANG_PUSH([C])
+        AC_COMPILE_IFELSE(  [AC_LANG_PROGRAM(
+                                    [${ucc_info_defs}],
+                                    [[
+                                        int main() {
+                                          #if !defined(HAVE_CUDA) || HAVE_CUDA != 1
+                                          #error macro not defined
+                                          #endif
+                                          return 0;
+                                        }
+                                    ]]
+                                    )
+                            ],[
+                                AC_MSG_RESULT(yes)
+                            ],[
+                                AC_MSG_RESULT(no)
+                                AC_MSG_ERROR([CUDA support is requested but no CUDA-aware UCC could be found.])
+                            ]
+                         )
+        AC_LANG_POP([C])
+    ],[
+        AC_MSG_WARN([ucc_info not found. Cannot check for CUDA awareness of UCC.])
+    ])
+])
+
+])dnl end _BODY
+
+[#] end of __file__


### PR DESCRIPTION
## Pull Request Description

This addresses [Issue #7305](https://github.com/pmodels/mpich/issues/7305).

The two commits in this pull request add support for [Unified Collective Communication (UCC)](https://ucfconsortium.org/projects/ucc/) and its [implementation](https://github.com/openucx/ucc) to MPICH and its CH4:UCX device.
The approach followed for this integration is inspired by the existing support for HCOLL and the UCC support in Open MPI.

The actual UCC support is provided by wrapper functions that are added to `mpid/common/ucc` with the first commit (and these wrapper functions become thus available to all ADI3 devices).
The invocations of these wrapper functions are then integrated into the UCX netmod of the CH4 device with the second commit.

Please note that this integration has already been merged into [ParaStation MPI](https://github.com/carsten-clauss/psmpi) as an MPICH derivative, and that there, in addition to CH4, the ParaStation-native PSP device also makes use of these wrappers.

Please also note that currently only the following *blocking* collectives are supported:
     - MPI_Barrier
     - MPI_Bcast
     - MPI_Gather
     - MPI_Gatherv
     - MPI_Scatter
     - MPI_Scatterv
     - MPI_Reduce
     - MPI_Reduce_scatter
     - MPI_Reduce_scatter_block
     - MPI_Allgather
     - MPI_Allgatherv
     - MPI_Allreduce
     - MPI_Alltoall
     - MPI_Alltoallv

However, support for non-blocking operations should be quite straight-forward to add in the future. The wrappers added so far can serve as a template for this, as can their CH4 integration for supporting other ADI3 devices.

Usage:
* make sure that UCC and CH4 are using the same UCX installation
* configure MPICH with UCC support via `--with-ucc=[path]`
* enable UCC support at runtime with `MPIR_CVAR_CH4_UCC_ENABLE=1`
* check for success messages when setting `MPIR_CVAR_CH4_UCC_VERBOSITY_LEVEL=collop!`

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
