### PR TITLE
attr: fix MPIX_(Type|Win)_create_keyval_x

### DIFF
--- a/src/mpi/attr/attr_impl.c
+++ b/src/mpi/attr/attr_impl.c
@@ -103,8 +103,8 @@ int MPIR_Comm_create_keyval_x_impl(MPI_Comm_copy_attr_function * comm_copy_attr_
     }
 #endif
 
-    return create_keyval_x(comm_copy_attr_fn, comm_delete_attr_fn, destructor_fn,
-                           comm_keyval, extra_state, MPIR_COMM);
+    return create_keyval_x(comm_copy_attr_fn, comm_delete_attr_fn,
+                           destructor_fn, comm_keyval, extra_state, MPIR_COMM);
 }
 
 int MPIR_Type_create_keyval_x_impl(MPI_Type_copy_attr_function * type_copy_attr_fn,
@@ -126,8 +126,9 @@ int MPIR_Type_create_keyval_x_impl(MPI_Type_copy_attr_function * type_copy_attr_
     /* Tell finalize to check for attributes on permanent types */
     MPII_Datatype_attr_finalize();
 
-    return create_keyval_x(type_copy_attr_fn, type_delete_attr_fn, destructor_fn,
-                           type_keyval, extra_state, MPIR_DATATYPE);
+    return create_keyval_x((MPI_Comm_copy_attr_function *) type_copy_attr_fn,
+                           (MPI_Comm_delete_attr_function *) type_delete_attr_fn,
+                           destructor_fn, type_keyval, extra_state, MPIR_DATATYPE);
 }
 
 int MPIR_Win_create_keyval_x_impl(MPI_Win_copy_attr_function * win_copy_attr_fn,
@@ -146,8 +147,9 @@ int MPIR_Win_create_keyval_x_impl(MPI_Win_copy_attr_function * win_copy_attr_fn,
     }
 #endif
 
-    return create_keyval_x(win_copy_attr_fn, win_delete_attr_fn, destructor_fn,
-                           win_keyval, extra_state, MPIR_WIN);
+    return create_keyval_x((MPI_Comm_copy_attr_function *) win_copy_attr_fn,
+                           (MPI_Comm_delete_attr_function *) win_delete_attr_fn,
+                           destructor_fn, win_keyval, extra_state, MPIR_WIN);
 }
 
 int MPIR_Comm_create_keyval_impl(MPI_Comm_copy_attr_function * comm_copy_attr_fn,


### PR DESCRIPTION
## Pull Request Description

Fixes issue introduced in 
```
commit 319b09eb33d78085522a120698120fe3da229393
Author: Hui Zhou <hzhou321@anl.gov>
Date:   Wed Jan 7 16:10:17 2026 -0600

    attr: add MPIX_Comm_create_keyval_x etc.
    
    Add MPIX_{Comm,Type,Win}_create_keyval_x.
    
    Similar to MPI_{Comm,Type,Win}_create_keyval, but with an additional
    destructor callback so the users can cleanup the extra_state.
```

Add function casts to silence GCC -Wincompatible-pointer-types
```console
  CC       src/mpi/attr/lib_libmpi_abi_la-attr_impl.lo
../mpich/src/mpi/attr/attr_impl.c: In function 'MPIR_Type_create_keyval_x_impl':
../mpich/src/mpi/attr/attr_impl.c:129:28: error: passing argument 1 of 'create_keyval_x' from incompatible pointer type [-Wincompatible-pointer-types]
  129 |     return create_keyval_x(type_copy_attr_fn, type_delete_attr_fn, destructor_fn,
      |                            ^~~~~~~~~~~~~~~~~
      |                            |
      |                            int (*)(struct MPI_ABI_Datatype *, int,  void *, void *, void *, int *)
../mpich/src/mpi/attr/attr_impl.c:48:58: note: expected 'int (*)(struct MPI_ABI_Comm *, int,  void *, void *, void *, int *)' but argument is of type 'int (*)(struct MPI_ABI_Datatype *, int,  void *, void *, void *, int *)'
   48 | static int create_keyval_x(MPI_Comm_copy_attr_function * copy_fn,
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
../mpich/src/mpi/attr/attr_impl.c:129:47: error: passing argument 2 of 'create_keyval_x' from incompatible pointer type [-Wincompatible-pointer-types]
  129 |     return create_keyval_x(type_copy_attr_fn, type_delete_attr_fn, destructor_fn,
      |                                               ^~~~~~~~~~~~~~~~~~~
      |                                               |
      |                                               int (*)(struct MPI_ABI_Datatype *, int,  void *, void *)
../mpich/src/mpi/attr/attr_impl.c:49:60: note: expected 'int (*)(struct MPI_ABI_Comm *, int,  void *, void *)' but argument is of type 'int (*)(struct MPI_ABI_Datatype *, int,  void *, void *)'
   49 |                            MPI_Comm_delete_attr_function * delete_fn,
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
../mpich/src/mpi/attr/attr_impl.c: In function 'MPIR_Win_create_keyval_x_impl':
../mpich/src/mpi/attr/attr_impl.c:149:28: error: passing argument 1 of 'create_keyval_x' from incompatible pointer type [-Wincompatible-pointer-types]
  149 |     return create_keyval_x(win_copy_attr_fn, win_delete_attr_fn, destructor_fn,
      |                            ^~~~~~~~~~~~~~~~
      |                            |
      |                            int (*)(struct MPI_ABI_Win *, int,  void *, void *, void *, int *)
../mpich/src/mpi/attr/attr_impl.c:48:58: note: expected 'int (*)(struct MPI_ABI_Comm *, int,  void *, void *, void *, int *)' but argument is of type 'int (*)(struct MPI_ABI_Win *, int,  void *, void *, void *, int *)'
   48 | static int create_keyval_x(MPI_Comm_copy_attr_function * copy_fn,
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
../mpich/src/mpi/attr/attr_impl.c:149:46: error: passing argument 2 of 'create_keyval_x' from incompatible pointer type [-Wincompatible-pointer-types]
  149 |     return create_keyval_x(win_copy_attr_fn, win_delete_attr_fn, destructor_fn,
      |                                              ^~~~~~~~~~~~~~~~~~
      |                                              |
      |                                              int (*)(struct MPI_ABI_Win *, int,  void *, void *)
../mpich/src/mpi/attr/attr_impl.c:49:60: note: expected 'int (*)(struct MPI_ABI_Comm *, int,  void *, void *)' but argument is of type 'int (*)(struct MPI_ABI_Win *, int,  void *, void *)'
   49 |                            MPI_Comm_delete_attr_function * delete_fn,
      |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
make[2]: *** [Makefile:24640: src/mpi/attr/lib_libmpi_abi_la-attr_impl.lo] Error 1
```

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
