### PR TITLE
hydra: refactor proxy exec list

### DIFF
--- a/src/mpl/include/mpl_hash.h
+++ b/src/mpl/include/mpl_hash.h
@@ -13,14 +13,14 @@ struct strpool {
 struct MPL_hash {
     int n_size;
     int n_count;
-    char *p_exist;
+    bool *p_exist;
     int *p_key;
     struct strpool pool;
     int *p_val;
 };
 
 struct MPL_hash *MPL_hash_new(void);
-int MPL_hash_has(struct MPL_hash *hv, const char *s_key);
+bool MPL_hash_has(struct MPL_hash *hv, const char *s_key);
 void MPL_hash_set(struct MPL_hash *hv, const char *s_key, const char *s_value);
 char *MPL_hash_get(struct MPL_hash *hv, const char *s_key);
 void MPL_hash_free(struct MPL_hash *hv);

--- a/src/mpl/include/mpl_hash.h
+++ b/src/mpl/include/mpl_hash.h
@@ -19,6 +19,8 @@ struct MPL_hash {
     int *p_val;
 };
 
+#define MPL_HASH_KEY  ((const char *) 1)        /* value is the same as key */
+
 struct MPL_hash *MPL_hash_new(void);
 bool MPL_hash_has(struct MPL_hash *hv, const char *s_key);
 void MPL_hash_set(struct MPL_hash *hv, const char *s_key, const char *s_value);

--- a/src/mpl/include/mpl_trmem.h
+++ b/src/mpl/include/mpl_trmem.h
@@ -53,6 +53,7 @@ typedef enum {
     MPL_MEM_COLL,               /* Memory related to collective operations */
     MPL_MEM_LOCAL,              /* Temporary allocation that will be freed after the operation */
     MPL_MEM_USER,               /* User memory allocations */
+    MPL_MEM_HASH,               /* MPL_hash */
     MPL_MEM_OTHER,              /* Other small memory allocations */
     MPL_MAX_MEMORY_CLASS
 } MPL_memory_class;

--- a/src/mpl/src/mem/mpl_trmem.c
+++ b/src/mpl/src/mem/mpl_trmem.c
@@ -134,6 +134,7 @@ static const char *allocation_class_strings[] = {
     "MPL_MEM_COLL",
     "MPL_MEM_LOCAL",
     "MPL_MEM_USER",
+    "MPL_MEM_HASH",
     "MPL_MEM_OTHER"
 };
 

--- a/src/mpl/src/str/mpl_hash.c
+++ b/src/mpl/src/str/mpl_hash.c
@@ -37,16 +37,19 @@ struct MPL_hash *MPL_hash_new(void)
 {
     struct MPL_hash *hv;
 
-    hv = (struct MPL_hash *) MPL_calloc(1, sizeof(struct MPL_hash), MPL_MEM_OTHER);
+    hv = (struct MPL_hash *) MPL_calloc(1, sizeof(struct MPL_hash), MPL_MEM_HASH);
     return hv;
 }
 
-int MPL_hash_has(struct MPL_hash *hv, const char *s_key)
+bool MPL_hash_has(struct MPL_hash * hv, const char *s_key)
 {
-    int k;
-
-    k = f_strhash_lookup(hv, (unsigned char *) s_key, strlen(s_key));
-    return hv->p_exist[k];
+    if (hv->n_size == 0) {
+        return 0;
+    } else {
+        int k;
+        k = f_strhash_lookup(hv, (unsigned char *) s_key, strlen(s_key));
+        return hv->p_exist[k];
+    }
 }
 
 void MPL_hash_set(struct MPL_hash *hv, const char *s_key, const char *s_value)
@@ -135,7 +138,7 @@ int f_strhash_lookup_left(void *hash, unsigned char *key, int keylen)
     k = f_strhash_lookup(h, key, keylen);
     if (!h->p_exist[k]) {
         h->p_key[k] = f_addto_strpool(&h->pool, (char *) key, keylen);
-        h->p_exist[k] = 1;
+        h->p_exist[k] = true;
         h->n_count++;
     }
     return k;
@@ -160,7 +163,7 @@ int f_addto_strpool(struct strpool *p_strpool, const char *s, int n)
             tn_avg_str_size = p_strpool->i_pool / p_strpool->i_str + 1;
         }
         p_strpool->pool_size = tn_avg_str_size * p_strpool->n_str + n;
-        p_strpool->pc_pool = MPL_realloc(p_strpool->pc_pool, p_strpool->pool_size, MPL_MEM_OTHER);
+        p_strpool->pc_pool = MPL_realloc(p_strpool->pc_pool, p_strpool->pool_size, MPL_MEM_HASH);
     }
     memcpy(p_strpool->pc_pool + p_strpool->i_pool, s, n);
     p_strpool->i_str++;
@@ -177,7 +180,7 @@ int f_addto_strpool(struct strpool *p_strpool, const char *s, int n)
 void f_strhash_resize(void *hash, int n_size)
 {
     struct MPL_hash *h = hash;
-    char *tp_exist = h->p_exist;
+    bool *tp_exist = h->p_exist;
     int *tp_key = h->p_key;
     int tn_old_size;
     int *tp_val = h->p_val;
@@ -197,9 +200,9 @@ void f_strhash_resize(void *hash, int n_size)
     tn_old_size = h->n_size;
 
     h->n_size = n_size;
-    h->p_key = (int *) MPL_calloc(n_size, sizeof(int), MPL_MEM_OTHER);
-    h->p_exist = (char *) MPL_calloc(n_size, sizeof(char), MPL_MEM_OTHER);
-    h->p_val = (void *) MPL_calloc(n_size, sizeof(int), MPL_MEM_OTHER);
+    h->p_key = (int *) MPL_calloc(n_size, sizeof(int), MPL_MEM_HASH);
+    h->p_exist = (bool *) MPL_calloc(n_size, sizeof(bool), MPL_MEM_HASH);
+    h->p_val = (void *) MPL_calloc(n_size, sizeof(int), MPL_MEM_HASH);
 
     p_strpool = &h->pool;
     if (tn_old_size > 0) {
@@ -208,7 +211,7 @@ void f_strhash_resize(void *hash, int n_size)
 
                 k = f_strhash_lookup(h, (unsigned char *) STRPOOL_STR(p_strpool, tp_key[i]),
                                      STRPOOL_STRLEN(p_strpool, tp_key[i]));
-                h->p_exist[k] = 1;
+                h->p_exist[k] = true;
                 h->p_key[k] = tp_key[i];
                 h->p_val[k] = tp_val[i];
             }
@@ -226,7 +229,7 @@ void f_resize_strpool_n(struct strpool *p_strpool, int n_size, int n_avg)
     }
     p_strpool->n_str = n_size;
     p_strpool->pn_str =
-        MPL_realloc(p_strpool->pn_str, p_strpool->n_str * sizeof(int), MPL_MEM_OTHER);
+        MPL_realloc(p_strpool->pn_str, p_strpool->n_str * sizeof(int), MPL_MEM_HASH);
 
     if (n_avg == 0) {
         n_avg = 6;
@@ -236,7 +239,7 @@ void f_resize_strpool_n(struct strpool *p_strpool, int n_size, int n_avg)
     }
     if (n_avg * p_strpool->n_str > p_strpool->pool_size) {
         p_strpool->pool_size = n_avg * p_strpool->n_str;
-        p_strpool->pc_pool = MPL_realloc(p_strpool->pc_pool, p_strpool->pool_size, MPL_MEM_OTHER);
+        p_strpool->pc_pool = MPL_realloc(p_strpool->pc_pool, p_strpool->pool_size, MPL_MEM_HASH);
         p_strpool->pc_pool[p_strpool->pool_size - 1] = 0;
     }
 

--- a/src/mpl/src/str/mpl_hash.c
+++ b/src/mpl/src/str/mpl_hash.c
@@ -12,6 +12,11 @@
  *    frequent deletion and modification and memory consumption is of concern. All
  *    memory will be released upon final free.
  *
+ *    To use it as set, use MPL_hash_set(hv, s_key, MPL_HASH_KEY), effectively
+ *    store the key as its value, avoiding an extra string storage. Consequently,
+ *    MPL_hash_get will retrieve the stored key string, thus MPL_hash can be used
+ *    as a persistent string storage.
+ *
  *    Compared to uthash.h, the usage interface is cleaner and more intuitive --
  *    hash_new, hash_set, hash_get, hash_has, and hash_free. In comparison, uthash
  *    requires extra data structure, does not manage string memory, and the code is
@@ -57,7 +62,11 @@ void MPL_hash_set(struct MPL_hash *hv, const char *s_key, const char *s_value)
     int k;
 
     k = f_strhash_lookup_left(hv, (unsigned char *) s_key, strlen(s_key));
-    hv->p_val[k] = f_addto_strpool(&hv->pool, s_value, strlen(s_value));
+    if (s_value == MPL_HASH_KEY) {
+        hv->p_val[k] = hv->p_key[k];
+    } else {
+        hv->p_val[k] = f_addto_strpool(&hv->pool, s_value, strlen(s_value));
+    }
 }
 
 char *MPL_hash_get(struct MPL_hash *hv, const char *s_key)

--- a/src/pm/hydra/lib/hydra.h
+++ b/src/pm/hydra/lib/hydra.h
@@ -307,8 +307,16 @@ struct HYD_exec {
     char *env_prop;
 
     int appnum;
+    int ref_count;              /* HYD_exec pointer may be held by proxy until HYD_pmcd_pmi_fill_in_exec_launch_info */
 
     struct HYD_exec *next;
+};
+
+struct HYD_proxy_exec {
+    struct HYD_exec *exec;
+    int rank;                   /* starting rank */
+    int count;                  /* consecutive processes for this exec */
+    struct HYD_proxy_exec *next;
 };
 
 /* Information about the node itself */
@@ -341,7 +349,7 @@ struct HYD_proxy {
 
     int proxy_process_count;
 
-    struct HYD_exec *exec_list;
+    struct HYD_proxy_exec *exec_list;
 
     int *pid;
     int *exit_status;

--- a/src/pm/hydra/lib/hydra.h
+++ b/src/pm/hydra/lib/hydra.h
@@ -301,14 +301,13 @@ struct HYD_exec {
     int exec_len, exec_size;
     char *wdir;
 
-    int start_rank;
     int proc_count;
     struct HYD_env *user_env;
     char *env_prop;
 
     int appnum;
-    int ref_count;              /* HYD_exec pointer may be held by proxy until HYD_pmcd_pmi_fill_in_exec_launch_info */
 
+    int tmp_exec_id;            /* tmp field during HYD_pmcd_pmi_fill_in_exec_launch_info */
     struct HYD_exec *next;
 };
 
@@ -488,6 +487,7 @@ void HYDU_free_proxy_list(struct HYD_proxy *proxy_list, int count);
 HYD_status HYDU_alloc_exec(struct HYD_exec **exec);
 HYD_status HYDU_exec_add_arg(struct HYD_exec *exec, const char *arg);
 void HYDU_free_exec_list(struct HYD_exec *exec_list);
+void HYDU_free_launch_list(struct HYD_proxy_exec *launch_list);
 HYD_status HYDU_create_proxy_list_singleton(struct HYD_node *node, int pgid,
                                             int *proxy_count_p, struct HYD_proxy **proxy_list_p);
 HYD_status HYDU_create_proxy_list(int count, struct HYD_exec *exec_list, struct HYD_node *node_list,

--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -143,13 +143,7 @@ void HYDU_free_proxy_list(struct HYD_proxy *proxy_list, int count)
 
         MPL_free(proxy->pid);
         MPL_free(proxy->exit_status);
-
-        struct HYD_proxy_exec *exec = proxy->exec_list;
-        while (exec) {
-            struct HYD_proxy_exec *cur = exec;
-            exec = cur->next;
-            MPL_free(cur);
-        }
+        HYDU_free_launch_list(proxy->exec_list);
     }
 
     MPL_free(proxy_list);
@@ -167,7 +161,6 @@ HYD_status HYDU_alloc_exec(struct HYD_exec **exec)
     (*exec)->exec_len = 0;
     (*exec)->exec_size = 0;
     (*exec)->wdir = NULL;
-    (*exec)->start_rank = -1;
     (*exec)->proc_count = -1;
     (*exec)->env_prop = NULL;
     (*exec)->user_env = NULL;
@@ -237,6 +230,16 @@ void HYDU_free_exec_list(struct HYD_exec *exec_list)
     }
 
     HYDU_FUNC_EXIT();
+}
+
+void HYDU_free_launch_list(struct HYD_proxy_exec *launch_list)
+{
+    struct HYD_proxy_exec *launch = launch_list;
+    while (launch) {
+        struct HYD_proxy_exec *cur = launch;
+        launch = cur->next;
+        MPL_free(cur);
+    }
 }
 
 static HYD_status add_exec_to_proxy(struct HYD_exec *exec, struct HYD_proxy *proxy,

--- a/src/pm/hydra/lib/utils/alloc.c
+++ b/src/pm/hydra/lib/utils/alloc.c
@@ -144,7 +144,12 @@ void HYDU_free_proxy_list(struct HYD_proxy *proxy_list, int count)
         MPL_free(proxy->pid);
         MPL_free(proxy->exit_status);
 
-        HYDU_free_exec_list(proxy->exec_list);
+        struct HYD_proxy_exec *exec = proxy->exec_list;
+        while (exec) {
+            struct HYD_proxy_exec *cur = exec;
+            exec = cur->next;
+            MPL_free(cur);
+        }
     }
 
     MPL_free(proxy_list);
@@ -239,29 +244,20 @@ static HYD_status add_exec_to_proxy(struct HYD_exec *exec, struct HYD_proxy *pro
 {
     HYD_status status = HYD_SUCCESS;
 
-    struct HYD_exec *texec;
-    status = HYDU_alloc_exec(&texec);
-    HYDU_ERR_POP(status, "unable to allocate proxy exec\n");
+    struct HYD_proxy_exec *texec;
+    HYDU_MALLOC_OR_JUMP(texec, struct HYD_proxy_exec *, sizeof(struct HYD_proxy_exec), status);
+    texec->exec = exec;
+    texec->rank = start_rank;
+    texec->count = num_procs;
+    texec->next = NULL;
 
     if (proxy->exec_list == NULL) {
         proxy->exec_list = texec;
     } else {
-        struct HYD_exec *tmp;
+        struct HYD_proxy_exec *tmp;
         for (tmp = proxy->exec_list; tmp->next; tmp = tmp->next);
         tmp->next = texec;
     }
-
-    for (int i = 0; exec->exec[i]; i++) {
-        status = HYDU_exec_add_arg(texec, exec->exec[i]);
-        HYDU_ERR_POP(status, "unable to add exec arg\n");
-    }
-
-    texec->wdir = exec->wdir ? MPL_strdup(exec->wdir) : NULL;
-    texec->start_rank = start_rank;
-    texec->proc_count = num_procs;
-    texec->env_prop = exec->env_prop ? MPL_strdup(exec->env_prop) : NULL;
-    texec->user_env = HYDU_env_list_dup(exec->user_env);
-    texec->appnum = exec->appnum;
 
     proxy->proxy_process_count += num_procs;
     proxy->node->active_processes += num_procs;

--- a/src/pm/hydra/mpiexec/debugger.c
+++ b/src/pm/hydra/mpiexec/debugger.c
@@ -5,6 +5,7 @@
 
 #include "hydra.h"
 #include "debugger.h"
+#include "mpl_hash.h"
 
 struct MPIR_PROCDESC *MPIR_proctable = NULL;
 int MPIR_proctable_size = 0;
@@ -16,6 +17,8 @@ char *MPIR_debug_abort_string = 0;
 
 volatile int MPIR_being_debugged = 0;
 
+static struct MPL_hash *MPIR_debug_str_hash = NULL;
+
 int (*MPIR_breakpointFn) (void) = MPIR_Breakpoint;
 
 int MPIR_Breakpoint(void)
@@ -25,59 +28,53 @@ int MPIR_Breakpoint(void)
 
 HYD_status HYDT_dbg_setup_procdesc(struct HYD_pg * pg)
 {
-    struct HYD_exec *exec;
-    int i, j, k, np, round;
     HYD_status status = HYD_SUCCESS;
-
     HYDU_FUNC_ENTER();
 
     HYDU_MALLOC_OR_JUMP(MPIR_proctable, struct MPIR_PROCDESC *,
                         pg->pg_process_count * sizeof(struct MPIR_PROCDESC), status);
 
-    round = 0;
-    /* We need to allocate the MPIR_proctable in COMM_WORLD rank
-     * order.  We do this in multiple rounds.  In each round, we
-     * allocate the proctable entries for the executables on the proxy
-     * that form a contiguous rank list.  Then we move to the next
-     * proxy.  When we run out of proxies, we go back to the first
-     * proxy and find the next set of contiguous ranks on that
-     * proxy. */
+    /* We need to allocate the MPIR_proctable in COMM_WORLD rank order. */
+    /* We use MPL_hash for duplicating the strings */
+    if (MPIR_debug_str_hash) {
+        MPL_hash_free(MPIR_debug_str_hash);
+    }
+    MPIR_debug_str_hash = MPL_hash_new();
 
-    i = 0;
-    for (int i_proxy = 0;; i_proxy++) {
-        struct HYD_proxy *proxy = &pg->proxy_list[i_proxy % pg->proxy_count];
-        round = i_proxy / pg->proxy_count;
-        j = 0;
-        k = 0;
-        for (exec = proxy->exec_list; exec; exec = exec->next) {
-            for (np = 0; np < exec->proc_count; np++) {
-                if (k + np >= ((round + 1) * proxy->node->core_count))
-                    break;
-                if (k + np < round * proxy->node->core_count)
-                    continue;
-                /* avoid storing multiple copies of the host name */
-                if (i > 0 && strcmp(MPIR_proctable[i - 1].host_name, proxy->node->hostname) == 0)
-                    MPIR_proctable[i].host_name = MPIR_proctable[i - 1].host_name;
-                else
-                    MPIR_proctable[i].host_name = MPL_strdup(proxy->node->hostname);
-                MPIR_proctable[i].pid = proxy->pid[(proxy->node->core_count * round) + j];
-                j++;
+    /* store all name strings in MPIR_debug_str_hash first before exposing the internal string pointers */
+#define HASH_NAME_STR(name) MPL_hash_set(MPIR_debug_str_hash, name, MPL_HASH_KEY)
+
+    for (int i_proxy = 0; i_proxy < pg->proxy_count; i_proxy++) {
+        struct HYD_proxy *proxy = &pg->proxy_list[i_proxy];
+        int j = 0;
+        for (struct HYD_exec * exec = proxy->exec_list; exec; exec = exec->next) {
+            for (int i = 0; i < exec->proc_count; i++) {
+                int rank = exec->start_rank + i;
+                MPIR_proctable[rank].host_name = proxy->node->hostname;
+                MPIR_proctable[rank].pid = proxy->pid[j];
+                HASH_NAME_STR(MPIR_proctable[rank].host_name);
                 if (exec->exec[0]) {
-                    /* avoid storing multiple copies of the executable name */
-                    if (i > 0 && strcmp(exec->exec[0], MPIR_proctable[i - 1].executable_name) == 0)
-                        MPIR_proctable[i].executable_name = MPIR_proctable[i - 1].executable_name;
-                    else
-                        MPIR_proctable[i].executable_name = MPL_strdup(exec->exec[0]);
+                    MPIR_proctable[rank].executable_name = exec->exec[0];
+                    HASH_NAME_STR(MPIR_proctable[rank].executable_name);
                 } else {
-                    MPIR_proctable[i].executable_name = NULL;
+                    MPIR_proctable[rank].executable_name = NULL;
                 }
-                i++;
+                j++;
             }
-            k += exec->proc_count;
         }
+    }
+    /* replace the name strings with allocated strings in MPIR_debug_str_hash.
+     * NOTE: MPIR_debug_str_hash should be frozen to avoid a realloc that invalidates the string pointers.
+     */
+#define REPLACE_NAME_STR(name) \
+    if (name) { \
+        name = MPL_hash_get(MPIR_debug_str_hash, name); \
+    }
 
-        if (i >= pg->pg_process_count)
-            break;
+    for (int rank = 0; rank < pg->pg_process_count; rank++) {
+        HYDU_ASSERT(MPIR_proctable[rank].host_name, status);
+        REPLACE_NAME_STR(MPIR_proctable[rank].host_name);
+        REPLACE_NAME_STR(MPIR_proctable[rank].executable_name);
     }
 
     MPIR_proctable_size = pg->pg_process_count;
@@ -94,19 +91,9 @@ HYD_status HYDT_dbg_setup_procdesc(struct HYD_pg * pg)
 
 void HYDT_dbg_free_procdesc(void)
 {
-    int i;
-
-    for (i = 0; i < MPIR_proctable_size; i++) {
-        /* skip over duplicate pointers when freeing */
-        if (MPIR_proctable[i].host_name) {
-            if (i == 0 || MPIR_proctable[i].host_name != MPIR_proctable[i - 1].host_name)
-                MPL_free(MPIR_proctable[i].host_name);
-        }
-        if (MPIR_proctable[i].executable_name) {
-            if (i == 0 ||
-                MPIR_proctable[i].executable_name != MPIR_proctable[i - 1].executable_name)
-                MPL_free(MPIR_proctable[i].executable_name);
-        }
+    if (MPIR_debug_str_hash) {
+        MPL_hash_free(MPIR_debug_str_hash);
+        MPIR_debug_str_hash = NULL;
     }
     MPL_free(MPIR_proctable);
 }

--- a/src/pm/hydra/mpiexec/debugger.c
+++ b/src/pm/hydra/mpiexec/debugger.c
@@ -47,14 +47,14 @@ HYD_status HYDT_dbg_setup_procdesc(struct HYD_pg * pg)
     for (int i_proxy = 0; i_proxy < pg->proxy_count; i_proxy++) {
         struct HYD_proxy *proxy = &pg->proxy_list[i_proxy];
         int j = 0;
-        for (struct HYD_exec * exec = proxy->exec_list; exec; exec = exec->next) {
-            for (int i = 0; i < exec->proc_count; i++) {
-                int rank = exec->start_rank + i;
+        for (struct HYD_proxy_exec * exec = proxy->exec_list; exec; exec = exec->next) {
+            for (int i = 0; i < exec->count; i++) {
+                int rank = exec->rank + i;
                 MPIR_proctable[rank].host_name = proxy->node->hostname;
                 MPIR_proctable[rank].pid = proxy->pid[j];
                 HASH_NAME_STR(MPIR_proctable[rank].host_name);
-                if (exec->exec[0]) {
-                    MPIR_proctable[rank].executable_name = exec->exec[0];
+                if (exec->exec->exec[0]) {
+                    MPIR_proctable[rank].executable_name = exec->exec->exec[0];
                     HASH_NAME_STR(MPIR_proctable[rank].executable_name);
                 } else {
                     MPIR_proctable[rank].executable_name = NULL;

--- a/src/pm/hydra/mpiexec/pmiserv_spawn.c
+++ b/src/pm/hydra/mpiexec/pmiserv_spawn.c
@@ -269,10 +269,11 @@ static HYD_status do_spawn(void)
                                     pg->pgid, pg->rankmap,
                                     &pg->min_node_id, &pg->proxy_count, &pg->proxy_list);
     HYDU_ERR_POP(status, "error creating proxy list\n");
-    HYDU_free_exec_list(exec_list);
 
     status = HYD_pmcd_pmi_fill_in_exec_launch_info(pg);
     HYDU_ERR_POP(status, "unable to fill in executable arguments\n");
+
+    HYDU_free_exec_list(exec_list);
 
     struct HYD_proxy **filtered_proxy_list;
     filtered_proxy_list = MPL_malloc(pg->proxy_count * sizeof(struct HYD_proxy *), MPL_MEM_OTHER);

--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -178,7 +178,6 @@ HYD_status HYD_pmcd_pmi_fill_in_exec_launch_info(struct HYD_pg *pg)
 {
     int inherited_env_count, user_env_count, system_env_count;
     struct HYD_env *env;
-    struct HYD_exec *exec;
     struct HYD_pmcd_pmi_pg_scratch *pg_scratch;
     char *mapping = NULL;
     struct HYD_string_stash exec_stash;
@@ -276,17 +275,18 @@ HYD_status HYD_pmcd_pmi_fill_in_exec_launch_info(struct HYD_pg *pg)
         HYD_STRING_STASH(exec_stash, HYDU_int_to_str(proxy->node->core_count), status);
 
         /* Now pass the local executable information */
-        for (exec = proxy->exec_list; exec; exec = exec->next) {
+        for (struct HYD_proxy_exec * cur = proxy->exec_list; cur; cur = cur->next) {
+            struct HYD_exec *exec = cur->exec;
             HYD_STRING_STASH(exec_stash, MPL_strdup("--exec"), status);
 
             HYD_STRING_STASH(exec_stash, MPL_strdup("--exec-appnum"), status);
             HYD_STRING_STASH(exec_stash, HYDU_int_to_str(exec->appnum), status);
 
             HYD_STRING_STASH(exec_stash, MPL_strdup("--exec-rank"), status);
-            HYD_STRING_STASH(exec_stash, HYDU_int_to_str(exec->start_rank), status);
+            HYD_STRING_STASH(exec_stash, HYDU_int_to_str(cur->rank), status);
 
             HYD_STRING_STASH(exec_stash, MPL_strdup("--exec-proc-count"), status);
-            HYD_STRING_STASH(exec_stash, HYDU_int_to_str(exec->proc_count), status);
+            HYD_STRING_STASH(exec_stash, HYDU_int_to_str(cur->count), status);
 
             status = add_env_to_exec_stash(&exec_stash, "--exec-local-env", exec->user_env);
             HYDU_ERR_POP(status, "error adding exec local env\n");

--- a/src/pm/hydra/mpiexec/pmiserv_utils.c
+++ b/src/pm/hydra/mpiexec/pmiserv_utils.c
@@ -274,19 +274,25 @@ HYD_status HYD_pmcd_pmi_fill_in_exec_launch_info(struct HYD_pg *pg)
         HYD_STRING_STASH(exec_stash, MPL_strdup("--proxy-core-count"), status);
         HYD_STRING_STASH(exec_stash, HYDU_int_to_str(proxy->node->core_count), status);
 
-        /* Now pass the local executable information */
+        /* first, reset tmp_exec_id */
         for (struct HYD_proxy_exec * cur = proxy->exec_list; cur; cur = cur->next) {
+            cur->exec->tmp_exec_id = -1;
+        }
+
+        /* pass the exec list while avoid duplicates */
+        int tmp_id = 0;
+        for (struct HYD_proxy_exec * cur = proxy->exec_list; cur; cur = cur->next) {
+            if (cur->exec->tmp_exec_id != -1) {
+                continue;
+            }
             struct HYD_exec *exec = cur->exec;
+            exec->tmp_exec_id = tmp_id;
+            tmp_id++;
+
             HYD_STRING_STASH(exec_stash, MPL_strdup("--exec"), status);
 
             HYD_STRING_STASH(exec_stash, MPL_strdup("--exec-appnum"), status);
             HYD_STRING_STASH(exec_stash, HYDU_int_to_str(exec->appnum), status);
-
-            HYD_STRING_STASH(exec_stash, MPL_strdup("--exec-rank"), status);
-            HYD_STRING_STASH(exec_stash, HYDU_int_to_str(cur->rank), status);
-
-            HYD_STRING_STASH(exec_stash, MPL_strdup("--exec-proc-count"), status);
-            HYD_STRING_STASH(exec_stash, HYDU_int_to_str(cur->count), status);
 
             status = add_env_to_exec_stash(&exec_stash, "--exec-local-env", exec->user_env);
             HYDU_ERR_POP(status, "error adding exec local env\n");
@@ -309,6 +315,14 @@ HYD_status HYD_pmcd_pmi_fill_in_exec_launch_info(struct HYD_pg *pg)
             for (int j = 0; exec->exec[j]; j++) {
                 HYD_STRING_STASH(exec_stash, MPL_strdup(exec->exec[j]), status);
             }
+        }
+
+        /* Now pass the local launch list */
+        for (struct HYD_proxy_exec * cur = proxy->exec_list; cur; cur = cur->next) {
+            char buf[30];
+            snprintf(buf, 30, "%d,%d,%d", cur->exec->tmp_exec_id, cur->rank, cur->count);
+            HYD_STRING_STASH(exec_stash, MPL_strdup("--launch"), status);
+            HYD_STRING_STASH(exec_stash, MPL_strdup(buf), status);
         }
 
         if (HYD_server_info.user_global.debug) {

--- a/src/pm/hydra/mpiexec/uiu.c
+++ b/src/pm/hydra/mpiexec/uiu.c
@@ -84,7 +84,6 @@ void HYD_uiu_free_params(void)
 void HYD_uiu_print_params(void)
 {
     struct HYD_env *env;
-    struct HYD_exec *exec;
 
     HYDU_FUNC_ENTER();
 
@@ -132,8 +131,8 @@ void HYD_uiu_print_params(void)
         HYDU_dump_noprefix(stdout, "      [%d] proxy: %s (%d cores)\n", i + 1,
                            proxy->node->hostname, proxy->node->core_count);
         HYDU_dump_noprefix(stdout, "      Exec list: ");
-        for (exec = proxy->exec_list; exec; exec = exec->next)
-            HYDU_dump_noprefix(stdout, "%s (%d processes); ", exec->exec[0], exec->proc_count);
+        for (struct HYD_proxy_exec * exec = proxy->exec_list; exec; exec = exec->next)
+            HYDU_dump_noprefix(stdout, "%s (%d processes); ", exec->exec->exec[0], exec->count);
         HYDU_dump_noprefix(stdout, "\n\n");
     }
 

--- a/src/pm/hydra/proxy/pmip.h
+++ b/src/pm/hydra/proxy/pmip.h
@@ -90,6 +90,7 @@ struct pmip_pg {
 
     /* Process segmentation information for this proxy */
     struct HYD_exec *exec_list;
+    struct HYD_proxy_exec *launch_list;
 
     struct pmip_kvs *kvs;
     /* An array of kvs entries (keys) that needs to be pushed to

--- a/src/pm/hydra/proxy/pmip_cb.c
+++ b/src/pm/hydra/proxy/pmip_cb.c
@@ -744,7 +744,6 @@ static HYD_status launch_procs(struct pmip_pg *pg)
     char *str, *envstr, *list, *pmi_port = NULL;
     struct HYD_string_stash stash;
     struct HYD_env *env, *force_env = NULL;
-    struct HYD_exec *exec;
     struct HYD_pmcd_hdr hdr;
     int pmi_fds[2] = { HYD_FD_UNSET, HYD_FD_UNSET };
     HYD_status status = HYD_SUCCESS;
@@ -752,8 +751,8 @@ static HYD_status launch_procs(struct pmip_pg *pg)
     HYDU_FUNC_ENTER();
 
     int num_procs = 0;
-    for (exec = pg->exec_list; exec; exec = exec->next) {
-        num_procs += exec->proc_count;
+    for (struct HYD_proxy_exec * launch = pg->launch_list; launch; launch = launch->next) {
+        num_procs += launch->count;
     }
 
     status = PMIP_pg_alloc_downstreams(pg, num_procs);
@@ -778,9 +777,9 @@ static HYD_status launch_procs(struct pmip_pg *pg)
     /* set pmi_rank */
     {
         int i = 0;
-        for (exec = pg->exec_list; exec; exec = exec->next) {
-            for (int j = 0; j < exec->proc_count; j++) {
-                pg->downstreams[i].pmi_rank = exec->start_rank + j;
+        for (struct HYD_proxy_exec * launch = pg->launch_list; launch; launch = launch->next) {
+            for (int j = 0; j < launch->count; j++) {
+                pg->downstreams[i].pmi_rank = launch->rank + j;
                 i++;
             }
         }
@@ -804,7 +803,8 @@ static HYD_status launch_procs(struct pmip_pg *pg)
 
     /* Spawn the processes */
     process_id = 0;
-    for (exec = pg->exec_list; exec; exec = exec->next) {
+    for (struct HYD_proxy_exec * launch = pg->launch_list; launch; launch = launch->next) {
+        struct HYD_exec *exec = launch->exec;
 
         /* Increasing priority order: (1) global inherited env; (2)
          * global user env; (3) local user env; (4) system env. We
@@ -894,7 +894,7 @@ static HYD_status launch_procs(struct pmip_pg *pg)
             allocate_subdev = false;
             n_local_gpus = HYD_pmcd_pmip.user_global.gpus_per_proc;
         }
-        for (int i = 0; i < exec->proc_count; i++) {
+        for (int i = 0; i < launch->count; i++) {
             struct pmip_downstream *p = &pg->downstreams[process_id];
             p->pmi_appnum = exec->appnum;
 

--- a/src/pm/hydra/proxy/pmip_pg.c
+++ b/src/pm/hydra/proxy/pmip_pg.c
@@ -18,6 +18,7 @@ static void pg_destructor(void *_elt)
     MPL_free(pg->iface_ip_env_name);
     MPL_free(pg->hostname);
     HYDU_free_exec_list(pg->exec_list);
+    HYDU_free_launch_list(pg->launch_list);
 
     struct pmip_kvs *s, *tmp;
     HASH_ITER(hh, pg->kvs, s, tmp) {

--- a/src/pm/hydra/proxy/pmip_utils.c
+++ b/src/pm/hydra/proxy/pmip_utils.c
@@ -450,32 +450,6 @@ static HYD_status exec_appnum_fn(char *arg, char ***argv)
     return status;
 }
 
-static HYD_status exec_rank_fn(char *arg, char ***argv)
-{
-    struct HYD_exec *exec = NULL;
-    HYD_status status = HYD_SUCCESS;
-
-    for (exec = cur_pg->exec_list; exec->next; exec = exec->next);
-    status = HYDU_set_int(arg, &exec->start_rank, atoi(**argv));
-
-    (*argv)++;
-
-    return status;
-}
-
-static HYD_status exec_proc_count_fn(char *arg, char ***argv)
-{
-    struct HYD_exec *exec = NULL;
-    HYD_status status = HYD_SUCCESS;
-
-    for (exec = cur_pg->exec_list; exec->next; exec = exec->next);
-    status = HYDU_set_int(arg, &exec->proc_count, atoi(**argv));
-
-    (*argv)++;
-
-    return status;
-}
-
 static HYD_status exec_local_env_fn(char *arg, char ***argv)
 {
     struct HYD_exec *exec = NULL;
@@ -568,6 +542,48 @@ static HYD_status exec_args_fn(char *arg, char ***argv)
     goto fn_exit;
 }
 
+static HYD_status launch_fn(char *arg, char ***argv)
+{
+    HYD_status status = HYD_SUCCESS;
+    HYDU_ASSERT(cur_pg, status);
+
+    struct HYD_proxy_exec *launch = MPL_malloc(sizeof(struct HYD_proxy_exec), MPL_MEM_OTHER);
+    HYDU_ASSERT(launch, status);
+
+    launch->exec = NULL;
+    launch->next = NULL;
+
+    /* arg is a 3-segment integers */
+    int tmp_id;
+    int ret = sscanf(**argv, "%d,%d,%d", &tmp_id, &launch->rank, &launch->count);
+    HYDU_ASSERT(ret == 3, status);
+
+    (*argv)++;
+
+    /* locate exec by tmp_id */
+    for (struct HYD_exec * exec = cur_pg->exec_list; exec && tmp_id >= 0; exec = exec->next) {
+        if (tmp_id == 0) {
+            launch->exec = exec;
+            break;
+        }
+        tmp_id--;
+    }
+    HYDU_ASSERT(launch->exec, status);
+
+    if (cur_pg->launch_list == NULL) {
+        cur_pg->launch_list = launch;
+    } else {
+        struct HYD_proxy_exec *t;
+        for (t = cur_pg->launch_list; t->next; t = t->next);
+        t->next = launch;
+    }
+
+  fn_exit:
+    return status;
+  fn_fail:
+    goto fn_exit;
+}
+
 struct HYD_arg_match_table HYD_pmip_args_match_table[] = {
     /* Proxy parameters */
     {"control-port", control_port_fn, NULL},
@@ -612,12 +628,11 @@ struct HYD_arg_match_table HYD_pmip_procinfo_match_table[] = {
     {"proxy-core-count", dummy1_fn, NULL},
     {"exec", exec_fn, NULL},
     {"exec-appnum", exec_appnum_fn, NULL},
-    {"exec-rank", exec_rank_fn, NULL},
-    {"exec-proc-count", exec_proc_count_fn, NULL},
     {"exec-local-env", exec_local_env_fn, NULL},
     {"exec-env-prop", exec_env_prop_fn, NULL},
     {"exec-wdir", exec_wdir_fn, NULL},
     {"exec-args", exec_args_fn, NULL},
+    {"launch", launch_fn, NULL},
     {"\0", NULL, NULL}
 };
 


### PR DESCRIPTION
## Pull Request Description
In a round-robin rank assignment, the launch list for each proxy are not in consecutive ranks, this resulted in duplicate exec arguments, which potentially can be very long due to environment strings. Avoid duplication by using separate `HYD_proxy_exec` struct.

[skip warnings]

* [x] **FIXME:**  returning strings from `MPL_hash` to `MPIR_proctable` is questionable because the strings may get reallocated. What we could do is a two-round. First insert all the strings to `MPL_hash`, then *freeze* the hash table, and set `proctable`.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
