### PR TITLE
mpl/ze: remove assertion global_dev < known_ze_device_count

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -2201,8 +2201,8 @@ int MPL_gpu_query_is_same_dev(int global_dev1, int global_dev2)
     MPL_ze_device_entry_t *device_state1, *device_state2;
     int local_dev1, local_dev2;
 
-    assert(global_dev1 >= 0 && global_dev1 < known_ze_device_count);
-    assert(global_dev2 >= 0 && global_dev2 < known_ze_device_count);
+    assert(global_dev1 >= 0);
+    assert(global_dev2 >= 0);
 
     if (IS_SAME_DEV(global_dev1, global_dev2))
         return 1;


### PR DESCRIPTION
## Pull Request Description
The global_dev id may point to a invisible device to the local process and the id is beyond its known max id due to visibility. This is due to we removed the collective during init that synchronizes on max_id from each process.

Fixes #7602


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
