### PR TITLE
mpl/gpu: Move cudalt.sh alongside CUDA code

### DIFF
--- a/src/mpl/src/gpu/Makefile.mk
+++ b/src/mpl/src/gpu/Makefile.mk
@@ -11,11 +11,11 @@ lib@MPLLIBNAME@_la_SOURCES += src/gpu/mpl_gpu_cuda_kernels.cu
 
 .cu.lo:
 	@if $(AM_V_P) ; then \
-		$(top_srcdir)/confdb/cudalt.sh --verbose $@ \
+		$(top_srcdir)/src/gpu/cudalt.sh --verbose $@ \
 			$(NVCC) $(AM_CPPFLAGS) -c $< ; \
 	else \
 		echo "  NVCC     $@" ; \
-		$(top_srcdir)/confdb/cudalt.sh $@ $(NVCC) $(AM_CPPFLAGS) -c $< ; \
+		$(top_srcdir)/src/gpu/cudalt.sh $@ $(NVCC) $(AM_CPPFLAGS) -c $< ; \
 	fi
 else
 if MPL_HAVE_ZE

--- a/src/mpl/src/gpu/cudalt.sh
+++ b/src/mpl/src/gpu/cudalt.sh
@@ -60,4 +60,3 @@ pic_object="$LOCAL_PIC_FILEPATH"
 # Name of the non-PIC object.
 non_pic_object="$LOCAL_NPIC_FILEPATH"
 EOF
-


### PR DESCRIPTION
## Pull Request Description

After commit f7e90c36 ("autogen: avoid duplicating confdb and submodules"), src/mpl/confdb/ is no longer populated from the top-level confdb/. This breaks the MPL CUDA build since it depended on the cudalt.sh script located in the top-level confdb.

Move cudalt.sh directly into src/mpl/src/gpu/ alongside the CUDA source files and update Makefile.mk to reference it via $(srcdir), eliminating the dependency.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
