### PR TITLE
test: use MTest_Init in run_mpitests.c

### DIFF
--- a/test/mpi/maint/gen_all_mpitests.py
+++ b/test/mpi/maint/gen_all_mpitests.py
@@ -102,7 +102,7 @@ def main():
             testdir, name = m.group(1,2)
             if not testdir in ldadd_incs:
                 ldadd_incs[testdir] = []
-            ldadd = "$(LDADD) $(run_mpitests_obj)"
+            ldadd = "$(run_mpitests_obj) $(LDADD)"
             if a + '-LDADD' in alltests_attrs:
                 ldadd += ' ' + alltests_attrs[a + '-LDADD']
             ldadd_incs[testdir].append("%s_LDADD = %s" % (name, ldadd))

--- a/test/mpi/util/run_mpitests.c
+++ b/test/mpi/util/run_mpitests.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
     concat_argv(args, ARGS_MAX, argc, argv);
 #endif
 
-    MPI_Init(NULL, NULL);
+    MTest_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &wsize);
     MPI_Comm_rank(MPI_COMM_WORLD, &wrank);
 


### PR DESCRIPTION
## Pull Request Description
Use MTest_Init so environment variables such as MPITEST_VERBOSE would work.

Alter the order between $(run_mpitests_obj) and $(LDADD) in individual makefiles since now run_mpitests.c uses function from mtest.c.



[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
