### PR TITLE
datatype: add `MPI_LONG_DOUBLE` as a valid match

### DIFF
--- a/src/mpi/datatype/datatype_impl.c
+++ b/src/mpi/datatype/datatype_impl.c
@@ -311,13 +311,16 @@ int MPIR_Type_match_size_impl(int typeclass, int size, MPI_Datatype * datatype)
      * not available. We test for that case separately.  We also
      * prefer the Fortran types to the C type, if they are available */
     static MPI_Datatype real_types[] = {
-        MPI_REAL2, MPI_REAL4, MPI_REAL8, MPI_REAL16, MPI_LONG_DOUBLE,
+        MPI_REAL2, MPI_REAL4, MPI_REAL8, MPI_REAL16,
+        MPI_FLOAT, MPI_DOUBLE, MPI_LONG_DOUBLE,
     };
     static MPI_Datatype int_types[] = {
         MPI_INTEGER1, MPI_INTEGER2, MPI_INTEGER4, MPI_INTEGER8, MPI_INTEGER16,
+        MPI_CHAR, MPI_SHORT, MPI_INT, MPI_LONG, MPI_LONG_LONG,
     };
     static MPI_Datatype complex_types[] = {
         MPI_COMPLEX4, MPI_COMPLEX8, MPI_COMPLEX16, MPI_COMPLEX32,
+        MPI_C_FLOAT_COMPLEX, MPI_C_DOUBLE_COMPLEX, MPI_C_LONG_DOUBLE_COMPLEX,
     };
 
     /* The following implementation follows the suggestion in the

--- a/src/mpi/datatype/datatype_impl.c
+++ b/src/mpi/datatype/datatype_impl.c
@@ -309,7 +309,7 @@ int MPIR_Type_match_size_impl(int typeclass, int size, MPI_Datatype * datatype)
      * not available. We test for that case separately.  We also
      * prefer the Fortran types to the C type, if they are available */
     static MPI_Datatype real_types[] = {
-        MPI_REAL2, MPI_REAL4, MPI_REAL8, MPI_REAL16,
+        MPI_REAL2, MPI_REAL4, MPI_REAL8, MPI_REAL16, MPI_LONG_DOUBLE,
     };
     static MPI_Datatype int_types[] = {
         MPI_INTEGER1, MPI_INTEGER2, MPI_INTEGER4, MPI_INTEGER8, MPI_INTEGER16,

--- a/src/mpi/datatype/datatype_impl.c
+++ b/src/mpi/datatype/datatype_impl.c
@@ -292,7 +292,9 @@ static MPI_Datatype type_match_size(MPI_Datatype type_list[], int nTypes, int si
 {
     for (int i = 0; i < nTypes; i++) {
         MPI_Aint tsize;
-        MPIR_Datatype_get_size_macro(type_list[i], tsize);
+        MPI_Datatype type = type_list[i];
+        MPIR_DATATYPE_REPLACE_BUILTIN(type);
+        MPIR_Datatype_get_size_macro(type, tsize);
         if (tsize == size) {
             return type_list[i];
         }


### PR DESCRIPTION
## Pull Request Description
Using `long double` on x86 maps to x87 80-bit extended precision floats on most compilers. Adding `MPI_LONG_DOUBLE` as a match prevents `MPIR_Type_match_size_impl` from failing to find a correctly sized datatype for `MPI_TYPECLASS_REAL` when using `long double` on x86.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
