### PR TITLE
configure: check whether complex is available for CXX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3584,18 +3584,30 @@ fi
 if test -n "$CXX" ; then
     len=`expr $ac_cv_sizeof_bool \* 8`
     AC_DEFINE_UNQUOTED([MPIR_CXX_BOOL_INTERNAL],      [MPIR_INT$len], [Internal type for MPI_CXX_BOOL])
-    len=`expr $ac_cv_sizeof_Complex / 2 \* 8`
-    AC_DEFINE_UNQUOTED([MPIR_CXX_FLOAT_COMPLEX_INTERNAL],[MPIR_COMPLEX$len], [Internal type for MPI_CXX_FLOAT_COMPLEX])
-    len=`expr $ac_cv_sizeof_DoubleComplex / 2 \* 8`
-    AC_DEFINE_UNQUOTED([MPIR_CXX_DOUBLE_COMPLEX_INTERNAL],[MPIR_COMPLEX$len], [Internal type for MPI_CXX_DOUBLE_COMPLEX])
-    len=`expr $ac_cv_sizeof_LongDoubleComplex / 2 \* 8`
-    if test "$len" = 64 ; then
-        # long double is an alias of double, e.g. arm64
-        internal_type=MPIR_COMPLEX$len
+    if test "$ac_cv_sizeof_Complex" -gt 0 ; then
+        len=`expr $ac_cv_sizeof_Complex / 2 \* 8`
+        AC_DEFINE_UNQUOTED([MPIR_CXX_FLOAT_COMPLEX_INTERNAL],[MPIR_COMPLEX$len], [Internal type for MPI_CXX_FLOAT_COMPLEX])
     else
-        internal_type=MPIR_ALT_COMPLEX$len
+        AC_DEFINE_UNQUOTED([MPIR_CXX_FLOAT_COMPLEX_INTERNAL], [MPI_DATATYPE_NULL], [Internal type for MPI_CXX_FLOAT_COMPLEX])
     fi
-    AC_DEFINE_UNQUOTED([MPIR_CXX_LONG_DOUBLE_COMPLEX_INTERNAL],[$internal_type], [Internal type for MPI_CXX_LONG_DOUBLE_COMPLEX])
+    if test "$ac_cv_sizeof_Complex" -gt 0 ; then
+        len=`expr $ac_cv_sizeof_DoubleComplex / 2 \* 8`
+        AC_DEFINE_UNQUOTED([MPIR_CXX_DOUBLE_COMPLEX_INTERNAL],[MPIR_COMPLEX$len], [Internal type for MPI_CXX_DOUBLE_COMPLEX])
+    else
+        AC_DEFINE_UNQUOTED([MPIR_CXX_DOUBLE_COMPLEX_INTERNAL],[MPI_DATATYPE_NULL], [Internal type for MPI_CXX_DOUBLE_COMPLEX])
+    fi
+    if test "$ac_cv_sizeof_LongDoubleComplex" -gt 0 ; then
+        len=`expr $ac_cv_sizeof_LongDoubleComplex / 2 \* 8`
+        if test "$len" = 64 ; then
+            # long double is an alias of double, e.g. arm64
+            internal_type=MPIR_COMPLEX$len
+        else
+            internal_type=MPIR_ALT_COMPLEX$len
+        fi
+        AC_DEFINE_UNQUOTED([MPIR_CXX_LONG_DOUBLE_COMPLEX_INTERNAL],[$internal_type], [Internal type for MPI_CXX_LONG_DOUBLE_COMPLEX])
+    else
+        AC_DEFINE_UNQUOTED([MPIR_CXX_LONG_DOUBLE_COMPLEX_INTERNAL],[MPI_DATATYPE_NULL], [Internal type for MPI_CXX_LONG_DOUBLE_COMPLEX])
+    fi
 else
     AC_DEFINE_UNQUOTED([MPIR_CXX_BOOL_INTERNAL],          [MPI_DATATYPE_NULL], [Internal type for MPI_CXX_BOOL])
     AC_DEFINE_UNQUOTED([MPIR_CXX_FLOAT_COMPLEX_INTERNAL], [MPI_DATATYPE_NULL], [Internal type for MPI_CXX_FLOAT_COMPLEX])


### PR DESCRIPTION
## Pull Request Description
Don't assume the complex types are always available in CXX.

Potentially fixes #7719

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
