### PR TITLE
ch4/shm: Set default iqueue cell size to 8KB

### DIFF
--- a/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
+++ b/src/mpid/ch4/shm/posix/eager/iqueue/iqueue_init.c
@@ -24,7 +24,7 @@ cvars:
     - name        : MPIR_CVAR_CH4_SHM_POSIX_IQUEUE_CELL_SIZE
       category    : CH4
       type        : int
-      default     : 16384
+      default     : 8192
       class       : none
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_ALL_EQ


### PR DESCRIPTION
## Pull Request Description

Experimental data shows that 8KB cells perform better than 16KB on most modern platforms in bandwidth tests.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
