### PR TITLE
ch4/ofi: check inject_size before fi_tsend

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -528,33 +528,49 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_eager(int rank, MPIR_Comm * c
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(MPIR_Comm * comm, fi_addr_t addr,
+/* emulated inject.
+ * * If msg_hdrp is not NULL, it is a am header, match_bits is ignored.
+ * * If msg_hdrp is NULL, it is a tagged send.
+ */
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
                                                           const MPIDI_OFI_am_header_t * msg_hdrp,
                                                           const void *am_hdr, size_t am_hdr_sz,
-                                                          int vci_src, int vci_dst)
+                                                          int nic, int vci, uint64_t match_bits)
 {
     int mpi_errno = MPI_SUCCESS;
     MPIR_Request *sreq;
     char *ibuf;
     size_t len;
-    int nic = 0;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vci_src, nic);
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
 
-    MPIDI_CH4_REQUEST_CREATE(sreq, MPIR_REQUEST_KIND__SEND, vci_src, 1);
+    MPIDI_CH4_REQUEST_CREATE(sreq, MPIR_REQUEST_KIND__SEND, vci, 1);
     MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-    len = am_hdr_sz + sizeof(*msg_hdrp);
-    ibuf = (char *) MPL_malloc(len, MPL_MEM_BUFFER);
-    MPIR_Assert(ibuf);
-    memcpy(ibuf, msg_hdrp, sizeof(*msg_hdrp));
-    memcpy(ibuf + sizeof(*msg_hdrp), am_hdr, am_hdr_sz);
+
+    if (msg_hdrp) {
+        len = am_hdr_sz + sizeof(*msg_hdrp);
+        ibuf = (char *) MPL_malloc(len, MPL_MEM_BUFFER);
+        MPIR_Assert(ibuf);
+        memcpy(ibuf, msg_hdrp, sizeof(*msg_hdrp));
+        memcpy(ibuf + sizeof(*msg_hdrp), am_hdr, am_hdr_sz);
+    } else {
+        len = am_hdr_sz;
+        ibuf = (char *) MPL_malloc(len, MPL_MEM_BUFFER);
+        MPIR_Assert(ibuf);
+        memcpy(ibuf, am_hdr, am_hdr_sz);
+    }
 
     MPIDI_OFI_REQUEST(sreq, event_id) = MPIDI_OFI_EVENT_INJECT_EMU;
     MPIDI_OFI_REQUEST(sreq, util.inject_buf) = ibuf;
-    MPIDI_OFI_global.per_vci[vci_src].am_inflight_inject_emus += 1;
+    MPIDI_OFI_global.per_vci[vci].am_inflight_inject_emus += 1;
 
-    MPIDI_OFI_CALL_RETRY_AM(fi_send(MPIDI_OFI_global.ctx[ctx_idx].tx, ibuf, len,
-                                    NULL /* desc */ , addr, &(MPIDI_OFI_REQUEST(sreq, context))),
-                            vci_src, send);
+    if (msg_hdrp) {
+        MPIDI_OFI_CALL_RETRY_AM(fi_send(MPIDI_OFI_global.ctx[ctx_idx].tx, ibuf, len, NULL,
+                                        addr, &(MPIDI_OFI_REQUEST(sreq, context))), vci, send);
+    } else {
+        MPIDI_OFI_CALL_RETRY_AM(fi_tsend(MPIDI_OFI_global.ctx[ctx_idx].tx, ibuf, len, NULL,
+                                         addr, match_bits, &(MPIDI_OFI_REQUEST(sreq, context))),
+                                vci, send);
+    }
   fn_exit:
     return mpi_errno;
   fn_fail:
@@ -590,8 +606,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_inject(int rank,
     MPIR_Assert((uint64_t) comm->rank < (1ULL << MPIDI_OFI_AM_RANK_BITS));
 
     if (unlikely(am_hdr_sz + sizeof(msg_hdr) > MPIDI_OFI_global.max_buffered_send)) {
-        mpi_errno = MPIDI_OFI_do_emulated_inject(comm, dst_addr, &msg_hdr,
-                                                 am_hdr, am_hdr_sz, vci_src, vci_dst);
+        mpi_errno = MPIDI_OFI_do_emulated_inject(dst_addr, &msg_hdr,
+                                                 am_hdr, am_hdr_sz, nic, vci_src, 0);
         goto fn_exit;
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -528,55 +528,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_am_isend_eager(int rank, MPIR_Comm * c
     goto fn_exit;
 }
 
-/* emulated inject.
- * * If msg_hdrp is not NULL, it is a am header, match_bits is ignored.
- * * If msg_hdrp is NULL, it is a tagged send.
- */
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
-                                                          const MPIDI_OFI_am_header_t * msg_hdrp,
-                                                          const void *am_hdr, size_t am_hdr_sz,
-                                                          int nic, int vci, uint64_t match_bits)
-{
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_Request *sreq;
-    char *ibuf;
-    size_t len;
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
-
-    MPIDI_CH4_REQUEST_CREATE(sreq, MPIR_REQUEST_KIND__SEND, vci, 1);
-    MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
-
-    if (msg_hdrp) {
-        len = am_hdr_sz + sizeof(*msg_hdrp);
-        ibuf = (char *) MPL_malloc(len, MPL_MEM_BUFFER);
-        MPIR_Assert(ibuf);
-        memcpy(ibuf, msg_hdrp, sizeof(*msg_hdrp));
-        memcpy(ibuf + sizeof(*msg_hdrp), am_hdr, am_hdr_sz);
-    } else {
-        len = am_hdr_sz;
-        ibuf = (char *) MPL_malloc(len, MPL_MEM_BUFFER);
-        MPIR_Assert(ibuf);
-        memcpy(ibuf, am_hdr, am_hdr_sz);
-    }
-
-    MPIDI_OFI_REQUEST(sreq, event_id) = MPIDI_OFI_EVENT_INJECT_EMU;
-    MPIDI_OFI_REQUEST(sreq, util.inject_buf) = ibuf;
-    MPIDI_OFI_global.per_vci[vci].am_inflight_inject_emus += 1;
-
-    if (msg_hdrp) {
-        MPIDI_OFI_CALL_RETRY_AM(fi_send(MPIDI_OFI_global.ctx[ctx_idx].tx, ibuf, len, NULL,
-                                        addr, &(MPIDI_OFI_REQUEST(sreq, context))), vci, send);
-    } else {
-        MPIDI_OFI_CALL_RETRY_AM(fi_tsend(MPIDI_OFI_global.ctx[ctx_idx].tx, ibuf, len, NULL,
-                                         addr, match_bits, &(MPIDI_OFI_REQUEST(sreq, context))),
-                                vci, send);
-    }
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
 MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_inject(int rank,
                                                  MPIR_Comm * comm,
                                                  int handler_id, const void *am_hdr,

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -637,20 +637,11 @@ int MPIDI_OFI_send_ack(MPIR_Request * rreq, int context_id, void *hdr, int hdr_s
         MPIDI_OFI_CALL_RETRY(fi_tinject(MPIDI_OFI_global.ctx[ctx_idx].tx, hdr, hdr_sz,
                                         dest_addr, match_bits), vci_local, tinject);
     } else {
-        /* the send_ack semantic is a blocking send since we need complete the hdr buffer */
-        /* Question: there is potential recursive progress issue. Are we concerned? */
-        MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE, "MPIDI_OFI_send_ack: using blocking send\n");
+        MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE, "MPIDI_OFI_send_ack: using emulated inject.\n");
 
-        MPIDI_OFI_dynamic_process_request_t req;
-        req.done = 0;
-        req.event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
-        MPIDI_OFI_CALL_RETRY(fi_tsend(MPIDI_OFI_global.ctx[ctx_idx].tx, hdr, hdr_sz, NULL,
-                                      dest_addr, match_bits, (void *) &req.context),
-                             vci_local, tsend);
-        do {
-            mpi_errno = MPIDI_OFI_progress_uninlined(vci_local);
-            MPIR_ERR_CHECK(mpi_errno);
-        } while (!req.done);
+        mpi_errno = MPIDI_OFI_do_emulated_inject(dest_addr, NULL, hdr, hdr_sz,
+                                                 nic, vci_local, match_bits);
+        MPIR_ERR_CHECK(mpi_errno);
     }
   fn_exit:
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -633,8 +633,25 @@ int MPIDI_OFI_send_ack(MPIR_Request * rreq, int context_id, void *hdr, int hdr_s
     int ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, nic);
     MPIDI_av_entry_t *av = MPIDIU_comm_rank_to_av(comm, src_rank);
     fi_addr_t dest_addr = MPIDI_OFI_av_to_phys(av, vci_local, nic, vci_remote, nic);
-    MPIDI_OFI_CALL_RETRY(fi_tinject(MPIDI_OFI_global.ctx[ctx_idx].tx, hdr, hdr_sz,
-                                    dest_addr, match_bits), vci_local, tinject);
+    if (hdr_sz <= MPIDI_OFI_global.max_buffered_send) {
+        MPIDI_OFI_CALL_RETRY(fi_tinject(MPIDI_OFI_global.ctx[ctx_idx].tx, hdr, hdr_sz,
+                                        dest_addr, match_bits), vci_local, tinject);
+    } else {
+        /* the send_ack semantic is a blocking send since we need complete the hdr buffer */
+        /* Question: there is potential recursive progress issue. Are we concerned? */
+        MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE, "MPIDI_OFI_send_ack: using blocking send\n");
+
+        MPIDI_OFI_dynamic_process_request_t req;
+        req.done = 0;
+        req.event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
+        MPIDI_OFI_CALL_RETRY(fi_tsend(MPIDI_OFI_global.ctx[ctx_idx].tx, hdr, hdr_sz, NULL,
+                                      dest_addr, match_bits, (void *) &req.context),
+                             vci_local, tsend);
+        do {
+            mpi_errno = MPIDI_OFI_progress_uninlined(vci_local);
+            MPIR_ERR_CHECK(mpi_errno);
+        } while (!req.done);
+    }
   fn_exit:
     return mpi_errno;
   fn_fail:

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -892,4 +892,53 @@ MPL_STATIC_INLINE_PREFIX MPL_gpu_engine_type_t MPIDI_OFI_gpu_get_recv_engine_typ
     }
 }
 
+/* emulated inject.
+ * * If msg_hdrp is not NULL, it is a am header, match_bits is ignored.
+ * * If msg_hdrp is NULL, it is a tagged send.
+ */
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_emulated_inject(fi_addr_t addr,
+                                                          const MPIDI_OFI_am_header_t * msg_hdrp,
+                                                          const void *am_hdr, size_t am_hdr_sz,
+                                                          int nic, int vci, uint64_t match_bits)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Request *sreq;
+    char *ibuf;
+    size_t len;
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci, nic);
+
+    MPIDI_CH4_REQUEST_CREATE(sreq, MPIR_REQUEST_KIND__SEND, vci, 1);
+    MPIR_ERR_CHKANDSTMT((sreq) == NULL, mpi_errno, MPIX_ERR_NOREQ, goto fn_fail, "**nomemreq");
+
+    if (msg_hdrp) {
+        len = am_hdr_sz + sizeof(*msg_hdrp);
+        ibuf = (char *) MPL_malloc(len, MPL_MEM_BUFFER);
+        MPIR_Assert(ibuf);
+        memcpy(ibuf, msg_hdrp, sizeof(*msg_hdrp));
+        memcpy(ibuf + sizeof(*msg_hdrp), am_hdr, am_hdr_sz);
+    } else {
+        len = am_hdr_sz;
+        ibuf = (char *) MPL_malloc(len, MPL_MEM_BUFFER);
+        MPIR_Assert(ibuf);
+        memcpy(ibuf, am_hdr, am_hdr_sz);
+    }
+
+    MPIDI_OFI_REQUEST(sreq, event_id) = MPIDI_OFI_EVENT_INJECT_EMU;
+    MPIDI_OFI_REQUEST(sreq, util.inject_buf) = ibuf;
+    MPIDI_OFI_global.per_vci[vci].am_inflight_inject_emus += 1;
+
+    if (msg_hdrp) {
+        MPIDI_OFI_CALL_RETRY_AM(fi_send(MPIDI_OFI_global.ctx[ctx_idx].tx, ibuf, len, NULL,
+                                        addr, &(MPIDI_OFI_REQUEST(sreq, context))), vci, send);
+    } else {
+        MPIDI_OFI_CALL_RETRY_AM(fi_tsend(MPIDI_OFI_global.ctx[ctx_idx].tx, ibuf, len, NULL,
+                                         addr, match_bits, &(MPIDI_OFI_REQUEST(sreq, context))),
+                                vci, send);
+    }
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
 #endif /* OFI_IMPL_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_rndv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rndv.h
@@ -50,24 +50,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_RNDV_send_hdr(void *hdr, int hdr_sz, MPID
     int mpi_errno = MPI_SUCCESS;
 
     /* control message always use nic 0 */
-    int ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, 0);
-    fi_addr_t addr = MPIDI_OFI_av_to_phys(av, vci_local, 0, vci_remote, 0);
+    int nic = 0;
+    int ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, nic);
+    fi_addr_t addr = MPIDI_OFI_av_to_phys(av, vci_local, nic, vci_remote, nic);
     if (hdr_sz <= MPIDI_OFI_global.max_buffered_send) {
         MPIDI_OFI_CALL_RETRY(fi_tinject(MPIDI_OFI_global.ctx[ctx_idx].tx,
                                         hdr, hdr_sz, addr, match_bits), vci_local, tinject);
     } else {
         MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
-                    "MPIDI_OFI_RNDV_send_hdr: using blocking send\n");
+                    "MPIDI_OFI_RNDV_send_hdr: using emulated inject.\n");
 
-        MPIDI_OFI_dynamic_process_request_t req;
-        req.done = 0;
-        req.event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
-        MPIDI_OFI_CALL_RETRY(fi_tsend(MPIDI_OFI_global.ctx[ctx_idx].tx, hdr, hdr_sz, NULL,
-                                      addr, match_bits, (void *) &req.context), vci_local, tsend);
-        do {
-            mpi_errno = MPIDI_OFI_progress_uninlined(vci_local);
-            MPIR_ERR_CHECK(mpi_errno);
-        } while (!req.done);
+        mpi_errno = MPIDI_OFI_do_emulated_inject(addr, NULL, hdr, hdr_sz,
+                                                 nic, vci_local, match_bits);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_rndv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rndv.h
@@ -52,8 +52,23 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_RNDV_send_hdr(void *hdr, int hdr_sz, MPID
     /* control message always use nic 0 */
     int ctx_idx = MPIDI_OFI_get_ctx_index(vci_local, 0);
     fi_addr_t addr = MPIDI_OFI_av_to_phys(av, vci_local, 0, vci_remote, 0);
-    MPIDI_OFI_CALL_RETRY(fi_tinject(MPIDI_OFI_global.ctx[ctx_idx].tx,
-                                    hdr, hdr_sz, addr, match_bits), vci_local, tinject);
+    if (hdr_sz <= MPIDI_OFI_global.max_buffered_send) {
+        MPIDI_OFI_CALL_RETRY(fi_tinject(MPIDI_OFI_global.ctx[ctx_idx].tx,
+                                        hdr, hdr_sz, addr, match_bits), vci_local, tinject);
+    } else {
+        MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                    "MPIDI_OFI_RNDV_send_hdr: using blocking send\n");
+
+        MPIDI_OFI_dynamic_process_request_t req;
+        req.done = 0;
+        req.event_id = MPIDI_OFI_EVENT_DYNPROC_DONE;
+        MPIDI_OFI_CALL_RETRY(fi_tsend(MPIDI_OFI_global.ctx[ctx_idx].tx, hdr, hdr_sz, NULL,
+                                      addr, match_bits, (void *) &req.context), vci_local, tsend);
+        do {
+            mpi_errno = MPIDI_OFI_progress_uninlined(vci_local);
+            MPIR_ERR_CHECK(mpi_errno);
+        } while (!req.done);
+    }
 
   fn_exit:
     return mpi_errno;


### PR DESCRIPTION
## Pull Request Description
Do that in `MPIDI_OFI_send_ack` and `MPIDI_OFI_RNDV_send_hdr`.

We need always check inject_size (`MPIDI_OFI_global.max_buffered_send`) before we use `fi_tinject`.

The semantics requires a blocking send here. Without using injection, we have a recursive progress situation. If this is shown to be an issue, then we need seek alternate design, such as `MPIDI_OFI_do_emulated_inject`.

Fixes #7780 

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
