### PR TITLE
datatype: integer_map use range not bytes

### DIFF
--- a/src/mpi/datatype/create_f90.c
+++ b/src/mpi/datatype/create_f90.c
@@ -16,12 +16,12 @@ typedef struct realModel {
 } realModel;
 
 static intModel f90_integer_map[] = {
-    {1, MPIR_INT8},
-    {2, MPIR_INT16},
-    {4, MPIR_INT32},
-    {8, MPIR_INT64},
+    {2, MPIR_INT8},
+    {4, MPIR_INT16},
+    {9, MPIR_INT32},
+    {18, MPIR_INT64},
 #if defined(MPIR_INT128_CTYPE)
-    {16, MPIR_INT128},
+    {38, MPIR_INT128},
 #endif
 };
 


### PR DESCRIPTION
## Pull Request Description
In MPI_Type_get_f90_integer, it uses range rather than bytes. This is a silly mistake from the commit 66cd573.

Fixes #7822 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
