### PR TITLE
abi/errhan: convert error_class in get_class_msg

### DIFF
--- a/maint/extracterrmsgs
+++ b/maint/extracterrmsgs
@@ -47,6 +47,7 @@ foreach my $k ("envvarparse", "cvar_val"){
 
 # Check for special args
 my $mpi_h = "src/include/mpi.h.in";
+my $mpi_abi_h = "src/binding/abi/mpi_abi.h";
 my $baseerrnames_txt = "src/mpi/errhan/baseerrnames.txt";
 my @files = ();
 my %skipFiles = ();
@@ -137,6 +138,20 @@ if (open In, $mpi_h) {
     die "Unable to read $mpi_h\n";
 }
 
+# Load mpi_abi.h for ABI error class constants
+my %abi_h_constants;
+$abi_h_constants{"MPI_SUCCESS"} = 0;
+if (open In, $mpi_abi_h) {
+    while (<In>) {
+        if (/^\s+(MPI_ERR_\w+)\s*=\s*(\d+)/) {
+            $abi_h_constants{$1} = $2;
+        }
+    }
+    close In;
+} else {
+    die "Unable to read $mpi_abi_h\n";
+}
+
 my $max_err_class = $mpi_h_constants{MPICH_ERR_LAST_MPIX};
 if (!$max_err_class) {
     die "Failed to load MPICH_ERR_LAST_MPIX from $mpi_h\n";
@@ -161,15 +176,20 @@ foreach my $sourcefile (@errnameFiles) {
 
 # Load baseerrnames.txt
 my @class_msgs;
+my @abi_class_msgs;
 if (open In, $baseerrnames_txt) {
     while (<In>) {
         if (/^(MPI\w+)\s+(\*\*\w+)/) {
             my ($name, $shortmsg) = ($1, $2, $3);
             my $id = $mpi_h_constants{$name};
+            my $abi_id = $abi_h_constants{$name};
             if (defined $id) {
                 $generic_msgs{$shortmsg}++;
                 $generic_loc{$shortmsg} = ":baseerrnames.txt";
                 $class_msgs[$id] = $shortmsg;
+                if (defined $abi_id) {
+                    $abi_class_msgs[$abi_id] = $shortmsg;
+                }
             } else {
                 die "error class $name not found in mpi.h\n";
             }
@@ -348,18 +368,40 @@ sub CreateErrMsgMapping {
     print $OUTFD "};\n";
 
     my $maxval = $max_err_class + 1;
-    print $OUTFD "static int class_to_index[] = {\n    ";
+    print $OUTFD "static int class_to_index[] = {\n";
+    print $OUTFD "#ifndef MPICH_BUILD_MPI_ABI\n";
     for (my $i=0; $i<=$max_err_class; $i++) {
         my $idx = $short_to_num{$class_msgs[$i]};
         if (!$idx) {
             # 0 is the "**UNKNOWN" entry
             $idx = 0;
         }
+        print $OUTFD "    " if $i % 10 == 0;
         print $OUTFD "$idx";
 	print $OUTFD "," if ($i < $max_err_class);
-	print $OUTFD "\n    " if !(($i + 1) % 10);
+	print $OUTFD "\n" if !(($i + 1) % 10);
     }
-    print $OUTFD "\n};\n";
+    print $OUTFD "\n";
+    print $OUTFD "#else  /* MPICH_BUILD_MPI_ABI */\n";
+    # NOTE: $abi_class_msgs[$i] should be defined for all standard MPI_ERR_XXX,
+    #       but use $class_msgs[$i] for MPIX_ERR_XXX.
+    for (my $i=0; $i<=$max_err_class; $i++) {
+        my $idx = $short_to_num{$class_msgs[$i]};
+        if (defined $abi_class_msgs[$i]) {
+            $idx = $short_to_num{$abi_class_msgs[$i]};
+        }
+        if (!$idx) {
+            # 0 is the "**UNKNOWN" entry
+            $idx = 0;
+        }
+        print $OUTFD "    " if $i % 10 == 0;
+        print $OUTFD "$idx";
+	print $OUTFD "," if ($i < $max_err_class);
+	print $OUTFD "\n" if !(($i + 1) % 10);
+    }
+    print $OUTFD "\n";
+    print $OUTFD "#endif /* MPICH_BUILD_MPI_ABI */\n";
+    print $OUTFD "};\n";
 }
 #
 # Add a call to test this message for the error message.

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -1074,7 +1074,11 @@ def dump_abi_wrappers(func, is_large):
                         pre_filters.append("} else if (recvtypes_abi != NULL) {")
                         pre_filters.append("INDENT")
                 pre_filters.append("if (%s > 0) {" % array_size)
-                pre_filters.append("    %s = MPL_malloc(sizeof(MPI_%s) * %s, MPL_MEM_OTHER);" % (name, array_type, array_size))
+                if array_size == "max_datatypes":
+                    # zero the output array so we know whether it is filled at output
+                    pre_filters.append("    %s = MPL_calloc(sizeof(MPI_%s), %s, MPL_MEM_OTHER);" % (name, array_type, array_size))
+                else:
+                    pre_filters.append("    %s = MPL_malloc(sizeof(MPI_%s) * %s, MPL_MEM_OTHER);" % (name, array_type, array_size))
                 pre_filters.append("}")
                 if p['param_direction'] == 'in' or p['param_direction'] == 'inout':
                     pre_filters.append("for (int i = 0; i < %s; i++) {" % array_size)
@@ -1092,6 +1096,12 @@ def dump_abi_wrappers(func, is_large):
                         post_filters.append("for (int i = 0; i < *outcount; i++) {")
                         post_filters.append("    int idx = array_of_indices[i];")
                         post_filters.append("    %s_abi[idx] = ABI_%s_from_mpi(%s[idx]);" % (name, array_type, name))
+                        post_filters.append("}")
+                    elif array_size == "max_datatypes":
+                        post_filters.append("for (int i = 0; i < %s; i++) {" % array_size)
+                        post_filters.append("    if (%s[i]) {" % name)
+                        post_filters.append("        %s_abi[i] = ABI_%s_from_mpi(%s[i]);" % (name, array_type, name))
+                        post_filters.append("    }")
                         post_filters.append("}")
                     else:
                         post_filters.append("for (int i = 0; i < %s; i++) {" % array_size)


### PR DESCRIPTION
## Pull Request Description
The standard MPI ABI error class value may not be the same as the corresponding values in MPICH ABI. Our error names are indexed using MPICH ABI values. Thus under MPICH_BUILD_MPI_ABI, we need convert the error_class value to MPICH ABI value before returning the error string.

Fix ABI test `datatype/createf90types` due to sporadic failure in `MPI_Type_get_contents`. The output type array may contain untouched data. Use `calloc` to zero the array at input so we can check whether the type is updated and thus need ABI conversions

Fixes #7835
[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
