### PR TITLE
autogen: patch libtool for nagfor

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -569,6 +569,7 @@ autoreconf_amdir() {
         _patch_successful=no
 
         _patch_libtool $_dir/confdb/ltmain.sh  intel-compiler.patch
+        _patch_libtool $_dir/confdb/ltmain.sh  nagfor.patch
         _patch_libtool $_dir/confdb/libtool.m4 sys_lib_dlsearch_path_spec.patch
         _patch_libtool $_dir/confdb/libtool.m4 big-sur.patch
         _patch_libtool $_dir/confdb/libtool.m4 hpc-sdk.patch

--- a/maint/patches/optional/confdb/nagfor.patch
+++ b/maint/patches/optional/confdb/nagfor.patch
@@ -1,0 +1,15 @@
+--- confdb/ltmain.sh	2025-09-23 13:54:31.782898806 -0500
++++ confdb/ltmain.sh.new	2025-09-23 17:06:28.926502645 -0500
+@@ -7991,7 +7991,11 @@
+ 	      func_fatal_error "cannot find name of link library for '$lib'"
+ 	    fi
+ 	    # It is a libtool convenience library, so add in its objects.
+-	    func_append convenience " $ladir/$objdir/$old_library"
++            if test "$wl" = "-Wl,-Wl,," ; then
++                func_append convenience " -Wl,$ladir/$objdir/$old_library"
++            else
++                func_append convenience " $ladir/$objdir/$old_library"
++            fi
+ 	    func_append old_convenience " $ladir/$objdir/$old_library"
+ 	    tmp_libs=
+ 	    for deplib in $dependency_libs; do


### PR DESCRIPTION

## Pull Request Description
When nagfor is used as linker, it will pass to gcc, and then gcc will pass to ld. Thus, ld options are passed with -Wl,-Wl,, prefix. The ld options to build so library from convenience library is -
```
    --whole-archive convenience-libs --no-whole-archive
```
However, due to the double-pass, nagfor need pass options like -
```
    -Wl,-Wl,,--whole-archive -Wl,convenience-libs -Wl,-Wl,,--no-whole-archive
```
In particular, the list of convenience-libs need be prefixed with -Wl, in order to be passed to gcc in the correct order.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
