### PR TITLE
session: Fix comm create from empty group and enhance tests

### DIFF
--- a/src/mpi/comm/comm_impl.c
+++ b/src/mpi/comm/comm_impl.c
@@ -534,6 +534,12 @@ int MPIR_Comm_create_from_group_impl(MPIR_Group * group_ptr, const char *stringt
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
+    if (group_ptr == MPIR_Group_empty) {
+        /* For empty group return MPI_COMM_NULL */
+        *p_newcom_ptr = NULL;
+        goto fn_exit;
+    }
+
     int tag = get_tag_from_stringtag(stringtag);
 
 #ifdef MPID_SESSION_USE_WORLD

--- a/test/mpi/session/Makefile.am
+++ b/test/mpi/session/Makefile.am
@@ -15,6 +15,8 @@ noinst_PROGRAMS = \
     session_mult_init \
     session_mult_init_with_world \
     session_re_init \
+    session_mod_group \
+    session_mod_group_re_init \
     session_psets \
     session_self \
     session_inter \
@@ -27,3 +29,7 @@ session_mult_init_with_world_SOURCES = session.c
 session_mult_init_with_world_CPPFLAGS = -DMULT_INIT -DWITH_WORLD $(AM_CPPFLAGS)
 session_re_init_SOURCES = session.c
 session_re_init_CPPFLAGS = -DRE_INIT $(AM_CPPFLAGS)
+session_mod_group_SOURCES = session.c
+session_mod_group_CPPFLAGS = -DMOD_GROUP $(AM_CPPFLAGS)
+session_mod_group_re_init_SOURCES = session.c
+session_mod_group_re_init_CPPFLAGS = -DMOD_GROUP -DRE_INIT $(AM_CPPFLAGS)

--- a/test/mpi/session/Makefile.am
+++ b/test/mpi/session/Makefile.am
@@ -13,6 +13,7 @@ EXTRA_DIST = testlist
 noinst_PROGRAMS = \
     session       \
     session_mult_init \
+    session_mult_init_with_world \
     session_re_init \
     session_psets \
     session_self \
@@ -22,5 +23,7 @@ noinst_PROGRAMS = \
 
 session_mult_init_SOURCES = session.c
 session_mult_init_CPPFLAGS = -DMULT_INIT $(AM_CPPFLAGS)
+session_mult_init_with_world_SOURCES = session.c
+session_mult_init_with_world_CPPFLAGS = -DMULT_INIT -DWITH_WORLD $(AM_CPPFLAGS)
 session_re_init_SOURCES = session.c
 session_re_init_CPPFLAGS = -DRE_INIT $(AM_CPPFLAGS)

--- a/test/mpi/session/Makefile.am
+++ b/test/mpi/session/Makefile.am
@@ -19,6 +19,7 @@ noinst_PROGRAMS = \
     session_mod_group_re_init \
     session_psets \
     session_self \
+    session_self_with_world \
     session_inter \
     session_4x4 \
     session_bsend
@@ -29,6 +30,8 @@ session_mult_init_with_world_SOURCES = session.c
 session_mult_init_with_world_CPPFLAGS = -DMULT_INIT -DWITH_WORLD $(AM_CPPFLAGS)
 session_re_init_SOURCES = session.c
 session_re_init_CPPFLAGS = -DRE_INIT $(AM_CPPFLAGS)
+session_self_with_world_SOURCES = session_self.c
+session_self_with_world_CPPFLAGS = -DWITH_WORLD $(AM_CPPFLAGS)
 session_mod_group_SOURCES = session.c
 session_mod_group_CPPFLAGS = -DMOD_GROUP $(AM_CPPFLAGS)
 session_mod_group_re_init_SOURCES = session.c

--- a/test/mpi/session/session.c
+++ b/test/mpi/session/session.c
@@ -20,6 +20,8 @@
  * WITH_WORLD:  Have MPI world model initialized prior to the first MPI_Session_init
  * RE_INIT:     Initialize another session after closing the previous one (only if
  *              not using MULT_INIT)
+ * MOD_GROUP:   Create the first communicator from an MPI Group that is smaller
+ *              than the world group
  */
 
 int errs = 0;
@@ -75,6 +77,9 @@ int main(int argc, char *argv[])
 
 static MPI_Session lib_shandle = MPI_SESSION_NULL;
 static MPI_Comm lib_comm = MPI_COMM_NULL;
+#ifdef MOD_GROUP
+static MPI_Comm lib_comm_group = MPI_COMM_NULL;
+#endif
 
 int check_thread_level(char *value)
 {
@@ -106,6 +111,30 @@ int library_foo_test(void)
     MPI_Comm_rank(lib_comm, &rank);
 
     int sum;
+#ifdef MOD_GROUP
+    /* Skip the reduce operation for rank that is not in smaller group/ comm */
+    if (lib_comm_group != MPI_COMM_NULL) {
+        int group_comm_size;
+        int group_comm_rank;
+
+        MPI_Comm_size(lib_comm_group, &group_comm_size);
+        MPI_Comm_rank(lib_comm_group, &group_comm_rank);
+
+        rc = MPI_Reduce(&group_comm_rank, &sum, 1, MPI_INT, MPI_SUM, 0, lib_comm_group);
+        if (rc != MPI_SUCCESS) {
+            printf("Error on reduce\n");
+            errs++;
+        }
+        if (group_comm_rank == 0) {
+            if (sum != (group_comm_size - 1) * group_comm_size / 2) {
+                printf("MPI_Reduce: expect %d, got %d\n",
+                       (group_comm_size - 1) * group_comm_size / 2, sum);
+                errs++;
+            }
+        }
+    }
+#endif
+    sum = 0;
     rc = MPI_Reduce(&rank, &sum, 1, MPI_INT, MPI_SUM, 0, lib_comm);
     if (rc != MPI_SUCCESS) {
         printf("Error on reduce\n");
@@ -171,7 +200,84 @@ void library_foo_init(void)
         errs++;
         goto fn_exit;
     }
+#ifdef MOD_GROUP
+    int grp_size, grp_rank, newgrp_size, newgrp_rank, comm_size = 0;
+    MPI_Group newgroup = MPI_GROUP_NULL;
+    MPI_Group_size(wgroup, &grp_size);
+    MPI_Group_rank(wgroup, &grp_rank);
+    int excl[1];
 
+    if (grp_size < 2) {
+        printf("This test has to be started with at least 2 processes!\n");
+        errs++;
+        goto fn_exit;
+    }
+
+    /* Create a new group where a rank is excluded */
+    excl[0] = grp_size - 2;
+    rc = MPI_Group_excl(wgroup, 1, excl, &newgroup);
+    if (rc != MPI_SUCCESS) {
+        printf("Error on MPI_Group_excl\n");
+        errs++;
+        goto fn_exit;
+    }
+
+    MPI_Group_size(newgroup, &newgrp_size);
+    MPI_Group_rank(newgroup, &newgrp_rank);
+    if (newgrp_size != grp_size - 1) {
+        printf("Error: newgrp_size = %d, expected %d\n", newgrp_size, grp_size - 1);
+        errs++;
+        goto fn_exit;
+    }
+
+    /* Use the new smaller group to create the lib_comm_group */
+    if (newgrp_rank == MPI_UNDEFINED) {
+        rc = MPI_Comm_create_from_group(MPI_GROUP_EMPTY, "group", MPI_INFO_NULL,
+                                        MPI_ERRORS_RETURN, &lib_comm_group);
+        if (lib_comm_group != MPI_COMM_NULL) {
+            printf
+                ("Error: Expected comm from group MPI_GROUP_EMPTY to be MPI_COMM_NULL, but it is not.\n");
+            errs++;
+            goto fn_exit;
+        }
+    } else {
+        rc = MPI_Comm_create_from_group(newgroup, "group", MPI_INFO_NULL,
+                                        MPI_ERRORS_RETURN, &lib_comm_group);
+        if (lib_comm_group == MPI_COMM_NULL) {
+            printf
+                ("Error: Expected comm from non-NULL group not to be MPI_COMM_NULL, but it is.\n");
+            errs++;
+            goto fn_exit;
+        }
+    }
+    if (rc != MPI_SUCCESS) {
+        errs++;
+        goto fn_exit;
+    }
+
+    if (lib_comm_group != MPI_COMM_NULL) {
+        MPI_Comm_size(lib_comm_group, &comm_size);
+        if (comm_size != newgrp_size) {
+            printf("Error: communicator for smaller group has size %d (expected %d)\n",
+                   comm_size, newgrp_size);
+            errs++;
+            goto fn_exit;
+        }
+    } else {
+        /* Only for the rank that has been excluded from the group it is ok to have MPI_COMM_NULL */
+        if (grp_rank != grp_size - 2) {
+            errs++;
+            printf("Error: communicator for smaller group is MPI_COMM_NULL\n");
+            goto fn_exit;
+        }
+    }
+
+    if (newgroup != MPI_GROUP_NULL) {
+        MPI_Group_free(&newgroup);
+    }
+
+  mod_group_end:
+#endif
     /* get a communicator */
     rc = MPI_Comm_create_from_group(wgroup, "org.mpi-forum.mpi-v4_0.example-ex10_8",
                                     MPI_INFO_NULL, MPI_ERRORS_RETURN, &lib_comm);
@@ -204,6 +310,16 @@ void library_foo_finalize(void)
             return;
         }
     }
+#ifdef MOD_GROUP
+    if (lib_comm_group != MPI_COMM_NULL) {
+        rc = MPI_Comm_free(&lib_comm_group);
+        if (rc != MPI_SUCCESS) {
+            printf("MPI_Comm_free returned %d\n", rc);
+            errs++;
+            return;
+        }
+    }
+#endif
 
     if (lib_shandle != MPI_SESSION_NULL) {
         rc = MPI_Session_finalize(&lib_shandle);

--- a/test/mpi/session/session.c
+++ b/test/mpi/session/session.c
@@ -13,6 +13,13 @@
  * Model. The pre-defined "mpi://WORLD" process set can be used to first create
  * a local MPI group and then subsequently to create an MPI communicator from
  * this group.
+ *
+ * Different variants of this test:
+ *
+ * MULT_INIT:   Multiple MPI_Session_init/finalize sequences in a row (not nested)
+ * WITH_WORLD:  Have MPI world model initialized prior to the first MPI_Session_init
+ * RE_INIT:     Initialize another session after closing the previous one (only if
+ *              not using MULT_INIT)
  */
 
 int errs = 0;
@@ -32,17 +39,24 @@ int main(int argc, char *argv[])
         /* basic sanity check */
         assert(num_repeat > 0 && num_repeat < 100);
     }
-
+#ifdef WITH_WORLD
     MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+#endif
     for (int i = 0; i < num_repeat; i++) {
+#ifdef WITH_WORLD
         library_foo_test();
+#else
+        rank = library_foo_test();
+#endif
         if (errs > 0) {
             break;
         }
     }
+#ifdef WITH_WORLD
     MPI_Finalize();
+#endif
 #else
     int rank = library_foo_test();
 #ifdef RE_INIT

--- a/test/mpi/session/session.c
+++ b/test/mpi/session/session.c
@@ -38,17 +38,24 @@ int main(int argc, char *argv[])
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     for (int i = 0; i < num_repeat; i++) {
         library_foo_test();
+        if (errs > 0) {
+            break;
+        }
     }
     MPI_Finalize();
 #else
     int rank = library_foo_test();
 #ifdef RE_INIT
+    if (errs > 0) {
+        goto fn_exit;
+    }
     library_foo_test();
 #endif
 #endif
     if (rank == 0 && errs == 0) {
         printf("No Errors\n");
     }
+  fn_exit:
     return MTestReturnValue(errs);
 }
 
@@ -72,14 +79,24 @@ int check_thread_level(char *value)
 int library_foo_test(void)
 {
     int rank, size;
+    int rc;
 
     library_foo_init();
+
+    if (errs > 0) {
+        rank = -1;
+        goto fn_exit;
+    }
 
     MPI_Comm_size(lib_comm, &size);
     MPI_Comm_rank(lib_comm, &rank);
 
     int sum;
-    MPI_Reduce(&rank, &sum, 1, MPI_INT, MPI_SUM, 0, lib_comm);
+    rc = MPI_Reduce(&rank, &sum, 1, MPI_INT, MPI_SUM, 0, lib_comm);
+    if (rc != MPI_SUCCESS) {
+        printf("Error on reduce\n");
+        errs++;
+    }
     if (rank == 0) {
         if (sum != (size - 1) * size / 2) {
             printf("MPI_Reduce: expect %d, got %d\n", (size - 1) * size / 2, sum);
@@ -87,6 +104,7 @@ int library_foo_test(void)
         }
     }
 
+  fn_exit:
     library_foo_finalize();
 
     return rank;
@@ -95,7 +113,6 @@ int library_foo_test(void)
 void library_foo_init(void)
 {
     int rc, flag;
-    int ret = 0;
     const char pset_name[] = "mpi://WORLD";
     const char mt_key[] = "thread_level";
     const char mt_value[] = "MPI_THREAD_MULTIPLE";
@@ -108,6 +125,7 @@ void library_foo_init(void)
     MPI_Info_set(sinfo, mt_key, mt_value);
     rc = MPI_Session_init(sinfo, MPI_ERRORS_RETURN, &lib_shandle);
     if (rc != MPI_SUCCESS) {
+        printf("Error on MPI_Session_init\n");
         errs++;
         goto fn_exit;
     }
@@ -115,6 +133,7 @@ void library_foo_init(void)
     /* check we got thread support level foo library needs */
     rc = MPI_Session_get_info(lib_shandle, &tinfo);
     if (rc != MPI_SUCCESS) {
+        printf("Error on MPI_Session_get_info\n");
         errs++;
         goto fn_exit;
     }
@@ -134,6 +153,7 @@ void library_foo_init(void)
     /* create a group from the WORLD process set */
     rc = MPI_Group_from_session_pset(lib_shandle, pset_name, &wgroup);
     if (rc != MPI_SUCCESS) {
+        printf("Error on MPI_Group_from_session_pset\n");
         errs++;
         goto fn_exit;
     }
@@ -157,26 +177,26 @@ void library_foo_init(void)
     if (tinfo != MPI_INFO_NULL) {
         MPI_Info_free(&tinfo);
     }
-    if (ret != MPI_SUCCESS) {
-        MPI_Session_finalize(&lib_shandle);
-    }
 }
 
 void library_foo_finalize(void)
 {
     int rc;
-
-    rc = MPI_Comm_free(&lib_comm);
-    if (rc != MPI_SUCCESS) {
-        printf("MPI_Comm_free returned %d\n", rc);
-        errs++;
-        return;
+    if (lib_comm != MPI_COMM_NULL) {
+        rc = MPI_Comm_free(&lib_comm);
+        if (rc != MPI_SUCCESS) {
+            printf("MPI_Comm_free returned %d\n", rc);
+            errs++;
+            return;
+        }
     }
 
-    rc = MPI_Session_finalize(&lib_shandle);
-    if (rc != MPI_SUCCESS) {
-        printf("MPI_Session_finalize returned %d\n", rc);
-        errs++;
-        return;
+    if (lib_shandle != MPI_SESSION_NULL) {
+        rc = MPI_Session_finalize(&lib_shandle);
+        if (rc != MPI_SUCCESS) {
+            printf("MPI_Session_finalize returned %d\n", rc);
+            errs++;
+            return;
+        }
     }
 }

--- a/test/mpi/session/session_psets.c
+++ b/test/mpi/session/session_psets.c
@@ -23,6 +23,7 @@ int main(int argc, char *argv[])
     int n_psets, psetlen, rc;
     int valuelen;
     int flag = 0;
+    int rank;
     char *info_val = NULL;
     char *pset_name = NULL;
     char **all_pset_names;
@@ -95,6 +96,10 @@ int main(int argc, char *argv[])
             errs++;
         }
 
+        if (strcmp("mpi://WORLD", all_pset_names[i]) == 0) {
+            MPI_Group_rank(pgroup, &rank);
+        }
+
         free(all_pset_names[i]);
         MPI_Group_free(&pgroup);
         MPI_Info_free(&sinfo);
@@ -111,10 +116,12 @@ int main(int argc, char *argv[])
         errs++;
     }
 
-    if (errs == 0) {
-        printf("No Errors\n");
-    } else {
-        printf("%d Errors\n", errs);
+    if (rank == 0) {
+        if (errs == 0) {
+            printf("No Errors\n");
+        } else {
+            printf("%d Errors\n", errs);
+        }
     }
     return MTestReturnValue(errs);
 }

--- a/test/mpi/session/session_self.c
+++ b/test/mpi/session/session_self.c
@@ -8,14 +8,32 @@
 #include <assert.h>
 #include "mpitest.h"
 
+void get_world_rank(MPI_Session session, int *rank)
+{
+    MPI_Group group = MPI_GROUP_NULL;
+    MPI_Comm comm = MPI_COMM_NULL;
+    int my_rank = 0;
+    MPI_Group_from_session_pset(session, "mpi://WORLD", &group);
+    MPI_Comm_create_from_group(group, "foo", MPI_INFO_NULL, MPI_ERRORS_ARE_FATAL, &comm);
+    MPI_Comm_rank(comm, &my_rank);
+    MPI_Group_free(&group);
+    MPI_Comm_free(&comm);
+    *rank = my_rank;
+}
+
 int main(int argc, char *argv[])
 {
     int errs = 0;
 
-    int ret;
-    MPI_Session session;
-    MPI_Group group;
-    MPI_Comm comm;
+    int ret, world_rank, grp_size, comm_size;
+    MPI_Session session = MPI_SESSION_NULL;
+    MPI_Group group = MPI_GROUP_NULL;
+    MPI_Comm comm = MPI_COMM_NULL;
+#ifdef WITH_WORLD
+    int provided;
+
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+#endif
 
     ret = MPI_Session_init(MPI_INFO_NULL, MPI_ERRORS_RETURN, &session);
     if (ret != MPI_SUCCESS) {
@@ -23,9 +41,20 @@ int main(int argc, char *argv[])
         goto fn_exit;
     }
 
-    ret = MPI_Group_from_session_pset(session, "mpi://self", &group);
+    /* Get the world rank of the process */
+    get_world_rank(session, &world_rank);
+
+    ret = MPI_Group_from_session_pset(session, "mpi://SELF", &group);
     if (ret != MPI_SUCCESS) {
         errs++;
+    }
+
+    MPI_Group_size(group, &grp_size);
+    if (grp_size != 1) {
+        printf("Error: Size of group generated from pset mpi://SELF is %d (expected size 1)\n",
+               grp_size);
+        errs++;
+        goto fn_exit;
     }
 
     ret = MPI_Comm_create_from_group(group, "tag", MPI_INFO_NULL, MPI_ERRORS_RETURN, &comm);
@@ -33,9 +62,17 @@ int main(int argc, char *argv[])
         errs++;
     }
 
-    ret = MPI_Group_free(&group);
-    if (ret != MPI_SUCCESS) {
+    if (comm == MPI_COMM_NULL) {
+        printf("Error: communicator for pset mpi://SELF is MPI_COMM_NULL\n");
         errs++;
+        goto fn_exit;
+    }
+
+    MPI_Comm_size(comm, &comm_size);
+    if (comm_size != grp_size) {
+        printf("Error: Comm for pset mpi://SELF has size %d (expected size 1)\n", comm_size);
+        errs++;
+        goto fn_exit;
     }
 
     MPI_Request req;
@@ -56,20 +93,37 @@ int main(int argc, char *argv[])
         errs++;
     }
 
-    ret = MPI_Comm_free(&comm);
-    if (ret != MPI_SUCCESS) {
-        errs++;
-    }
-
-    ret = MPI_Session_finalize(&session);
-    if (ret != MPI_SUCCESS) {
-        errs++;
-    }
-
-    if (errs == 0) {
-        printf("No Errors\n");
-    }
-
   fn_exit:
+    if (group != MPI_GROUP_NULL) {
+        ret = MPI_Group_free(&group);
+        if (ret != MPI_SUCCESS) {
+            errs++;
+        }
+    }
+
+    if (comm != MPI_COMM_NULL) {
+        ret = MPI_Comm_free(&comm);
+        if (ret != MPI_SUCCESS) {
+            errs++;
+        }
+    }
+
+    if (session != MPI_SESSION_NULL) {
+        ret = MPI_Session_finalize(&session);
+        if (ret != MPI_SUCCESS) {
+            errs++;
+        }
+    }
+
+    if (world_rank == 0) {
+        if (errs == 0) {
+            printf("No Errors\n");
+        } else {
+            printf("%d Errors\n", errs);
+        }
+    }
+#ifdef WITH_WORLD
+    MPI_Finalize();
+#endif
     return errs;
 }

--- a/test/mpi/session/testlist
+++ b/test/mpi/session/testlist
@@ -1,6 +1,8 @@
 session 4
 session_mult_init 4
 session_mult_init 4 arg=5
+session_mult_init_with_world 4
+session_mult_init_with_world 4 arg=5
 session_re_init 4
 session_psets 1
 session_self 1

--- a/test/mpi/session/testlist
+++ b/test/mpi/session/testlist
@@ -12,6 +12,8 @@ session_psets 1
 session_psets 4
 session_self 1
 session_self 4
+session_self_with_world 1
+session_self_with_world 4
 session_inter 5
 session_4x4 16
 session_bsend 2

--- a/test/mpi/session/testlist
+++ b/test/mpi/session/testlist
@@ -4,6 +4,10 @@ session_mult_init 4 arg=5
 session_mult_init_with_world 4
 session_mult_init_with_world 4 arg=5
 session_re_init 4
+session_mod_group 2
+session_mod_group 4
+session_mod_group_re_init 2
+session_mod_group_re_init 4
 session_psets 1
 session_psets 4
 session_self 1

--- a/test/mpi/session/testlist
+++ b/test/mpi/session/testlist
@@ -5,7 +5,9 @@ session_mult_init_with_world 4
 session_mult_init_with_world 4 arg=5
 session_re_init 4
 session_psets 1
+session_psets 4
 session_self 1
+session_self 4
 session_inter 5
 session_4x4 16
 session_bsend 2


### PR DESCRIPTION
## Pull Request Description

The MPI 5.0 Standard says about `MPI_COMM_CREATE_FROM_GROUP` (see chapter 7.4.2 on p. 336):

> In the event that MPI_GROUP_EMPTY is supplied as the group argument, then the
call is a local operation and MPI_COMM_NULL is returned as newcomm.

This PR includes a commit that fixes this in `MPIR_Comm_create_from_group_impl` so that this function returns immediately with a null-comm in the case of an empty group.

In addition, some enhancements that we've added to ParaStationMPI for the tests compiled from `session.c` test file are added with this PR - including additional tests that catch the case with the empty group mentioned above. Here is a summary of the proposed test enhancements:
- Add more error checks to catch some error cases earlier and clearer.
- Test the session mult-init case with initialized world model and without it. This allows to catch more (corner) cases.
- Add tests with 4 procs for `session_self` and `session_pset` to ensure that these cases also work in multi-proc conditions.
- Add two new tests `session_mod_group` and `session_mod_group_re_init` that stress the group-wise communicator bootstrapping and also cover the case of `MPI_COMM_CREATE_FROM_GROUP` with an empty group.

I admit that the addition of the new tests to `session.c` make this test file more cluttered. :see_no_evil:  I've added some documentation at the beginning of the file to help understand the various flavours that can be built for this test.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
