### PR TITLE
ch4: use 1 bit to distinguish message direction

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_rndv.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rndv.c
@@ -137,7 +137,7 @@ int MPIDI_OFI_recv_rndv_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Reque
         p->remote_data_sz = -1;
     }
 
-    int am_tag = MPIDIG_get_next_am_tag(comm);
+    int am_tag = MPIDIG_get_next_am_tag(comm, src_rank);
     p->match_bits = MPIDI_OFI_init_sendtag(comm->recvcontext_id, 0, am_tag) | MPIDI_OFI_AM_SEND;
 
     bool send_need_pack = MPIDI_OFI_is_tag_rndv_pack(wc->tag);

--- a/src/mpid/ch4/src/ch4_comm.c
+++ b/src/mpid/ch4/src/ch4_comm.c
@@ -150,9 +150,8 @@ int MPID_Comm_commit_pre_hook(MPIR_Comm * comm)
 
     /* initialize next_am_tag for internal messaging */
     int total_tag_bits = get_num_bits(MPIR_Process.attrs.tag_ub);
-    int rank_tag_bits = get_num_bits(comm->local_size - 1);
     MPIDI_COMM(comm, next_am_tag) = 0;
-    MPIDI_COMM(comm, next_am_tag_bits) = total_tag_bits - rank_tag_bits;
+    MPIDI_COMM(comm, next_am_tag_bits) = total_tag_bits - 1;
     /* make sure we have sufficient number of am_tag bits (8 is arbitrary) */
     MPIR_Assert(MPIDI_COMM(comm, next_am_tag_bits) > 8);
 

--- a/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_pt2pt_callbacks.c
@@ -32,7 +32,7 @@ int MPIDIG_do_cts(MPIR_Request * rreq)
     am_hdr.sreq_ptr = (MPIDIG_REQUEST(rreq, req->rreq.peer_req_ptr));
     am_hdr.rreq_ptr = rreq;
     if (can_do_tag(rreq)) {
-        am_hdr.tag = MPIDIG_get_next_am_tag(rreq->comm);
+        am_hdr.tag = MPIDIG_get_next_am_tag(rreq->comm, source_rank);
         CH4_CALL(am_tag_recv(source_rank, rreq->comm,
                              MPIDIG_TAG_RECV_COMPLETE, am_hdr.tag,
                              MPIDIG_REQUEST(rreq, buffer), MPIDIG_REQUEST(rreq, count),


### PR DESCRIPTION
## Pull Request Description
The native rndv is established per-message and per-pair-of-ranks. Just using incrementing am_ranks from the receiver is insufficient to distinguish two messages with opposite sender and receivers. Add 1 bit to distinguish the message direction.

Reference: https://github.com/pmodels/mpich/pull/7643/commits/08a13e3ae70757eeed19200938c89d86475c1b92

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
