### PR TITLE
ch3/nemesis: consistently check shm_base_addrs

### DIFF
--- a/src/mpid/ch3/channels/nemesis/src/ch3_rma_shm.c
+++ b/src/mpid/ch3/channels/nemesis/src/ch3_rma_shm.c
@@ -15,7 +15,7 @@ int MPIDI_CH3_SHM_Win_shared_query(MPIR_Win * win_ptr, int target_rank, MPI_Aint
 
     MPIR_FUNC_ENTER;
 
-    if (win_ptr->comm_ptr->node_comm == NULL) {
+    if (!win_ptr->shm_base_addr) {
         mpi_errno = MPIDI_CH3U_Win_shared_query(win_ptr, target_rank, size, disp_unit, baseptr);
         MPIR_ERR_CHECK(mpi_errno);
         goto fn_exit;
@@ -47,7 +47,7 @@ int MPIDI_CH3_SHM_Win_shared_query(MPIR_Win * win_ptr, int target_rank, MPI_Aint
     }
     else {
         int local_target_rank = MPIR_Get_intranode_rank(win_ptr->comm_ptr, target_rank);
-        if (local_target_rank >= 0 && win_ptr->shm_base_addrs) {
+        if (local_target_rank >= 0) {
             MPIR_Assert(local_target_rank < win_ptr->comm_ptr->node_comm->local_size);
             *size = win_ptr->basic_info_table[target_rank].size;
             *disp_unit = win_ptr->basic_info_table[target_rank].disp_unit;


### PR DESCRIPTION
## Pull Request Description
In `MPIDI_CH3_SHM_Win_shared_query`, `node_comm == NULL` is not equivalent to having shared memory. Directly check `win_ptr->shm_base_addr` instead.


Fixes #7499 
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
