### PR TITLE
ch4/ofi: use pipeline_pool for pack_buffer

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_events.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.c
@@ -572,7 +572,7 @@ int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret)
                             MPIR_Datatype_release_if_not_builtin(MPIDI_OFI_REQUEST(req, datatype));
                             if ((event_id == MPIDI_OFI_EVENT_RECV_PACK) &&
                                 MPIDI_OFI_REQUEST(req, noncontig.pack.pack_buffer)) {
-                                MPL_free(MPIDI_OFI_REQUEST(req, noncontig.pack.pack_buffer));
+                                MPIDI_OFI_free_pack_buf(req, vci);
                             } else if (event_id == MPIDI_OFI_EVENT_RECV_NOPACK) {
                                 MPL_free(MPIDI_OFI_REQUEST(req, noncontig.nopack.iovs));
                             }

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -48,7 +48,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_event(int vci,
     /* free the packing buffers and datatype */
     if ((event_id == MPIDI_OFI_EVENT_SEND_PACK) &&
         (MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer))) {
-        MPL_free(MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer));
+        MPIDI_OFI_free_pack_buf(sreq, vci);
     } else if (MPIDI_OFI_ENABLE_PT2PT_NOPACK && (event_id == MPIDI_OFI_EVENT_SEND_NOPACK)) {
         MPL_free(MPIDI_OFI_REQUEST(sreq, noncontig.nopack.iovs));
     }
@@ -96,7 +96,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_complete(MPIR_Request * rreq, int ev
         if (mpi_errno) {
             MPIR_ERR_SET(rreq->status.MPI_ERROR, MPI_ERR_TYPE, "**dtypemismatch");
         }
-        MPL_free(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer));
+        MPIDI_OFI_free_pack_buf(rreq, MPIDI_Request_get_vci(rreq));
     } else if (event_id == MPIDI_OFI_EVENT_RECV_NOPACK) {
 #ifdef HAVE_ERROR_CHECKING
         MPI_Count elements;

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -289,6 +289,46 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_mr_bind(struct fi_info *prov, struct fid_
     goto fn_exit;
 }
 
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_alloc_pack_buf(MPIR_Request * req, MPI_Aint data_sz, int vci)
+{
+    int mpi_errno = MPI_SUCCESS;
+    void *pack_buf = NULL;
+    bool use_pipeline_pool = false;
+    if (data_sz <= MPIR_CVAR_CH4_OFI_PIPELINE_CHUNK_SZ) {
+        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vci[vci].pipeline_pool, &pack_buf);
+    }
+
+    if (pack_buf) {
+        use_pipeline_pool = true;
+    } else {
+        pack_buf = MPL_aligned_alloc(64, data_sz, MPL_MEM_OTHER);
+        MPIR_ERR_CHKANDJUMP1(pack_buf == NULL, mpi_errno,
+                             MPI_ERR_OTHER, "**nomem", "**nomem %s", "Pack buffer alloc failed.");
+    }
+
+    MPIDI_OFI_REQUEST(req, noncontig.pack.pack_buffer) = pack_buf;
+    MPIDI_OFI_REQUEST(req, noncontig.pack.use_pipeline_pool) = use_pipeline_pool;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_free_pack_buf(MPIR_Request * req, int vci)
+{
+    int mpi_errno = MPI_SUCCESS;
+    if (MPIDI_OFI_REQUEST(req, noncontig.pack.pack_buffer)) {
+        if (MPIDI_OFI_REQUEST(req, noncontig.pack.use_pipeline_pool)) {
+            MPIDU_genq_private_pool_free_cell(MPIDI_OFI_global.per_vci[vci].pipeline_pool,
+                                              MPIDI_OFI_REQUEST(req, noncontig.pack.pack_buffer));
+        } else {
+            MPL_free(MPIDI_OFI_REQUEST(req, noncontig.pack.pack_buffer));
+        }
+    }
+    return mpi_errno;
+}
+
 /* Externs:  see util.c for definition */
 #define MPIDI_OFI_LOCAL_MR_KEY 0
 #define MPIDI_OFI_COLL_MR_KEY 1

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -308,6 +308,7 @@ typedef struct {
     union {
         struct {
             char *pack_buffer;
+            bool use_pipeline_pool;
         } pack;
         struct {
             struct iovec *iovs;

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -226,10 +226,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
 
         /* Unpack */
         MPIDI_OFI_REQUEST(rreq, event_id) = MPIDI_OFI_EVENT_RECV_PACK;
-        MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer) =
-            MPL_aligned_alloc(64, data_sz, MPL_MEM_OTHER);
-        MPIR_ERR_CHKANDJUMP1(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer) == NULL, mpi_errno,
-                             MPI_ERR_OTHER, "**nomem", "**nomem %s", "Recv Pack Buffer alloc");
+        mpi_errno = MPIDI_OFI_alloc_pack_buf(rreq, data_sz, vci_local);
+        MPIR_ERR_CHECK(mpi_errno);
         recv_buf = MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer);
     } else {
         MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer) = NULL;

--- a/src/mpid/ch4/netmod/ofi/ofi_rndv.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rndv.c
@@ -88,7 +88,7 @@ int MPIDI_OFI_recv_rndv_event(int vci, struct fi_cq_tagged_entry *wc, MPIR_Reque
     /* if we were expecting an eager send, free the unneeded pack_buffer or iovs array */
     switch (MPIDI_OFI_REQUEST(rreq, event_id)) {
         case MPIDI_OFI_EVENT_RECV_PACK:
-            MPL_free(MPIDI_OFI_REQUEST(rreq, noncontig.pack.pack_buffer));
+            MPIDI_OFI_free_pack_buf(rreq, MPIDI_OFI_REQUEST(rreq, vci_local));
             break;
         case MPIDI_OFI_EVENT_RECV_NOPACK:
             MPL_free(MPIDI_OFI_REQUEST(rreq, noncontig.nopack.iovs));

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -389,8 +389,16 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
         (data_sz <= MPIDI_OFI_global.max_buffered_send)) {
         /* inject path */
         void *pack_buf = NULL;
+#define MPIDI_OFI_LOCAL_PACK_BUF_SIZE 1024
+        char local_pack_buf[MPIDI_OFI_LOCAL_PACK_BUF_SIZE];
+        bool need_free_pack_buf = false;
         if (need_pack) {
-            pack_buf = MPL_aligned_alloc(64, data_sz, MPL_MEM_OTHER);
+            if (data_sz <= MPIDI_OFI_LOCAL_PACK_BUF_SIZE) {
+                pack_buf = local_pack_buf;
+            } else {
+                pack_buf = MPL_aligned_alloc(64, data_sz, MPL_MEM_OTHER);
+                need_free_pack_buf = true;
+            }
             mpi_errno = MPIR_Localcopy_gpu(buf, count, datatype, 0, &attr,
                                            pack_buf, data_sz, MPIR_BYTE_INTERNAL, 0,
                                            MPIR_GPU_ATTR_HOST,
@@ -401,7 +409,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
         mpi_errno = MPIDI_OFI_send_lightweight(send_buf, data_sz, cq_data, dst_rank, tag, comm,
                                                match_bits, addr,
                                                vci_src, vci_dst, sender_nic, receiver_nic);
-        if (pack_buf) {
+        if (need_free_pack_buf) {
             MPL_free(pack_buf);
         }
 
@@ -464,18 +472,15 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
 
         void *data = NULL;
         if (need_pack) {
-            void *pack_buf = MPL_aligned_alloc(64, data_sz, MPL_MEM_OTHER);
-            MPIR_ERR_CHKANDJUMP1(pack_buf == NULL, mpi_errno,
-                                 MPI_ERR_OTHER, "**nomem", "**nomem %s", "Send Pack buffer alloc");
+            mpi_errno = MPIDI_OFI_alloc_pack_buf(sreq, data_sz, vci_src);
+            MPIR_ERR_CHECK(mpi_errno);
 
+            data = MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer);
             mpi_errno = MPIR_Localcopy_gpu(buf, count, datatype, 0, &attr,
-                                           pack_buf, data_sz, MPIR_BYTE_INTERNAL, 0,
+                                           data, data_sz, MPIR_BYTE_INTERNAL, 0,
                                            MPIR_GPU_ATTR_HOST,
                                            MPIDI_OFI_gpu_get_send_engine_type(), true);
             MPIR_ERR_CHECK(mpi_errno);
-
-            data = pack_buf;
-            MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer) = pack_buf;
         } else {
             data = MPIR_get_contig_ptr(buf, dt_true_lb);
             MPIDI_OFI_REQUEST(sreq, noncontig.pack.pack_buffer) = NULL;


### PR DESCRIPTION

## Pull Request Description
Instead of allocating a new temporary pack_buffer each time, use the pipeline genq pool whenever the data_sz fits.

This avoids lower-layer memory registration cache or monitoring issue and potentially improves performance.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
