### PR TITLE
configure: fix a typo using == instead of =

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3075,7 +3075,7 @@ if test "$enable_f77" = yes ; then
     fi
 
     # Include a defined value for Fint is int
-    if test "$pac_cv_f77_sizeof_integer" == "$ac_cv_sizeof_int" ; then
+    if test "$pac_cv_f77_sizeof_integer" = "$ac_cv_sizeof_int" ; then
         AC_DEFINE(HAVE_FINT_IS_INT,1,[Define if Fortran integer are the same size as C ints])
     else
         AC_MSG_WARN([Fortran integers and C ints are not the same size.  Support for this case is experimental; use at your own risk])


### PR DESCRIPTION
## Pull Request Description
In shell, we use = for equality test.

Thanks @e-kwsm for catching it (https://github.com/pmodels/mpich/pull/5676#discussion_r2494969568).

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
