### PR TITLE
Add missing snprintf call to MPL_DBG_MSG_FMT

### DIFF
--- a/src/mpl/include/mpl_dbg.h
+++ b/src/mpl/include/mpl_dbg.h
@@ -70,6 +70,7 @@
     {                                                                   \
         if ((_class & MPL_dbg_active_classes) && MPL_DBG_##_level <= MPL_dbg_max_level) { \
             char _s[MPL_DBG_MAXLINE];                                   \
+            snprintf _fmatargs ;                                        \
             MPL_dbg_outevent(__FILE__, __LINE__, _class, 0, "%s", _s);  \
         }                                                               \
     }


### PR DESCRIPTION
## Pull Request Description

Commit 3deff3c removed the call `MPL_snprintf _fmatargs;` in macro `MPL_DBG_MSG_FMT`, which caused the user-provided logging format string and va_list to be ignored. The buffer _s is instead populated with random bits on the stack, causing the printed log to contain garbage values.

This PR adds the missing snprintf call and fixes #7772.

Note that this causes build-failures due to improper use of the currently broken MPL_DBG_MSG_FMT makro in some MPICH components.
Example from function [`am_recv_event`](https://github.com/pmodels/mpich/blob/c7858e99868898648ff548750bbb5547b06bf2e8/src/mpid/ch4/netmod/ofi/ofi_events.c#L238-L242):
```
src/mpid/ch4/netmod/ofi/ofi_events.c:242:80: error: ‘MPIDI_OFI_am_header_t’ has no member named ‘src_rank’
```

## Example

Before patch:
```
$ MPICH_DBG_LEVEL=VERBOSE MPICH_DBG_CLASS=ALL mpirun demo_app
[...]
0	1	7f822e0c37c0[2005528]	2048	0.325912	./src/include/mpir_handlemem.h	354	�/e�
[...]
```

After patch:

```
$ MPICH_DBG_LEVEL=VERBOSE MPICH_DBG_CLASS=ALL mpirun demo_app
[...]
0	0	7f731afb0c00[2040302]	2048	0.380447	./src/include/mpir_handlemem.h	354	Allocating object ptr 0x7f731ab88380 (handle val 0xac000000)
[...]
```