### PR TITLE
ch4/cma: check ptrace_scope at init

### DIFF
--- a/src/mpid/ch4/shm/ipc/cma/cma_init.c
+++ b/src/mpid/ch4/shm/ipc/cma/cma_init.c
@@ -12,6 +12,28 @@ int MPIDI_CMA_init_local(void)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
+    bool cma_happy = false;
+
+    /* check ptrace permission */
+    int fd = open("/proc/sys/kernel/yama/ptrace_scope", O_RDONLY);
+    char buffer = '0';
+    if (fd >= 0) {
+        int ret = read(fd, &buffer, 1);
+        if (ret >= 0) {
+            if (buffer != '0') {
+                cma_happy = true;
+            }
+            close(fd);
+        }
+    }
+
+    if (!cma_happy) {
+        /* strictly we need a collective, which is troublesome during init.
+         * For now, let's assume users will have ptrace_scope setting consistently.
+         */
+        MPIR_CVAR_CH4_CMA_ENABLE = 0;
+    }
+
     MPIR_FUNC_EXIT;
     return mpi_errno;
 }


### PR DESCRIPTION
## Pull Request Description
Users may not have ptrace_scope permission set. Check it at init and turn MPIR_CVAR_CH4_CMA_ENABLE off if we don't have the permission.

Fixes #7653
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
