### PR TITLE
ch4/cma: fix typo in probing ptrace_scope

### DIFF
--- a/src/mpid/ch4/shm/ipc/cma/cma_init.c
+++ b/src/mpid/ch4/shm/ipc/cma/cma_init.c
@@ -14,13 +14,13 @@ int MPIDI_CMA_init_local(void)
 
     bool cma_happy = false;
 
-    /* check ptrace permission */
+    /* check ptrace permission. ref: https://www.kernel.org/doc/Documentation/security/Yama.txt */
     int fd = open("/proc/sys/kernel/yama/ptrace_scope", O_RDONLY);
     char buffer = '0';
     if (fd >= 0) {
         int ret = read(fd, &buffer, 1);
         if (ret >= 0) {
-            if (buffer != '0') {
+            if (buffer == '0') {
                 cma_happy = true;
             }
             close(fd);


### PR DESCRIPTION
## Pull Request Description
We need 0 here:
0 - classic ptrace permissions: a process can PTRACE_ATTACH to any other
    process running under the same uid, as long as it is dumpable (i.e.
    did not transition uids, start privileged, or have called
    prctl(PR_SET_DUMPABLE...) already). Similarly, PTRACE_TRACEME is
    unchanged.


[skip warnings]

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
