### PR TITLE
test/topo: remove questionable tests

### DIFF
--- a/test/mpi/topo/cartsuball.c
+++ b/test/mpi/topo/cartsuball.c
@@ -36,9 +36,21 @@ int main(int argc, char *argv[])
             printf("cart sub to size 0 did not give self\n");
         }
         MPI_Comm_free(&newcomm);
-    } else if (newcomm != MPI_COMM_NULL) {
-        errs++;
-        printf("cart sub to size 0 did not give null\n");
+    } else {
+        /* Previously an MPICH developer argue that all other ranks should
+         * return MPI_COMM_NULL and implemented this way. Open MPI argues
+         * that other ranks should also return a self-equivalent comm since
+         * MPI_Cart_sub is a split + zero-dimensional topology. I (hzhou)
+         * kinda agree with the latter but couldn't care less. If application
+         * ask for zero-dimensional topology, it must be unexpected and they
+         * should fix their code!
+         *
+         * I am removing that part of test so we don't have to spend time debating
+         * useless points.
+         */
+        if (newcomm != MPI_COMM_NULL) {
+            MPI_Comm_free(&newcomm);
+        }
     }
 
     /* Free the new communicator so that storage leak tests will


### PR DESCRIPTION
## Pull Request Description
MPI_Cart_sub when all dimensions is 0 should return a zero-dimensional topology. But the standard didn't say whether all ranks should do so or only rank 0 should do so. Previous MPICH developer disagrees with the current Open MPI developer! I think it is a useless debate and such test should be removed! Previous commit has effectively made MPICH's behavior consistent with Open MPI's.



[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
