### PR TITLE
makefile: fix missing semicolon in `uninstall-local`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -338,7 +338,7 @@ uninstall-local:
 	done ; \
 	for x in @MPICC_ABI_NAME@ @MPICXX_ABI_NAME@ ; do \
 		rm -f ${DESTDIR}${bindir}/$$x ; \
-	done \
+	done ; \
 	for x in mpl opa mpich fmpich mpichf90 mpichcxx ; do \
 		rm -f ${DESTDIR}${libdir}/lib$$x@SHLIB_EXT@ ; \
 	done


### PR DESCRIPTION
## Pull Request Description
The missing semicolon causes `make uninstall` to fail.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
