### PR TITLE
ch4/abort: missing critical section in abort path

### DIFF
--- a/src/mpid/ch4/src/mpidig_comm_abort.c
+++ b/src/mpid/ch4/src/mpidig_comm_abort.c
@@ -45,12 +45,14 @@ int MPIDIG_am_comm_abort(MPIR_Comm * comm, int exit_code)
             continue;
 
         /* 2 references, 1 for MPID-layer and 1 for MPIR-layer */
+        MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_REQUEST_POOL_MUTEXES[0]);
         sreq = MPIDIG_request_create(MPIR_REQUEST_KIND__SEND, 2, 0, 0);
         MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
 
         /* FIXME: only NM? */
         mpi_errno = MPIDI_NM_am_isend(dest, comm, MPIDIG_COMM_ABORT, &am_hdr,
                                       sizeof(am_hdr), NULL, 0, MPI_INT, 0, 0, sreq);
+        MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_REQUEST_POOL_MUTEXES[0]);
         if (mpi_errno)
             continue;
         else


### PR DESCRIPTION
## Pull Request Description
In comm_abort, we send active messages to all other processes. The request creation and am_isend need be protected by a vci critical section.

In debug build, this triggers missing mutex assertion and hides the original error messages that triggers the comm abort.

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
