### PR TITLE
test/runtests: add MPITEST_IGNORE_OUTPUT

### DIFF
--- a/test/mpi/runtests
+++ b/test/mpi/runtests
@@ -100,6 +100,7 @@ $g_opt{defaultTimeLimitMultiplier} = 1.0; # default multiplier for timeout limit
 $g_opt{verbose} = 0;            # Set to true to get more output
 $g_opt{debug} = 1;
 $g_opt{showprogress} = 0;       # Set to true to get a "." with each run program.
+$g_opt{ignore_output} = 0;      # Set to allow output to stdout/stderr without triggering error
 $g_opt{newline} = "\r\n";       # Set to \r\n for Windows-friendly, \n for Unix only
 $g_opt{run_mpitests} = 1;       # Set to true to functional tests using run_mpitests
                                 # (i.e., run tests inside a single MPI_Init/Finalize)
@@ -178,6 +179,10 @@ if (defined($ENV{"MPITEST_TIMEOUT"})) {
  
 if (defined($ENV{"MPITEST_TIMEOUT_MULTIPLIER"})) {
     $g_opt{defaultTimeLimitMultiplier} = $ENV{"MPITEST_TIMEOUT_MULTIPLIER"};
+}
+
+if (defined($ENV{"MPITEST_IGNORE_OUTPUT"})) {
+    $g_opt{ignore_output} = $ENV{"MPITEST_IGNORE_OUTPUT"};
 }
 
 for my $key ("memory_total", "memory_multiplier", "cleanup") {
@@ -1232,7 +1237,7 @@ sub check_result {
         elsif (/psm3_sockets_tcp_recvhdrq_progress: First PKT received is not PSM pkt./) {
             # skip
         }
-        else {
+        elsif (!$g_opt{ignore_output}) {
             $stray_output++;
         }
     }


### PR DESCRIPTION
## Pull Request Description

Set environment variable MPITEST_IGNORE_OUTPUT if we want to enable verbose mode such as FI_LOG_LEVEL and prevent unexpected output triggering test failures. The tests will rely on "No Errors" output and exit status for pass/failure.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
