### PR TITLE
yaksa: fix automatic compilation for CUDA 13

### DIFF
--- a/src/mpi/datatype/typerep/yaksa/src/backend/cuda/subcfg.m4
+++ b/src/mpi/datatype/typerep/yaksa/src/backend/cuda/subcfg.m4
@@ -161,7 +161,7 @@ fi
 ##########################################################################
 
 if test "${have_cuda}" = "yes" ; then
-    for version in 12000 11080 11050 11010 11000 10000 9000 8000 7000 6000 5000 ; do
+    for version in 13000 12000 11080 11050 11010 11000 10000 9000 8000 7000 6000 5000 ; do
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
                               #include <cuda.h>
                               int x[[CUDA_VERSION - $version]];
@@ -222,7 +222,10 @@ if test "${have_cuda}" = "yes" ; then
     for sm in ${with_cuda_sm} ; do
         case "$sm" in
             all-major)
-                if test ${cuda_version} -ge 11080 ; then
+                if test ${cuda_version} -ge 13000; then
+                    # ampere (80) to blackwell (120)
+                    supported_cuda_sms="80 100 120"
+                elif test ${cuda_version} -ge 11080 ; then
                     # maxwell (52) to hopper (90)
                     supported_cuda_sms="52 60 70 80 90"
                 elif test ${cuda_version} -ge 11010 ; then
@@ -292,6 +295,13 @@ if test "${have_cuda}" = "yes" ; then
             hopper)
                 PAC_APPEND_FLAG([90],[CUDA_SM])
                 PAC_APPEND_FLAG([90a],[CUDA_SM])
+                ;;
+
+            blackwell)
+                PAC_APPEND_FLAG([100],[CUDA_SM])
+                PAC_APPEND_FLAG([100a],[CUDA_SM])
+                PAC_APPEND_FLAG([120],[CUDA_SM])
+                PAC_APPEND_FLAG([120a],[CUDA_SM])
                 ;;
 
             none)


### PR DESCRIPTION
Allow the "all-major" sm option to correctly set the supported architectures for CUDA 13. All sm values below 80 have been removed resulting in compilation errors with the existing options. Also adds a --with-cuda-sm=blackwell options similar to previous arch names.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
