### PR TITLE
hydra: do not use -lhydra to link

### DIFF
--- a/src/pm/hydra/Makefile.am
+++ b/src/pm/hydra/Makefile.am
@@ -10,6 +10,8 @@ external_ldflags = @RPATHS@
 # NOTE: the order matters, libpmi depends on libmpl.
 external_libs = @pmi_lib@ @mpl_lib@ @hwloc_lib@ @WRAPPER_LIBS@
 
+internal_libs = libhydra.la
+
 bin_PROGRAMS =
 noinst_HEADERS =
 DISTCLEANFILES =

--- a/src/pm/hydra/mpiexec/Makefile.mk
+++ b/src/pm/hydra/mpiexec/Makefile.mk
@@ -23,5 +23,5 @@ mpiexec_hydra_SOURCES = \
 
 mpiexec_hydra_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/mpiexec -DHYDRA_CONF_FILE=\"@sysconfdir@/mpiexec.hydra.conf\"
 mpiexec_hydra_LDFLAGS = $(external_ldflags) -L$(top_builddir)
-mpiexec_hydra_LDADD = -lhydra $(external_libs)
-mpiexec_hydra_DEPENDENCIES = libhydra.la
+mpiexec_hydra_LDADD = $(internal_libs) $(external_libs)
+mpiexec_hydra_DEPENDENCIES = $(internal_libs)

--- a/src/pm/hydra/nameserver/Makefile.mk
+++ b/src/pm/hydra/nameserver/Makefile.mk
@@ -8,5 +8,5 @@ bin_PROGRAMS += hydra_nameserver
 hydra_nameserver_SOURCES = nameserver/hydra_nameserver.c
 hydra_nameserver_CFLAGS = $(AM_CFLAGS)
 hydra_nameserver_LDFLAGS = $(external_ldflags) 
-hydra_nameserver_LDADD = -lhydra $(external_libs)
-hydra_nameserver_DEPENDENCIES = libhydra.la
+hydra_nameserver_LDADD = $(internal_libs) $(external_libs)
+hydra_nameserver_DEPENDENCIES = $(internal_libs)

--- a/src/pm/hydra/persist_server/Makefile.mk
+++ b/src/pm/hydra/persist_server/Makefile.mk
@@ -8,5 +8,5 @@ bin_PROGRAMS += hydra_persist
 hydra_persist_SOURCES = persist_server/persist_server.c
 hydra_persist_CFLAGS = $(AM_CFLAGS)
 hydra_persist_LDFLAGS = $(external_ldflags) -L$(top_builddir)
-hydra_persist_LDADD = -lhydra $(external_libs)
-hydra_persist_DEPENDENCIES = libhydra.la
+hydra_persist_LDADD = $(internal_libs) $(external_libs)
+hydra_persist_DEPENDENCIES = $(internal_libs)

--- a/src/pm/hydra/proxy/Makefile.mk
+++ b/src/pm/hydra/proxy/Makefile.mk
@@ -15,8 +15,8 @@ hydra_pmi_proxy_SOURCES = \
 
 hydra_pmi_proxy_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/proxy
 hydra_pmi_proxy_LDFLAGS = $(external_ldflags) -L$(top_builddir)
-hydra_pmi_proxy_LDADD = -lhydra $(external_libs)
-hydra_pmi_proxy_DEPENDENCIES = libhydra.la
+hydra_pmi_proxy_LDADD = $(internal_libs) $(external_libs)
+hydra_pmi_proxy_DEPENDENCIES = $(internal_libs)
 
 if HYDRA_HAVE_HWLOC
 hydra_pmi_proxy_CPPFLAGS += -I$(top_srcdir)/lib/tools/topo/hwloc


### PR DESCRIPTION
## Pull Request Description
Usually libtool will resolve -lhydra with libhydra.la if it is found. However, there is report some system (e.g. SUSE) does not resolve that. Use libhydra.la explicitly to avoid potential issues.


@SteveO-Cray

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
