### PR TITLE
ch4/ipc/gpu: fix broken IPC mapping cache retrieval

### DIFF
--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -58,17 +58,19 @@ int MPIDI_GPU_mpi_finalize_hook(void)
     MPIR_FUNC_ENTER;
 
     {
-        struct MPIDI_GPUI_map_cache_entry *entry, *tmp;
-        HASH_ITER(hh, MPIDI_GPUI_global.ipc_map_cache, entry, tmp) {
-            HASH_DEL(MPIDI_GPUI_global.ipc_map_cache, entry);
-            for (int i = 0; i < MPIDI_GPUI_global.local_device_count; i++) {
-                if (entry->mapped_addrs[i]) {
-                    int mpl_err = MPL_gpu_ipc_handle_unmap((void *) entry->mapped_addrs[i]);
-                    MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                                        "**gpu_ipc_handle_unmap");
+        for (int e = 0; e < MPIDI_CH4_IPC_GPU_MAX_CACHE_ENTRIES; e++) {
+            struct MPIDI_GPUI_map_cache_entry *entry = MPIDI_GPUI_global.ipc_map_cache[e];
+            if (entry) {
+                for (int i = 0; i < MPIDI_GPUI_global.local_device_count; i++) {
+                    if (entry->mapped_addrs[i]) {
+                        int mpl_err = MPL_gpu_ipc_handle_unmap((void *) entry->mapped_addrs[i]);
+                        MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                                            "**gpu_ipc_handle_unmap");
+                    }
                 }
+                MPL_free(entry);
+                MPIDI_GPUI_global.ipc_map_cache[e] = NULL;
             }
-            MPL_free(entry);
         }
     }
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -7,31 +7,6 @@
 #include "gpu_post.h"
 #include "gpu_types.h"
 
-static void ipc_handle_free_hook(void *dptr)
-{
-    int mpl_err ATTRIBUTE((unused));
-    MPL_pointer_attr_t gpu_attr;
-
-    MPIR_FUNC_ENTER;
-
-    if (MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE == MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE_generic) {
-        struct MPIDI_GPUI_handle_cache_entry *entry;
-
-        HASH_FIND_PTR(MPIDI_GPUI_global.ipc_handle_cache, &dptr, entry);
-        if (entry) {
-            HASH_DEL(MPIDI_GPUI_global.ipc_handle_cache, entry);
-            MPL_free(entry);
-
-            MPIR_GPU_query_pointer_attr(dptr, &gpu_attr);
-            mpl_err = MPL_gpu_ipc_handle_destroy(dptr, &gpu_attr);
-            MPIR_Assert(mpl_err == MPL_SUCCESS);
-        }
-    }
-
-    MPIR_FUNC_EXIT;
-    return;
-}
-
 int MPIDI_GPU_init_local(void)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -48,7 +23,6 @@ int MPIDI_GPU_init_local(void)
                             "**gpu_get_dev_count");
 
         MPIDI_GPUI_global.local_device_count = device_count;
-        MPL_gpu_free_hook_register(ipc_handle_free_hook);
 
         MPIDI_GPUI_global.initialized = 1;
     }
@@ -94,22 +68,6 @@ int MPIDI_GPU_mpi_finalize_hook(void)
                                         "**gpu_ipc_handle_unmap");
                 }
             }
-            MPL_free(entry);
-        }
-    }
-
-    {
-        struct MPIDI_GPUI_handle_cache_entry *entry, *tmp;
-        HASH_ITER(hh, MPIDI_GPUI_global.ipc_handle_cache, entry, tmp) {
-            MPL_pointer_attr_t gpu_attr;
-            int mpl_err;
-
-            MPIR_GPU_query_pointer_attr(entry->base_addr, &gpu_attr);
-            mpl_err = MPL_gpu_ipc_handle_destroy(entry->base_addr, &gpu_attr);
-            MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                                "**gpu_ipc_handle_destroy");
-
-            HASH_DEL(MPIDI_GPUI_global.ipc_handle_cache, entry);
             MPL_free(entry);
         }
     }

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_init.c
@@ -58,18 +58,12 @@ int MPIDI_GPU_mpi_finalize_hook(void)
     MPIR_FUNC_ENTER;
 
     {
-        for (int e = 0; e < MPIDI_CH4_IPC_GPU_MAX_CACHE_ENTRIES; e++) {
-            struct MPIDI_GPUI_map_cache_entry *entry = MPIDI_GPUI_global.ipc_map_cache[e];
-            if (entry) {
-                for (int i = 0; i < MPIDI_GPUI_global.local_device_count; i++) {
-                    if (entry->mapped_addrs[i]) {
-                        int mpl_err = MPL_gpu_ipc_handle_unmap((void *) entry->mapped_addrs[i]);
-                        MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                                            "**gpu_ipc_handle_unmap");
-                    }
-                }
-                MPL_free(entry);
-                MPIDI_GPUI_global.ipc_map_cache[e] = NULL;
+        for (int i = 0; i < MPIDI_CH4_IPC_GPU_MAX_CACHE_ENTRIES; i++) {
+            struct MPIDI_GPUI_map_cache_entry *entry = &MPIDI_GPUI_global.ipc_map_cache[i];
+            if (entry->mapped_addr) {
+                int mpl_err = MPL_gpu_ipc_handle_unmap((void *) entry->mapped_addr);
+                MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                                    "**gpu_ipc_handle_unmap");
             }
         }
     }

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -180,7 +180,8 @@ static int ipc_track_cache_remove(const void *addr)
 /* -- mapped_track_tree -- */
 
 static int ipc_mapped_cache_search(const void *remote_addr, int remote_rank, int device_id,
-                                   void **mapped_base_addr_out)
+                                   void **mapped_base_addr_out,
+                                   MPL_gpu_buffer_id_t * mapped_remote_buffer_id)
 {
     struct MPIDI_GPUI_map_cache_entry *entry;
     struct map_key key;
@@ -194,16 +195,19 @@ static int ipc_mapped_cache_search(const void *remote_addr, int remote_rank, int
         MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "mapped gpu ipc handle cache HIT for %p",
                       remote_addr);
         *mapped_base_addr_out = (void *) entry->mapped_addrs[device_id];
+        *mapped_remote_buffer_id = entry->remote_buffer_id;
     } else {
         MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "mapped gpu ipc handle MISS for %p", remote_addr);
         *mapped_base_addr_out = NULL;
+        *mapped_remote_buffer_id = 0;
     }
 
     return MPI_SUCCESS;
 }
 
 static int ipc_mapped_cache_insert(const void *remote_addr, int remote_rank, int device_id,
-                                   const void *mapped_base_addr)
+                                   const void *mapped_base_addr,
+                                   MPL_gpu_buffer_id_t mapped_remote_buffer_id)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -219,6 +223,7 @@ static int ipc_mapped_cache_insert(const void *remote_addr, int remote_rank, int
 
     if (entry) {
         entry->mapped_addrs[device_id] = mapped_base_addr;
+        entry->remote_buffer_id = mapped_remote_buffer_id;
     } else {
         /* create and add new entry */
         int entry_size = sizeof(struct MPIDI_GPUI_map_cache_entry) +
@@ -228,6 +233,7 @@ static int ipc_mapped_cache_insert(const void *remote_addr, int remote_rank, int
         entry->key.remote_rank = remote_rank;
         entry->key.remote_addr = remote_addr;
         entry->mapped_addrs[device_id] = mapped_base_addr;
+        entry->remote_buffer_id = mapped_remote_buffer_id;
         HASH_ADD(hh, MPIDI_GPUI_global.ipc_map_cache, key, sizeof(struct map_key), entry,
                  MPL_MEM_SHM);
     }
@@ -483,18 +489,30 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int map_dev_id, void
         mpi_errno = ipc_mapped_cache_delete((void *) handle.remote_base_addr, handle.node_rank);
         MPIR_ERR_CHECK(mpi_errno);
     }
+#ifdef MPL_HAVE_ZE
+    MPL_gpu_buffer_id_t incoming_remote_buffer_id = handle.ipc_handle.data.mem_id;
+#else
+    MPL_gpu_buffer_id_t incoming_remote_buffer_id = handle.ipc_handle.id;
+#endif
 
     void *pbase = NULL;
     if (need_cache) {
+        MPL_gpu_buffer_id_t cached_remote_buffer_id;
         mpi_errno =
             ipc_mapped_cache_search((void *) handle.remote_base_addr, handle.node_rank, map_dev_id,
-                                    &pbase);
+                                    &pbase, &cached_remote_buffer_id);
         MPIR_ERR_CHECK(mpi_errno);
 
         if (pbase) {
-            /* found in cache */
-            *vaddr = (void *) ((char *) pbase + handle.offset);
-            goto fn_exit;
+            /* found the base address in cache, check the buffer id */
+            if (cached_remote_buffer_id == incoming_remote_buffer_id) {
+                /* found an allocation w/ the same base address and buffer id in the cache */
+                *vaddr = (void *) ((char *) pbase + handle.offset);
+                goto fn_exit;
+            }
+            /* otherwise, we need to unmap to remap below */
+            mpi_errno = ipc_mapped_cache_delete((void *) handle.remote_base_addr, handle.node_rank);
+            MPIR_ERR_CHECK(mpi_errno);
         }
     }
 
@@ -516,7 +534,7 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int map_dev_id, void
     if (need_cache) {
         mpi_errno =
             ipc_mapped_cache_insert((void *) handle.remote_base_addr, handle.node_rank, map_dev_id,
-                                    pbase);
+                                    pbase, incoming_remote_buffer_id);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -125,35 +125,47 @@ cvars:
 
 /* -- mapped_track_tree -- */
 
-static int ipc_mapped_cache_search_and_delete(const void *remote_addr, int remote_rank,
-                                              MPL_gpu_buffer_id_t remote_buffer_id, uintptr_t len,
-                                              int device_id, void **mapped_addr)
+static int ipc_mapped_cache_delete(struct MPIDI_GPUI_map_cache_entry *entry)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    struct MPIDI_GPUI_map_cache_entry *entry, *tmp;
-    HASH_ITER(hh, MPIDI_GPUI_global.ipc_map_cache, entry, tmp) {
-        if (entry->key.remote_addr < remote_addr + len &&
-            remote_addr < entry->key.remote_addr + entry->len) {
-            if (entry->remote_buffer_id == remote_buffer_id &&
-                entry->key.remote_rank == remote_rank) {
+    MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE,
+                  "removing STALE mapped gpu ipc handle for %p", entry->remote_addr);
+
+    for (int i = 0; i < MPIDI_GPUI_global.local_device_count; i++) {
+        if (entry->mapped_addrs[i]) {
+            int mpl_err = MPL_gpu_ipc_handle_unmap((void *) entry->mapped_addrs[i]);
+            MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                                "**gpu_ipc_handle_unmap");
+        }
+    }
+    MPL_free(entry);
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int ipc_mapped_cache_search(const void *remote_addr, int remote_rank,
+                                   MPL_gpu_buffer_id_t remote_buffer_id, uintptr_t len,
+                                   int device_id, void **mapped_addr)
+{
+    for (int i = 0; i < MPIDI_CH4_IPC_GPU_MAX_CACHE_ENTRIES; i++) {
+        struct MPIDI_GPUI_map_cache_entry *entry = MPIDI_GPUI_global.ipc_map_cache[i];
+        /* overlap condition: (entry_start < remote_end) && (entry_end > remote_start) */
+        if (entry && (char *) entry->remote_addr < (char *) remote_addr + len &&
+            (char *) remote_addr < (char *) entry->remote_addr + entry->len &&
+            entry->remote_rank == remote_rank) {
+            if (entry->remote_buffer_id == remote_buffer_id) {
                 MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "mapped gpu ipc handle cache HIT for %p",
                               remote_addr);
+                entry->usage = ++MPIDI_GPUI_global.ipc_map_cache_usage_counter;
                 *mapped_addr = (void *) entry->mapped_addrs[device_id];
                 goto fn_exit;
             } else {
-                MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE,
-                              "removing STALE mapped gpu ipc handle for %p",
-                              entry->key.remote_addr);
-                HASH_DEL(MPIDI_GPUI_global.ipc_map_cache, entry);
-                for (int i = 0; i < MPIDI_GPUI_global.local_device_count; i++) {
-                    if (entry->mapped_addrs[i]) {
-                        int mpl_err = MPL_gpu_ipc_handle_unmap((void *) entry->mapped_addrs[i]);
-                        MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                                            "**gpu_ipc_handle_unmap");
-                    }
-                }
-                MPL_free(entry);
+                ipc_mapped_cache_delete(entry);
+                MPIDI_GPUI_global.ipc_map_cache[i] = NULL;
             }
         }
     }
@@ -162,47 +174,55 @@ static int ipc_mapped_cache_search_and_delete(const void *remote_addr, int remot
     *mapped_addr = NULL;
 
   fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
+    return MPI_SUCCESS;
 }
 
 static int ipc_mapped_cache_insert(const void *remote_addr, int remote_rank,
                                    MPL_gpu_buffer_id_t remote_buffer_id, uintptr_t len,
                                    int device_id, const void *mapped_addr)
 {
-    int mpi_errno = MPI_SUCCESS;
-
-    struct MPIDI_GPUI_map_cache_entry *entry;
-    struct map_key key;
-
     MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "caching NEW mapped ipc handle for %p", remote_addr);
 
-    memset(&key, 0, sizeof(key));
-    key.remote_rank = remote_rank;
-    key.remote_addr = remote_addr;
-    HASH_FIND(hh, MPIDI_GPUI_global.ipc_map_cache, &key, sizeof(struct map_key), entry);
+    unsigned long long min_usage = ULLONG_MAX;
+    int min_usage_index = 0;
 
-    if (entry) {
-        entry->mapped_addrs[device_id] = mapped_addr;
-        entry->remote_buffer_id = remote_buffer_id;
-        entry->len = len;
-    } else {
-        /* create and add new entry */
-        int entry_size = sizeof(struct MPIDI_GPUI_map_cache_entry) +
-            (MPIDI_GPUI_global.local_device_count * sizeof(void *));
-        entry = MPL_malloc(entry_size, MPL_MEM_OTHER);
-        memset(entry, 0, entry_size);
-        entry->key.remote_rank = remote_rank;
-        entry->key.remote_addr = remote_addr;
-        entry->mapped_addrs[device_id] = mapped_addr;
-        entry->remote_buffer_id = remote_buffer_id;
-        entry->len = len;
-        HASH_ADD(hh, MPIDI_GPUI_global.ipc_map_cache, key, sizeof(struct map_key), entry,
-                 MPL_MEM_SHM);
+    for (int i = 0; i < MPIDI_CH4_IPC_GPU_MAX_CACHE_ENTRIES; i++) {
+        struct MPIDI_GPUI_map_cache_entry *entry = MPIDI_GPUI_global.ipc_map_cache[i];
+        if (entry) {
+            if (entry->remote_buffer_id == remote_buffer_id && entry->remote_rank == remote_rank) {
+                entry->mapped_addrs[device_id] = mapped_addr;
+                goto fn_exit;
+            }
+            if (entry->usage < min_usage) {
+                min_usage = entry->usage;
+                min_usage_index = i;
+            }
+        } else {
+            min_usage = 0;
+            min_usage_index = i;
+        }
     }
 
-    return mpi_errno;
+    struct MPIDI_GPUI_map_cache_entry *entry = MPIDI_GPUI_global.ipc_map_cache[min_usage_index];
+    if (entry) {
+        ipc_mapped_cache_delete(entry);
+    }
+
+    int entry_size = sizeof(struct MPIDI_GPUI_map_cache_entry) +
+        (MPIDI_GPUI_global.local_device_count * sizeof(void *));
+    entry = MPL_malloc(entry_size, MPL_MEM_OTHER);
+    memset(entry, 0, entry_size);
+    entry->remote_rank = remote_rank;
+    entry->remote_addr = remote_addr;
+    entry->remote_buffer_id = remote_buffer_id;
+    entry->len = len;
+    entry->usage = ++MPIDI_GPUI_global.ipc_map_cache_usage_counter;
+    entry->mapped_addrs[device_id] = mapped_addr;
+
+    MPIDI_GPUI_global.ipc_map_cache[min_usage_index] = entry;
+
+  fn_exit:
+    return MPI_SUCCESS;
 }
 
 int MPIDI_GPU_get_ipc_attr(const void *buf, MPI_Aint count, MPI_Datatype datatype,
@@ -393,8 +413,8 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int map_dev_id, void
     void *pbase = NULL;
     if (need_cache) {
         mpi_errno =
-            ipc_mapped_cache_search_and_delete((void *) handle.remote_base_addr, handle.node_rank,
-                                               remote_buffer_id, handle.len, map_dev_id, &pbase);
+            ipc_mapped_cache_search((void *) handle.remote_base_addr, handle.node_rank,
+                                    remote_buffer_id, handle.len, map_dev_id, &pbase);
         MPIR_ERR_CHECK(mpi_errno);
 
         if (pbase) {

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -379,7 +379,6 @@ int MPIDI_GPU_fill_ipc_handle(MPIDI_IPCI_ipc_attr_t * ipc_attr,
         (MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE == MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE_generic);
 
     MPL_gpu_ipc_mem_handle_t handle;
-    int handle_status;
     if (need_cache) {
         bool found = false;
         mpi_errno = ipc_track_cache_search(pbase, &handle, &found);
@@ -387,7 +386,6 @@ int MPIDI_GPU_fill_ipc_handle(MPIDI_IPCI_ipc_attr_t * ipc_attr,
 
         if (found) {
             if (MPL_gpu_ipc_handle_is_valid(&handle, pbase)) {
-                handle_status = MPIDI_GPU_IPC_HANDLE_VALID;
                 goto fn_done;
             } else {
                 /* remove and destroy invalid handle */
@@ -408,7 +406,6 @@ int MPIDI_GPU_fill_ipc_handle(MPIDI_IPCI_ipc_attr_t * ipc_attr,
         mpi_errno = ipc_track_cache_insert(pbase, handle);
         MPIR_ERR_CHECK(mpi_errno);
     }
-    handle_status = MPIDI_GPU_IPC_HANDLE_REMAP_REQUIRED;
 
   fn_done:
     /* MPIDI_GPU_get_ipc_attr will be called by sender to create an ipc handle.
@@ -423,7 +420,6 @@ int MPIDI_GPU_fill_ipc_handle(MPIDI_IPCI_ipc_attr_t * ipc_attr,
     ipc_handle->gpu.len = len;
     ipc_handle->gpu.node_rank = MPIR_Process.local_rank;
     ipc_handle->gpu.offset = (uintptr_t) ipc_attr->u.gpu.vaddr - (uintptr_t) pbase;
-    ipc_handle->gpu.handle_status = handle_status;
 
     if (req && MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE == MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE_disabled) {
         /* needed in MPIDI_GPU_send_complete */
@@ -485,10 +481,6 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int map_dev_id, void
 
     bool need_cache;
     need_cache = (MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE == MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE_generic);
-    if (need_cache && handle.handle_status == MPIDI_GPU_IPC_HANDLE_REMAP_REQUIRED) {
-        mpi_errno = ipc_mapped_cache_delete((void *) handle.remote_base_addr, handle.node_rank);
-        MPIR_ERR_CHECK(mpi_errno);
-    }
 #ifdef MPL_HAVE_ZE
     MPL_gpu_buffer_id_t incoming_remote_buffer_id = handle.ipc_handle.data.mem_id;
 #else

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -123,60 +123,6 @@ cvars:
 
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
 
-static int ipc_track_cache_search(const void *addr, MPL_gpu_ipc_mem_handle_t * handle_out,
-                                  bool * found)
-{
-    struct MPIDI_GPUI_handle_cache_entry *entry;
-
-    HASH_FIND_PTR(MPIDI_GPUI_global.ipc_handle_cache, &addr, entry);
-    if (entry) {
-        MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "cached gpu ipc handle HIT for %p", addr);
-        *handle_out = entry->handle;
-        *found = true;
-    } else {
-        MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "cached gpu ipc handle MISS for %p", addr);
-        *found = false;
-    }
-
-    return MPI_SUCCESS;
-}
-
-static int ipc_track_cache_insert(const void *addr, MPL_gpu_ipc_mem_handle_t handle)
-{
-    int mpi_errno = MPI_SUCCESS;
-    struct MPIDI_GPUI_handle_cache_entry *entry;
-
-    MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "caching NEW gpu ipc handle for %p", addr);
-
-    entry = MPL_malloc(sizeof(struct MPIDI_GPUI_handle_cache_entry), MPL_MEM_SHM);
-    MPIR_ERR_CHKANDJUMP(!entry, mpi_errno, MPI_ERR_OTHER, "**nomem");
-    entry->base_addr = addr;
-    entry->handle = handle;
-    HASH_ADD_PTR(MPIDI_GPUI_global.ipc_handle_cache, base_addr, entry, MPL_MEM_SHM);
-
-  fn_exit:
-    MPIR_FUNC_EXIT;
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-static int ipc_track_cache_remove(const void *addr)
-{
-    int mpi_errno = MPI_SUCCESS;
-    struct MPIDI_GPUI_handle_cache_entry *entry;
-
-    MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "removing STALE gpu ipc handle for %p", addr);
-
-    HASH_FIND_PTR(MPIDI_GPUI_global.ipc_handle_cache, &addr, entry);
-    if (entry) {
-        HASH_DEL(MPIDI_GPUI_global.ipc_handle_cache, entry);
-        MPL_free(entry);
-    }
-
-    return mpi_errno;
-}
-
 /* -- mapped_track_tree -- */
 
 static int ipc_mapped_cache_search(const void *remote_addr, int remote_rank, int device_id,
@@ -373,41 +319,12 @@ int MPIDI_GPU_fill_ipc_handle(MPIDI_IPCI_ipc_attr_t * ipc_attr,
 
     void *pbase = ipc_attr->u.gpu.bounds_base;
     MPI_Aint len = ipc_attr->u.gpu.bounds_len;
-    int remote_rank = ipc_attr->u.gpu.remote_rank;
-
-    int need_cache = (remote_rank != MPI_PROC_NULL) &&
-        (MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE == MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE_generic);
 
     MPL_gpu_ipc_mem_handle_t handle;
-    if (need_cache) {
-        bool found = false;
-        mpi_errno = ipc_track_cache_search(pbase, &handle, &found);
-        MPIR_ERR_CHECK(mpi_errno);
-
-        if (found) {
-            if (MPL_gpu_ipc_handle_is_valid(&handle, pbase)) {
-                goto fn_done;
-            } else {
-                /* remove and destroy invalid handle */
-                mpi_errno = ipc_track_cache_remove(pbase);
-                MPIR_ERR_CHECK(mpi_errno);
-
-                mpl_err = MPL_gpu_ipc_handle_destroy(pbase, &ipc_attr->u.gpu.gpu_attr);
-                MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                                    "**gpu_ipc_handle_destroy");
-            }
-        }
-    }
-
     mpl_err = MPL_gpu_ipc_handle_create(pbase, &ipc_attr->u.gpu.gpu_attr.device_attr, &handle);
     MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
                         "**gpu_ipc_handle_create");
-    if (need_cache) {
-        mpi_errno = ipc_track_cache_insert(pbase, handle);
-        MPIR_ERR_CHECK(mpi_errno);
-    }
 
-  fn_done:
     /* MPIDI_GPU_get_ipc_attr will be called by sender to create an ipc handle.
      * remote_base_addr, len and node_rank attributes in ipc handle will be sent
      * to receiver and used to search cached ipc handle and/or insert new allocated

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -125,35 +125,51 @@ cvars:
 
 /* -- mapped_track_tree -- */
 
-static int ipc_mapped_cache_search(const void *remote_addr, int remote_rank, int device_id,
-                                   void **mapped_base_addr_out,
-                                   MPL_gpu_buffer_id_t * mapped_remote_buffer_id)
+static int ipc_mapped_cache_search_and_delete(const void *remote_addr, int remote_rank,
+                                              MPL_gpu_buffer_id_t remote_buffer_id, uintptr_t len,
+                                              int device_id, void **mapped_addr)
 {
-    struct MPIDI_GPUI_map_cache_entry *entry;
-    struct map_key key;
+    int mpi_errno = MPI_SUCCESS;
 
-    memset(&key, 0, sizeof(key));
-    key.remote_rank = remote_rank;
-    key.remote_addr = remote_addr;
-    HASH_FIND(hh, MPIDI_GPUI_global.ipc_map_cache, &key, sizeof(struct map_key), entry);
-
-    if (entry) {
-        MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "mapped gpu ipc handle cache HIT for %p",
-                      remote_addr);
-        *mapped_base_addr_out = (void *) entry->mapped_addrs[device_id];
-        *mapped_remote_buffer_id = entry->remote_buffer_id;
-    } else {
-        MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "mapped gpu ipc handle MISS for %p", remote_addr);
-        *mapped_base_addr_out = NULL;
-        *mapped_remote_buffer_id = 0;
+    struct MPIDI_GPUI_map_cache_entry *entry, *tmp;
+    HASH_ITER(hh, MPIDI_GPUI_global.ipc_map_cache, entry, tmp) {
+        if (entry->key.remote_addr < remote_addr + len &&
+            remote_addr < entry->key.remote_addr + entry->len) {
+            if (entry->remote_buffer_id == remote_buffer_id &&
+                entry->key.remote_rank == remote_rank) {
+                MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "mapped gpu ipc handle cache HIT for %p",
+                              remote_addr);
+                *mapped_addr = (void *) entry->mapped_addrs[device_id];
+                goto fn_exit;
+            } else {
+                MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE,
+                              "removing STALE mapped gpu ipc handle for %p",
+                              entry->key.remote_addr);
+                HASH_DEL(MPIDI_GPUI_global.ipc_map_cache, entry);
+                for (int i = 0; i < MPIDI_GPUI_global.local_device_count; i++) {
+                    if (entry->mapped_addrs[i]) {
+                        int mpl_err = MPL_gpu_ipc_handle_unmap((void *) entry->mapped_addrs[i]);
+                        MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                                            "**gpu_ipc_handle_unmap");
+                    }
+                }
+                MPL_free(entry);
+            }
+        }
     }
 
-    return MPI_SUCCESS;
+    MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "mapped gpu ipc handle MISS for %p", remote_addr);
+    *mapped_addr = NULL;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
-static int ipc_mapped_cache_insert(const void *remote_addr, int remote_rank, int device_id,
-                                   const void *mapped_base_addr,
-                                   MPL_gpu_buffer_id_t mapped_remote_buffer_id)
+static int ipc_mapped_cache_insert(const void *remote_addr, int remote_rank,
+                                   MPL_gpu_buffer_id_t remote_buffer_id, uintptr_t len,
+                                   int device_id, const void *mapped_addr)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -168,8 +184,9 @@ static int ipc_mapped_cache_insert(const void *remote_addr, int remote_rank, int
     HASH_FIND(hh, MPIDI_GPUI_global.ipc_map_cache, &key, sizeof(struct map_key), entry);
 
     if (entry) {
-        entry->mapped_addrs[device_id] = mapped_base_addr;
-        entry->remote_buffer_id = mapped_remote_buffer_id;
+        entry->mapped_addrs[device_id] = mapped_addr;
+        entry->remote_buffer_id = remote_buffer_id;
+        entry->len = len;
     } else {
         /* create and add new entry */
         int entry_size = sizeof(struct MPIDI_GPUI_map_cache_entry) +
@@ -178,45 +195,14 @@ static int ipc_mapped_cache_insert(const void *remote_addr, int remote_rank, int
         memset(entry, 0, entry_size);
         entry->key.remote_rank = remote_rank;
         entry->key.remote_addr = remote_addr;
-        entry->mapped_addrs[device_id] = mapped_base_addr;
-        entry->remote_buffer_id = mapped_remote_buffer_id;
+        entry->mapped_addrs[device_id] = mapped_addr;
+        entry->remote_buffer_id = remote_buffer_id;
+        entry->len = len;
         HASH_ADD(hh, MPIDI_GPUI_global.ipc_map_cache, key, sizeof(struct map_key), entry,
                  MPL_MEM_SHM);
     }
 
     return mpi_errno;
-}
-
-static int ipc_mapped_cache_delete(const void *remote_addr, int remote_rank)
-{
-    int mpi_errno = MPI_SUCCESS;
-    struct MPIDI_GPUI_map_cache_entry *entry;
-    struct map_key key;
-
-    MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "removing STALE mapped gpu ipc handle for %p",
-                  remote_addr);
-
-    memset(&key, 0, sizeof(key));
-    key.remote_rank = remote_rank;
-    key.remote_addr = remote_addr;
-    HASH_FIND(hh, MPIDI_GPUI_global.ipc_map_cache, &key, sizeof(struct map_key), entry);
-
-    if (entry) {
-        HASH_DEL(MPIDI_GPUI_global.ipc_map_cache, entry);
-        for (int i = 0; i < MPIDI_GPUI_global.local_device_count; i++) {
-            if (entry->mapped_addrs[i]) {
-                int mpl_err = MPL_gpu_ipc_handle_unmap((void *) entry->mapped_addrs[i]);
-                MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                                    "**gpu_ipc_handle_unmap");
-            }
-        }
-        MPL_free(entry);
-    }
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
 }
 
 int MPIDI_GPU_get_ipc_attr(const void *buf, MPI_Aint count, MPI_Datatype datatype,
@@ -399,29 +385,22 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int map_dev_id, void
     bool need_cache;
     need_cache = (MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE == MPIR_CVAR_CH4_IPC_GPU_HANDLE_CACHE_generic);
 #ifdef MPL_HAVE_ZE
-    MPL_gpu_buffer_id_t incoming_remote_buffer_id = handle.ipc_handle.data.mem_id;
+    MPL_gpu_buffer_id_t remote_buffer_id = handle.ipc_handle.data.mem_id;
 #else
-    MPL_gpu_buffer_id_t incoming_remote_buffer_id = handle.ipc_handle.id;
+    MPL_gpu_buffer_id_t remote_buffer_id = handle.ipc_handle.id;
 #endif
 
     void *pbase = NULL;
     if (need_cache) {
-        MPL_gpu_buffer_id_t cached_remote_buffer_id;
         mpi_errno =
-            ipc_mapped_cache_search((void *) handle.remote_base_addr, handle.node_rank, map_dev_id,
-                                    &pbase, &cached_remote_buffer_id);
+            ipc_mapped_cache_search_and_delete((void *) handle.remote_base_addr, handle.node_rank,
+                                               remote_buffer_id, handle.len, map_dev_id, &pbase);
         MPIR_ERR_CHECK(mpi_errno);
 
         if (pbase) {
-            /* found the base address in cache, check the buffer id */
-            if (cached_remote_buffer_id == incoming_remote_buffer_id) {
-                /* found an allocation w/ the same base address and buffer id in the cache */
-                *vaddr = (void *) ((char *) pbase + handle.offset);
-                goto fn_exit;
-            }
-            /* otherwise, we need to unmap to remap below */
-            mpi_errno = ipc_mapped_cache_delete((void *) handle.remote_base_addr, handle.node_rank);
-            MPIR_ERR_CHECK(mpi_errno);
+            /* cache hit */
+            *vaddr = (void *) ((char *) pbase + handle.offset);
+            goto fn_exit;
         }
     }
 
@@ -442,8 +421,8 @@ int MPIDI_GPU_ipc_handle_map(MPIDI_GPU_ipc_handle_t handle, int map_dev_id, void
 
     if (need_cache) {
         mpi_errno =
-            ipc_mapped_cache_insert((void *) handle.remote_base_addr, handle.node_rank, map_dev_id,
-                                    pbase, incoming_remote_buffer_id);
+            ipc_mapped_cache_insert((void *) handle.remote_base_addr, handle.node_rank,
+                                    remote_buffer_id, handle.len, map_dev_id, pbase);
         MPIR_ERR_CHECK(mpi_errno);
     }
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -125,47 +125,31 @@ cvars:
 
 /* -- mapped_track_tree -- */
 
-static int ipc_mapped_cache_delete(struct MPIDI_GPUI_map_cache_entry *entry)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE,
-                  "removing STALE mapped gpu ipc handle for %p", entry->remote_addr);
-
-    for (int i = 0; i < MPIDI_GPUI_global.local_device_count; i++) {
-        if (entry->mapped_addrs[i]) {
-            int mpl_err = MPL_gpu_ipc_handle_unmap((void *) entry->mapped_addrs[i]);
-            MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                                "**gpu_ipc_handle_unmap");
-        }
-    }
-    MPL_free(entry);
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
 static int ipc_mapped_cache_search(const void *remote_addr, int remote_rank,
                                    MPL_gpu_buffer_id_t remote_buffer_id, uintptr_t len,
                                    int device_id, void **mapped_addr)
 {
+    int mpi_errno = MPI_SUCCESS;
+
     for (int i = 0; i < MPIDI_CH4_IPC_GPU_MAX_CACHE_ENTRIES; i++) {
-        struct MPIDI_GPUI_map_cache_entry *entry = MPIDI_GPUI_global.ipc_map_cache[i];
+        struct MPIDI_GPUI_map_cache_entry *entry = &MPIDI_GPUI_global.ipc_map_cache[i];
         /* overlap condition: (entry_start < remote_end) && (entry_end > remote_start) */
-        if (entry && (char *) entry->remote_addr < (char *) remote_addr + len &&
+        if ((char *) entry->remote_addr < (char *) remote_addr + len &&
             (char *) remote_addr < (char *) entry->remote_addr + entry->len &&
             entry->remote_rank == remote_rank) {
-            if (entry->remote_buffer_id == remote_buffer_id) {
+            if (entry->remote_buffer_id != remote_buffer_id) {
+                MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE,
+                              "removing STALE mapped gpu ipc handle for %p", entry->remote_addr);
+                int mpl_err = MPL_gpu_ipc_handle_unmap((void *) entry->mapped_addr);
+                MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                                    "**gpu_ipc_handle_unmap");
+                memset(entry, 0, sizeof(struct MPIDI_GPUI_map_cache_entry));
+            } else if (entry->device_id == device_id) {
                 MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "mapped gpu ipc handle cache HIT for %p",
                               remote_addr);
                 entry->usage = ++MPIDI_GPUI_global.ipc_map_cache_usage_counter;
-                *mapped_addr = (void *) entry->mapped_addrs[device_id];
+                *mapped_addr = (void *) entry->mapped_addr;
                 goto fn_exit;
-            } else {
-                ipc_mapped_cache_delete(entry);
-                MPIDI_GPUI_global.ipc_map_cache[i] = NULL;
             }
         }
     }
@@ -174,55 +158,52 @@ static int ipc_mapped_cache_search(const void *remote_addr, int remote_rank,
     *mapped_addr = NULL;
 
   fn_exit:
-    return MPI_SUCCESS;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 static int ipc_mapped_cache_insert(const void *remote_addr, int remote_rank,
                                    MPL_gpu_buffer_id_t remote_buffer_id, uintptr_t len,
                                    int device_id, const void *mapped_addr)
 {
+    int mpi_errno = MPI_SUCCESS;
+
     MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE, "caching NEW mapped ipc handle for %p", remote_addr);
 
-    unsigned long long min_usage = ULLONG_MAX;
+    unsigned long long min_usage = MPIDI_GPUI_global.ipc_map_cache[0].usage;
     int min_usage_index = 0;
 
-    for (int i = 0; i < MPIDI_CH4_IPC_GPU_MAX_CACHE_ENTRIES; i++) {
-        struct MPIDI_GPUI_map_cache_entry *entry = MPIDI_GPUI_global.ipc_map_cache[i];
-        if (entry) {
-            if (entry->remote_buffer_id == remote_buffer_id && entry->remote_rank == remote_rank) {
-                entry->mapped_addrs[device_id] = mapped_addr;
-                goto fn_exit;
-            }
-            if (entry->usage < min_usage) {
-                min_usage = entry->usage;
-                min_usage_index = i;
-            }
-        } else {
-            min_usage = 0;
+    /* LRU eviction policy: find oldest (possibly empty) cache member */
+    for (int i = 1; min_usage > 0 && i < MPIDI_CH4_IPC_GPU_MAX_CACHE_ENTRIES; i++) {
+        struct MPIDI_GPUI_map_cache_entry *entry = &MPIDI_GPUI_global.ipc_map_cache[i];
+        if (entry->usage < min_usage) {
+            min_usage = entry->usage;
             min_usage_index = i;
         }
     }
 
-    struct MPIDI_GPUI_map_cache_entry *entry = MPIDI_GPUI_global.ipc_map_cache[min_usage_index];
-    if (entry) {
-        ipc_mapped_cache_delete(entry);
+    struct MPIDI_GPUI_map_cache_entry *entry = &MPIDI_GPUI_global.ipc_map_cache[min_usage_index];
+    if (entry->mapped_addr) {
+        MPL_DBG_MSG_P(MPIDI_CH4_DBG_IPC, VERBOSE,
+                      "removing STALE mapped gpu ipc handle for %p", entry->remote_addr);
+        int mpl_err = MPL_gpu_ipc_handle_unmap((void *) entry->mapped_addr);
+        MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                            "**gpu_ipc_handle_unmap");
     }
 
-    int entry_size = sizeof(struct MPIDI_GPUI_map_cache_entry) +
-        (MPIDI_GPUI_global.local_device_count * sizeof(void *));
-    entry = MPL_malloc(entry_size, MPL_MEM_OTHER);
-    memset(entry, 0, entry_size);
     entry->remote_rank = remote_rank;
     entry->remote_addr = remote_addr;
     entry->remote_buffer_id = remote_buffer_id;
     entry->len = len;
+    entry->device_id = device_id;
     entry->usage = ++MPIDI_GPUI_global.ipc_map_cache_usage_counter;
-    entry->mapped_addrs[device_id] = mapped_addr;
-
-    MPIDI_GPUI_global.ipc_map_cache[min_usage_index] = entry;
+    entry->mapped_addr = mapped_addr;
 
   fn_exit:
-    return MPI_SUCCESS;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
 }
 
 int MPIDI_GPU_get_ipc_attr(const void *buf, MPI_Aint count, MPI_Datatype datatype,

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
@@ -8,11 +8,6 @@
 
 #include "mpl.h"
 
-enum {
-    MPIDI_GPU_IPC_HANDLE_VALID,
-    MPIDI_GPU_IPC_HANDLE_REMAP_REQUIRED,
-};
-
 /* memory handle definition */
 typedef struct MPIDI_GPU_ipc_handle {
     MPL_gpu_ipc_mem_handle_t ipc_handle;
@@ -22,7 +17,6 @@ typedef struct MPIDI_GPU_ipc_handle {
     uintptr_t len;
     int node_rank;
     uintptr_t offset;
-    int handle_status;
 } MPIDI_GPU_ipc_handle_t;
 
 /* local struct used for query and preparing memory handle */

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
@@ -18,17 +18,10 @@ struct MPIDI_GPUI_map_cache_entry {
     const void *mapped_addrs[]; /* array of base addresses indexed by device id */
 };
 
-struct MPIDI_GPUI_handle_cache_entry {
-    UT_hash_handle hh;
-    const void *base_addr;
-    MPL_gpu_ipc_mem_handle_t handle;
-};
-
 typedef struct {
     int local_device_count;
     int initialized;
     struct MPIDI_GPUI_map_cache_entry *ipc_map_cache;
-    struct MPIDI_GPUI_handle_cache_entry *ipc_handle_cache;
 } MPIDI_GPUI_global_t;
 
 extern MPIDI_GPUI_global_t MPIDI_GPUI_global;

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
@@ -15,15 +15,16 @@ struct MPIDI_GPUI_map_cache_entry {
     const void *remote_addr;
     MPL_gpu_buffer_id_t remote_buffer_id;
     uintptr_t len;
+    int device_id;
     unsigned long long usage;
-    const void *mapped_addrs[]; /* array of base addresses indexed by device id */
+    const void *mapped_addr;
 };
 
 typedef struct {
     int local_device_count;
     int initialized;
     unsigned long long ipc_map_cache_usage_counter;
-    struct MPIDI_GPUI_map_cache_entry *ipc_map_cache[MPIDI_CH4_IPC_GPU_MAX_CACHE_ENTRIES];
+    struct MPIDI_GPUI_map_cache_entry ipc_map_cache[MPIDI_CH4_IPC_GPU_MAX_CACHE_ENTRIES];
 } MPIDI_GPUI_global_t;
 
 extern MPIDI_GPUI_global_t MPIDI_GPUI_global;

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
@@ -15,6 +15,7 @@ struct MPIDI_GPUI_map_cache_entry {
         const void *remote_addr;
     } key;
     MPL_gpu_buffer_id_t remote_buffer_id;
+    uintptr_t len;
     const void *mapped_addrs[]; /* array of base addresses indexed by device id */
 };
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
@@ -14,6 +14,7 @@ struct MPIDI_GPUI_map_cache_entry {
         int remote_rank;
         const void *remote_addr;
     } key;
+    MPL_gpu_buffer_id_t remote_buffer_id;
     const void *mapped_addrs[]; /* array of base addresses indexed by device id */
 };
 

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_types.h
@@ -8,21 +8,22 @@
 
 #include "uthash.h"
 
+#define MPIDI_CH4_IPC_GPU_MAX_CACHE_ENTRIES 100
+
 struct MPIDI_GPUI_map_cache_entry {
-    UT_hash_handle hh;
-    struct map_key {
-        int remote_rank;
-        const void *remote_addr;
-    } key;
+    int remote_rank;
+    const void *remote_addr;
     MPL_gpu_buffer_id_t remote_buffer_id;
     uintptr_t len;
+    unsigned long long usage;
     const void *mapped_addrs[]; /* array of base addresses indexed by device id */
 };
 
 typedef struct {
     int local_device_count;
     int initialized;
-    struct MPIDI_GPUI_map_cache_entry *ipc_map_cache;
+    unsigned long long ipc_map_cache_usage_counter;
+    struct MPIDI_GPUI_map_cache_entry *ipc_map_cache[MPIDI_CH4_IPC_GPU_MAX_CACHE_ENTRIES];
 } MPIDI_GPUI_global_t;
 
 extern MPIDI_GPUI_global_t MPIDI_GPUI_global;

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -119,7 +119,6 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
 int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr);
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle, int dev_id, void **ptr);
 int MPL_gpu_ipc_handle_unmap(void *ptr);
-bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr);
 
 int MPL_gpu_malloc_host(void **ptr, size_t size);
 int MPL_gpu_free_host(void *ptr);

--- a/src/mpl/include/mpl_gpu_cuda.h
+++ b/src/mpl/include/mpl_gpu_cuda.h
@@ -9,9 +9,10 @@
 #include "cuda.h"
 #include "cuda_runtime_api.h"
 
+typedef unsigned long long MPL_gpu_buffer_id_t;
 typedef struct {
     cudaIpcMemHandle_t handle;
-    unsigned long long id;
+    MPL_gpu_buffer_id_t id;
 } MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
 typedef struct cudaPointerAttributes MPL_gpu_device_attr;

--- a/src/mpl/include/mpl_gpu_fallback.h
+++ b/src/mpl/include/mpl_gpu_fallback.h
@@ -6,6 +6,7 @@
 #ifndef MPL_GPU_CUDA_H_INCLUDED
 #define MPL_GPU_CUDA_H_INCLUDED
 
+typedef int MPL_gpu_buffer_id_t;
 typedef int MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
 typedef int MPL_gpu_device_attr;        /* dummy type */

--- a/src/mpl/include/mpl_gpu_hip.h
+++ b/src/mpl/include/mpl_gpu_hip.h
@@ -13,9 +13,10 @@
 #include "hip/hip_runtime.h"
 #include "hip/hip_runtime_api.h"
 
+typedef uint32_t MPL_gpu_buffer_id_t;
 typedef struct {
     hipIpcMemHandle_t handle;
-    uint32_t id;
+    MPL_gpu_buffer_id_t id;
 } MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
 typedef struct hipPointerAttribute_t MPL_gpu_device_attr;

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -13,12 +13,13 @@ typedef struct {
     ze_device_handle_t device;
 } ze_alloc_attr_t;
 
+typedef uint64_t MPL_gpu_buffer_id_t;
 typedef struct {
     int fds[2];
     uint32_t nfds;
     pid_t pid;
     int dev_id;
-    uint64_t mem_id;
+    MPL_gpu_buffer_id_t mem_id;
 } fd_pid_t;
 
 typedef struct _MPL_gpu_ipc_mem_handle_t {

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -191,17 +191,6 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
     goto fn_exit;
 }
 
-bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr)
-{
-    CUresult ret;
-    MPL_gpu_buffer_id_t buffer_id;
-
-    ret = cuPointerGetAttribute(&buffer_id, CU_POINTER_ATTRIBUTE_BUFFER_ID, (CUdeviceptr) ptr);
-    assert(ret == cudaSuccess);
-
-    return buffer_id == handle->id;
-}
-
 int MPL_gpu_malloc_host(void **ptr, size_t size)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -138,13 +138,15 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
                               MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     int mpl_err = MPL_SUCCESS;
-    cudaError_t ret;
 
+    cudaError_t ret;
     ret = cudaIpcGetMemHandle(&ipc_handle->handle, (void *) ptr);
     CUDA_ERR_CHECK(ret);
 
-    ret = cuPointerGetAttribute(&ipc_handle->id, CU_POINTER_ATTRIBUTE_BUFFER_ID, (CUdeviceptr) ptr);
-    CUDA_ERR_CHECK(ret);
+    CUresult curet;
+    curet =
+        cuPointerGetAttribute(&ipc_handle->id, CU_POINTER_ATTRIBUTE_BUFFER_ID, (CUdeviceptr) ptr);
+    CU_ERR_CHECK(curet);
 
   fn_exit:
     return mpl_err;

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -194,7 +194,7 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
 bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr)
 {
     CUresult ret;
-    unsigned long long buffer_id;
+    MPL_gpu_buffer_id_t buffer_id;
 
     ret = cuPointerGetAttribute(&buffer_id, CU_POINTER_ATTRIBUTE_BUFFER_ID, (CUdeviceptr) ptr);
     assert(ret == cudaSuccess);

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -226,7 +226,7 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
 bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr)
 {
     hipError_t ret;
-    uint32_t buffer_id;
+    MPL_gpu_buffer_id_t buffer_id;
 
     ret = hipPointerGetAttribute(&buffer_id, HIP_POINTER_ATTRIBUTE_BUFFER_ID, (hipDeviceptr_t) ptr);
     assert(ret == hipSuccess);

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -223,17 +223,6 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
     goto fn_exit;
 }
 
-bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr)
-{
-    hipError_t ret;
-    MPL_gpu_buffer_id_t buffer_id;
-
-    ret = hipPointerGetAttribute(&buffer_id, HIP_POINTER_ATTRIBUTE_BUFFER_ID, (hipDeviceptr_t) ptr);
-    assert(ret == hipSuccess);
-
-    return buffer_id == handle->id;
-}
-
 int MPL_gpu_malloc_host(void **ptr, size_t size)
 {
     int mpl_err = MPL_SUCCESS;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -2091,24 +2091,6 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
     goto fn_exit;
 }
 
-bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr)
-{
-    ze_result_t ret;
-    ze_device_handle_t device = NULL;
-    ze_memory_allocation_properties_t ptr_attr = {
-        .stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES,
-        .pNext = NULL,
-        .type = 0,
-        .id = 0,
-        .pageSize = 0,
-    };
-
-    ret = zeMemGetAllocProperties(ze_context, ptr, &ptr_attr, &device);
-    assert(ret == ZE_RESULT_SUCCESS);
-
-    return handle->data.mem_id == ptr_attr.id;
-}
-
 /* at finalize, to free a cache entry in ipc_cache_removal cache */
 static int remove_ipc_handle_entry(MPL_ze_mapped_buffer_entry_t * cache_entry, int dev_id)
 {


### PR DESCRIPTION
## Pull Request Description
Closes #7819.
In `MPIDI_GPU_ipc_handle_map()`, if the receiver had already mapped and cached an IPC memory allocation (as given by the input handler) with the same base address, we were assuming this mapping continued to be valid on a second encounter of the same base address. It just so happens that this second input handler might refer to an allocation with the same base address, but of different size, meaning the allocation needs to be remapped to avoid bounds checks failures later on, e.g. on a `cudaMemcpyAsync()` as in #7819.

One would then think that fixing this would just be a matter of more judiciously setting `MPIDI_GPU_IPC_HANDLE_REMAP_REQUIRED` on the handles, sender-side. Problem is, the sender doesn't have enough information to do this. On a first call to `MPIDI_GPU_fill_ipc_handle()` for some device allocation, we were correctly setting the handle status to `MPIDI_GPU_IPC_HANDLE_REMAP_REQUIRED` (even if this pertains to an allocation of different size on a base address seen before), but a subsequent call with some input attributes referencing a different offset inside the allocation but the same base address, would incorrectly set the handler status to `MPIDI_GPU_IPC_HANDLE_VALID`. When the receiver sees this handler, it doesn't know to remap, leading to the problem above.

Obviously, setting `MPIDI_GPU_IPC_HANDLE_REMAP_REQUIRED` unconditionally solves the problem, but that's effectively the same as disabling the cache on the receiver side, so instead I've introduced a check on the allocation sizes.

Cheers,
-Nuno

## summary of key changes
* Sender - side handle cache is removed
* Receiver -side always cache handle map
* Rely on buffer id for cache validation

