### PR TITLE
cma: fix CMA detection

### DIFF
--- a/src/mpid/ch4/shm/ipc/cma/cma_init.c
+++ b/src/mpid/ch4/shm/ipc/cma/cma_init.c
@@ -24,7 +24,10 @@ int MPIDI_CMA_init_local(void)
                 cma_happy = true;
             }
         }
-        close(fd);
+    } else {
+        /* if we cannot open the yama files, it means Yama security module is not loaded. There
+         * is not ptrace scope control and CMA should always work. */
+        cma_happy = true;
     }
 
     if (!cma_happy) {


### PR DESCRIPTION
The Yama security module may not present. When Yama is not present, CMA should always work since there is no ptrace_scope management.

## Pull Request Description


## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
