### PR TITLE
pm/gforker: fix build due to rename of mpllib

### DIFF
--- a/src/pm/gforker/Makefile.mk
+++ b/src/pm/gforker/Makefile.mk
@@ -14,17 +14,15 @@ if BUILD_PM_GFORKER
 if PRIMARY_PM_GFORKER
 bin_PROGRAMS += src/pm/gforker/mpiexec
 src_pm_gforker_mpiexec_SOURCES = src/pm/gforker/mpiexec.c 
-src_pm_gforker_mpiexec_LDADD = src/pm/util/libmpiexec.la $(mpllib)
-src_pm_gforker_mpiexec_LDFLAGS = $(mpllibdir)
-EXTRA_src_pm_gforker_mpiexec_DEPENDENCIES = $(mpllib)
+src_pm_gforker_mpiexec_LDADD = src/pm/util/libmpiexec.la $(mpl_lib)
+EXTRA_src_pm_gforker_mpiexec_DEPENDENCIES = $(mpl_lib)
 # we may not want to add AM_CPPFLAGS for this program
 src_pm_gforker_mpiexec_CPPFLAGS = $(common_pm_includes) $(AM_CPPFLAGS)
 else !PRIMARY_PM_GFORKER
 bin_PROGRAMS += src/pm/gforker/mpiexec.gforker
 src_pm_gforker_mpiexec_gforker_SOURCES = src/pm/gforker/mpiexec.c 
-src_pm_gforker_mpiexec_gforker_LDADD = src/pm/util/libmpiexec.la $(mpllib)
-src_pm_gforker_mpiexec_gforker_LDFLAGS = $(mpllibdir)
-EXTRA_src_pm_gforker_mpiexec_gforker_DEPENDENCIES = $(mpllib)
+src_pm_gforker_mpiexec_gforker_LDADD = src/pm/util/libmpiexec.la $(mpl_lib)
+EXTRA_src_pm_gforker_mpiexec_gforker_DEPENDENCIES = $(mpl_lib)
 # we may not want to add AM_CPPFLAGS for this program
 src_pm_gforker_mpiexec_gforker_CPPFLAGS = $(common_pm_includes) $(AM_CPPFLAGS)
 endif !PRIMARY_PM_GFORKER

--- a/src/pm/remshell/Makefile.mk
+++ b/src/pm/remshell/Makefile.mk
@@ -14,17 +14,15 @@ if BUILD_PM_REMSHELL
 if PRIMARY_PM_REMSHELL
 bin_PROGRAMS += src/pm/remshell/mpiexec
 src_pm_remshell_mpiexec_SOURCES = src/pm/remshell/mpiexec.c 
-src_pm_remshell_mpiexec_LDADD = src/pm/util/libmpiexec.la $(mpllib)
-src_pm_remshell_mpiexec_LDFLAGS = $(mpllibdir)
-EXTRA_src_pm_remshell_mpiexec_DEPENDENCIES = $(mpllib)
+src_pm_remshell_mpiexec_LDADD = src/pm/util/libmpiexec.la $(mpl_lib)
+EXTRA_src_pm_remshell_mpiexec_DEPENDENCIES = $(mpl_lib)
 # we may not want to add AM_CPPFLAGS for this program
 src_pm_remshell_mpiexec_CPPFLAGS = $(common_pm_includes) $(AM_CPPFLAGS)
 else !PRIMARY_PM_REMSHELL
 bin_PROGRAMS += src/pm/remshell/mpiexec.remshell
 src_pm_remshell_mpiexec_remshell_SOURCES = src/pm/remshell/mpiexec.c 
-src_pm_remshell_mpiexec_remshell_LDADD = src/pm/util/libmpiexec.la $(mpllib)
-src_pm_remshell_mpiexec_remshell_LDFLAGS = $(mpllibdir)
-EXTRA_src_pm_remshell_mpiexec_remshell_DEPENDENCIES = $(mpllib)
+src_pm_remshell_mpiexec_remshell_LDADD = src/pm/util/libmpiexec.la $(mpl_lib)
+EXTRA_src_pm_remshell_mpiexec_remshell_DEPENDENCIES = $(mpl_lib)
 # we may not want to add AM_CPPFLAGS for this program
 src_pm_remshell_mpiexec_remshell_CPPFLAGS = $(common_pm_includes) $(AM_CPPFLAGS)
 endif !PRIMARY_PM_REMSHELL

--- a/src/pm/util/Makefile.mk
+++ b/src/pm/util/Makefile.mk
@@ -25,9 +25,8 @@ src_pm_util_libmpiexec_la_CFLAGS = -g $(AM_CFLAGS)
 src_pm_util_libmpiexec_la_CPPFLAGS = $(common_pm_includes) $(AM_CPPFLAGS)
 
 # MPL
-src_pm_util_libmpiexec_la_LIBADD = $(mpllib)
-src_pm_util_libmpiexec_la_LDFLAGS = $(mpllibdir)
-EXTRA_src_pm_util_libmpiexec_la_DEPENDENCIES = $(mpllib)
+src_pm_util_libmpiexec_la_LIBADD = $(mpl_lib)
+EXTRA_src_pm_util_libmpiexec_la_DEPENDENCIES = $(mpl_lib)
 
 # We use the msg print routines (for now) - include these in the mpiexec
 # library so that we don't need to copy the source files


### PR DESCRIPTION
## Pull Request Description
The autoconf macro mpllib was changed to mpl_lib in the previous PR #7688 and we neglected to update the makefiles for gforker and remshell.


Fixes #7728 

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
