### PR TITLE
hydra: consistently allocate ranks in spawn

### DIFF
--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -110,7 +110,8 @@ void HYDU_free_node_list(struct HYD_node *node_list)
     }
 }
 
-static void init_proxy(struct HYD_proxy *proxy, int pgid, struct HYD_node *node)
+static void init_proxy(struct HYD_proxy *proxy, int pgid, struct HYD_node *node,
+                       int max_oversubscribe)
 {
     proxy->node = node;
     proxy->pgid = pgid;
@@ -119,7 +120,11 @@ static void init_proxy(struct HYD_proxy *proxy, int pgid, struct HYD_node *node)
     proxy->exec_launch_info = NULL;
 
     proxy->proxy_process_count = 0;
-    proxy->filler_processes = node->core_count - node->active_processes % node->core_count;
+    if (max_oversubscribe > 0) {
+        proxy->filler_processes = node->core_count * max_oversubscribe - node->active_processes;
+    } else {
+        proxy->filler_processes = 0;
+    }
 
     proxy->pid = NULL;
     proxy->exit_status = NULL;
@@ -292,7 +297,7 @@ HYD_status HYDU_create_proxy_list_singleton(struct HYD_node *node, int pgid,
     proxy = MPL_malloc(sizeof(struct HYD_proxy), MPL_MEM_OTHER);
     HYDU_ASSERT(proxy, status);
 
-    init_proxy(proxy, pgid, node);
+    init_proxy(proxy, pgid, node, 0);
 
     proxy->proxy_id = 0;
     proxy->proxy_process_count = 1;
@@ -308,9 +313,35 @@ HYD_status HYDU_create_proxy_list_singleton(struct HYD_node *node, int pgid,
     goto fn_exit;
 }
 
-HYD_status HYDU_create_proxy_list(int count, struct HYD_exec *exec_list, struct HYD_node *node_list,
-                                  int pgid, int *rankmap, int *min_node_id_p,
-                                  int *proxy_count_p, struct HYD_proxy **proxy_list_p)
+static int get_max_overscribe(struct HYD_node *node_list)
+{
+    int max_oversubscribe = 0;
+    for (struct HYD_node * node = node_list; node; node = node->next) {
+        int c = HYDU_dceil(node->active_processes, node->core_count);
+        if (max_oversubscribe < c) {
+            max_oversubscribe = c;
+        }
+    }
+
+    bool has_spare = false;
+    for (struct HYD_node * node = node_list; node; node = node->next) {
+        if (node->core_count * max_oversubscribe - node->active_processes > 0) {
+            has_spare = true;
+            break;
+        }
+    }
+    if (!has_spare) {
+        max_oversubscribe = 0;
+    }
+
+    /* NOTE: returning 0 means we can skip the filler round */
+    return max_oversubscribe;
+}
+
+HYD_status HYDU_create_proxy_list(int count, struct HYD_exec * exec_list,
+                                  struct HYD_node * node_list, int pgid, int *rankmap,
+                                  int *min_node_id_p, int *proxy_count_p,
+                                  struct HYD_proxy ** proxy_list_p)
 {
     HYD_status status = HYD_SUCCESS;
     HYDU_FUNC_ENTER();
@@ -331,11 +362,21 @@ HYD_status HYDU_create_proxy_list(int count, struct HYD_exec *exec_list, struct 
     struct HYD_proxy *proxy_list = MPL_malloc(num_nodes * sizeof(struct HYD_proxy), MPL_MEM_OTHER);
     HYDU_ASSERT(proxy_list, status);
 
+    int count_nonfilled = 0;
+    int max_oversubscribe = get_max_overscribe(node_list);
     for (struct HYD_node * node = node_list; node; node = node->next) {
         int id = node->node_id;
         if (id >= min_node_id && id <= max_node_id) {
             int i_proxy = id - min_node_id;
-            init_proxy(&proxy_list[i_proxy], pgid, node);
+            init_proxy(&proxy_list[i_proxy], pgid, node, max_oversubscribe);
+            if (proxy_list[i_proxy].filler_processes > 0) {
+                count_nonfilled++;
+            }
+        }
+    }
+    if (count_nonfilled == 0) {
+        for (int i_proxy = 0; i_proxy < num_nodes; i_proxy++) {
+            proxy_list[i_proxy].filler_processes += proxy_list[i_proxy].node->core_count;
         }
     }
 
@@ -352,6 +393,7 @@ HYD_status HYDU_create_proxy_list(int count, struct HYD_exec *exec_list, struct 
 
         int node_id, c;
         node_id = rankmap[rank];
+        printf("* rankmap[%d] = %d\n", rank, node_id);
         c = 1;
         rank++;
         while (c < exec_rem_procs && rank < count && rankmap[rank] == node_id) {


### PR DESCRIPTION

## Pull Request Description
Use the same code in assigning `proxy->filler_proesses` as in `HYDU_gen_rankmap`.

Fixes #7794 
[skip warnings]

**TODO**: replace the `--global-core-map` and `--pmi-id-map` using direct `rankmap[]`. The former is still a good compression technique, but we need alternate syntax for arbitrary `rankmap[]`

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
