### PR TITLE
ch4/shm: enable CMA by default

### DIFF
--- a/src/mpid/ch4/shm/ipc/cma/cma_post.h
+++ b/src/mpid/ch4/shm/ipc/cma/cma_post.h
@@ -14,8 +14,8 @@
 cvars:
     - name        : MPIR_CVAR_CH4_CMA_ENABLE
       category    : CH4
-      type        : int
-      default     : 0
+      type        : boolean
+      default     : true
       class       : none
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_ALL_EQ
@@ -26,7 +26,7 @@ cvars:
     - name        : MPIR_CVAR_CH4_IPC_CMA_P2P_THRESHOLD
       category    : CH4
       type        : int
-      default     : 16384
+      default     : 8192
       class       : none
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_ALL_EQ


### PR DESCRIPTION
CMA should be enabled by default because test result show CMA outperform POSIX in mid to large message size.

The CMA threshold is set to 8K to match the eager threshold. 8KB message using POSIX pipeline is about 10% faster than using CMA in intra-NUMA case on Cascade Lake (fig 1), but not in all other cases. So setting the CMA threshold to the same as the eager threshold and completely bypass the POSIX pipeline seems a good idea.

Also, CMA seems not affected by across NUMA access and way outperformed POSIX pipeline.

@intel may need to change this if using eager module other than iqueue.

On Intel Xeon Gold 6226R (Cascade Lake)

<img width="710" height="373" alt="image" src="https://github.com/user-attachments/assets/edd02766-4827-40b5-b1bc-867e2da47a99" />

<img width="649" height="392" alt="image" src="https://github.com/user-attachments/assets/53bd9091-6345-4649-a89c-e5eb7b9982d6" />

On AMD, this seems to be a OK setting. Although AMD has this weird drop at 16KB message size in almost all cases.
 
<img width="639" height="392" alt="image" src="https://github.com/user-attachments/assets/1571657f-0f70-42cd-9802-d75e76f4bf2c" />

<img width="646" height="389" alt="image" src="https://github.com/user-attachments/assets/53528504-ad8f-43be-800d-9464dda399ea" />

TODO: add numbers for Aurora.


## Pull Request Description


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
