### PR TITLE
[5.0.x] mpl: Improved check for AVX/AVX512F support

### DIFF
--- a/src/mpl/configure.ac
+++ b/src/mpl/configure.ac
@@ -207,12 +207,28 @@ fi
 
 # check if compiler supports avx, avx512f
 # also check if the building machine can run them if not force enabled
-AC_CACHE_CHECK([whether -mavx2 is supported], pac_cv_found_avx,
-              [PAC_C_CHECK_COMPILER_OPTION([-mavx2],pac_cv_found_avx=yes,pac_cv_found_avx=no)],
-              pac_cv_found_avx=no,pac_cv_found_avx=yes)
-AC_CACHE_CHECK([whether -mavx512f is supported], pac_cv_found_avx512f,
-               [PAC_C_CHECK_COMPILER_OPTION([-mavx512f],pac_cv_found_avx512f=yes,pac_cv_found_avx512f=no)],
-               pac_cv_found_avx512f=no,pac_cv_found_avx512f=yes)
+AC_CACHE_CHECK([whether -mavx2 is supported], pac_cv_found_avx, [
+    PAC_PUSH_FLAG([CFLAGS])
+    PAC_APPEND_FLAG([-mavx2], [CFLAGS])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <immintrin.h>]],[[
+        const void *src;
+        void *dest;
+        __m256i ymm = _mm256_loadu_si256(src);
+        _mm256_stream_si256(dest, ymm);
+    ]])],
+    pac_cv_found_avx=yes,pac_cv_found_avx=no)
+    PAC_POP_FLAG([CFLAGS])])
+AC_CACHE_CHECK([whether -mavx512f is supported], pac_cv_found_avx512f, [
+    PAC_PUSH_FLAG([CFLAGS])
+    PAC_APPEND_FLAG([-mavx512f], [CFLAGS])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <immintrin.h>]],[[
+        const void *src;
+        void *dest;
+        __m512i zmm = _mm512_loadu_si512(src);
+        _mm512_stream_si512(dest, zmm);
+    ]])],
+    pac_cv_found_avx512f=yes,pac_cv_found_avx512f=no)
+    PAC_POP_FLAG([CFLAGS])])
 
 AM_CONDITIONAL([MPL_BUILD_AVX], [test "x$pac_cv_found_avx" = "xyes"])
 if test "x$pac_cv_found_avx" = "xyes"; then


### PR DESCRIPTION
## Pull Request Description

PAC_C_CHECK_COMPILER_OPTION checks for warning messages, but those can be silenced by the user e.g. with clang's -Qunused-arguments. Try to compile a simple program using the extensions needed by MPL for a more robust test for this functionality.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
