### PR TITLE
ch4/shm: fix SHM page alignment

### DIFF
--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -268,6 +268,7 @@ int MPIDI_POSIX_comm_bootstrap(MPIR_Comm * comm)
 
         int eager_shm_size = MPIDI_POSIX_eager_shm_size(MPIR_Process.local_size);
         int head_shm_size = calc_head_shm_size(MPIR_Process.local_size);
+        head_shm_size = MPL_ROUND_UP_ALIGN(head_shm_size, sysconf(_SC_PAGESIZE));
         int slab_size = head_shm_size + eager_shm_size;
         MPIDI_POSIX_global.shm_slab_size = slab_size;
 


### PR DESCRIPTION
Moving the shm header structure to the end of the shm slab align communication buffers at page boundary correctly.

## Pull Request Description

I rerun the test and it turns out the 4K alignment fix on SHM buffer does help with the bandwidth. Not sure why I missed this in previous analysis.

<img width="681" height="450" alt="image" src="https://github.com/user-attachments/assets/59b529f2-8725-4593-a97e-e0d4cc88e245" />


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
