### PR TITLE
datatype: Allocate datatype object in MPIR_Typerep_unflatten

### DIFF
--- a/src/include/mpir_typerep.h
+++ b/src/include/mpir_typerep.h
@@ -41,7 +41,7 @@ void MPIR_Typerep_free(MPIR_Datatype * typeptr);
 
 int MPIR_Typerep_flatten_size(MPIR_Datatype * datatype_ptr, int *flattened_type_size);
 int MPIR_Typerep_flatten(MPIR_Datatype * datatype_ptr, void *flattened_type);
-int MPIR_Typerep_unflatten(MPIR_Datatype * datatype_ptr, void *flattened_type);
+int MPIR_Typerep_unflatten(MPIR_Datatype ** datatype_ptr, void *flattened_type);
 
 /* byte-based offset routine: do not use; only maintained for backward
  * compatibility with ch3 */

--- a/src/mpid/ch3/src/ch3u_handle_recv_req.c
+++ b/src/mpid/ch3/src/ch3u_handle_recv_req.c
@@ -502,14 +502,8 @@ int MPIDI_CH3_ReqHandler_PutDerivedDTRecvComplete(MPIDI_VC_t * vc ATTRIBUTE((unu
     MPIR_FUNC_ENTER;
 
     /* get data from extended header */
-    new_dtp = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
-    if (!new_dtp) {
-        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
-                             "MPIR_Datatype_mem");
-    }
-    /* Note: handle is filled in by MPIR_Handle_obj_alloc() */
-    MPIR_Object_set_ref(new_dtp, 1);
-    MPIR_Typerep_unflatten(new_dtp, rreq->dev.flattened_type);
+    mpi_errno = MPIR_Typerep_unflatten(&new_dtp, rreq->dev.flattened_type);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* update request to get the data */
     MPIDI_Request_set_type(rreq, MPIDI_REQUEST_TYPE_PUT_RECV);
@@ -558,14 +552,8 @@ int MPIDI_CH3_ReqHandler_AccumMetadataRecvComplete(MPIDI_VC_t * vc ATTRIBUTE((un
     }
 
     if (MPIDI_Request_get_type(rreq) == MPIDI_REQUEST_TYPE_ACCUM_RECV_DERIVED_DT) {
-        new_dtp = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
-        if (!new_dtp) {
-            MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
-                                 "MPIR_Datatype_mem");
-        }
-        /* Note: handle is filled in by MPIR_Handle_obj_alloc() */
-        MPIR_Object_set_ref(new_dtp, 1);
-        MPIR_Typerep_unflatten(new_dtp, rreq->dev.flattened_type);
+        mpi_errno = MPIR_Typerep_unflatten(&new_dtp, rreq->dev.flattened_type);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* update new request to get the data */
         MPIDI_Request_set_type(rreq, MPIDI_REQUEST_TYPE_ACCUM_RECV);
@@ -670,14 +658,8 @@ int MPIDI_CH3_ReqHandler_GaccumMetadataRecvComplete(MPIDI_VC_t * vc,
     }
 
     if (MPIDI_Request_get_type(rreq) == MPIDI_REQUEST_TYPE_GET_ACCUM_RECV_DERIVED_DT) {
-        new_dtp = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
-        if (!new_dtp) {
-            MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
-                                 "MPIR_Datatype_mem");
-        }
-        /* Note: handle is filled in by MPIR_Handle_obj_alloc() */
-        MPIR_Object_set_ref(new_dtp, 1);
-        MPIR_Typerep_unflatten(new_dtp, rreq->dev.flattened_type);
+        mpi_errno = MPIR_Typerep_unflatten(&new_dtp, rreq->dev.flattened_type);
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* update new request to get the data */
         MPIDI_Request_set_type(rreq, MPIDI_REQUEST_TYPE_GET_ACCUM_RECV);
@@ -771,14 +753,8 @@ int MPIDI_CH3_ReqHandler_GetDerivedDTRecvComplete(MPIDI_VC_t * vc,
     MPIR_Assert(!(rreq->dev.pkt_flags & MPIDI_CH3_PKT_FLAG_RMA_IMMED_RESP));
 
     /* get data from extended header */
-    new_dtp = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
-    if (!new_dtp) {
-        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
-                             "MPIR_Datatype_mem");
-    }
-    /* Note: handle is filled in by MPIR_Handle_obj_alloc() */
-    MPIR_Object_set_ref(new_dtp, 1);
-    MPIR_Typerep_unflatten(new_dtp, rreq->dev.flattened_type);
+    mpi_errno = MPIR_Typerep_unflatten(&new_dtp, rreq->dev.flattened_type);
+    MPIR_ERR_CHECK(mpi_errno);
 
     /* create request for sending data */
     sreq = MPIR_Request_create(MPIR_REQUEST_KIND__UNDEFINED);

--- a/src/mpid/ch4/shm/ipc/cma/cma_post.c
+++ b/src/mpid/ch4/shm/ipc/cma/cma_post.c
@@ -36,9 +36,8 @@ int MPIDI_CMA_copy_data(MPIDI_IPC_hdr * ipc_hdr, MPIR_Request * rreq, MPI_Aint s
         src_iovs[0].iov_len = src_data_sz;
     } else {
         void *flattened_type = ipc_hdr + 1;
-        MPIR_Datatype *dt = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
-        MPIR_Assert(dt);
-        mpi_errno = MPIR_Typerep_unflatten(dt, flattened_type);
+        MPIR_Datatype *dt;
+        mpi_errno = MPIR_Typerep_unflatten(&dt, flattened_type);
         MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = get_iovs((void *) ipc_hdr->ipc_handle.cma.vaddr, ipc_hdr->count, dt->handle,

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -671,9 +671,7 @@ int MPIDI_GPU_copy_data_async(MPIDI_IPC_hdr * ipc_hdr, MPIR_Request * req, MPI_A
     } else {
         /* TODO: get sender datatype and call MPIR_Typerep_op with mapped_device set to dev_id */
         void *flattened_type = ipc_hdr + 1;
-        src_dt_ptr = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
-        MPIR_Assert(src_dt_ptr);
-        mpi_errno = MPIR_Typerep_unflatten(src_dt_ptr, flattened_type);
+        mpi_errno = MPIR_Typerep_unflatten(&src_dt_ptr, flattened_type);
         MPIR_ERR_CHECK(mpi_errno);
 
         src_count = ipc_hdr->count;
@@ -732,9 +730,8 @@ int MPIDI_GPU_write_data_async(MPIDI_IPC_hdr * ipc_hdr, MPIR_Request * sreq)
     } else {
         /* TODO: get sender datatype and call MPIR_Typerep_op with mapped_device set to dev_id */
         void *flattened_type = ipc_hdr + 1;
-        MPIR_Datatype *dt_ptr = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
-        MPIR_Assert(dt_ptr);
-        mpi_errno = MPIR_Typerep_unflatten(dt_ptr, flattened_type);
+        MPIR_Datatype *dt_ptr;
+        mpi_errno = MPIR_Typerep_unflatten(&dt_ptr, flattened_type);
         MPIR_ERR_CHECK(mpi_errno);
 
         dst_count = ipc_hdr->count;

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -324,9 +324,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_copy_data(MPIDI_IPC_hdr * ipc_hdr, MPIR_
         MPIR_Assert(actual_unpack_bytes == src_data_sz);
     } else {
         void *flattened_type = ipc_hdr + 1;
-        MPIR_Datatype *dt = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
-        MPIR_Assert(dt);
-        mpi_errno = MPIR_Typerep_unflatten(dt, flattened_type);
+        MPIR_Datatype *dt;
+        mpi_errno = MPIR_Typerep_unflatten(&dt, flattened_type);
         MPIR_ERR_CHECK(mpi_errno);
 
         mpi_errno = MPIR_Localcopy(src_buf, ipc_hdr->count, dt->handle,

--- a/src/mpid/ch4/src/mpidig_rma_callbacks.c
+++ b/src/mpid/ch4/src/mpidig_rma_callbacks.c
@@ -871,11 +871,9 @@ static void handle_acc_data(MPI_Aint in_data_sz, MPIR_Request * rreq)
     MPIDIG_REQUEST(rreq, req->areq.data) = p_data;
 
     if (MPIDIG_REQUEST(rreq, req->areq.flattened_dt)) {
-        /* FIXME: MPIR_Typerep_unflatten should allocate the new object */
-        MPIR_Datatype *dt = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
+        MPIR_Datatype *dt;
+        MPIR_Typerep_unflatten(&dt, MPIDIG_REQUEST(rreq, req->areq.flattened_dt));
         MPIR_Assert(dt);
-        MPIR_Object_set_ref(dt, 1);
-        MPIR_Typerep_unflatten(dt, MPIDIG_REQUEST(rreq, req->areq.flattened_dt));
         MPIDIG_REQUEST(rreq, req->areq.target_datatype) = dt->handle;
     }
 
@@ -912,14 +910,9 @@ static int get_target_cmpl_cb(MPIR_Request * rreq)
         goto fn_exit;
     }
 
-    /* FIXME: MPIR_Typerep_unflatten should allocate the new object */
-    MPIR_Datatype *dt = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
-    if (!dt) {
-        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
-                             "MPIR_Datatype_mem");
-    }
-    MPIR_Object_set_ref(dt, 1);
-    MPIR_Typerep_unflatten(dt, MPIDIG_REQUEST(rreq, req->greq.flattened_dt));
+    MPIR_Datatype *dt;
+    mpi_errno = MPIR_Typerep_unflatten(&dt, MPIDIG_REQUEST(rreq, req->greq.flattened_dt));
+    MPIR_ERR_CHECK(mpi_errno);
     MPIDIG_REQUEST(rreq, datatype) = dt->handle;
     /* count is still target_data_sz now, use it for reply */
     get_ack.target_data_sz = MPIDIG_REQUEST(rreq, count);
@@ -1472,14 +1465,9 @@ int MPIDIG_put_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
 
     offset = win->disp_unit * msg_hdr->target_disp;
     if (msg_hdr->flattened_sz) {
-        /* FIXME: MPIR_Typerep_unflatten should allocate the new object */
-        MPIR_Datatype *dt = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
-        if (!dt) {
-            MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
-                                 "MPIR_Datatype_mem");
-        }
-        MPIR_Object_set_ref(dt, 1);
-        MPIR_Typerep_unflatten(dt, (char *) am_hdr + sizeof(*msg_hdr));
+        MPIR_Datatype *dt;
+        mpi_errno = MPIR_Typerep_unflatten(&dt, (char *) am_hdr + sizeof(*msg_hdr));
+        MPIR_ERR_CHECK(mpi_errno);
         MPIDIG_REQUEST(rreq, req->preq.flattened_dt) = NULL;
 
         MPIDIG_REQUEST(rreq, buffer) = (void *) (base + offset);
@@ -1715,15 +1703,9 @@ int MPIDIG_put_data_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
 
     rreq = (MPIR_Request *) msg_hdr->preq_ptr;
 
-    /* FIXME: MPIR_Typerep_unflatten should allocate the new object */
-    MPIR_Datatype *dt = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
-    if (!dt) {
-        MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
-                             "MPIR_Datatype_mem");
-    }
-    /* Note: handle is filled in by MPIR_Handle_obj_alloc() */
-    MPIR_Object_set_ref(dt, 1);
-    MPIR_Typerep_unflatten(dt, MPIDIG_REQUEST(rreq, req->preq.flattened_dt));
+    MPIR_Datatype *dt;
+    mpi_errno = MPIR_Typerep_unflatten(&dt, MPIDIG_REQUEST(rreq, req->preq.flattened_dt));
+    MPIR_ERR_CHECK(mpi_errno);
     MPIDIG_REQUEST(rreq, datatype) = dt->handle;
 
     MPIDIG_REQUEST(rreq, req->target_cmpl_cb) = put_target_cmpl_cb;
@@ -1922,14 +1904,9 @@ int MPIDIG_acc_target_msg_cb(void *am_hdr, void *data, MPI_Aint in_data_sz,
     MPIDIG_REQUEST(rreq, u.target.origin_rank) = msg_hdr->src_rank;
 
     if (msg_hdr->flattened_sz) {
-        /* FIXME: MPIR_Typerep_unflatten should allocate the new object */
-        MPIR_Datatype *dt = (MPIR_Datatype *) MPIR_Handle_obj_alloc(&MPIR_Datatype_mem);
-        if (!dt) {
-            MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
-                                 "MPIR_Datatype_mem");
-        }
-        MPIR_Object_set_ref(dt, 1);
-        MPIR_Typerep_unflatten(dt, (char *) am_hdr + sizeof(*msg_hdr));
+        MPIR_Datatype *dt;
+        mpi_errno = MPIR_Typerep_unflatten(&dt, (char *) am_hdr + sizeof(*msg_hdr));
+        MPIR_ERR_CHECK(mpi_errno);
         MPIDIG_REQUEST(rreq, req->areq.target_datatype) = dt->handle;
     }
 


### PR DESCRIPTION
## Pull Request Description

Unflattening a datatype requires a freshly allocated datatype object. Allocate the object within the unflatten function to save the extra code at all the call sites.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
