### PR TITLE
ch4: shm: fix data type for recv_bytes in MPIDI_POSIX_mpi_release_gat…

### DIFF
--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.h
@@ -124,7 +124,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
                               datatype, root, MPIR_BCAST_TAG, comm_ptr, &status);
                 MPIR_ERR_CHECK(mpi_errno);
                 MPIR_Get_count_impl(&status, MPIR_BYTE_INTERNAL, &recv_bytes);
-                MPIR_Typerep_copy(bcast_data_addr, &recv_bytes, sizeof(int),
+                MPIR_Typerep_copy(bcast_data_addr, &recv_bytes, sizeof(MPI_Aint),
                                   MPIR_TYPEREP_FLAG_NONE);
                 /* It is necessary to copy the coll_attr as well to handle the case when non-root
                  * becomes temporary root as part of compositions (or smp aware colls). These temp
@@ -149,7 +149,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
             /* When error checking is enabled, place the datasize in shm_buf first, followed by the
              * coll_attr, followed by the actual data with an offset of (2*cacheline_size) bytes from
              * the starting address */
-            MPIR_Typerep_copy(bcast_data_addr, &count, sizeof(int), MPIR_TYPEREP_FLAG_NONE);
+            MPIR_Typerep_copy(bcast_data_addr, &count, sizeof(MPI_Aint), MPIR_TYPEREP_FLAG_NONE);
             /* It is necessary to copy the coll_attr as well to handle the case when non-root
              * becomes root as part of compositions (or smp aware colls). These roots might
              * expect same data as other ranks but different from the actual root. So only
@@ -221,8 +221,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_release_gather_release(void *local_
              * datasize is copied out from shm_buffer and compared against the count a rank was
              * expecting. Also, the coll_attr is copied out. In case of mismatch mpi_errno is set.
              * Actual data starts after (2*cacheline_size) bytes */
-            int recv_bytes, recv_errflag;
-            MPIR_Typerep_copy(&recv_bytes, bcast_data_addr, sizeof(int), MPIR_TYPEREP_FLAG_NONE);
+            MPI_Aint recv_bytes;
+            int recv_errflag;
+            MPIR_Typerep_copy(&recv_bytes, bcast_data_addr, sizeof(MPI_Aint),
+                              MPIR_TYPEREP_FLAG_NONE);
             MPIR_Typerep_copy(&recv_errflag, (char *) bcast_data_addr + MPIDU_SHM_CACHE_LINE_LEN,
                               sizeof(int), MPIR_TYPEREP_FLAG_NONE);
             MPIR_ERR_CHKANDJUMP2(recv_bytes != count, mpi_errno, MPI_ERR_OTHER,


### PR DESCRIPTION
The number of received bytes in release_gather_release is badly cast between int and MPI_Aint. On most arch this is not an issue, but for Big-Endian 64b arch (s390x) it ends up losing the actual value.
Fix the issue but writing the whole MPI_AInt in the shm_buf instead of just an int.

This bug was found on 4.3.2 while debugging on s390x with ch4:ofi:
```
> mpiexec -np 4     ./file_info -fname test
Abort(476133135) on node 1 (rank 1 in comm 0): Fatal error in internal_Bcast: Other MPI error, error stack:
internal_Bcast(116)........................: MPI_Bcast(buffer=0x1004174, count=1, MPI_INT, 0, MPI_COMM_WORLD) failed
MPID_Bcast(295)............................: 
MPIDI_Bcast_allcomm_composition_json(239)..: 
MPIDI_Bcast_intra_composition_alpha(292)...: 
MPIDI_POSIX_mpi_bcast(278).................: 
MPIDI_POSIX_mpi_bcast_release_gather(127)..: 
MPIDI_POSIX_mpi_release_gather_release(225): message sizes do not match across processes in the collective routine: Received 0 but expected 4
```