### PR TITLE
ch4: window inherit vci from parent communicator

### DIFF
--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -40,6 +40,7 @@ enum MPIR_COMM_HINT_PREDEFINED_t {
     MPIR_COMM_HINT_EXACT_LENGTH,
     MPIR_COMM_HINT_ALLOW_OVERTAKING,
     MPIR_COMM_HINT_STRICT_PCOLL_ORDERING,
+    MPIR_COMM_HINT_INHERIT_VCI, /* new comm use the same seq as parent comm */
     /* device specific hints.
      * Potentially, we can use macros and configure to hide them */
     MPIR_COMM_HINT_EAGER_THRESH,        /* ch3 */

--- a/src/mpi/comm/commutil.c
+++ b/src/mpi/comm/commutil.c
@@ -240,6 +240,8 @@ void MPIR_Comm_hint_init(void)
                             NULL, MPIR_COMM_HINT_TYPE_BOOL, 0, -1);
     MPIR_Comm_register_hint(MPIR_COMM_HINT_MULTI_NIC_PREF_NIC, "multi_nic_pref_nic", NULL,
                             MPIR_COMM_HINT_TYPE_INT, 0, -1);
+    MPIR_Comm_register_hint(MPIR_COMM_HINT_INHERIT_VCI, "inherit_vci", NULL,
+                            MPIR_COMM_HINT_TYPE_BOOL, 0, 0);
 }
 
 /* FIXME :
@@ -769,7 +771,7 @@ static int init_comm_seq(MPIR_Comm * comm)
     /* Every user-level communicator gets a sequence number, which can be
      * used, for example, to hash vci.
      * Builtin-comm, e.g. MPI_COMM_WORLD, always have seq at 0 */
-    if (!HANDLE_IS_BUILTIN(comm->handle)) {
+    if (!HANDLE_IS_BUILTIN(comm->handle) && !comm->hints[MPIR_COMM_HINT_INHERIT_VCI]) {
         static MPL_atomic_int_t vci_seq = MPL_ATOMIC_INT_T_INITIALIZER(0);
         MPL_atomic_fetch_add_int(&vci_seq, 1);
 
@@ -965,6 +967,9 @@ int MPII_Comm_copy(MPIR_Comm * comm_ptr, int size, MPIR_Info * info, MPIR_Comm *
 
     if (info) {
         MPII_Comm_set_hints(newcomm_ptr, info, true);
+        if (newcomm_ptr->hints[MPIR_COMM_HINT_INHERIT_VCI]) {
+            newcomm_ptr->seq = comm_ptr->seq;
+        }
     }
 
     newcomm_ptr->vcis_enabled = comm_ptr->vcis_enabled;

--- a/src/mpid/ch4/src/mpidig_win.c
+++ b/src/mpid/ch4/src/mpidig_win.c
@@ -282,9 +282,18 @@ static int win_init(MPI_Aint length, int disp_unit, MPIR_Win ** win_ptr, MPIR_In
 
     memset(&win->dev.am, 0, sizeof(MPIDIG_win_t));
 
+    MPIR_Info *tmp_info;
+    mpi_errno = MPIR_Info_alloc(&tmp_info);
+    MPIR_ERR_CHECK(mpi_errno);
+    mpi_errno = MPIR_Info_push(tmp_info, "inherit_vci", "true");
+    MPIR_ERR_CHECK(mpi_errno);
+
     /* Duplicate the original communicator here to avoid having collisions
      * between internal collectives */
-    mpi_errno = MPIR_Comm_dup_impl(comm_ptr, &win_comm_ptr);
+    mpi_errno = MPIR_Comm_dup_with_info_impl(comm_ptr, tmp_info, &win_comm_ptr);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = MPIR_Info_free_impl(tmp_info);
     MPIR_ERR_CHECK(mpi_errno);
 
     MPIDIG_WIN(win, targets) = targets;


### PR DESCRIPTION
## Pull Request Description
Avoid window using a different vci from the comm that it's created from.
If user want to use multiple VCI for different windows, they should
create multiple communicators first. This way, the vci is always
allocated by communicators, simplifying the concept.

At user-level, since the window is created from a communicator, it makes
sense to share the vci. Application may use direct pt2pt or collective
messages for synchronization during RMA. Using different vcis often
defeats the synchronization purpose. For example, some of our rma tests
are slow in multi-vci due to lack of global progress even when there is
explicit MPI_Barrier for synchronization.


This should fix the sporadic timeout of `rma/atomic_rmw_gacc 3` `ucx-vci` test and potentially a few more similar tests.
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
