### PR TITLE
abi: double inclusion of mpi_abi_util.c under noweak

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -127,6 +127,7 @@ mpi_abi_sources =
 mpi_fc_modules =
 mpi_cxx_sources =
 mpi_core_sources =
+mpi_abi_core_sources =
 mpifort_convenience_libs = @mpl_lib@
 
 lib_LTLIBRARIES =
@@ -168,7 +169,7 @@ if BUILD_PROFILING_LIB
 # dropping mpi_fc_sources and mpi_cxx_sources from libmpmpi since they
 # don't contribute any PMPI symbols.
 lib_LTLIBRARIES += lib/lib@PMPIABILIBNAME@.la
-lib_lib@PMPIABILIBNAME@_la_SOURCES = $(mpi_abi_sources) $(mpi_f77_sources) $(mpi_core_sources)
+lib_lib@PMPIABILIBNAME@_la_SOURCES = $(mpi_abi_sources) $(mpi_f77_sources) $(mpi_core_sources) $(mpi_abi_core_sources)
 lib_lib@PMPIABILIBNAME@_la_LDFLAGS = $(external_ldflags) $(ABI_ABIVERSIONFLAGS)
 lib_lib@PMPIABILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) -DF77_USE_PMPI $(abi_cppflags)
 lib_lib@PMPIABILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs) $(abi_convenience_libs)
@@ -186,7 +187,7 @@ lib_lib@MPIABILIBNAME@_la_LIBADD = lib/lib@PMPIABILIBNAME@.la
 else !BUILD_PROFILING_LIB
 
 lib_LTLIBRARIES += lib/lib@MPIABILIBNAME@.la
-lib_lib@MPIABILIBNAME@_la_SOURCES = $(mpi_abi_sources) $(mpi_core_sources)
+lib_lib@MPIABILIBNAME@_la_SOURCES = $(mpi_abi_sources) $(mpi_core_sources) $(mpi_abi_core_sources)
 lib_lib@MPIABILIBNAME@_la_LDFLAGS = $(external_ldflags) $(ABI_ABIVERSIONFLAGS)
 lib_lib@MPIABILIBNAME@_la_CPPFLAGS = $(AM_CPPFLAGS) $(abi_cppflags)
 lib_lib@MPIABILIBNAME@_la_LIBADD = $(external_libs) $(pmpi_convenience_libs) $(abi_convenience_libs)

--- a/src/binding/abi/Makefile.mk
+++ b/src/binding/abi/Makefile.mk
@@ -8,8 +8,10 @@ if BUILD_ABI_LIB
 include_HEADERS += src/binding/abi/mpi_abi.h
 
 mpi_abi_sources += \
-    src/binding/abi/mpi_abi_util.c \
     src/binding/abi/c_binding_abi.c \
     src/binding/abi/io_abi.c
+
+mpi_abi_core_sources += \
+    src/binding/abi/mpi_abi_util.c
 
 endif BUILD_ABI_LIB


### PR DESCRIPTION
## Pull Request Description
When weak symbols are unavailable, we build both libmpi.so and libpmpi.so. Internal symbols should only included in libpmpi. Including mpi_abi_util.c in mpi_abi_sources cause it to be included in both libmpi and libpmpi. This causes the internal global varaible such as abi_datatype_builtins, that used to covert between ABI handles had two copies and result in inconsistencies.

Fixes #7834 
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
