### PR TITLE
maint: remove extra autogen in test/mpl in release.pl

### DIFF
--- a/maint/release.pl
+++ b/maint/release.pl
@@ -235,17 +235,6 @@ chdir($expdir);
 }
 print("done\n");
 
-# Create test/mpi/configure
-print("===> Creating configure in the test/mpi... ");
-chdir("$expdir/test/mpi");
-{
-    my $cmd = "./autogen.sh";
-    $cmd .= " --with-autoconf=$with_autoconf" if $with_autoconf;
-    $cmd .= " --with-automake=$with_automake" if $with_automake;
-    run_cmd($cmd);
-}
-print("done\n");
-
 # Disable unnecessary tests in the release tarball
 print("===> Disabling unnecessary tests in the main codebase... ");
 chdir($expdir);


### PR DESCRIPTION
## Pull Request Description

The main `autogen.sh` already ran `autogen` in `test/mpl`. A separate run in `test/mpl` without setting `MPICH_CONFDB` produces broken `configure` script due to missing `confdb` libraries.

This PR fixes the current nightly CI testing
## Background

The separate autogen for `test/mpi` was added here: https://github.com/pmodels/mpich/pull/5711/changes/8c65c2fb77525cc93efcb2383413e704b50ad2da

I don't recall why it was added, but it appears to be a mistake. It used to be harmless. But with #7688, the sub-autogen need be run from the main `autogen.sh` or with `MPICH_CONFDB` set.

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
