### PR TITLE
datatype: fix MPIR_Status_set_elements_x_impl

### DIFF
--- a/src/mpi/datatype/datatype_impl.c
+++ b/src/mpi/datatype/datatype_impl.c
@@ -134,20 +134,168 @@ int MPIR_Pack_external_size_impl(const char *datarep,
     return MPI_SUCCESS;
 }
 
+/* utility function for MPIR_Status_set_elements_x_impl.
+ * Recursively count the total number of bytes from a given number of elements, where
+ * we assume the datatype does not contain a single element type.
+ */
+static MPI_Count MPIR_Type_get_element_bytes(MPI_Count * elements_p,
+                                             MPI_Count count, MPI_Datatype datatype)
+{
+    if (HANDLE_IS_BUILTIN(datatype)) {
+        MPI_Count element_size = MPIR_Datatype_get_basic_size(datatype);
+        if (*elements_p > count) {
+            *elements_p -= count;
+            return count * element_size;
+        } else {
+            MPI_Count nbytes = (*elements_p) * element_size;
+            *elements_p = 0;
+            return nbytes;
+        }
+    }
+
+    MPIR_Datatype *datatype_ptr;
+    MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+
+    if (datatype_ptr->builtin_element_size != -1) {
+        MPI_Count element_size = datatype_ptr->builtin_element_size;
+        count *= (datatype_ptr->size / element_size);
+        if (*elements_p > count) {
+            *elements_p -= count;
+            return count * element_size;
+        } else {
+            MPI_Count nbytes = (*elements_p) * element_size;
+            *elements_p = 0;
+            return nbytes;
+        }
+    }
+
+    /* let's peel the datatype layer by layer */
+    int *ints;
+    MPI_Aint *aints;
+    MPI_Aint *counts;
+    MPI_Datatype *types;
+
+    MPIR_Datatype_contents *cp = datatype_ptr->contents;
+    MPIR_Datatype_access_contents(cp, &ints, &aints, &counts, &types);
+    MPIR_Assert(ints && aints && counts && types);
+
+    switch (datatype_ptr->contents->combiner) {
+        case MPI_COMBINER_NAMED:
+        case MPI_COMBINER_DUP:
+        case MPI_COMBINER_RESIZED:
+            return MPIR_Type_get_element_bytes(elements_p, count, *types);
+        case MPI_COMBINER_CONTIGUOUS:
+        case MPI_COMBINER_VECTOR:
+        case MPI_COMBINER_HVECTOR:
+        case MPI_COMBINER_SUBARRAY:
+            if (cp->nr_counts == 0) {
+                return MPIR_Type_get_element_bytes(elements_p, count * ints[0], *types);
+            } else {
+                return MPIR_Type_get_element_bytes(elements_p, count * counts[0], *types);
+            }
+        case MPI_COMBINER_INDEXED_BLOCK:
+        case MPI_COMBINER_HINDEXED_BLOCK:
+            if (cp->nr_counts == 0) {
+                return MPIR_Type_get_element_bytes(elements_p, count * ints[0] * ints[1], *types);
+            } else {
+                return MPIR_Type_get_element_bytes(elements_p, count * counts[0] * counts[1],
+                                                   *types);
+            }
+        case MPI_COMBINER_INDEXED:
+        case MPI_COMBINER_HINDEXED:
+            {
+                MPI_Aint typecount = 0; /* total number of subtypes */
+                if (cp->nr_counts == 0) {
+                    for (int i = 0; i < ints[0]; i++) {
+                        typecount += ints[i + 1];
+                    }
+                } else {
+                    for (MPI_Aint i = 0; i < counts[0]; i++) {
+                        typecount += counts[i + 1];
+                    }
+                }
+                return MPIR_Type_get_element_bytes(elements_p, count * typecount, *types);
+            }
+        case MPI_COMBINER_STRUCT:
+            if (cp->nr_counts == 0) {
+                MPI_Count nbytes = 0;
+                for (MPI_Count j = 0; j < count; j++) {
+                    for (int i = 0; i < ints[0]; i++) {
+                        /* skip zero-count elements of the struct */
+                        if (ints[i + 1] == 0)
+                            continue;
+
+                        nbytes += MPIR_Type_get_element_bytes(elements_p, ints[i + 1], types[i]);
+                        if (*elements_p == 0) {
+                            return nbytes;
+                        }
+                    }
+                }
+                return nbytes;
+            } else {
+                MPI_Count nbytes = 0;
+                for (MPI_Count j = 0; j < count; j++) {
+                    for (MPI_Count i = 0; i < counts[0]; i++) {
+                        /* skip zero-count elements of the struct */
+                        if (counts[i + 1] == 0)
+                            continue;
+
+                        nbytes += MPIR_Type_get_element_bytes(elements_p, counts[i + 1], types[i]);
+                        if (*elements_p == 0) {
+                            return nbytes;
+                        }
+                    }
+                }
+                return nbytes;
+            }
+        case MPI_COMBINER_DARRAY:
+        case MPI_COMBINER_F90_REAL:
+        case MPI_COMBINER_F90_COMPLEX:
+        case MPI_COMBINER_F90_INTEGER:
+#ifndef BUILD_MPI_ABI
+        case MPI_COMBINER_HVECTOR_INTEGER:
+        case MPI_COMBINER_HINDEXED_INTEGER:
+        case MPI_COMBINER_STRUCT_INTEGER:
+#endif
+        default:
+            /* --BEGIN ERROR HANDLING-- */
+            MPIR_Assert(0);
+            return 0;
+            /* --END ERROR HANDLING-- */
+    }
+}
+
 int MPIR_Status_set_elements_x_impl(MPI_Status * status, MPI_Datatype datatype, MPI_Count count)
 {
     int mpi_errno = MPI_SUCCESS;
-    MPI_Count size_x;
+    MPI_Count nbytes;
 
-    MPIR_Datatype_get_size_macro(datatype, size_x);
+    if (HANDLE_IS_BUILTIN(datatype)) {
+        nbytes = count * MPIR_Datatype_get_basic_size(datatype);
+    } else {
+        MPIR_Datatype *datatype_ptr;
+        MPIR_Datatype_get_ptr(datatype, datatype_ptr);
+        if (datatype_ptr->builtin_element_size != -1) {
+            nbytes = count * datatype_ptr->builtin_element_size;
+        } else {
+            if (datatype_ptr->size == 0) {
+                nbytes = 0;
+            } else {
+                MPI_Count orig_count = count;
+                nbytes = MPIR_Type_get_element_bytes(&count, 1, datatype);
+                /* it'll be so much easier if we store datatype_ptr->nr_elements */
+                if (count > 0) {
+                    MPI_Count nr_elements = orig_count - count;
+                    nbytes *= (orig_count / nr_elements);
 
-    /* overflow check, should probably be a real error check? */
-    if (count != 0) {
-        MPIR_Assert(size_x >= 0 && count > 0);
-        MPIR_Assert(count * size_x < MPIR_COUNT_MAX);
+                    MPI_Count remain = orig_count % nr_elements;
+                    nbytes += MPIR_Type_get_element_bytes(&remain, 1, datatype);
+                }
+            }
+        }
     }
 
-    MPIR_STATUS_SET_COUNT(*status, size_x * count);
+    MPIR_STATUS_SET_COUNT(*status, nbytes);
 
     return mpi_errno;
 }

--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -110,7 +110,8 @@ void HYDU_free_node_list(struct HYD_node *node_list)
     }
 }
 
-static void init_proxy(struct HYD_proxy *proxy, int pgid, struct HYD_node *node)
+static void init_proxy(struct HYD_proxy *proxy, int pgid, struct HYD_node *node,
+                       int max_oversubscribe)
 {
     proxy->node = node;
     proxy->pgid = pgid;
@@ -119,7 +120,11 @@ static void init_proxy(struct HYD_proxy *proxy, int pgid, struct HYD_node *node)
     proxy->exec_launch_info = NULL;
 
     proxy->proxy_process_count = 0;
-    proxy->filler_processes = node->core_count - node->active_processes % node->core_count;
+    if (max_oversubscribe > 0) {
+        proxy->filler_processes = node->core_count * max_oversubscribe - node->active_processes;
+    } else {
+        proxy->filler_processes = 0;
+    }
 
     proxy->pid = NULL;
     proxy->exit_status = NULL;
@@ -292,7 +297,7 @@ HYD_status HYDU_create_proxy_list_singleton(struct HYD_node *node, int pgid,
     proxy = MPL_malloc(sizeof(struct HYD_proxy), MPL_MEM_OTHER);
     HYDU_ASSERT(proxy, status);
 
-    init_proxy(proxy, pgid, node);
+    init_proxy(proxy, pgid, node, 0);
 
     proxy->proxy_id = 0;
     proxy->proxy_process_count = 1;
@@ -308,9 +313,35 @@ HYD_status HYDU_create_proxy_list_singleton(struct HYD_node *node, int pgid,
     goto fn_exit;
 }
 
-HYD_status HYDU_create_proxy_list(int count, struct HYD_exec *exec_list, struct HYD_node *node_list,
-                                  int pgid, int *rankmap, int *min_node_id_p,
-                                  int *proxy_count_p, struct HYD_proxy **proxy_list_p)
+static int get_max_overscribe(struct HYD_node *node_list)
+{
+    int max_oversubscribe = 0;
+    for (struct HYD_node * node = node_list; node; node = node->next) {
+        int c = HYDU_dceil(node->active_processes, node->core_count);
+        if (max_oversubscribe < c) {
+            max_oversubscribe = c;
+        }
+    }
+
+    bool has_spare = false;
+    for (struct HYD_node * node = node_list; node; node = node->next) {
+        if (node->core_count * max_oversubscribe - node->active_processes > 0) {
+            has_spare = true;
+            break;
+        }
+    }
+    if (!has_spare) {
+        max_oversubscribe = 0;
+    }
+
+    /* NOTE: returning 0 means we can skip the filler round */
+    return max_oversubscribe;
+}
+
+HYD_status HYDU_create_proxy_list(int count, struct HYD_exec * exec_list,
+                                  struct HYD_node * node_list, int pgid, int *rankmap,
+                                  int *min_node_id_p, int *proxy_count_p,
+                                  struct HYD_proxy ** proxy_list_p)
 {
     HYD_status status = HYD_SUCCESS;
     HYDU_FUNC_ENTER();
@@ -331,11 +362,21 @@ HYD_status HYDU_create_proxy_list(int count, struct HYD_exec *exec_list, struct 
     struct HYD_proxy *proxy_list = MPL_malloc(num_nodes * sizeof(struct HYD_proxy), MPL_MEM_OTHER);
     HYDU_ASSERT(proxy_list, status);
 
+    int count_nonfilled = 0;
+    int max_oversubscribe = get_max_overscribe(node_list);
     for (struct HYD_node * node = node_list; node; node = node->next) {
         int id = node->node_id;
         if (id >= min_node_id && id <= max_node_id) {
             int i_proxy = id - min_node_id;
-            init_proxy(&proxy_list[i_proxy], pgid, node);
+            init_proxy(&proxy_list[i_proxy], pgid, node, max_oversubscribe);
+            if (proxy_list[i_proxy].filler_processes > 0) {
+                count_nonfilled++;
+            }
+        }
+    }
+    if (count_nonfilled == 0) {
+        for (int i_proxy = 0; i_proxy < num_nodes; i_proxy++) {
+            proxy_list[i_proxy].filler_processes += proxy_list[i_proxy].node->core_count;
         }
     }
 
@@ -352,6 +393,7 @@ HYD_status HYDU_create_proxy_list(int count, struct HYD_exec *exec_list, struct 
 
         int node_id, c;
         node_id = rankmap[rank];
+        printf("* rankmap[%d] = %d\n", rank, node_id);
         c = 1;
         rank++;
         while (c < exec_rem_procs && rank < count && rankmap[rank] == node_id) {

--- a/test/mpi/datatype/large_count.c
+++ b/test/mpi/datatype/large_count.c
@@ -39,7 +39,7 @@ static void check_set_elements(MPI_Status status, MPI_Datatype type, MPI_Count e
     elements = elements_x = count = 0xfeedface;
     /* can't use legacy "set" for large element counts */
     if (expected <= INT_MAX) {
-        MPI_Status_set_elements(&status, type, 1);
+        MPI_Status_set_elements(&status, type, expected);
         MPI_Get_elements(&status, type, &elements);
         MPI_Get_elements_x(&status, type, &elements_x);
         MPI_Get_count(&status, type, &count);
@@ -49,7 +49,7 @@ static void check_set_elements(MPI_Status status, MPI_Datatype type, MPI_Count e
     }
 
     elements = elements_x = count = 0xfeedface;
-    MPI_Status_set_elements_x(&status, type, 1);
+    MPI_Status_set_elements_x(&status, type, expected);
     MPI_Get_elements(&status, type, &elements);
     MPI_Get_elements_x(&status, type, &elements_x);
     MPI_Get_count(&status, type, &count);
@@ -63,7 +63,7 @@ static void check_set_elements(MPI_Status status, MPI_Datatype type, MPI_Count e
 
 #if MTEST_HAVE_MIN_MPI_VERSION(4,0)
     elements = elements_x = count = 0xfeedface;
-    MPI_Status_set_elements_c(&status, type, 1);
+    MPI_Status_set_elements_c(&status, type, expected);
     MPI_Get_elements(&status, type, &elements);
     MPI_Get_elements_c(&status, type, &elements_x);
     MPI_Get_count(&status, type, &count);

--- a/test/mpi/datatype/large_count.c
+++ b/test/mpi/datatype/large_count.c
@@ -88,6 +88,7 @@ int main(int argc, char *argv[])
     MPI_Datatype four_ints = MPI_DATATYPE_NULL;
     MPI_Datatype imx4i = MPI_DATATYPE_NULL;
     MPI_Datatype imx4i_rsz = MPI_DATATYPE_NULL;
+    MPI_Datatype four_struct = MPI_DATATYPE_NULL;
     MPI_Status status;
 
     MTest_Init(&argc, &argv);
@@ -135,6 +136,17 @@ int main(int argc, char *argv[])
     MPI_Type_create_resized(imx4i, /*lb= */ INT_MAX, /*extent= */ -1024, &imx4i_rsz);
     MPI_Type_commit(&imx4i_rsz);
 
+    /* four_struct: a struct with four elements */
+    int blklens[4] = { 1, 1, 1, 1 };
+    MPI_Aint displs[4] = { 0, 8, 16, 24 };
+    MPI_Datatype types[4] = { MPI_CHAR, MPI_INT, MPI_DOUBLE, MPI_SHORT };
+    MPI_Type_create_struct(4, blklens, displs, types, &four_struct);
+    MPI_Type_commit(&four_struct);
+
+    MPI_Aint four_struct_extent = displs[3] + sizeof(double);
+    MPI_Aint four_struct_true_extent = displs[3] + sizeof(short);
+    MPI_Aint four_struct_size = sizeof(char) + sizeof(int) + sizeof(double) + sizeof(short);
+
     /* MPI_Type_size */
     MPI_Type_size(imax_contig, &size);
     check(size == INT_MAX);
@@ -144,6 +156,8 @@ int main(int argc, char *argv[])
     check(size == MPI_UNDEFINED);       /* should overflow an int */
     MPI_Type_size(imx4i_rsz, &size);
     check(size == MPI_UNDEFINED);       /* should overflow an int */
+    MPI_Type_size(four_struct, &size);
+    check(size == four_struct_size);
 
     /* MPI_Type_size_x */
     MPI_Type_size_x(imax_contig, &size_x);
@@ -154,6 +168,8 @@ int main(int argc, char *argv[])
     check(size_x == 4LL * sizeof(int) * (INT_MAX / 2)); /* should overflow an int */
     MPI_Type_size_x(imx4i_rsz, &size_x);
     check(size_x == 4LL * sizeof(int) * (INT_MAX / 2)); /* should overflow an int */
+    MPI_Type_size_x(four_struct, &size_x);
+    check(size_x == four_struct_size);
 
     /* MPI_Type_get_extent */
     MPI_Type_get_extent(imax_contig, &lb, &extent);
@@ -172,6 +188,9 @@ int main(int argc, char *argv[])
     MPI_Type_get_extent(imx4i_rsz, &lb, &extent);
     check(lb == INT_MAX);
     check(extent == -1024);
+    MPI_Type_get_extent(four_struct, &lb, &extent);
+    check(lb == 0);
+    check(extent == four_struct_extent);
 
     /* MPI_Type_get_extent_x */
     MPI_Type_get_extent_x(imax_contig, &lb_x, &extent_x);
@@ -186,6 +205,9 @@ int main(int argc, char *argv[])
     MPI_Type_get_extent_x(imx4i_rsz, &lb_x, &extent_x);
     check(lb_x == INT_MAX);
     check(extent_x == -1024);
+    MPI_Type_get_extent_x(four_struct, &lb_x, &extent_x);
+    check(lb_x == 0);
+    check(extent_x == four_struct_extent);
 
     /* MPI_Type_get_true_extent */
     MPI_Type_get_true_extent(imax_contig, &lb, &extent);
@@ -206,6 +228,9 @@ int main(int argc, char *argv[])
         check(extent == MPI_UNDEFINED);
     else
         check(extent == imx4i_true_extent);
+    MPI_Type_get_true_extent(four_struct, &lb, &extent);
+    check(lb == 0);
+    check(extent == four_struct_true_extent);
 
     /* MPI_Type_get_true_extent_x */
     MPI_Type_get_true_extent_x(imax_contig, &lb_x, &extent_x);
@@ -220,6 +245,9 @@ int main(int argc, char *argv[])
     MPI_Type_get_true_extent_x(imx4i_rsz, &lb_x, &extent_x);
     check(lb_x == 0);
     check(extent_x == imx4i_true_extent);
+    MPI_Type_get_true_extent_x(four_struct, &lb_x, &extent_x);
+    check(lb_x == 0);
+    check(extent == four_struct_true_extent);
 
 
     /* MPI_{Status_set_elements,Get_elements}{,_x} */
@@ -246,6 +274,7 @@ int main(int argc, char *argv[])
     check_set_elements(status, four_ints, 4);
     check_set_elements(status, imx4i, 4LL * (INT_MAX / 2));
     check_set_elements(status, imx4i_rsz, 4LL * (INT_MAX / 2));
+    check_set_elements(status, four_struct, 4);
 
   epilogue:
     if (imax_contig != MPI_DATATYPE_NULL)
@@ -256,6 +285,8 @@ int main(int argc, char *argv[])
         MPI_Type_free(&imx4i);
     if (imx4i_rsz != MPI_DATATYPE_NULL)
         MPI_Type_free(&imx4i_rsz);
+    if (four_struct != MPI_DATATYPE_NULL)
+        MPI_Type_free(&four_struct);
 
     MTest_Finalize(errs);
 


### PR DESCRIPTION
## Pull Request Description
In MPI_Status_set_elements, the count refers to the number of elements,
rather than the count of datatypes.

Fixes #7764 
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
