### PR TITLE
abi: cast to uintptr_t in ABI_IS_BUILTIN

### DIFF
--- a/src/binding/abi/mpi_abi_util.h
+++ b/src/binding/abi/mpi_abi_util.h
@@ -4,7 +4,7 @@
 #include "mpi_abi_internal.h"
 #include "mpiimpl.h"
 
-#define ABI_IS_BUILTIN(h)  ((intptr_t)(h) < 0x1000)
+#define ABI_IS_BUILTIN(h)  ((uintptr_t)(h) < 0x1000)
 
 #define ABI_DATATYPE_BUILTIN_MASK 0x1ff
 #define ABI_OP_BUILTIN_MASK 0x1f


### PR DESCRIPTION
## Pull Request Description
On 32-bit systems, a pointer cast to `intptr_t` can be negative, which makes the check for the range `0` to `0x1000` invalid. Cast to `uintptr_t` fixes it.


Fixes #7770 

[skips warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
