### PR TITLE
topo: MPI_Cart_sub and zero-dimensional topology

### DIFF
--- a/src/mpi/topo/topo_impl.c
+++ b/src/mpi/topo/topo_impl.c
@@ -318,7 +318,10 @@ int MPIR_Cart_sub_impl(MPIR_Comm * comm_ptr, const int remain_dims[], MPIR_Comm 
     if (all_false) {
         /* ndims=0, or all entries in remain_dims are false.
          * MPI 2.1 says return a 0D Cartesian topology. */
-        mpi_errno = MPIR_Cart_create_impl(comm_ptr, 0, NULL, NULL, 0, p_newcomm_ptr);
+        /* Use comm_self instead of comm_ptr since MPI_Cart_sub is a split + topology
+         * FIXME: the sub comms should inherit from the parent comm, such as hints.
+         */
+        mpi_errno = MPIR_Cart_create_impl(MPIR_Process.comm_self, 0, NULL, NULL, 0, p_newcomm_ptr);
         MPIR_ERR_CHECK(mpi_errno);
     } else {
         /* Determine the number of remaining dimensions */


### PR DESCRIPTION
## Pull Request Description
A zero-dimensional cartesion topology is essentially a self comm. `MPI_Cart_create` return a self comm to rank 0 but `MPI_COMM_NULL` for the rest of the ranks because `MPI_Cart_create`'s semantics is associated to a single communicator. On the hand, `MPI_Cart_sub`'s semantics is a comm-split + topology. The comm-split results in individual self comm then we attach a zero-dimensional cartesion topology. Thus all ranks should return a self comm.

Fixes #7832 

[skip warnings]


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
