### PR TITLE
env: fix accidental wrong use of eval

### DIFF
--- a/src/env/mpicc.def
+++ b/src/env/mpicc.def
@@ -204,6 +204,8 @@ subcode: parse_args
     for arg in "$@" ; do
         \x23 Set addarg to no if this arg should be ignored by the $(C) compiler
         addarg=yes
+        $(if:sh=sh)
+            qarg=$arg
         case "$arg" in
             $call filter_arg_cases
             $call parse_arg_cases
@@ -310,19 +312,38 @@ subcode: parse_args
 
     subcode: parse_other_args_sh
         $(set:addarg=1)
-        \x23 FIXME: there no safe way of handling arguments that contains spaces or quotes
-        \x23        We hope user either have a shell that support array or they won't use
-        \x23        arguments that contain spaces or quotes.
+        \x23 Other arguments.  We are careful to handle arguments with
+        \x23 quotes (we try to quote all arguments in case they include
+        \x23 any spaces)
+        $(if:cc=cc or cc=cxx)
+            &call case, *\'*
+                qarg="'"`echo $arg | sed -e "s/'/'\"'\"'/g"`"'"
+        $(else)
+            &call case, *\"*
+                qarg="'"$arg"'"
+                $call handle_arg_D
+            &call case, *\'*
+                qarg='\"'"$arg"'\"'
+                $call handle_arg_D
         BLOCK
+        &call case, *
+            qarg="'$arg'"
 
         $(block:parse_args_init)
             allargs=""
         $(block:post_arg_case)
             if [ $addarg = yes ] ; then
-                allargs="$allargs $arg"
+                allargs="$allargs $qarg"
             fi
 
         $(setmacro:allargs=$allargs)
+
+        subcode: handle_arg_D
+            case "$arg" in
+                -D*)
+                    $call append_array, cppflags, $qarg
+                    ;;
+            esac
 
     subcode: parse_other_args_bash
         $(set:addarg=1)

--- a/src/env/mpicc.def
+++ b/src/env/mpicc.def
@@ -153,7 +153,7 @@ subcode: set_wrapper_dl_type_flags
     fi
 
 subcode: custom_environment
-    $(if:sh=bash)
+    $(if:sh=sh)
         Show=eval
     $(else)
         Show=


### PR DESCRIPTION
## Pull Request Description
The `eval` is supposed to be used in `sh` scripts to remove the extra quotes we added around arguments. Previously we swapped between sh and bash versions, and it resulted in a wrong fix in https://github.com/pmodels/mpich/pull/6469/changes/863085c650b949f05b3605d4cde552aedec50139

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
