### PR TITLE
Fix MPIR_Internal_op_dt_check to allow MPI_LOGICAL with MPI_LAND/MPI_LOR/MPI_LXOR

### DIFF
--- a/src/include/mpir_datatype.h
+++ b/src/include/mpir_datatype.h
@@ -894,6 +894,14 @@ MPL_STATIC_INLINE_PREFIX bool MPIR_Internal_op_dt_check(MPI_Op op, MPI_Datatype 
         case MPI_LAND:
         case MPI_LOR:
         case MPI_LXOR:
+            switch (dt_type) {
+                case MPIR_TYPE_SIGNED:
+                case MPIR_TYPE_UNSIGNED:
+                case MPIR_TYPE_FORTRAN_LOGICAL:
+                    return true;
+                default:
+                    return false;
+            }
         case MPI_BAND:
         case MPI_BOR:
         case MPI_BXOR:


### PR DESCRIPTION
## Pull Request Description
`MPIR_Internal_op_dt_check` in `src/include/mpir_datatype.h` groups `MPI_LAND/MPI_LOR/MPI_LXOR` with `MPI_BAND/MPI_BOR/MPI_BXOR` and only allows `MPIR_TYPE_SIGNED` and `MPIR_TYPE_UNSIGNED`. This causes an assertion failure in [reduce_local.c:64](https://github.com/pmodels/mpich/blob/main/src/mpi/coll/reduce_local/reduce_local.c#L64) when using `MPI_Allreduce` with `MPI_LOGICAL` + `MPI_LOR`/`MPI_LAND`/`MPI_LXOR` (≥2 processes), which is a valid combination per the MPI standard (MPI-4.1, §6.9.2, p.228; and MPI-5.0, §6.9.2, p.227). This breaks real-world applications such as CP2K/DBCSR.

The fix splits the logical ops from the bitwise ops and adds `MPIR_TYPE_FORTRAN_LOGICAL` to the logical ops branch. Hope this fix can be included in the next release.

Reproducer for this problem (`test_lor.f90`):
```
program test_lor
  use mpi
  implicit none
  integer :: ierr, rank
  logical :: val
  call MPI_Init(ierr)
  call MPI_Comm_rank(MPI_COMM_WORLD, rank, ierr)
  val = (rank == 0)
  call MPI_Allreduce(MPI_IN_PLACE, val, 1, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD, ierr)
  print *, "Rank", rank, "result:", val
  call MPI_Finalize(ierr)
end program
```

**P.S. I have read and signed Individual Contributors’ License Agreement and posted to cla@mpich.org from uwsy1059@qq.com.**

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
