### PR TITLE
test/runtests: suppress a psm3 warning

### DIFF
--- a/test/mpi/runtests
+++ b/test/mpi/runtests
@@ -1228,6 +1228,8 @@ sub check_result {
         }
         elsif (/^srun: error: .*: signal: Communication connection failure/) {
             # skip
+        elsif (/psm3_sockets_tcp_recvhdrq_progress: First PKT received is not PSM pkt./) {
+            # skip
         }
         else {
             $stray_output++;


### PR DESCRIPTION
## Pull Request Description
The psm3 provider sometime prints warnings like:
```
    [1760689999.740239472] pmrs-gpu-240-01:rank2.psm3_sockets_tcp_recvhdrq_progress: First PKT received is not PSM pkt. Close unknown connection fd=27
```
Fiter it in runtests to prevent untracable test failures.


A recent example is here - https://jenkins-pmrs.cels.anl.gov/job/mpich-main-ch4-ofi/1131/testReport/

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
