### PR TITLE
mpl: fix AVX detection on macOS-x64_64

### DIFF
--- a/src/mpl/src/arch/mpl_arch_x86.c
+++ b/src/mpl/src/arch/mpl_arch_x86.c
@@ -6,6 +6,10 @@
 #include "mpl.h"
 #include "mpl_base.h"
 
+#ifdef __APPLE__
+#undef MPL_HAVE_BUILTIN_CPU_SUPPORTS
+#endif
+
 uint64_t mpl_arch_features = MPL_ARCH_FLAG__UNKNOWN;
 
 #ifndef MPL_HAVE_BUILTIN_CPU_SUPPORTS


### PR DESCRIPTION
The detection of AVX support based in compiler builtins is broken on macOS-x64_64, leading to a linker error. Use CPUID instructions instead.

## Pull Request Description

Resolve issue AVX detection on macOS x86_64. The use of builtin compiler features is broken (linker error), use CPUID instructions instead.

Fixes #7843 

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
