### PR TITLE
autogen: Quote path variables that may contain contains spaces

### DIFF
--- a/test/mpi/autogen.sh
+++ b/test/mpi/autogen.sh
@@ -63,12 +63,12 @@ check_copy() {
 }
 
 generate_benchmarks() {
-    MYDEF_BOOT=$PWD/../../modules/mydef_boot
-    if test -d $MYDEF_BOOT/bin ; then
+    MYDEF_BOOT="$PWD/../../modules/mydef_boot"
+    if test -d "$MYDEF_BOOT/bin" ; then
         echo "Generating benchmark tests"
-        export PATH=$MYDEF_BOOT/bin:$PATH
-        export PERL5LIB=$MYDEF_BOOT/lib/perl5
-        export MYDEFLIB=$MYDEF_BOOT/lib/MyDef
+        export PATH="$MYDEF_BOOT/bin:$PATH"
+        export PERL5LIB="$MYDEF_BOOT/lib/perl5"
+        export MYDEFLIB="$MYDEF_BOOT/lib/MyDef"
         (cd bench && ./autogen.sh)
     fi
 }


### PR DESCRIPTION
## Pull Request Description

File paths may include directories with spaces in their names. Make sure
to quote shell variables to avoid issues. Fixes https://github.com/pmodels/mpich/issues/7581.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
