### PR TITLE
mpir/pmi: do not return from MPIR_pmi_abort

### DIFF
--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -333,6 +333,7 @@ void MPIR_pmi_abort(int exit_code, const char *error_msg)
 {
     SWITCH_PMI(pmi1_abort(exit_code, error_msg),
                pmi2_abort(exit_code, error_msg), pmix_abort(exit_code, error_msg));
+    exit(exit_code);
 }
 
 /* getters for internal constants */


### PR DESCRIPTION
## Pull Request Description

When user call MPI_Abort(MPI_COMM_WORLD), we call PMI_Abort and rely on the PMI server to kill all processes. This results in a gap when user code continue to run after MPI_Abort before it is being killed by the process manager. While this is not a critical issue - user is aborting anyway - it creates indeterministic error behaviors and obfuscates debugging.

Add exit after PMI_Abort.

Fixes #7716
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
