### PR TITLE
coll: cleanup a couple more outdated CVARs

### DIFF
--- a/src/mpi/coll/cvars.txt
+++ b/src/mpi/coll/cvars.txt
@@ -174,17 +174,6 @@ cvars:
         broadcast based on a scatter followed by a ring allgather algorithm.
         (See also: MPIR_CVAR_BCAST_MIN_PROCS, MPIR_CVAR_BCAST_SHORT_MSG_SIZE)
 
-    - name        : MPIR_CVAR_MAX_SMP_BCAST_MSG_SIZE
-      category    : COLLECTIVE
-      type        : int
-      default     : 0
-      class       : none
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_ALL_EQ
-      description : >-
-        Maximum message size for which SMP-aware broadcast is used.  A
-        value of '0' uses SMP-aware broadcast for all message sizes.
-
     - name        : MPIR_CVAR_BCAST_INTRA_ALGORITHM
       category    : COLLECTIVE
       type        : enum
@@ -1360,17 +1349,6 @@ cvars:
       description : >-
         the short message algorithm will be used if the send buffer size is <=
         this value (in bytes)
-
-    - name        : MPIR_CVAR_MAX_SMP_ALLREDUCE_MSG_SIZE
-      category    : COLLECTIVE
-      type        : int
-      default     : 0
-      class       : none
-      verbosity   : MPI_T_VERBOSITY_USER_BASIC
-      scope       : MPI_T_SCOPE_ALL_EQ
-      description : >-
-        Maximum message size for which SMP-aware allreduce is used.  A
-        value of '0' uses SMP-aware allreduce for all message sizes.
 
     - name        : MPIR_CVAR_ALLREDUCE_INTRA_ALGORITHM
       category    : COLLECTIVE


### PR DESCRIPTION
## Pull Request Description
Following PR #7644, we found a couple more unused CVARs.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
