### PR TITLE
[4.3.x] romio: test: fix bad snprintf arguments

### DIFF
--- a/src/mpi/romio/test/noncontig_coll2.c
+++ b/src/mpi/romio/test/noncontig_coll2.c
@@ -181,12 +181,14 @@ int cb_gather_name_array(MPI_Comm comm, ADIO_cb_name_array * arrayp)
 void default_str(int mynod, int len, ADIO_cb_name_array array, char *dest)
 {
     char *ptr;
-    int i, p;
+    int i, p, rlen;
     if (!mynod) {
         ptr = dest;
+        rlen = len;
         for (i = 0; i < array->namect; i++) {
-            p = snprintf(ptr, len, "%s,", array->names[i]);
+            p = snprintf(ptr, rlen, "%s,", array->names[i]);
             ptr += p;
+            rlen = rlen - p;
         }
         /* chop off that last comma */
         dest[strlen(dest) - 1] = '\0';
@@ -197,12 +199,14 @@ void default_str(int mynod, int len, ADIO_cb_name_array array, char *dest)
 void reverse_str(int mynod, int len, ADIO_cb_name_array array, char *dest)
 {
     char *ptr;
-    int i, p;
+    int i, p, rlen;
     if (!mynod) {
         ptr = dest;
+        rlen = len;
         for (i = (array->namect - 1); i >= 0; i--) {
-            p = snprintf(ptr, len, "%s,", array->names[i]);
+            p = snprintf(ptr, rlen, "%s,", array->names[i]);
             ptr += p;
+            rlen = rlen - p;
         }
         dest[strlen(dest) - 1] = '\0';
     }
@@ -212,18 +216,21 @@ void reverse_str(int mynod, int len, ADIO_cb_name_array array, char *dest)
 void reverse_alternating_str(int mynod, int len, ADIO_cb_name_array array, char *dest)
 {
     char *ptr;
-    int i, p;
+    int i, p, rlen;
     if (!mynod) {
         ptr = dest;
+        rlen = len;
         /* evens */
         for (i = (array->namect - 1); i >= 0; i -= 2) {
-            p = snprintf(ptr, len, "%s,", array->names[i]);
+            p = snprintf(ptr, rlen, "%s,", array->names[i]);
             ptr += p;
+            rlen = rlen - p;
         }
         /* odds */
         for (i = (array->namect - 2); i > 0; i -= 2) {
-            p = snprintf(ptr, len, "%s,", array->names[i]);
+            p = snprintf(ptr, rlen, "%s,", array->names[i]);
             ptr += p;
+            rlen = rlen - p;
         }
         dest[strlen(dest) - 1] = '\0';
     }
@@ -233,16 +240,19 @@ void reverse_alternating_str(int mynod, int len, ADIO_cb_name_array array, char 
 void simple_shuffle_str(int mynod, int len, ADIO_cb_name_array array, char *dest)
 {
     char *ptr;
-    int i, p;
+    int i, p, rlen;
     if (!mynod) {
         ptr = dest;
+        rlen = len;
         for (i = (array->namect / 2); i < array->namect; i++) {
-            p = snprintf(ptr, len, "%s,", array->names[i]);
+            p = snprintf(ptr, rlen, "%s,", array->names[i]);
             ptr += p;
+            rlen = rlen - p;
         }
         for (i = 0; i < (array->namect / 2); i++) {
-            p = snprintf(ptr, len, "%s,", array->names[i]);
+            p = snprintf(ptr, rlen, "%s,", array->names[i]);
             ptr += p;
+            rlen = rlen - p;
         }
         dest[strlen(dest) - 1] = '\0';
     }


### PR DESCRIPTION
Even though there can not be a buffer overflow as the string is properly sized, noncontig_coll2 fails when built with -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 : ----
FAIL: noncontig_coll2
=====================
Thread 1 "noncontig_coll2" received signal SIGABRT, Aborted. 0x00007ffff709c5fc in __pthread_kill_implementation () from /lib64/libc.so.6 (gdb) bt
 #0  0x00007ffff709c5fc in __pthread_kill_implementation ()
    from /lib64/libc.so.6
 #1  0x00007ffff7042106 in raise () from /lib64/libc.so.6
 #2  0x00007ffff702938b in abort () from /lib64/libc.so.6
 #3  0x00007ffff702a3ab in __libc_message_impl.cold () from /lib64/libc.so.6
 #4  0x00007ffff712b4fb in __fortify_fail () from /lib64/libc.so.6
 #5  0x00007ffff712adc6 in __chk_fail () from /lib64/libc.so.6
 #6  0x00007ffff712c8f5 in __snprintf_chk () from /lib64/libc.so.6
 #7  0x000000000040275e in snprintf (__s=0x4aafee "", __n=<optimized out>,
     __fmt=0x404077 "%s,") at /usr/include/bits/stdio2.h:68
 #8  default_str (mynod=<optimized out>, len=61, array=0x59fca0,
     dest=0x4aafd0 "hostname,")
     at src/mpi/romio/test/noncontig_coll2.c:189
 #9  main (argc=<optimized out>, argv=<optimized out>)
     at src/mpi/romio/test/noncontig_coll2.c:330
----
This is due to the len parameter of snprintf not being updated as we advance in the string.
Fix this issue by introducing a remaining len var that contains the exact amount of bytes left.

Patch is already applied in main. Backporting to 4.3.x as discussed in #7596 