### PR TITLE
fortran/user_proxy: add missing return

### DIFF
--- a/src/binding/fortran/mpif_h/user_proxy.c
+++ b/src/binding/fortran/mpif_h/user_proxy.c
@@ -33,6 +33,8 @@ static int F77_attr_copy_proxy(int handle, int keyval, void *context,
     p->copy_fn(&fhandle, &fkeyval, fextra, &fvalue, &fnew, &fflag, &ierr);
     *flag = MPII_FROM_FLOG(fflag);
     *(void **) value_out = (void *) fnew;
+
+    return (int) ierr;
 }
 
 static int F77_attr_delete_proxy(int handle, int keyval, void *value, void *context)


### PR DESCRIPTION
## Pull Request Description
Add the missing return in the Fortran attribute copy proxy. This was not caught in our review CI because the return value is random depends on the compiler. Intel's oneapi compiler caught this.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
