### PR TITLE
ch4/shm: add leading slash in posix shm name

### DIFF
--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -276,9 +276,9 @@ int MPIDI_POSIX_comm_bootstrap(MPIR_Comm * comm)
         unsigned world_id = MPIR_Process.world_id;
         int node_id = MPIR_Process.node_map[MPIR_Process.rank];
         snprintf(MPIDI_POSIX_global.shm_name, sizeof(MPIDI_POSIX_global.shm_name),
-                 "mpich_shm_%x_%d", world_id, node_id);
+                 "/mpich_shm_%x_%d", world_id, node_id);
         snprintf(MPIDI_POSIX_global.shm_vci_name, sizeof(MPIDI_POSIX_global.shm_vci_name),
-                 "mpich_vci_%x_%d", world_id, node_id);
+                 "/mpich_vci_%x_%d", world_id, node_id);
 
         bool is_root;
         slab = MPL_initshm_open(MPIDI_POSIX_global.shm_name, slab_size, &is_root);


### PR DESCRIPTION
## Pull Request Description
The name argument of the shm_open() function require leading slash for portability. Although implementations (such as linux) may work with missing leading slash, FreeBSD will not.

## Reference

https://man7.org/linux/man-pages/man3/shm_open.3.html
> The operation of shm_open() is analogous to that of [open(2)](https://man7.org/linux/man-pages/man2/open.2.html).  name
       specifies the shared memory object to be created or opened.  For
       portable use, a shared memory object should be identified by a
       name of the form /somename; that is, a null-terminated string of
       up to NAME_MAX (i.e., 255) characters consisting of an initial
       slash, followed by one or more characters, none of which are
       slashes.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
