### PR TITLE
ch4/ofi: prevent debug summary messages get interleaved

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -697,10 +697,14 @@ int MPIDI_OFI_init_local(int *tag_bits)
         if (MPIR_Process.rank == 0) {
             fprintf(stdout, "====== Rank to NIC assignment ========\n");
         }
+        /* prevent messages from different ranks get interleaved. */
+        fflush(stdout);
+        MPIR_pmi_barrier();
         fprintf(stdout, "Rank: %d, Local_rank: %d, NIC: %s\n", MPIR_Process.rank,
                 MPIR_Process.local_rank, MPIDI_OFI_global.prov_use[0]->domain_attr->name);
+        fflush(stdout);
+        MPIR_pmi_barrier();
     }
-    fflush(stdout);
 
     /* Finally open the fabric */
     MPIDI_OFI_CALL(fi_fabric(MPIDI_OFI_global.prov_use[0]->fabric_attr,


### PR DESCRIPTION
## Pull Request Description
When multiple ranks each print summary message, the output may get interleaved due to concurrency. Add barrier synchronizations prevents that. Unfortunately, we have to use PMI barriers during init.

Fixes #7526
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
