### PR TITLE
romio/gpfs: fix build with MPI ABI enabled.

### DIFF
--- a/src/mpi/romio/adio/ad_gpfs/ad_gpfs_tuning.c
+++ b/src/mpi/romio/adio/ad_gpfs/ad_gpfs_tuning.c
@@ -16,7 +16,6 @@
  *---------------------------------------------------------------------*/
 
 #include "ad_gpfs_tuning.h"
-#include "mpi.h"
 
 #if !defined(PVFS2_SUPER_MAGIC)
 #define PVFS2_SUPER_MAGIC (0x20030528)


### PR DESCRIPTION
Avoid direct include of mpi.h to ensure proper ABI handling via adio.h.

## Pull Request Description
When building with romio, GPFS support, _and_ MPI ABI enabled (i.e., `--with-file-system=ufs+gpfs --enable-romio --enable-mpi-abi` passed to `configure`), the build fails due to the direct include of `mpi.h` which expects `mpi_abi_internal.h` to be present. 

The include of `mpi.h` should not be necessary and the correct handling should be done by `adio.h` (cf. e5b8534b172608a1b4f617e21974d92994e5c3df).

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
