### PR TITLE
hydra: remove a stray printf

### DIFF
--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -393,7 +393,6 @@ HYD_status HYDU_create_proxy_list(int count, struct HYD_exec * exec_list,
 
         int node_id, c;
         node_id = rankmap[rank];
-        printf("* rankmap[%d] = %d\n", rank, node_id);
         c = 1;
         rank++;
         while (c < exec_rem_procs && rank < count && rankmap[rank] == node_id) {


### PR DESCRIPTION
## Pull Request Description
The commit 8e674596f8 was accidentally merged from another pull request. It contains an extra debug printf.




## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
