### PR TITLE
misc: fine tune default fast copy threshold

### DIFF
--- a/src/mpi/misc/utils.c
+++ b/src/mpi/misc/utils.c
@@ -21,7 +21,7 @@ cvars:
     - name        : MPIR_CVAR_GPU_FAST_COPY_MAX_SIZE_H2D
       category    : CH4
       type        : int
-      default     : 1048576
+      default     : 4096
       class       : none
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_ALL_EQ
@@ -32,7 +32,7 @@ cvars:
     - name        : MPIR_CVAR_GPU_FAST_COPY_MAX_SIZE_D2H
       category    : CH4
       type        : int
-      default     : 1024
+      default     : 256
       class       : none
       verbosity   : MPI_T_VERBOSITY_USER_BASIC
       scope       : MPI_T_SCOPE_ALL_EQ


### PR DESCRIPTION
## Pull Request Description
The default value for MPIR_CVAR_GPU_FAST_COPY_MAX_SIZE_H2D and MPIR_CVAR_GPU_FAST_COPY_MAX_SIZE_D2H need fine tune for smoother performance transition measured using gpu pipeline bandwidth. The previous MPIR_CVAR_GPU_FAST_COPY_MAX_SIZE_H2D default of 1048576 resulted in every chunk copy using fast copy path, resulting in subpar bandwidths even for very large messages..

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
