### PR TITLE
test/datatype: use error return for checking optional types

### DIFF
--- a/test/mpi/coll/opprod.c
+++ b/test/mpi/coll/opprod.c
@@ -21,6 +21,17 @@ typedef struct {
 } ld_complex;
 #endif
 
+static bool check_type_is_available(MPI_Datatype datatype)
+{
+    int size;
+    int err = MPI_Type_size(datatype, &size);
+    if (err || size == 0) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
 /*
  * This test looks at the handling of logical and for types that are not
  * integers or are not required integers (e.g., long long).  MPICH allows
@@ -37,6 +48,9 @@ int main(int argc, char *argv[])
     d_complex dinbuf[3], doutbuf[3];
 
     MTest_Init(&argc, &argv);
+
+    /* set error return for checking optional types */
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
 
     comm = MPI_COMM_WORLD;
 

--- a/test/mpi/coll/opsum.c
+++ b/test/mpi/coll/opsum.c
@@ -21,6 +21,17 @@ typedef struct {
 } ld_complex;
 #endif
 
+static bool check_type_is_available(MPI_Datatype datatype)
+{
+    int size;
+    int err = MPI_Type_size(datatype, &size);
+    if (err || size == 0) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
 /*
  * This test looks at the handling of logical and for types that are not
  * integers or are not required integers (e.g., long long).  MPICH allows
@@ -37,6 +48,9 @@ int main(int argc, char *argv[])
     d_complex dinbuf[3], doutbuf[3];
 
     MTest_Init(&argc, &argv);
+
+    /* set error return for checking optional types */
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
 
     comm = MPI_COMM_WORLD;
 
@@ -121,7 +135,7 @@ int main(int argc, char *argv[])
     }
 #ifndef USE_STRICT_MPI
     /* For some reason, complex is not allowed for sum and prod */
-    if (MPI_DOUBLE_COMPLEX != MPI_DATATYPE_NULL) {
+    if (!check_type_is_available(MPI_DOUBLE_COMPLEX)) {
         int dc;
 #ifdef HAVE_LONG_DOUBLE
         ld_complex ldinbuf[3], ldoutbuf[3];

--- a/test/mpi/datatype/typename.c
+++ b/test/mpi/datatype/typename.c
@@ -131,6 +131,17 @@ static mpi_names_t mpi_names[] = {
     {0, (char *) 0},    /* Sentinel used to indicate the last element */
 };
 
+static bool check_type_is_available(MPI_Datatype datatype)
+{
+    int size;
+    int err = MPI_Type_size(datatype, &size);
+    if (err || size == 0) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
 int main(int argc, char **argv)
 {
     char name[MPI_MAX_OBJECT_NAME];
@@ -138,6 +149,9 @@ int main(int argc, char **argv)
     int errs = 0;
 
     MTest_Init(&argc, &argv);
+
+    /* set error return for checking optional types */
+    MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN);
 
     /* Sample some datatypes */
     /* See 8.4, "Naming Objects" in MPI-2.  The default name is the same
@@ -168,7 +182,7 @@ int main(int argc, char **argv)
 #endif
         }
         /* If this optional type is not supported, skip it */
-        if (inOptional && mpi_names[i].dtype == MPI_DATATYPE_NULL)
+        if (inOptional && !check_type_is_available(mpi_names[i].dtype))
             continue;
         if (mpi_names[i].dtype == MPI_DATATYPE_NULL) {
             /* Report an error because all of the standard types


### PR DESCRIPTION
## Pull Request Description

We no longer set unavailable builtin MPI types as MPI_DATATYPE_NULL. We can't do that with MPI ABI anyway. Users should check error return for checking optional builtin types.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
