### PR TITLE
warnings: fix error and warnings in MPL_DBG_MSG_FMT

### DIFF
--- a/src/mpi/coll/allgather/allgather_intra_k_brucks.c
+++ b/src/mpi/coll/allgather/allgather_intra_k_brucks.c
@@ -137,16 +137,14 @@ MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
             }
 
             /* Receive at the exact location. */
-            mpi_errno = MPIC_Irecv((char *) tmp_recvbuf + j * recvcount * delta * recvtype_extent,
-                                   count, recvtype, src, MPIR_ALLGATHER_TAG, comm,
+            char *tmpbuf = (char *) tmp_recvbuf + j * recvcount * delta * recvtype_extent;
+            mpi_errno = MPIC_Irecv(tmpbuf, count, recvtype, src, MPIR_ALLGATHER_TAG, comm,
                                    &reqs[num_reqs++]);
             MPIR_ERR_CHECK(mpi_errno);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST,
-                                                     "Phase#%d:, k:%d Recv at:%p for count:%d", i,
-                                                     k, ((char *) tmp_recvbuf +
-                                                         j * recvcount * delta * recvtype_extent),
-                                                     count));
+                                                     "Phase#%d:, k:%d Recv at:%p for count:%ld",
+                                                     i, k, tmpbuf, (long) count));
 
             /* Send from the start of recv till `count` amount of data. */
             mpi_errno =
@@ -155,8 +153,8 @@ MPIR_Allgather_intra_k_brucks(const void *sendbuf, MPI_Aint sendcount,
             MPIR_ERR_CHECK(mpi_errno);
 
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE, (MPL_DBG_FDEST,
-                                                     "Phase#%d:, k:%d Send from:%p for count:%d",
-                                                     i, k, tmp_recvbuf, count));
+                                                     "Phase#%d:, k:%d Send from:%p for count:%ld",
+                                                     i, k, tmp_recvbuf, (long) count));
 
         }
         mpi_errno = MPIC_Waitall(num_reqs, reqs, MPI_STATUSES_IGNORE);

--- a/src/mpi/coll/iallgather/iallgather_tsp_recexch.c
+++ b/src/mpi/coll/iallgather/iallgather_tsp_recexch.c
@@ -26,8 +26,8 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_data_exchange(int rank, int n
         MPII_Recexchalgo_get_count_and_offset(rank, 0, k, nranks, &count, &offset);
         MPI_Aint send_offset = offset * recv_extent * recvcount;
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                        (MPL_DBG_FDEST, "data exchange with %d send_offset %d count %d", partner,
-                         send_offset, count));
+                        (MPL_DBG_FDEST, "data exchange with %d send_offset %ld count %ld",
+                         partner, (long) send_offset, (long) count));
         /* send my data to partner */
         mpi_errno =
             MPIR_TSP_sched_isend(((char *) recvbuf + send_offset), count * recvcount, recvtype,
@@ -39,8 +39,8 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_data_exchange(int rank, int n
         MPII_Recexchalgo_get_count_and_offset(partner, 0, k, nranks, &count, &offset);
         MPI_Aint recv_offset = offset * recv_extent * recvcount;
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                        (MPL_DBG_FDEST, "data exchange with %d recv_offset %d count %d", partner,
-                         recv_offset, count));
+                        (MPL_DBG_FDEST, "data exchange with %d recv_offset %ld count %ld",
+                         partner, (long) recv_offset, (long) count));
         /* recv data from my partner */
         mpi_errno =
             MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), count * recvcount, recvtype,
@@ -136,8 +136,8 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step2(int step1_sendto, int s
             MPIR_ERR_CHECK(mpi_errno);
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST,
-                             "phase %d nbr is %d send offset %d count %d depend on %d", phase,
-                             nbr, send_offset, count, ((k - 1) * j)));
+                             "phase %d nbr is %d send offset %ld count %ld depend on %d",
+                             phase, nbr, (long) send_offset, (long) count, ((k - 1) * j)));
         }
         /* receive from the neighbors */
         for (i = 0; i < k - 1; i++) {
@@ -158,8 +158,8 @@ static int MPIR_TSP_Iallgather_sched_intra_recexch_step2(int step1_sendto, int s
             nrecvs++;
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST,
-                             "phase %d recv from %d recv offset %d cur_count %d recv returns id[%d] %d",
-                             phase, nbr, recv_offset, count, j * (k - 1) + i,
+                             "phase %d recv from %d recv offset %ld cur_count %ld recv returns id[%d] %d",
+                             phase, nbr, (long) recv_offset, (long) count, j * (k - 1) + i,
                              recv_id[j * (k - 1) + i]));
         }
         if (is_dist_halving == 1)

--- a/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
+++ b/src/mpi/coll/iallgatherv/iallgatherv_tsp_recexch.c
@@ -33,8 +33,8 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int 
         for (i = 0; i < count; i++)
             send_count += recvcounts[offset + i];
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                        (MPL_DBG_FDEST, "data exchange with %d send_offset %d count %d \n", partner,
-                         send_offset, send_count));
+                        (MPL_DBG_FDEST, "data exchange with %d send_offset %ld count %ld\n",
+                         partner, (long) send_offset, (long) send_count));
         /* send my data to partner */
         mpi_errno =
             MPIR_TSP_sched_isend(((char *) recvbuf + send_offset), send_count, recvtype, partner,
@@ -48,8 +48,8 @@ static int MPIR_TSP_Iallgatherv_sched_intra_recexch_data_exchange(int rank, int 
         for (i = 0; i < count; i++)
             recv_count += recvcounts[offset + i];
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
-                        (MPL_DBG_FDEST, "data exchange with %d recv_offset %d count %d \n", partner,
-                         recv_offset, recv_count));
+                        (MPL_DBG_FDEST, "data exchange with %d recv_offset %ld count %ld\n",
+                         partner, (long) recv_offset, (long) recv_count));
         /* recv data from my partner */
         mpi_errno = MPIR_TSP_sched_irecv(((char *) recvbuf + recv_offset), recv_count, recvtype,
                                          partner, tag, comm, sched, 0, NULL, &vtx_id);
@@ -150,8 +150,8 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
             MPIR_ERR_CHECK(mpi_errno);
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST,
-                             "phase %d nbr is %d send offset %d count %d depend on %d \n", phase,
-                             nbr, send_offset, count, ((k - 1) * j)));
+                             "phase %d nbr is %d send offset %ld count %ld depend on %d \n",
+                             phase, nbr, (long) send_offset, (long) count, ((k - 1) * j)));
         }
         /* receive from the neighbors */
         for (i = 0; i < k - 1; i++) {
@@ -174,8 +174,8 @@ int MPIR_TSP_Iallgatherv_sched_intra_recexch_step2(int step1_sendto, int step2_n
             nrecvs++;
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST,
-                             "phase %d recv from %d recv offset %d cur_count %d recv returns id[%d] %d\n",
-                             phase, nbr, recv_offset, count, j * (k - 1) + i,
+                             "phase %d recv from %d recv offset %ld cur_count %ld recv returns id[%d] %d\n",
+                             phase, nbr, (long) recv_offset, (long) count, j * (k - 1) + i,
                              recv_id[j * (k - 1) + i]));
         }
         if (is_dist_halving == 1)

--- a/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
+++ b/src/mpi/coll/ibcast/ibcast_tsp_scatterv_allgatherv.c
@@ -131,8 +131,9 @@ int MPIR_TSP_Ibcast_sched_intra_scatterv_allgatherv(void *buffer, MPI_Aint count
         }
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                         (MPL_DBG_FDEST,
-                         "i:%d rank:%d current_child:%d, next_child:%d, child_subtree_size[i]:%d, recv_size:%d",
-                         i, rank, current_child, next_child, child_subtree_size[i], recv_size));
+                         "i:%d rank:%d current_child:%d, next_child:%d, child_subtree_size[i]:%d, recv_size:%ld",
+                         i, rank, current_child, next_child, child_subtree_size[i],
+                         (long) recv_size));
         recv_size += child_subtree_size[i];
     }
     if (my_tree.parent != -1)

--- a/src/mpi/coll/igather/igather_tsp_tree.c
+++ b/src/mpi/coll/igather/igather_tsp_tree.c
@@ -99,8 +99,9 @@ int MPIR_TSP_Igather_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
         child_subtree_size[i] = next_child - current_child;
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                         (MPL_DBG_FDEST,
-                         "i:%d rank:%d current_child:%d, next_child:%d, child_subtree_size[i]:%d, recv_size:%d\n",
-                         i, rank, current_child, next_child, child_subtree_size[i], recv_size));
+                         "i:%d rank:%d current_child:%d, next_child:%d, child_subtree_size[i]:%d, recv_size:%ld\n",
+                         i, rank, current_child, next_child, child_subtree_size[i],
+                         (long) recv_size));
         recv_size += child_subtree_size[i];
     }
 

--- a/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
+++ b/src/mpi/coll/ireduce_scatter/ireduce_scatter_tsp_recexch.c
@@ -80,8 +80,8 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
                 send_cnt += recvcounts[offset + j];
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST,
-                             "phase %d sending to %d send_offset %d send_count %d", phase, dst,
-                             send_offset, send_cnt));
+                             "phase %d sending to %d send_offset %ld send_count %ld",
+                             phase, dst, (long) send_offset, (long) send_cnt));
             mpi_errno =
                 MPIR_TSP_sched_isend((char *) tmp_results + send_offset, send_cnt,
                                      datatype, dst, tag, comm, sched, nvtcs, vtcs, &send_id);
@@ -97,8 +97,8 @@ int MPIR_TSP_Ireduce_scatter_sched_intra_recexch_step2(void *tmp_results, void *
                 recv_cnt += recvcounts[offset + j];
             MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                             (MPL_DBG_FDEST,
-                             "phase %d recving from %d recv_offset %d recv_count %d", phase, dst,
-                             recv_offset, recv_cnt));
+                             "phase %d recving from %d recv_offset %ld recv_count %ld",
+                             phase, dst, (long) recv_offset, (long) recv_cnt));
             mpi_errno =
                 MPIR_TSP_sched_irecv((char *) tmp_recvbuf + recv_offset, recv_cnt,
                                      datatype, dst, tag, comm, sched, nvtcs, vtcs, &recv_id);

--- a/src/mpi/coll/iscatter/iscatter_tsp_tree.c
+++ b/src/mpi/coll/iscatter/iscatter_tsp_tree.c
@@ -101,8 +101,9 @@ int MPIR_TSP_Iscatter_sched_intra_tree(const void *sendbuf, MPI_Aint sendcount,
         child_subtree_size[i] = next_child - current_child;
         MPL_DBG_MSG_FMT(MPIR_DBG_COLL, VERBOSE,
                         (MPL_DBG_FDEST,
-                         "i:%d rank:%d current_child:%d, next_child:%d, child_subtree_size[i]:%d, recv_size:%d",
-                         i, rank, current_child, next_child, child_subtree_size[i], recv_size));
+                         "i:%d rank:%d current_child:%d, next_child:%d, child_subtree_size[i]:%d, recv_size:%ld",
+                         i, rank, current_child, next_child, child_subtree_size[i],
+                         (long) recv_size));
         recv_size += child_subtree_size[i];
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -237,9 +237,10 @@ static int am_recv_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Request * 
          * Put it in the queue to process it later. */
         MPL_DBG_MSG_FMT(MPIDI_CH4_DBG_GENERAL, TERSE,
                         (MPL_DBG_FDEST,
-                         "Expected seqno=%d but got %d (am_type=%d src_rank=%d). "
+                         "Expected seqno=%d but got %d (am_type=%d src_id=%lx). "
                          "Enqueueing it to the queue.\n",
-                         expected_seqno, am_hdr->seqno, am_hdr->am_type, am_hdr->src_rank));
+                         expected_seqno, am_hdr->seqno,
+                         am_hdr->am_type, (unsigned long) am_hdr->src_id));
         mpi_errno = MPIDI_OFI_am_enqueue_unordered_msg(vci, orig_buf);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;

--- a/src/mpl/include/mpl_dbg.h
+++ b/src/mpl/include/mpl_dbg.h
@@ -53,7 +53,7 @@
         }                                                               \
     }
 
-#define MPL_DBG_MAXLINE 256
+#define MPL_DBG_MAXLINE 2048
 #define MPL_DBG_FDEST _s,(size_t)MPL_DBG_MAXLINE
 /*M
   MPL_DBG_MSG_FMT - General debugging output macro


### PR DESCRIPTION
## Pull Request Description
Previously `MPL_DBG_MSG_FMT` was skipping the actual `snprintf` due to a bug fixed in https://github.com/pmodels/mpich/commit/9f7a9415e3d11680203492b5dd7b1d9f1331df64. The fix revealed some accumulated bugs that are fixed in this PR.

Fixes #7778 

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
