### PR TITLE
ch4/cma: fix ptrace_scope check

### DIFF
--- a/src/mpid/ch4/shm/ipc/cma/cma_init.c
+++ b/src/mpid/ch4/shm/ipc/cma/cma_init.c
@@ -16,15 +16,15 @@ int MPIDI_CMA_init_local(void)
 
     /* check ptrace permission. ref: https://www.kernel.org/doc/Documentation/security/Yama.txt */
     int fd = open("/proc/sys/kernel/yama/ptrace_scope", O_RDONLY);
-    char buffer = '0';
+    char buffer = 0;
     if (fd >= 0) {
         int ret = read(fd, &buffer, 1);
         if (ret >= 0) {
             if (buffer == '0') {
                 cma_happy = true;
             }
-            close(fd);
         }
+        close(fd);
     }
 
     if (!cma_happy) {

--- a/src/mpid/ch4/shm/ipc/src/ipc_init.c
+++ b/src/mpid/ch4/shm/ipc/src/ipc_init.c
@@ -25,6 +25,11 @@ int MPIDI_IPC_init_local(void)
     MPIR_ERR_CHECK(mpi_errno);
 #endif
 
+#ifdef MPIDI_CH4_SHM_ENABLE_CMA
+    mpi_errno = MPIDI_CMA_init_local();
+    MPIR_ERR_CHECK(mpi_errno);
+#endif
+
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
     mpi_errno = MPIDI_GPU_init_local();
     MPIR_ERR_CHECK(mpi_errno);


### PR DESCRIPTION
## Pull Request Description
Turns out we neglected to call MPIDI_CMA_init_local altogether!

Reminder: we need always require some testing.


Fixes #7653 

NOTE: I manually tested it this time.
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
