### PR TITLE
ch3/tcp: remove an outdated assertion

### DIFF
--- a/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
+++ b/src/mpid/ch3/channels/nemesis/netmod/tcp/socksm.c
@@ -1535,7 +1535,6 @@ static int MPID_nem_tcp_recv_handler(sockconn_t * const sc)
         int (*reqFn) (MPIDI_VC_t *, MPIR_Request *, int *);
 
         MPIR_Assert(rreq->dev.iov_count > 0);
-        MPIR_Assert(rreq->dev.iov_count + rreq->dev.iov_offset <= MPL_IOV_LIMIT);
 
         bytes_recvd = MPL_large_readv(sc_fd, iov, rreq->dev.iov_count);
         if (bytes_recvd <= 0) {


### PR DESCRIPTION
## Pull Request Description
Following the fix in commit 806bfbfcfe, the assertion for limiting rreq->iov array to MPL_IOV_LIMIT no longer applies.

This fixes the `rma/acc_pairtype` test using ch3+yaksa

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
