### PR TITLE
abi: fix MPI_Abi_get_fortran_info

### DIFF
--- a/src/binding/c/abi_api.txt
+++ b/src/binding/c/abi_api.txt
@@ -41,13 +41,15 @@ MPI_Abi_get_fortran_info:
     .desc: Return an info object that provides information related to the Fortran ABI
     .seealso: MPI_Abi_get_info
 {
-#ifdef HAVE_FORTRAN_BINDING
-    MPIR_Info *info_ptr;
-    mpi_errno = MPIR_Info_alloc(&info_ptr);
-    MPIR_ERR_CHECK(mpi_errno);
+    if (MPIR_Internal_types[MPI_INTEGER & 0xff].internal_type == MPI_DATATYPE_NULL) {
+        *info = MPI_INFO_NULL;
+    } else {
+        MPIR_Info *info_ptr;
+        mpi_errno = MPIR_Info_alloc(&info_ptr);
+        MPIR_ERR_CHECK(mpi_errno);
 
-    MPI_Datatype type;
-    char str[8];
+        MPI_Datatype type;
+        char str[8];
 #define PUSH_TYPE_INFO(type_, keyname) \
     do { \
         type = type_; \
@@ -55,10 +57,10 @@ MPI_Abi_get_fortran_info:
         snprintf(str, sizeof(str), "%d", MPIR_Datatype_get_basic_size(type)); \
         MPIR_Info_push(info_ptr, keyname, str); \
     } while (0)
-    PUSH_TYPE_INFO(MPI_LOGICAL, "mpi_logical_size");
-    PUSH_TYPE_INFO(MPI_INTEGER, "mpi_integer_size");
-    PUSH_TYPE_INFO(MPI_REAL, "mpi_real_size");
-    PUSH_TYPE_INFO(MPI_DOUBLE_PRECISION, "mpi_double_precision_size");
+        PUSH_TYPE_INFO(MPI_LOGICAL, "mpi_logical_size");
+        PUSH_TYPE_INFO(MPI_INTEGER, "mpi_integer_size");
+        PUSH_TYPE_INFO(MPI_REAL, "mpi_real_size");
+        PUSH_TYPE_INFO(MPI_DOUBLE_PRECISION, "mpi_double_precision_size");
 #undef PUSH_TYPE_INFO
 #define PUSH_TYPE_INFO(type_, keyname) \
     do { \
@@ -66,31 +68,28 @@ MPI_Abi_get_fortran_info:
         MPIR_DATATYPE_REPLACE_BUILTIN(type); \
         MPIR_Info_push(info_ptr, keyname, type != MPI_DATATYPE_NULL ? "true" : "false"); \
     } while (0)
-    PUSH_TYPE_INFO(MPI_LOGICAL1, "mpi_logical1_supported");
-    PUSH_TYPE_INFO(MPI_LOGICAL2, "mpi_logical2_supported");
-    PUSH_TYPE_INFO(MPI_LOGICAL4, "mpi_logical4_supported");
-    PUSH_TYPE_INFO(MPI_LOGICAL8, "mpi_logical8_supported");
-    PUSH_TYPE_INFO(MPI_LOGICAL16, "mpi_logical16_supported");
-    PUSH_TYPE_INFO(MPI_INTEGER1, "mpi_integer1_supported");
-    PUSH_TYPE_INFO(MPI_INTEGER2, "mpi_integer2_supported");
-    PUSH_TYPE_INFO(MPI_INTEGER4, "mpi_integer4_supported");
-    PUSH_TYPE_INFO(MPI_INTEGER8, "mpi_integer8_supported");
-    PUSH_TYPE_INFO(MPI_INTEGER16, "mpi_integer16_supported");
-    PUSH_TYPE_INFO(MPI_REAL2, "mpi_real2_supported");
-    PUSH_TYPE_INFO(MPI_REAL4, "mpi_real4_supported");
-    PUSH_TYPE_INFO(MPI_REAL8, "mpi_real8_supported");
-    PUSH_TYPE_INFO(MPI_REAL16, "mpi_real16_supported");
-    PUSH_TYPE_INFO(MPI_COMPLEX4, "mpi_complex4_supported");
-    PUSH_TYPE_INFO(MPI_COMPLEX8, "mpi_complex8_supported");
-    PUSH_TYPE_INFO(MPI_COMPLEX16, "mpi_complex16_supported");
-    PUSH_TYPE_INFO(MPI_COMPLEX32, "mpi_complex32_supported");
-    PUSH_TYPE_INFO(MPI_DOUBLE_COMPLEX, "mpi_double_complex_supported");
+        PUSH_TYPE_INFO(MPI_LOGICAL1, "mpi_logical1_supported");
+        PUSH_TYPE_INFO(MPI_LOGICAL2, "mpi_logical2_supported");
+        PUSH_TYPE_INFO(MPI_LOGICAL4, "mpi_logical4_supported");
+        PUSH_TYPE_INFO(MPI_LOGICAL8, "mpi_logical8_supported");
+        PUSH_TYPE_INFO(MPI_LOGICAL16, "mpi_logical16_supported");
+        PUSH_TYPE_INFO(MPI_INTEGER1, "mpi_integer1_supported");
+        PUSH_TYPE_INFO(MPI_INTEGER2, "mpi_integer2_supported");
+        PUSH_TYPE_INFO(MPI_INTEGER4, "mpi_integer4_supported");
+        PUSH_TYPE_INFO(MPI_INTEGER8, "mpi_integer8_supported");
+        PUSH_TYPE_INFO(MPI_INTEGER16, "mpi_integer16_supported");
+        PUSH_TYPE_INFO(MPI_REAL2, "mpi_real2_supported");
+        PUSH_TYPE_INFO(MPI_REAL4, "mpi_real4_supported");
+        PUSH_TYPE_INFO(MPI_REAL8, "mpi_real8_supported");
+        PUSH_TYPE_INFO(MPI_REAL16, "mpi_real16_supported");
+        PUSH_TYPE_INFO(MPI_COMPLEX4, "mpi_complex4_supported");
+        PUSH_TYPE_INFO(MPI_COMPLEX8, "mpi_complex8_supported");
+        PUSH_TYPE_INFO(MPI_COMPLEX16, "mpi_complex16_supported");
+        PUSH_TYPE_INFO(MPI_COMPLEX32, "mpi_complex32_supported");
+        PUSH_TYPE_INFO(MPI_DOUBLE_COMPLEX, "mpi_double_complex_supported");
 #undef PUSH_TYPE_INFO
-    *info = info_ptr->handle;
-#else
-    *info = MPI_INFO_NULL;
-    MPIR_ERR_CHECK(mpi_errno);
-#endif
+        *info = info_ptr->handle;
+    }
 }
 
 MPI_Abi_get_info:


### PR DESCRIPTION
## Pull Request Description
When it is built with MPI ABI enabled, the HAVE_FORTRAN_BINDING micro no longer works. Check the availability of MPI_INTEGER instead.

Fixes #7691


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
