### PR TITLE
ch4/ofi: avoid FI_MATCH_COMPLETE for small messages

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_pipeline.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_pipeline.c
@@ -311,7 +311,16 @@ static bool send_copy_complete(MPIR_Request * sreq, int chunk_index,
     msg.context = (void *) &(chunk_req->context);
     msg.data = 0;
 
-    uint64_t flags = FI_COMPLETION | FI_MATCH_COMPLETE | FI_DELIVERY_COMPLETE;
+    uint64_t flags = FI_COMPLETION;
+    if (chunk_sz == MPIR_CVAR_CH4_OFI_PIPELINE_CHUNK_SZ) {
+        /* request remote match completion to avoid too many unexpected chunks going out.
+         * NOTE: we skip the last chunk because
+         *       1. it's unnecessary
+         *       2. work around a provider issue due to match event arrives later than the
+         *          completion event for small messages
+         */
+        flags |= FI_MATCH_COMPLETE;
+    }
 
     MPIDI_OFI_CALL_RETRY(fi_tsendmsg(MPIDI_OFI_global.ctx[ctx_idx].tx, &msg, flags),
                          p->vci_local, tsendv);


### PR DESCRIPTION
## Pull Request Description
To work around a provider bug that small messages may result in double dequeue a request (inside libfabric) and corrupts the message queue.


Fixes #7713 
[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
