### PR TITLE
hydra: avoid duplicate proxies in spawn

### DIFF
--- a/src/pm/hydra/lib/hydra.h
+++ b/src/pm/hydra/lib/hydra.h
@@ -529,6 +529,8 @@ HYD_status HYDU_create_process(char **client_arg, struct HYD_env *env_list,
 /* others */
 int HYDU_dceil(int x, int y);
 HYD_status HYDU_add_to_node_list(const char *hostname, int num_procs, struct HYD_node **node_list);
+HYD_status HYDU_merge_user_node_list(struct HYD_node *user_node_list,
+                                     struct HYD_node **node_list_p);
 void HYDU_delay(unsigned long delay);
 
 /* signals */

--- a/src/pm/hydra/lib/utils/others.c
+++ b/src/pm/hydra/lib/utils/others.c
@@ -56,6 +56,74 @@ HYD_status HYDU_add_to_node_list(const char *hostname, int num_procs, struct HYD
     goto fn_exit;
 }
 
+/* user may spawn with a separate host list (potentially with different core count).
+ * We create a separate user_node_list and use it to generate rankmap, but also need
+ * merge with the main node list to avoid duplicate proxies.
+ *
+ * This is a variation of HYDU_add_to_node_list. It checks for existing nodes. If exist,
+ * update the core_count to the max of both; Otherwise, add to existing nodes. It returns
+ * the ndoe id from the node list.
+ */
+static HYD_status merge_to_node_list(const char *hostname, int num_procs,
+                                     struct HYD_node **node_list, int *new_node_id)
+{
+    HYD_status status = HYD_SUCCESS;
+
+    struct HYD_node *node = NULL;
+    struct HYD_node *last_node = NULL;
+
+    for (node = *node_list; node; node = node->next) {
+        if (strcmp(node->hostname, hostname) == 0) {
+            break;
+        }
+        last_node = node;
+    }
+
+    if (node) {
+        /* if found, update core_count */
+        if (num_procs > node->core_count) {
+            node->core_count = num_procs;
+        }
+    } else {
+        /* not found, add to node_list */
+        status = HYDU_alloc_node(&node);
+        HYDU_ERR_POP(status, "unable to allocate node\n");
+
+        node->hostname = MPL_strdup(hostname);
+        node->core_count = num_procs;
+
+        if (last_node) {
+            last_node->next = node;
+            node->node_id = last_node->node_id + 1;
+        } else {
+            node->node_id = 0;
+            *node_list = node;
+        }
+    }
+
+    *new_node_id = node->node_id;
+
+  fn_exit:
+    return status;
+  fn_fail:
+    goto fn_exit;
+}
+
+HYD_status HYDU_merge_user_node_list(struct HYD_node *user_node_list, struct HYD_node **node_list_p)
+{
+    HYD_status status = HYD_SUCCESS;
+
+    for (struct HYD_node * node = user_node_list; node; node = node->next) {
+        status = merge_to_node_list(node->hostname, node->core_count, node_list_p, &node->node_id);
+        HYDU_ERR_POP(status, "unable to allocate node\n");
+    }
+
+  fn_exit:
+    return status;
+  fn_fail:
+    goto fn_exit;
+}
+
 void HYDU_delay(unsigned long delay)
 {
     struct timeval start, end;

--- a/src/pm/hydra/mpiexec/pmiserv_spawn.c
+++ b/src/pm/hydra/mpiexec/pmiserv_spawn.c
@@ -250,11 +250,20 @@ static HYD_status do_spawn(void)
     struct HYD_node *node_list;
     if (pg->user_node_list) {
         node_list = pg->user_node_list;
+        status = HYDU_merge_user_node_list(pg->user_node_list, &HYD_server_info.node_list);
+        HYDU_ERR_POP(status, "unable to merge user_node_list\n");
     } else {
         node_list = HYD_server_info.node_list;
     }
     status = HYDU_gen_rankmap(pg->pg_process_count, node_list, &pg->rankmap);
     HYDU_ERR_POP(status, "error create rankmap\n");
+
+    /* we only need user_node_list to generate rankmap */
+    if (pg->user_node_list) {
+        HYDU_free_node_list(pg->user_node_list);
+        pg->user_node_list = NULL;
+        node_list = HYD_server_info.node_list;
+    }
 
     status = HYDU_create_proxy_list(pg->pg_process_count, exec_list, node_list,
                                     pg->pgid, pg->rankmap,


### PR DESCRIPTION
## Pull Request Description
When user spawn with a host list in info hints, hydra creates new user_node_list, which results in launching new proxies. We only need the separate user_node_list for figuring out where to create the new processes, i.e. rankmap; but we should merge to the main node list to reuse the proxies.

For example, the following code will create multiple proxies even though all processes are launched on the local host:
```
    MPI_Info_create(&info);
    MPI_Info_set(info, "host", hostname);
    MPI_Info_set(info, "map-by", "ppr:1:node");
    MPI_Info_set(info, "bind_to", "core");

    for (int i = 0; i < 5; ++i)
    {
        MPI_Comm_spawn("./TestSpawn", argv, 1, info, 0, MPI_COMM_SELF, &null_comm, error_codes);
    }
```
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
