### PR TITLE
hydra: fix standalone build on MacOS

### DIFF
--- a/src/pm/hydra/configure.ac
+++ b/src/pm/hydra/configure.ac
@@ -115,6 +115,11 @@ AC_DEFINE_UNQUOTED(HYDRA_CONFIGURE_ARGS_CLEAN,"`echo $ac_configure_args`",[Confi
 if test -z "$FROM_MPICH" ; then
     FROM_HYDRA=yes
     export FROM_HYDRA
+    if test -z "$builddir" ; then
+       builddir="`pwd`"
+    fi
+    AC_SUBST(builddir)
+    export builddir
 fi
 
 # MPL


### PR DESCRIPTION
The builddir is never set in standalone build which results failure in retrieving hwloc_darwin_ldflags.

HYDRA standalone build on MacOS is broken since 4.2.0 after we updated hwloc to 2.9.0. Failing to retrieve the hwloc_darwin_ldflags results linking error because the MacOS framework libraries are not linked. We should get this into 5.0.0 release.

@lowpolyneko Can we add a Jenkins job to at least exercise this build configuration? The steps to reproduce the issue are as follow. This essentially a standalone build of hydra on MacOS.
```sh
git clone https://github.com/pmodels/mpich --recursive
cd mpich
./autogen.sh
cd src/pm/hydra
./configure
make -j
```

The current main should fail with a message similar to this.
```
/Library/Developer/CommandLineTools/usr/bin/make  all-recursive
Making all in modules/pmi
make[3]: Nothing to be done for `all-am'.
Making all in modules/mpl
make[2]: Nothing to be done for `all'.
Making all in modules/hwloc
Making all in include
make[3]: Nothing to be done for `all'.
Making all in hwloc
make[3]: Nothing to be done for `all'.
make[3]: Nothing to be done for `all-am'.
Making all in .
  CCLD     mpiexec.hydra
Undefined symbols for architecture arm64:
  "_CFCopyTypeIDDescription", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
  "_CFDataGetBytes", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
  "_CFDataGetLength", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
  "_CFDataGetTypeID", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
  "_CFGetTypeID", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
  "_CFNumberGetTypeID", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
  "_CFNumberGetValue", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
  "_CFRelease", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
  "_CFStringGetCStringPtr", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
  "_IOIteratorNext", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
  "_IOObjectRelease", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
  "_IORegistryEntryFromPath", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
  "_IORegistryEntryGetChildIterator", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
  "_IORegistryEntrySearchCFProperty", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
  "___CFConstantStringClassReference", referenced from:
       in libhwloc_embedded.a[19](topology-darwin.o)
       in libhwloc_embedded.a[19](topology-darwin.o)
       in libhwloc_embedded.a[19](topology-darwin.o)
  "_kCFAllocatorDefault", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
  "_kIOMainPortDefault", referenced from:
      _hwloc_look_darwin in libhwloc_embedded.a[19](topology-darwin.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [mpiexec.hydra] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```

## Pull Request Description


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
