### PR TITLE
abi: rename BUILD_MPI_ABI to MPICH_BUILD_MPI_ABI

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -161,7 +161,7 @@ EXTRA_lib_lib@MPILIBNAME@_la_DEPENDENCIES = $(pmpi_convenience_libs) $(mpi_conve
 endif !BUILD_PROFILING_LIB
 
 if BUILD_ABI_LIB
-abi_cppflags = -DBUILD_MPI_ABI -I$(srcdir)/src/binding/abi
+abi_cppflags = -DMPICH_BUILD_MPI_ABI -I$(srcdir)/src/binding/abi
 if BUILD_PROFILING_LIB
 # dropping mpi_fc_sources and mpi_cxx_sources from libmpmpi since they
 # don't contribute any PMPI symbols.

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -222,7 +222,7 @@ def dump_mpir_io_impl_h(f):
         print("", file=Out)
 
         # io_abi.c doesn't have access to MPICH internal
-        print("#ifdef BUILD_MPI_ABI", file=Out)
+        print("#ifdef MPICH_BUILD_MPI_ABI", file=Out)
         print("#define MPIR_ERR_RECOVERABLE 0", file=Out)
         print("#define MPIR_ERR_FATAL 1", file=Out)
         print("int MPIR_Err_create_code(int, int, const char[], int, int, const char[], const char[], ...);", file=Out)

--- a/src/glue/romio/glue_romio.c
+++ b/src/glue/romio/glue_romio.c
@@ -9,7 +9,7 @@
 
 #include "mpiimpl.h"
 
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 #include "mpir_ext.h"
 #else
 #include "mpi_abi_util.h"
@@ -218,7 +218,7 @@ static int ext_abort(MPI_Comm comm, int mpi_errno, int exit_code, const char *er
     return MPID_Abort(comm_ptr, mpi_errno, exit_code, error_msg);
 }
 
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 int MPIR_Ext_datatype_iscommitted(MPI_Datatype datatype)
 {
     return ext_datatype_iscommitted(datatype);

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -19,7 +19,7 @@
 #define MPICH_API_PUBLIC
 #endif
 
-#ifdef BUILD_MPI_ABI
+#ifdef MPICH_BUILD_MPI_ABI
 /* include adapted version of mpi_abi.h, which -
  *     * defines handle types with ABI_ prefix
  *         - internally we will type convert
@@ -34,10 +34,10 @@
 #include "mpi_abi_internal.h"
 #endif
 
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 #define MPI_VERSION    5
 #define MPI_SUBVERSION 0
-#endif /* BUILD_MPI_ABI */
+#endif /* MPICH_BUILD_MPI_ABI */
 
 #define MPICH_NAME     5
 #define MPICH         1
@@ -286,7 +286,7 @@ typedef int MPI_Session;
    as in src/mpi/romio/include/mpio.h.in  */
 typedef struct ADIOI_FileD *MPI_File;
 /* When building MPI_ABI, directly use ABI MPI_FILE_NULL */
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 #define MPI_FILE_NULL ((MPI_File)0)
 #endif
 
@@ -371,7 +371,7 @@ typedef int MPI_Info;
 #define MPI_WIN_CREATE_FLAVOR 0x66000007
 #define MPI_WIN_MODEL         0x66000009
 
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 /* Definitions that are determined by configure. */
 typedef @MPI_AINT@ MPI_Aint;
 typedef @MPI_FINT@ MPI_Fint;
@@ -423,7 +423,7 @@ typedef struct {
 extern MPIU_DLL_SPEC MPI_F08_status *MPI_F08_STATUS_IGNORE MPICH_API_PUBLIC;
 extern MPIU_DLL_SPEC MPI_F08_status *MPI_F08_STATUSES_IGNORE MPICH_API_PUBLIC;
 
-#endif /* BUILD_MPI_ABI */
+#endif /* MPICH_BUILD_MPI_ABI */
 
 #ifdef MPICH_DEFINE_ATTR_TYPE_TYPES
 static const MPI_Datatype mpich_mpi_datatype_null MPICH_ATTR_TYPE_TAG_MUST_BE_NULL() = MPI_DATATYPE_NULL;
@@ -504,7 +504,7 @@ static const MPI_Datatype mpich_mpi_offset MPICH_ATTR_TYPE_TAG(MPI_Offset) = MPI
 #define MPI_AINT_FMT_DEC_SPEC "@MPI_AINT_FMT_DEC_SPEC@"
 #define MPI_AINT_FMT_HEX_SPEC "@MPI_AINT_FMT_HEX_SPEC@"
 
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 /* These are only guesses; make sure you change them in mpif.h as well */
 #define MPI_MAX_PROCESSOR_NAME @MPI_MAX_PROCESSOR_NAME@
 #define MPI_MAX_LIBRARY_VERSION_STRING @MPI_MAX_LIBRARY_VERSION_STRING@
@@ -625,10 +625,10 @@ enum MPIR_Combiner_enum {
 #define MPI_COMM_TYPE_HW_UNGUIDED 3
 #define MPI_COMM_TYPE_RESOURCE_GUIDED 4
 
-#endif /* BUILD_MPI_ABI */
+#endif /* MPICH_BUILD_MPI_ABI */
 /* MPICH-specific types */
 #define MPIX_COMM_TYPE_NEIGHBORHOOD 5
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 
 /* For supported thread levels */
 #define MPI_THREAD_SINGLE 0
@@ -766,7 +766,7 @@ enum MPIR_Combiner_enum {
 
 #define MPI_ERR_LASTCODE    0x3fffffff  /* Last valid error code for a
 					   predefined error class */
-#endif /* BUILD_MPI_ABI */
+#endif /* MPICH_BUILD_MPI_ABI */
 
 
 #define MPICH_ERR_LAST_CLASS 81     /* It is also helpful to know the
@@ -815,7 +815,7 @@ enum {
 
 typedef struct MPIR_Async_thing * MPIX_Async_thing;
 
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 /* C callback functions */
 typedef void (MPI_Handler_function) ( MPI_Comm *, int *, ... );
 typedef int (MPI_Comm_copy_attr_function)(MPI_Comm, int, void *, void *,
@@ -860,11 +860,11 @@ typedef void (MPIX_Destructor_function) (void *);
 typedef int (MPI_Grequest_cancel_function)(void *, int);
 typedef int (MPI_Grequest_free_function)(void *);
 typedef int (MPI_Grequest_query_function)(void *, MPI_Status *);
-#endif /* BUILD_MPI_ABI */
+#endif /* MPICH_BUILD_MPI_ABI */
 typedef int (MPIX_Grequest_poll_function)(void *, MPI_Status *);
 typedef int (MPIX_Grequest_wait_function)(int, void **, double, MPI_Status *);
 typedef int (MPIX_Async_poll_function)(MPIX_Async_thing);
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 
 /* Function type defs */
 typedef int (MPI_Datarep_conversion_function)(void *, MPI_Datatype, int,
@@ -895,9 +895,9 @@ typedef int (MPI_Datarep_conversion_function_c)(void *, MPI_Datatype, MPI_Count,
 #define MPI_CONVERSION_FN_NULL ((MPI_Datarep_conversion_function *)0)
 #define MPI_CONVERSION_FN_NULL_C ((MPI_Datarep_conversion_function_c *)0)
 
-#endif /* BUILD_MPI_ABI */
+#endif /* MPICH_BUILD_MPI_ABI */
 
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 /* types for the MPI_T_ interface */
 struct MPIR_T_enum_s;
 struct MPIR_T_cvar_handle_s;
@@ -1014,12 +1014,12 @@ typedef void (MPI_T_event_cb_function)(MPI_T_event_instance event_instance, MPI_
 typedef void (MPI_T_event_free_cb_function)(MPI_T_event_registration event_registration, MPI_T_cb_safety cb_safety, void *user_data);
 typedef void (MPI_T_event_dropped_cb_function)(MPI_Count count, MPI_T_event_registration event_registration, int source_index, MPI_T_cb_safety cb_safety, void *user_data);
 
-#else  /* BUILD_MPI_ABI */
+#else  /* MPICH_BUILD_MPI_ABI */
 /* FIXME: make it less hacky (fix the implementation) */
 #define MPIR_T_PVAR_CLASS_FIRST MPI_T_PVAR_CLASS_STATE
 #define MPIR_T_PVAR_CLASS_LAST  MPI_T_PVAR_CLASS_GENERIC
 #define MPIR_T_PVAR_CLASS_NUMBER 10
-#endif /* BUILD_MPI_ABI */
+#endif /* MPICH_BUILD_MPI_ABI */
 
 typedef struct {
     void **storage_stack;
@@ -1054,7 +1054,7 @@ typedef struct MPIX_Iov {
  * Normally, we provide prototypes for all MPI routines.  In a few weird
  * cases, we need to suppress the prototypes.
  */
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 /* We require that the C compiler support prototypes */
 #include <mpi_proto.h>
 
@@ -1107,7 +1107,7 @@ typedef struct MPIX_Iov {
 #define PMPI_Session_f2c(session) (MPI_Session)(session)
 #endif
 
-#endif /* BUILD_MPI_ABI */
+#endif /* MPICH_BUILD_MPI_ABI */
 
 #if defined(__cplusplus)
 }

--- a/src/include/mpir_attr.h
+++ b/src/include/mpir_attr.h
@@ -198,7 +198,7 @@ void MPIR_free_keyval(MPII_Keyval * keyval_ptr);
 
 int MPIR_Dup_fn(MPI_Comm comm, int keyval, void *extra_state,
                 void *attr_in, void *attr_out, int *flag);
-#ifdef BUILD_MPI_ABI
+#ifdef MPICH_BUILD_MPI_ABI
 int MPIR_Comm_dup_fn(ABI_Comm comm, int keyval, void *extra_state,
                      void *attr_in, void *attr_out, int *flag);
 int MPIR_Type_dup_fn(ABI_Datatype datatype, int keyval, void *extra_state,

--- a/src/include/mpir_op.h
+++ b/src/include/mpir_op.h
@@ -78,7 +78,7 @@ typedef enum MPIR_Op_kind {
   Collective-DS
   S*/
 typedef union MPIR_User_function {
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
     void (*c_function) (const void *, void *, const int *, const MPI_Datatype *);
     void (*c_large_function) (const void *, void *, const MPI_Count *, const MPI_Datatype *);
     void (*c_x_function) (void *, void *, MPI_Count, MPI_Datatype, void *);

--- a/src/include/mpir_process.h
+++ b/src/include/mpir_process.h
@@ -84,7 +84,7 @@ typedef struct MPIR_Process_t {
      * and the C function to call (itself a function defined by the
      * C++ interface and exported to C).  The first argument is used
      * to specify the kind (comm,file,win) */
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
     void (*cxx_call_errfn) (int, int *, int *, void (*)(void));
 #else
     void (*cxx_call_errfn) (int, ABI_Comm *, int *, void (*)(void));

--- a/src/mpi/attr/attr_impl.c
+++ b/src/mpi/attr/attr_impl.c
@@ -92,7 +92,7 @@ int MPIR_Comm_create_keyval_x_impl(MPI_Comm_copy_attr_function * comm_copy_attr_
                                    MPIX_Destructor_function * destructor_fn,
                                    int *comm_keyval, void *extra_state)
 {
-#ifdef BUILD_MPI_ABI
+#ifdef MPICH_BUILD_MPI_ABI
     if (comm_copy_attr_fn == MPI_COMM_NULL_COPY_FN) {
         comm_copy_attr_fn = NULL;
     } else if (comm_copy_attr_fn == MPI_COMM_DUP_FN) {
@@ -112,7 +112,7 @@ int MPIR_Type_create_keyval_x_impl(MPI_Type_copy_attr_function * type_copy_attr_
                                    MPIX_Destructor_function * destructor_fn,
                                    int *type_keyval, void *extra_state)
 {
-#ifdef BUILD_MPI_ABI
+#ifdef MPICH_BUILD_MPI_ABI
     if (type_copy_attr_fn == MPI_TYPE_NULL_COPY_FN) {
         type_copy_attr_fn = NULL;
     } else if (type_copy_attr_fn == MPI_TYPE_DUP_FN) {
@@ -136,7 +136,7 @@ int MPIR_Win_create_keyval_x_impl(MPI_Win_copy_attr_function * win_copy_attr_fn,
                                   MPIX_Destructor_function * destructor_fn,
                                   int *win_keyval, void *extra_state)
 {
-#ifdef BUILD_MPI_ABI
+#ifdef MPICH_BUILD_MPI_ABI
     if (win_copy_attr_fn == MPI_WIN_NULL_COPY_FN) {
         win_copy_attr_fn = NULL;
     } else if (win_copy_attr_fn == MPI_WIN_DUP_FN) {

--- a/src/mpi/attr/attrutil.c
+++ b/src/mpi/attr/attrutil.c
@@ -4,7 +4,7 @@
  */
 
 #include "mpiimpl.h"
-#ifdef BUILD_MPI_ABI
+#ifdef MPICH_BUILD_MPI_ABI
 #include "mpi_abi_util.h"
 #endif
 /*
@@ -271,7 +271,7 @@ MPII_Attr_copy_c_proxy(MPI_Comm_copy_attr_function * user_function,
     int ret;
 
     attrib_val = attrib;
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
     ret = user_function(handle, keyval, extra_state, attrib_val, attrib_copy, flag);
 #else
     ret = user_function(ABI_Handle_from_mpi(handle), keyval, extra_state, attrib_val,
@@ -290,7 +290,7 @@ MPII_Attr_delete_c_proxy(MPI_Comm_delete_attr_function * user_function,
     int ret;
 
     attrib_val = attrib;
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
     ret = user_function(handle, keyval, attrib_val, extra_state);
 #else
     ret = user_function(ABI_Handle_from_mpi(handle), keyval, attrib_val, extra_state);

--- a/src/mpi/attr/dup_fn.c
+++ b/src/mpi/attr/dup_fn.c
@@ -31,7 +31,7 @@ int MPIR_Dup_fn(MPI_Comm comm ATTRIBUTE((unused)),
     return attr_dup_fn(attr_in, attr_out, flag);
 }
 
-#ifdef BUILD_MPI_ABI
+#ifdef MPICH_BUILD_MPI_ABI
 int MPIR_Comm_dup_fn(ABI_Comm comm, int keyval, void *extra_state,
                      void *attr_in, void *attr_out, int *flag)
 {

--- a/src/mpi/coll/op/op_impl.c
+++ b/src/mpi/coll/op/op_impl.c
@@ -33,7 +33,7 @@ int MPIR_Op_create_impl(MPI_User_function * user_fn, int commute, MPIR_Op ** p_o
 
     op_ptr->is_commute = commute;
     op_ptr->kind = MPIR_OP_KIND__USER;
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
     op_ptr->function.c_function = (void (*)(const void *, void *,
                                             const int *, const MPI_Datatype *)) user_fn;
 #else
@@ -58,7 +58,7 @@ int MPIR_Op_create_large_impl(MPI_User_function_c * user_fn, int commute, MPIR_O
     if (mpi_errno == MPI_SUCCESS) {
         (*p_op_ptr)->is_commute = commute;
         (*p_op_ptr)->kind = MPIR_OP_KIND__USER_LARGE;
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
         (*p_op_ptr)->function.c_large_function = (void (*)(const void *, void *,
                                                            const MPI_Count *,
                                                            const MPI_Datatype *)) user_fn;

--- a/src/mpi/coll/reduce_local/reduce_local.c
+++ b/src/mpi/coll/reduce_local/reduce_local.c
@@ -4,7 +4,7 @@
  */
 
 #include "mpiimpl.h"
-#ifdef BUILD_MPI_ABI
+#ifdef MPICH_BUILD_MPI_ABI
 #include "mpi_abi_util.h"
 #endif
 
@@ -13,7 +13,7 @@ static void call_user_op(const void *inbuf, void *inoutbuf, int count, MPI_Datat
 {
     /* Take off the global locks before calling user functions */
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
     (uop.c_function) ((void *) inbuf, inoutbuf, &count, &datatype);
 #else
     ABI_Datatype t = ABI_Datatype_from_mpi(datatype);
@@ -27,7 +27,7 @@ static void call_user_op_large(const void *inbuf, void *inoutbuf, MPI_Count coun
 {
     /* Take off the global locks before calling user functions */
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
     (uop.c_large_function) ((void *) inbuf, inoutbuf, &count, &datatype);
 #else
     ABI_Datatype t = ABI_Datatype_from_mpi(datatype);
@@ -41,7 +41,7 @@ static void call_user_op_x(const void *inbuf, void *inoutbuf, MPI_Count count,
 {
     /* Take off the global locks before calling user functions */
     MPID_THREAD_CS_EXIT(GLOBAL, MPIR_THREAD_GLOBAL_ALLFUNC_MUTEX);
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
     (uop.c_x_function) ((void *) inbuf, inoutbuf, count, datatype, extra_state);
 #else
     ABI_Datatype t = ABI_Datatype_from_mpi(datatype);

--- a/src/mpi/comm/comm_split_type_nbhd.c
+++ b/src/mpi/comm/comm_split_type_nbhd.c
@@ -56,7 +56,7 @@ int MPIR_Comm_split_type_neighborhood(MPIR_Comm * comm_ptr, int split_type, int 
 }
 
 #ifdef HAVE_ROMIO
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 #include "mpir_ext.h"
 
 static int ext_split_filesystem(MPI_Comm comm, int key, const char *dirname, MPI_Comm * newcomm)
@@ -76,7 +76,7 @@ static int ext_split_filesystem(MPI_Comm comm, int key, const char *dirname, MPI
     return ret;
 }
 
-#endif /* BUILD_MPI_ABI */
+#endif /* MPICH_BUILD_MPI_ABI */
 #endif /* HAVE_ROMIO */
 
 static int split_type_nbhd_common_dir(MPIR_Comm * user_comm_ptr, int key, const char *hintval,

--- a/src/mpi/datatype/get_elements_x.c
+++ b/src/mpi/datatype/get_elements_x.c
@@ -223,7 +223,7 @@ static MPI_Count MPIR_Type_get_elements(MPI_Count * bytes_p, MPI_Count count, MP
             case MPI_COMBINER_F90_REAL:
             case MPI_COMBINER_F90_COMPLEX:
             case MPI_COMBINER_F90_INTEGER:
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
             case MPI_COMBINER_HVECTOR_INTEGER:
             case MPI_COMBINER_HINDEXED_INTEGER:
             case MPI_COMBINER_STRUCT_INTEGER:

--- a/src/mpi/datatype/type_debug.c
+++ b/src/mpi/datatype/type_debug.c
@@ -243,7 +243,7 @@ char *MPIR_Datatype_combiner_to_string(int combiner)
         return c_struct;
     if (combiner == MPI_COMBINER_DUP)
         return c_dup;
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
     if (combiner == MPI_COMBINER_HVECTOR_INTEGER)
         return c_hvector_integer;
     if (combiner == MPI_COMBINER_HINDEXED_INTEGER)

--- a/src/mpi/datatype/typerep/src/typerep_dataloop_commit.c
+++ b/src/mpi/datatype/typerep/src/typerep_dataloop_commit.c
@@ -63,7 +63,7 @@ void MPIR_Typerep_commit(MPI_Datatype type)
                 goto clean_exit;
             }
             break;
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
         case MPI_COMBINER_HVECTOR_INTEGER:
         case MPI_COMBINER_HINDEXED_INTEGER:
         case MPI_COMBINER_STRUCT_INTEGER:

--- a/src/mpi/errhan/errhan_file.c
+++ b/src/mpi/errhan/errhan_file.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 #include "mpir_ext.h"
 #define get_file_errhand MPIR_ROMIO_Get_file_errhand
 #define set_file_errhand MPIR_ROMIO_Set_file_errhand
@@ -178,7 +178,7 @@ static int call_file_errhandler(MPI_Errhandler e, int errorcode, MPI_File f)
     return mpi_errno;
 }
 
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 int MPIR_Call_file_errhandler(MPI_Errhandler e, int errorcode, MPI_File f)
 {
     return call_file_errhandler(e, errorcode, f);

--- a/src/mpi/errhan/errhan_impl.c
+++ b/src/mpi/errhan/errhan_impl.c
@@ -4,7 +4,7 @@
  */
 
 #include "mpiimpl.h"
-#ifdef BUILD_MPI_ABI
+#ifdef MPICH_BUILD_MPI_ABI
 #include "mpi_abi_util.h"
 #endif
 

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -14,7 +14,7 @@
 /* stdio is needed for vsprintf and vsnprintf */
 #include <stdio.h>
 
-#ifdef BUILD_MPI_ABI
+#ifdef MPICH_BUILD_MPI_ABI
 #include "mpi_abi_util.h"
 #endif
 
@@ -187,7 +187,7 @@ int MPIR_call_errhandler(MPIR_Errhandler * errhandler, int errorcode, MPIR_handl
         mpi_errno = errorcode;
         goto fn_exit;
     }
-#ifdef BUILD_MPI_ABI
+#ifdef MPICH_BUILD_MPI_ABI
     void *abi_handle = NULL;
     if (h.kind == MPIR_COMM) {
         abi_handle = ABI_Comm_from_mpi(h.u.handle);
@@ -207,7 +207,7 @@ int MPIR_call_errhandler(MPIR_Errhandler * errhandler, int errorcode, MPIR_handl
         case MPIR_LANG__C:
             /* We pass a final 0 (for a null pointer) to these routines
              * because MPICH-1 expected that */
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
             if (h.kind == MPIR_FILE) {
                 (*errhandler->errfn.C_File_Handler_function) (&h.u.fh, &errorcode);
             } else {
@@ -222,7 +222,7 @@ int MPIR_call_errhandler(MPIR_Errhandler * errhandler, int errorcode, MPIR_handl
         case MPIR_LANG__X:
             {
                 void *extra_state = errhandler->extra_state;
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
                 if (h.kind == MPIR_FILE) {
                     (*errhandler->errfn.X_File_Handler_function) (h.u.fh, errorcode, extra_state);
                 } else {

--- a/src/mpi/init/globals.c
+++ b/src/mpi/init/globals.c
@@ -16,7 +16,7 @@ MPIR_Process_t MPIR_Process = {
 
 MPIR_Thread_info_t MPIR_ThreadInfo;
 
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 /* These are initialized as null (avoids making these into common symbols).
    If the Fortran binding is supported, these can be initialized to
    their Fortran values (MPI only requires that they be valid between

--- a/src/mpi/misc/f2c_impl.c
+++ b/src/mpi/misc/f2c_impl.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 
 int MPIR_Status_f2c_impl(const MPI_Fint * f_status, MPI_Status * c_status)
 {
@@ -101,4 +101,4 @@ int MPIR_Status_c2f08_impl(const MPI_Status * c_status, MPI_F08_status * f08_sta
     return MPI_SUCCESS;
 }
 
-#endif /* BUILD_MPI_ABI */
+#endif /* MPICH_BUILD_MPI_ABI */

--- a/src/mpi/romio/Makefile.am
+++ b/src/mpi/romio/Makefile.am
@@ -101,12 +101,12 @@ endif !BUILD_PROFILING_LIB
 if BUILD_ABI_LIB
 noinst_LTLIBRARIES += libromio_abi.la
 libromio_abi_la_SOURCES = $(romio_mpi_sources) $(romio_other_sources) $(glue_sources)
-libromio_abi_la_CPPFLAGS = $(AM_CPPFLAGS) -DBUILD_MPI_ABI
+libromio_abi_la_CPPFLAGS = $(AM_CPPFLAGS) -DMPICH_BUILD_MPI_ABI
 
 if BUILD_PROFILING_LIB
 noinst_LTLIBRARIES += libpromio_abi.la
 libpromio_abi_la_SOURCES = $(romio_mpi_sources)
-libpromio_abi_la_CPPFLAGS = $(AM_CPPFLAGS) -DMPIO_BUILD_PROFILING -DBUILD_MPI_ABI
+libpromio_abi_la_CPPFLAGS = $(AM_CPPFLAGS) -DMPIO_BUILD_PROFILING -DMPICH_BUILD_MPI_ABI
 libpromio_abi_la_LDFLAGS = $(external_ldflags)
 libpromio_abi_la_LIBADD = $(external_libs)
 endif BUILD_PROFILING_LIB

--- a/src/mpi/romio/adio/include/adio.h
+++ b/src/mpi/romio/adio/include/adio.h
@@ -62,7 +62,7 @@
 #define ROMIOCONF_H_INCLUDED
 #endif
 
-#ifdef BUILD_MPI_ABI
+#ifdef MPICH_BUILD_MPI_ABI
 #include "romio_abi_internal.h"
 #else
 #include "mpi.h"
@@ -264,7 +264,7 @@ typedef struct {
 
 
 /* access modes */
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 #define ADIO_CREATE              1
 #define ADIO_RDONLY              2
 #define ADIO_WRONLY              4

--- a/src/mpi/topo/topoutil.c
+++ b/src/mpi/topo/topoutil.c
@@ -5,7 +5,7 @@
 
 #include "mpiimpl.h"
 
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 static int unweighted_dummy = 0x46618;
 static int weights_empty_dummy = 0x022284;
 /* cannot ==NULL, would be ambiguous */
@@ -17,7 +17,7 @@ int *const MPI_WEIGHTS_EMPTY = &weights_empty_dummy;
 static int MPIR_Topology_keyval = MPI_KEYVAL_INVALID;
 
 /* Local functions */
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 static int MPIR_Topology_copy_fn(MPI_Comm, int, void *, void *, void *, int *);
 static int MPIR_Topology_delete_fn(MPI_Comm, int, void *, void *);
 #else
@@ -228,7 +228,7 @@ static int MPIR_Topology_delete_internal(void *attr_val)
     return MPI_SUCCESS;
 }
 
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 static int MPIR_Topology_copy_fn(MPI_Comm comm ATTRIBUTE((unused)),
                                  int keyval ATTRIBUTE((unused)),
                                  void *extra_data ATTRIBUTE((unused)),

--- a/src/mpi_t/pvar_impl.c
+++ b/src/mpi_t/pvar_impl.c
@@ -9,7 +9,7 @@
 /* Define storage for the ALL_HANDLES constant */
 MPIR_T_pvar_handle_t MPIR_T_pvar_all_handles_obj;
 
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 MPIR_T_pvar_handle_t *const MPI_T_PVAR_ALL_HANDLES = &MPIR_T_pvar_all_handles_obj;
 #define CHECK_PVAR_ALL_HANDLES(handle) do { } while (0)
 #else

--- a/src/mpid/common/shm/mpidu_shm_alloc.c
+++ b/src/mpid/common/shm/mpidu_shm_alloc.c
@@ -191,7 +191,7 @@ static void ull_maxloc_op(void *invec, void *inoutvec, int *len)
     }
 }
 
-#ifndef BUILD_MPI_ABI
+#ifndef MPICH_BUILD_MPI_ABI
 static void ull_maxloc_op_func(void *invec, void *inoutvec, int *len, MPI_Datatype * datatype)
 {
     ull_maxloc_op(invec, inoutvec, len);


### PR DESCRIPTION
## Pull Request Description
Avoid generic macro, `BUILD_MPI_ABI`, in `mpi.h`. Software and libraries derived from MPI may collide with such generic macro usage. Add `MPICH_` prefix instead.


Fixes #7618
[skips warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
