### PR TITLE
typerep: use original builtin when calculating size

### DIFF
--- a/src/include/mpir_typerep.h
+++ b/src/include/mpir_typerep.h
@@ -79,7 +79,7 @@ int MPIR_Typerep_iunpack(const void *inbuf, MPI_Aint insize, void *outbuf, MPI_A
                          MPI_Datatype datatype, MPI_Aint outoffset, MPI_Aint * actual_unpack_bytes,
                          MPIR_Typerep_req * typerep_req, uint32_t flags);
 
-int MPIR_Typerep_size_external32(MPI_Datatype type);
+MPI_Aint MPIR_Typerep_size_external32(MPI_Datatype type);
 int MPIR_Typerep_pack_external(const void *inbuf, MPI_Aint incount, MPI_Datatype datatype,
                                void *outbuf, MPI_Aint * actual_pack_bytes);
 int MPIR_Typerep_unpack_external(const void *inbuf, void *outbuf, MPI_Aint outcount,

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_size_external.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_size_external.c
@@ -7,7 +7,7 @@
 #include "mpir_typerep.h"
 #include "dataloop.h"
 
-int MPIR_Typerep_size_external32(MPI_Datatype type)
+MPI_Aint MPIR_Typerep_size_external32(MPI_Datatype type)
 {
     return MPIR_Dataloop_size_external32(type);
 }

--- a/src/mpi/datatype/typerep/src/typerep_yaksa_pack_external.c
+++ b/src/mpi/datatype/typerep/src/typerep_yaksa_pack_external.c
@@ -306,7 +306,7 @@ int MPIR_Typerep_unpack_external(const void *inbuf, void *outbuf, MPI_Aint outco
     goto fn_exit;
 }
 
-int MPIR_Typerep_size_external32(MPI_Datatype type)
+MPI_Aint MPIR_Typerep_size_external32(MPI_Datatype type)
 {
     MPIR_FUNC_ENTER;
 


### PR DESCRIPTION
`typeptr` is incorrectly used by `MPIR_Typerep_size_external32` when calculating the size of built-in datatypes. If the size of a built-in and the size of its internal type pointed by `typeptr` differ, an incorrect size is calculated. Moving the layout size calculation to only happen when `type` is not a built-in fixes this behavior.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
