### PR TITLE
build: Run legacy romio tests against the build tree

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -54,6 +54,9 @@ external_subdirs = @mpl_srcdir@ @hwloc_srcdir@ @json_srcdir@ @yaksa_srcdir@ @pmi
 external_ldflags = @RPATHS@
 external_libs = @WRAPPER_LIBS@
 
+ROMIO_TEST_MPIEXEC = @ROMIO_TEST_MPIEXEC@
+export ROMIO_TEST_MPIEXEC
+
 # convenience libs that do not depend on MPI
 pmpi_convenience_libs = @mpl_lib@ @hwloc_lib@ @json_lib@ @yaksa_lib@ @pmi_lib@
 

--- a/configure.ac
+++ b/configure.ac
@@ -903,6 +903,9 @@ AC_ARG_VAR([PMPIABILIBNAME],[can be used to override the name of the MPI profili
 AC_ARG_VAR([MPICXXLIBNAME],[can be used to override the name of the MPI C++ library (default: "${MPILIBNAME}cxx")])
 AC_ARG_VAR([MPIFCLIBNAME],[can be used to override the name of the MPI fortran library (default: "${MPILIBNAME}fort")])
 MPILIBNAME=${MPILIBNAME:-"mpi"}
+# ROMIO is configured as a subdirectory and needs the resolved library name
+# when building its legacy tests against the top-level build tree.
+export MPILIBNAME
 PMPILIBNAME_set=no
 if test -n "$PMPILIBNAME" ; then
    PMPILIBNAME_set=yes
@@ -1558,6 +1561,25 @@ fi
 # pm_name is the *primary* pm
 pm_name=$first_pm_name
 AC_SUBST(pm_name)
+
+# Legacy ROMIO tests run before the configured installation prefix is
+# populated.  Use the primary process manager built in this tree instead of
+# the future $(bindir)/mpiexec path.
+case "$pm_name" in
+  hydra)
+    ROMIO_TEST_MPIEXEC="${main_top_builddir}/src/pm/hydra/mpiexec.hydra"
+    ;;
+  gforker)
+    ROMIO_TEST_MPIEXEC="${main_top_builddir}/src/pm/gforker/mpiexec"
+    ;;
+  remshell)
+    ROMIO_TEST_MPIEXEC="${main_top_builddir}/src/pm/remshell/mpiexec"
+    ;;
+  *)
+    ROMIO_TEST_MPIEXEC=""
+    ;;
+esac
+AC_SUBST(ROMIO_TEST_MPIEXEC)
 
 dnl
 dnl gforker and remshell does not use separate configure. 

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -1230,24 +1230,15 @@ elif test $FROM_MPICH = yes ; then
    MPICH_HOME=`dirname $MPICH_HOME`
    MPICH_HOME=`dirname $MPICH_HOME`
    if test -z "$MPI_BIN_DIR" ; then MPI_BIN_DIR=$MPICH_HOME/bin ; fi
-   # No special compiler script.
-   # BUT we need the include paths
-   # CC="$CC -I${use_top_srcdir}/src/include -I${top_build_dir}/src/include"
-   # TEST_CC="$CC"
-   # MPI_LIB="$LIBNAME"
-   # To allow ROMIO to work with the LIBTOOL scripts, we want to
-   # work directly with the CC, not the mpicc, compiler.
-   # Note that in the "FROM_MPICH" case, the CPPFLAGS and INCLUDES are already
-   # properly set
-   #CC=${top_build_dir}/bin/mpicc
-   #
-   # set the compilers to the ones in MPICH bin directory (main_top_builddir/bin)
-   TEST_CC='$(bindir)/mpicc'
+   # Run the tests against the uninstalled MPICH build tree.  Use the
+   # configured C compiler and let libtool resolve the dependencies recorded
+   # in the top-level MPI library, rather than using an installed wrapper.
+   TEST_CC="$CC"
+   TEST_LIBNAME="${main_top_builddir}/lib/lib${MPILIBNAME}.la"
    MPI_H_INCLUDE="-I${main_top_builddir}/src/include -I${main_top_srcdir}/src/include"
    ROMIO_INCLUDE=""
    USER_CFLAGS=""
-   TEST_LIBNAME=""
-   MPIRUN='${bindir}/mpiexec'
+   MPIRUN=""
    #
    # Turn off the building of the Fortran interface and the Info routines
    EXTRA_DIRS=""

--- a/src/mpi/romio/test/Makefile.am
+++ b/src/mpi/romio/test/Makefile.am
@@ -17,7 +17,7 @@ OUR_LIBS = @TEST_LIBNAME@ @MPI_LIB@
 
 LDADD = $(OUR_LIBS)
 
-AM_CPPFLAGS = $(ROMIO_INCLUDE)
+AM_CPPFLAGS = $(ROMIO_INCLUDE) @MPI_H_INCLUDE@
 AM_CPPFLAGS += -I$(top_builddir)/include -I$(top_srcdir)/include
 AM_CPPFLAGS += -I$(top_builddir)/adio/include -I$(top_srcdir)/adio/include @mpl_includedir@
 AM_CFLAGS = $(USER_CFLAGS)

--- a/src/mpi/romio/test/parallel_run.sh.in
+++ b/src/mpi/romio/test/parallel_run.sh.in
@@ -12,7 +12,15 @@ set -e
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 bindir=@bindir@
-mpirun="@MPIRUN@"
+# MPICH exports ROMIO_TEST_MPIEXEC from the top-level Makefile.  It points
+# to the process manager built in this tree rather than the launcher that will
+# later be installed in $(bindir).
+mpirun="${ROMIO_TEST_MPIEXEC:-@MPIRUN@}"
+
+if test -z "$mpirun" ; then
+    echo "SKIP: no usable MPI launcher in the build tree" >&2
+    exit 77
+fi
 
 # valgrind_opt="libtool --mode=execute valgrind --quiet --leak-check=full"
 


### PR DESCRIPTION
## Pull Request Description

The legacy ROMIO tests currently invoke `$(bindir)/mpicc` and `$(bindir)/mpiexec`, which assumes that MPICH has already been installed into its final prefix. This breaks `make check` in staged-install environments such as RPM builds, where the installation is available only under `DESTDIR`.

Run these tests against the current build tree instead: compile and link with the configured compiler and build-tree MPI library, and use the build-tree process-manager launcher. This preserves the existing ROMIO test coverage without relying on an installed MPICH wrapper or distribution-specific workarounds.

Resolves #7817.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
