### PR TITLE
Fix syntax error in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -338,7 +338,7 @@ uninstall-local:
 	done ; \
 	for x in @MPICC_ABI_NAME@ @MPICXX_ABI_NAME@ ; do \
 		rm -f ${DESTDIR}${bindir}/$$x ; \
-	done \
+	done ; \
 	for x in mpl opa mpich fmpich mpichf90 mpichcxx ; do \
 		rm -f ${DESTDIR}${libdir}/lib$$x@SHLIB_EXT@ ; \
 	done


### PR DESCRIPTION
Missing semicolon in uninstall-local target causes `make uninstall` to fail. This fixes that.

## Pull Request Description


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
