### PR TITLE
ch4/ofi: Always process window accumulate hints

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_win.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.c
@@ -124,6 +124,8 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
 
     MPIR_FUNC_ENTER;
 
+    load_acc_hint(win);
+
     if (!MPIDI_OFI_ENABLE_MR_PROV_KEY) {
         if (MPIDIG_WIN(win, info_args).optimized_mr &&
             MPIDIG_WIN(win, info_args).accumulate_ordering == 0) {
@@ -209,8 +211,6 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
             MPIR_ERR_CHECK(mpi_errno);
         }
     } else if (win->create_flavor == MPI_WIN_FLAVOR_DYNAMIC) {
-        /* We may still do native atomics with collective attach, let's load acc_hint */
-        load_acc_hint(win);
         goto fn_exit;
     } else {
         /* Do nothing */
@@ -259,8 +259,6 @@ static int win_allgather(MPIR_Win * win, void *base, int disp_unit)
             MPIDI_OFI_WIN(win).winfo = NULL;
         }
     }
-
-    load_acc_hint(win);
 
   fn_exit:
     MPIR_FUNC_EXIT;


### PR DESCRIPTION
## Pull Request Description

MPI_WIN_CREATE_DYNAMIC may attempt to register the whole virtual address space. When this fails, win_allgather exits early and skips over load_acc_hints. Later, after a collective MPI_WIN_ATTACH, processes may attempt accumulate operations. This results in a crash when querying the ops supported since the hints were never processed.

Always load the hints since it is a local operation on the control path (window construction). This way code can always safely access them later.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
