### PR TITLE
warnings: suppress gcc-15 warnings such as Wstringop-overflow

### DIFF
--- a/src/include/mpir_coll.h
+++ b/src/include/mpir_coll.h
@@ -57,7 +57,7 @@ int MPIC_Isend(const void *buf, MPI_Aint count, MPI_Datatype datatype, int dest,
                MPIR_Comm * comm_ptr, MPIR_Request ** request, int coll_attr);
 int MPIC_Irecv(void *buf, MPI_Aint count, MPI_Datatype datatype, int source,
                int tag, MPIR_Comm * comm_ptr, MPIR_Request ** request);
-int MPIC_Waitall(int numreq, MPIR_Request * requests[], MPI_Status * statuses);
+int MPIC_Waitall(int numreq, MPIR_Request ** requests, MPI_Status * statuses);
 
 int MPIR_Reduce_local(const void *inbuf, void *inoutbuf, MPI_Aint count, MPI_Datatype datatype,
                       MPI_Op op);

--- a/src/mpi/attr/attrutil.c
+++ b/src/mpi/attr/attrutil.c
@@ -44,8 +44,9 @@ MPIR_Attribute *MPID_Attr_alloc(void)
     MPIR_Attribute *attr = (MPIR_Attribute *) MPIR_Handle_obj_alloc(&MPID_Attr_mem);
     /* attributes don't have refcount semantics, but let's keep valgrind and
      * the debug logging pacified */
-    MPIR_Assert(attr != NULL);
-    MPIR_Object_set_ref(attr, 0);
+    if (attr) {
+        MPIR_Object_set_ref(attr, 0);
+    }
     return attr;
 }
 

--- a/src/mpid/ch4/src/ch4_proc.c
+++ b/src/mpid/ch4/src/ch4_proc.c
@@ -333,7 +333,8 @@ void MPIDIU_upidhash_add(const void *upid, int upid_len, MPIR_Lpid lpid)
     t = MPL_malloc(sizeof(MPIDI_upid_hash), MPL_MEM_OTHER);
     t->lpid = lpid;
     t->upid = MPL_malloc(upid_len, MPL_MEM_OTHER);
-    memcpy(t->upid, upid, upid_len);
+    /* the unsigned cast is to suppress the gcc warning when it believes upid_len can take negative values */
+    memcpy(t->upid, upid, (unsigned) upid_len);
     t->upid_len = upid_len;
     HASH_ADD_KEYPTR(hh, upid_hash, t->upid, upid_len, t, MPL_MEM_OTHER);
 


### PR DESCRIPTION
## Pull Request Description

Suppress warnings from gcc-15. All of them are false positives, but not suppressing them will keep haunting us.

Fixes #7766


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
