### PR TITLE
hydra: filler_processes not set in init_proxy

### DIFF
--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -119,7 +119,7 @@ static void init_proxy(struct HYD_proxy *proxy, int pgid, struct HYD_node *node)
     proxy->exec_launch_info = NULL;
 
     proxy->proxy_process_count = 0;
-    proxy->filler_processes = 0;
+    proxy->filler_processes = node->core_count - node->active_processes % node->core_count;
 
     proxy->pid = NULL;
     proxy->exit_status = NULL;


### PR DESCRIPTION
## Pull Request Description
The filler_processes are not set in init_proxy, causing the rank assignment not reflecting the rank map, especially during spawn when some of the node->active_processes are non-empty and non-full.



Fixes #7794. Supersedes #7795 

**NOTE**: we need multinode CI testing to catch such issues.
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
