### PR TITLE
ch4: do not touch status cancelling SHM anysrc_partner

### DIFF
--- a/src/mpid/ch4/ch4_api.txt
+++ b/src/mpid/ch4/ch4_api.txt
@@ -156,7 +156,7 @@ Native API:
      SHM*: buf-2, count, datatype, message
   mpi_cancel_recv : int
       NM*: rreq, is_blocking
-     SHM*: rreq
+     SHM*: rreq, is_anysrc_partner
   mpi_psend_init : int
       NM: buf, partitions, count, datatype, rank, tag, comm, info, av, req_p
      SHM: buf, partitions, count, datatype, rank, tag, comm, info, av, req_p
@@ -465,6 +465,7 @@ PARAM:
     info: MPIR_Info *
     info_p: MPIR_Info **
     iov_len: size_t
+    is_anysrc_partner: bool
     is_blocking: bool
     is_remote: bool
     length: MPI_Aint

--- a/src/mpid/ch4/netmod/include/netmod_am_fallback_recv.h
+++ b/src/mpid/ch4/netmod/include/netmod_am_fallback_recv.h
@@ -61,7 +61,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_irecv(void *buf,
 
 MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq, bool is_blocking)
 {
-    return MPIDIG_mpi_cancel_recv(rreq);
+    return MPIDIG_mpi_cancel_recv(rreq, false /* is_anysrc_partner */);
 }
 
 #endif /* NETMOD_AM_FALLBACK_RECV_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -393,7 +393,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_cancel_recv(MPIR_Request * rreq, bool 
     int ctx_idx = MPIDI_OFI_get_ctx_index(vci, MPIDI_OFI_REQUEST(rreq, nic_num));
 
     if (!MPIDI_OFI_ENABLE_TAGGED) {
-        mpi_errno = MPIDIG_mpi_cancel_recv(rreq);
+        mpi_errno = MPIDIG_mpi_cancel_recv(rreq, false /* is_anysrc_partner */);
         goto fn_exit;
     }
 

--- a/src/mpid/ch4/shm/posix/posix_recv.h
+++ b/src/mpid/ch4/shm/posix/posix_recv.h
@@ -75,9 +75,10 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_irecv(void *buf,
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_cancel_recv(MPIR_Request * rreq)
+MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_mpi_cancel_recv(MPIR_Request * rreq,
+                                                         bool is_anysrc_partner)
 {
-    return MPIDIG_mpi_cancel_recv(rreq);
+    return MPIDIG_mpi_cancel_recv(rreq, is_anysrc_partner);
 }
 
 #endif /* POSIX_RECV_H_INCLUDED */

--- a/src/mpid/ch4/shm/src/shm_am_fallback_recv.h
+++ b/src/mpid/ch4/shm/src/shm_am_fallback_recv.h
@@ -53,9 +53,9 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_irecv(void *buf,
     return mpi_errno;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_recv(MPIR_Request * rreq)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_recv(MPIR_Request * rreq, bool is_anysrc_partner)
 {
-    return MPIDIG_mpi_cancel_recv(rreq);
+    return MPIDIG_mpi_cancel_recv(rreq, is_anysrc_partner);
 }
 
 #endif /* SHM_AM_FALLBACK_RECV_H_INCLUDED */

--- a/src/mpid/ch4/shm/src/shm_p2p.h
+++ b/src/mpid/ch4/shm/src/shm_p2p.h
@@ -85,13 +85,13 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_imrecv(void *buf, MPI_Aint count, MPI
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_recv(MPIR_Request * rreq)
+MPL_STATIC_INLINE_PREFIX int MPIDI_SHM_mpi_cancel_recv(MPIR_Request * rreq, bool is_anysrc_partner)
 {
     int ret;
 
     MPIR_FUNC_ENTER;
 
-    ret = MPIDI_POSIX_mpi_cancel_recv(rreq);
+    ret = MPIDI_POSIX_mpi_cancel_recv(rreq, is_anysrc_partner);
 
     MPIR_FUNC_EXIT;
     return ret;

--- a/src/mpid/ch4/src/ch4_recv.h
+++ b/src/mpid/ch4/src/ch4_recv.h
@@ -69,7 +69,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_cancel_recv_unsafe(MPIR_Request * rreq)
             MPIR_ERR_CHECK(mpi_errno);
             MPIDI_CH4_REQUEST_FREE(partner_rreq);
         }
-        mpi_errno = MPIDI_SHM_mpi_cancel_recv(rreq);
+        mpi_errno = MPIDI_SHM_mpi_cancel_recv(rreq, false /* is_anysrc_partner */);
     } else {
         mpi_errno = MPIDI_NM_mpi_cancel_recv(rreq, false);
     }


### PR DESCRIPTION
## Pull Request Description
In anysrc receive, we create both a NM request and a SHM request. The SHM request is the user visible one. When the NM matches (or in progress), we will cancel the SHM partner. But since the SHM request is user-visible, we can't touch the cancel bits. Instead, we use another mechanism to mark the SHM request is cancelled (by resetting its anysrc_partner fields).

Fixes #7702


[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
