### PR TITLE
ch4/progress: improve the error message for progress timeout

### DIFF
--- a/src/include/mpir_request.h
+++ b/src/include/mpir_request.h
@@ -371,7 +371,8 @@ extern MPIR_Request MPIR_Request_direct[MPIR_REQUEST_PREALLOC];
                 DEBUG_PROGREE_HOOK; \
                 progress_timed_out = true; \
             } else if (time_diff > MPIR_CVAR_PROGRESS_TIMEOUT * 2) { \
-                MPIR_ERR_SETANDJUMP(mpi_errno, MPI_ERR_OTHER, "**timeout"); \
+                MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER, "**progresstimeout", \
+                                     "**progresstimeout %d", MPIR_CVAR_PROGRESS_TIMEOUT); \
             } \
             iter = 0; \
         } \

--- a/src/mpi/errhan/errnames.txt
+++ b/src/mpi/errhan/errnames.txt
@@ -502,6 +502,8 @@ unexpected messages queued.
 #**argnull %s:Invalid null parameter %s
 **commstack:Internal overflow in stack used for MPI_Comm_split
 **timeout:Operation timed out
+**progresstimeout:Progress TIMEOUT. Check MPIR_CVAR_PROGRESS_TIMEOUT setting. Reset it to 0 to disable progress TIMEOUT. 
+**progresstimeout %d:Progress TIMEOUT due to MPIR_CVAR_PROGRESS_TIMEOUT set to %d (seconds). Reset it to 0 to disable progress TIMEOUT.
 **cmaread:process_vm_readv failed
 **cmaread %d:process_vm_readv failed (errno %d)
 **cmadata:process_vm_readv bytes mismatch


### PR DESCRIPTION
## Pull Request Description
Progress timeout is generally useful for systems to prevent unnecessary deadlocks or hangs and avoid wasting core hours. However, there is no good default value for MPIR_CVAR_PROGRESS_TIMEOUT value since some application may legitimately have long pending communications. Improve the error message so user are explained on the reason for the error and direction on how to reset MPIR_CVAR_PROGRESS_TIMEOUT.




## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
