### PR TITLE
abi: add mpix.h for ABI build

### DIFF
--- a/maint/gen_abi.py
+++ b/maint/gen_abi.py
@@ -54,7 +54,7 @@ def dump_mpi_abi_internal_h(mpi_abi_internal_h):
                 out.append("    %s count_lo;" % T)
                 out.append("    %s count_hi_and_cancelled;" % T)
                 out.append("    %s reserved[%d];" % (T, n - 2))
-            elif RE.match(r'#define\s+(MPI_\w+)\s+\(?\((MPI_\w+)\)\s*(0x\w+)\)?', line):
+            elif RE.match(r'#define\s+(MPIX?_\w+)\s+\(?\((MPI_\w+)\)\s*(0x\w+)\)?', line):
                 (name, T, val) = RE.m.group(1,2,3)
                 if T == "MPI_File":
                     # Both ROMIO and ABI use pointers, thus we can directly replace constants
@@ -67,7 +67,7 @@ def dump_mpi_abi_internal_h(mpi_abi_internal_h):
                     idx = int(val, 0) & G.op_mask
                     G.abi_ops[idx] = name
                 # replace param prefix
-                out.append(re.sub(r'\bMPI_', 'ABI_', line.rstrip()))
+                out.append(re.sub(r'\bMPIX?_', 'ABI_', line.rstrip()))
             elif RE.match(r'#define MPI_(LONG_LONG|C_COMPLEX)', line):
                 # datatype aliases
                 out.append(re.sub(r'\bMPI_', 'ABI_', line.rstrip()))

--- a/maint/gen_abi.py
+++ b/maint/gen_abi.py
@@ -24,6 +24,7 @@ class RE:
 
 def main():
     load_mpi_abi_h("src/binding/abi/mpi_abi.h")
+    load_mpi_abi_h("src/include/mpix.h")
     dump_mpi_abi_internal_h("src/binding/abi/mpi_abi_internal.h")
     dump_io_abi_internal_h("src/binding/abi/io_abi_internal.h")
     dump_romio_abi_internal_h("src/mpi/romio/include/romio_abi_internal.h")
@@ -31,17 +32,19 @@ def main():
 
 def load_mpi_abi_h(mpi_abi_h):
     with open(mpi_abi_h, "r") as In:
-        G.abi_h_lines = In.readlines()
+        for line in In:
+            if RE.search(r'(MPI_ABI|MPIX)_H_INCLUDED', line):
+                # skip the include guard, harmless
+                pass
+            else:
+                G.abi_h_lines.append(line)
 
 def dump_mpi_abi_internal_h(mpi_abi_internal_h):
     define_constants = {}
     def gen_mpi_abi_internal_h(out):
         re_Handle = r'\bMPI_(Comm|Datatype|Errhandler|Group|Info|Message|Op|Request|Session|Win|File|KEYVAL_INVALID|TAG_UB|IO|HOST|WTIME_IS_GLOBAL|APPNUM|LASTUSEDCODE|UNIVERSE_SIZE|WIN_BASE|WIN_DISP_UNIT|WIN_SIZE|WIN_CREATE_FLAVOR|WIN_MODEL)\b'
         for line in G.abi_h_lines:
-            if RE.search(r'MPI_ABI_H_INCLUDED', line):
-                # skip the include guard, harmless
-                pass
-            elif RE.match(r'\s*int MPI_(SOURCE|TAG|ERROR);', line):
+            if RE.match(r'\s*int MPI_(SOURCE|TAG|ERROR);', line):
                 # no need to rename status fields
                 out.append(line.rstrip())
             elif RE.match(r'\s*(int|MPI_Fint) .*(reserved|internal)\[(\d+)\];', line):
@@ -144,7 +147,7 @@ def dump_romio_abi_internal_h(romio_abi_internal_h):
         out.append("#endif")
         out.append("")
 
-    def add_mpix_grequest(out):
+    def add_mpio_request(out):
         out.append("#define MPIO_Request MPI_Request")
         out.append("#define MPIO_USES_MPI_REQUEST")
         out.append("#define MPIO_Wait MPI_Wait")
@@ -152,30 +155,6 @@ def dump_romio_abi_internal_h(romio_abi_internal_h):
         out.append("#define PMPIO_Wait PMPI_Wait")
         out.append("#define PMPIO_Test PMPI_Test")
         out.append("#define MPIO_REQUEST_DEFINED")
-        out.append("")
-        # they are not in the header, but they are in c_binding_abi.c
-        out.append("typedef int MPIX_Grequest_class;")
-        out.append("typedef int (MPIX_Grequest_poll_function)(void *, MPI_Status *);")
-        out.append("typedef int (MPIX_Grequest_wait_function)(int, void **, double, MPI_Status *);")
-        out.append("int MPIX_Grequest_start(MPI_Grequest_query_function *query_fn, MPI_Grequest_free_function *free_fn, MPI_Grequest_cancel_function *cancel_fn, MPIX_Grequest_poll_function *poll_fn, MPIX_Grequest_wait_function *wait_fn, void *extra_state, MPI_Request *request);")
-        out.append("int MPIX_Grequest_class_create(MPI_Grequest_query_function *query_fn, MPI_Grequest_free_function *free_fn, MPI_Grequest_cancel_function *cancel_fn, MPIX_Grequest_poll_function *poll_fn, MPIX_Grequest_wait_function *wait_fn, MPIX_Grequest_class *greq_class);")
-        out.append("int MPIX_Grequest_class_allocate(MPIX_Grequest_class greq_class, void *extra_state, MPI_Request *request);")
-        out.append("int PMPIX_Grequest_start(MPI_Grequest_query_function *query_fn, MPI_Grequest_free_function *free_fn, MPI_Grequest_cancel_function *cancel_fn, MPIX_Grequest_poll_function *poll_fn, MPIX_Grequest_wait_function *wait_fn, void *extra_state, MPI_Request *request);")
-        out.append("int PMPIX_Grequest_class_create(MPI_Grequest_query_function *query_fn, MPI_Grequest_free_function *free_fn, MPI_Grequest_cancel_function *cancel_fn, MPIX_Grequest_poll_function *poll_fn, MPIX_Grequest_wait_function *wait_fn, MPIX_Grequest_class *greq_class);")
-        out.append("int PMPIX_Grequest_class_allocate(MPIX_Grequest_class greq_class, void *extra_state, MPI_Request *request);")
-        out.append("")
-
-    def add_mpix_iov(out):
-        out.append("typedef struct MPIX_Iov {")
-        out.append("    void *iov_base;")
-        out.append("    MPI_Aint iov_len;")
-        out.append("} MPIX_Iov;")
-        out.append("")
-        out.append("int MPIX_Type_iov_len(MPI_Datatype datatype, MPI_Count max_iov_bytes, MPI_Count *iov_len, MPI_Count *actual_iov_bytes);")
-        out.append("int MPIX_Type_iov(MPI_Datatype datatype, MPI_Count iov_offset, MPIX_Iov *iov, MPI_Count max_iov_len, MPI_Count *actual_iov_len);")
-        out.append("int PMPIX_Type_iov_len(MPI_Datatype datatype, MPI_Count max_iov_bytes, MPI_Count *iov_len, MPI_Count *actual_iov_bytes);")
-        out.append("int PMPIX_Type_iov(MPI_Datatype datatype, MPI_Count iov_offset, MPIX_Iov *iov, MPI_Count max_iov_len, MPI_Count *actual_iov_len);")
-        out.append("")
 
     def add_other(out):
         out.append("#define MPICH")  # ref. mpi-io/mpich_fileutil.c
@@ -185,8 +164,7 @@ def dump_romio_abi_internal_h(romio_abi_internal_h):
     output_lines = []
     add_romio_visibility(output_lines)
     gen_romio_abi_internal_h(output_lines)
-    add_mpix_grequest(output_lines)
-    add_mpix_iov(output_lines)
+    add_mpio_request(output_lines)
     add_other(output_lines)
 
     print(" --> [%s]" % romio_abi_internal_h)

--- a/src/binding/abi/mpi_abi.h
+++ b/src/binding/abi/mpi_abi.h
@@ -436,7 +436,6 @@ enum {
 
 typedef void (MPI_User_function)(void *invec, void *inoutvec, int *len, MPI_Datatype *datatype);
 typedef void (MPI_User_function_c)(void *invec, void *inoutvec, MPI_Count *len, MPI_Datatype *datatype);
-typedef void (MPIX_User_function_x) ( void *invec, void *inoutvec, MPI_Count count, MPI_Datatype datatype, void *extra_state);
 
 typedef int (MPI_Grequest_query_function)(void *extra_state, MPI_Status *status);
 typedef int (MPI_Grequest_free_function)(void *extra_state);
@@ -460,17 +459,10 @@ typedef void (MPI_File_errhandler_function)(MPI_File *file, int *error_code, ...
 typedef void (MPI_Win_errhandler_function)(MPI_Win *win, int *error_code, ...);
 typedef void (MPI_Session_errhandler_function)(MPI_Session *session, int *error_code, ...);
 
-typedef void (MPIX_Comm_errhandler_function_x)(MPI_Comm comm, int error_code, void *extra_state);
-typedef void (MPIX_File_errhandler_function_x)(MPI_File file, int error_code, void *extra_state);
-typedef void (MPIX_Win_errhandler_function_x)(MPI_Win win, int error_code, void *extra_state);
-typedef void (MPIX_Session_errhandler_function_x)(MPI_Session session, int error_code, void *extra_state);
-
 typedef MPI_Comm_errhandler_function MPI_Comm_errhandler_fn;
 typedef MPI_File_errhandler_function MPI_File_errhandler_fn;
 typedef MPI_Win_errhandler_function MPI_Win_errhandler_fn;
 typedef MPI_Session_errhandler_function MPI_Session_errhandler_fn;
-
-typedef void (MPIX_Destructor_function) (void *extra_state);
 
 #define MPI_NULL_COPY_FN               ((MPI_Copy_function*)0x0) /* deprecated: MPI-2.0 */
 #define MPI_DUP_FN                     ((MPI_Copy_function*)0x1) /* deprecated: MPI-2.0 */
@@ -643,7 +635,6 @@ int MPI_Comm_compare(MPI_Comm comm1, MPI_Comm comm2, int *result);
 int MPI_Comm_connect(const char *port_name, MPI_Info info, int root, MPI_Comm comm, MPI_Comm *newcomm);
 int MPI_Comm_create(MPI_Comm comm, MPI_Group group, MPI_Comm *newcomm);
 int MPI_Comm_create_errhandler(MPI_Comm_errhandler_function *comm_errhandler_fn, MPI_Errhandler *errhandler);
-int MPIX_Comm_create_errhandler_x(MPIX_Comm_errhandler_function_x *comm_errhandler_fn_x, MPIX_Destructor_function *destructor_fn, void *extra_state, MPI_Errhandler *errhandler);
 int MPI_Comm_create_from_group(MPI_Group group, const char *stringtag, MPI_Info info, MPI_Errhandler errhandler, MPI_Comm *newcomm);
 int MPI_Comm_create_group(MPI_Comm comm, MPI_Group group, int tag, MPI_Comm *newcomm);
 int MPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn, MPI_Comm_delete_attr_function *comm_delete_attr_fn, int *comm_keyval, void *extra_state);
@@ -696,7 +687,6 @@ int MPI_Fetch_and_op(const void *origin_addr, void *result_addr, MPI_Datatype da
 int MPI_File_call_errhandler(MPI_File fh, int errorcode);
 int MPI_File_close(MPI_File *fh);
 int MPI_File_create_errhandler(MPI_File_errhandler_function *file_errhandler_fn, MPI_Errhandler *errhandler);
-int MPIX_File_create_errhandler_x(MPIX_File_errhandler_function_x *comm_errhandler_fn_x, MPIX_Destructor_function *destructor_fn, void *extra_state, MPI_Errhandler *errhandler);
 int MPI_File_delete(const char *filename, MPI_Info info);
 int MPI_File_get_amode(MPI_File fh, int *amode);
 int MPI_File_get_atomicity(MPI_File fh, int *flag);
@@ -936,7 +926,6 @@ int MPI_Neighbor_alltoallw_init_c(const void *sendbuf, const MPI_Count sendcount
 int MPI_Op_commutative(MPI_Op op, int *commute);
 int MPI_Op_create(MPI_User_function *user_fn, int commute, MPI_Op *op);
 int MPI_Op_create_c(MPI_User_function_c *user_fn, int commute, MPI_Op *op);
-int MPIX_Op_create_x(MPIX_User_function_x *user_fn_x, MPIX_Destructor_function *destructor_fn, int commute, void *extra_state, MPI_Op *op);
 int MPI_Op_free(MPI_Op *op);
 int MPI_Open_port(MPI_Info info, char *port_name);
 int MPI_Pack(const void *inbuf, int incount, MPI_Datatype datatype, void *outbuf, int outsize, int *position, MPI_Comm comm);
@@ -1023,7 +1012,6 @@ int MPI_Session_attach_buffer(MPI_Session session, void *buffer, int size);
 int MPI_Session_attach_buffer_c(MPI_Session session, void *buffer, MPI_Count size);
 int MPI_Session_call_errhandler(MPI_Session session, int errorcode);
 int MPI_Session_create_errhandler(MPI_Session_errhandler_function *session_errhandler_fn, MPI_Errhandler *errhandler);
-int MPIX_Session_create_errhandler_x(MPIX_Session_errhandler_function_x *comm_errhandler_fn_x, MPIX_Destructor_function *destructor_fn, void *extra_state, MPI_Errhandler *errhandler);
 int MPI_Session_detach_buffer(MPI_Session session, void *buffer_addr, int *size);
 int MPI_Session_detach_buffer_c(MPI_Session session, void *buffer_addr, MPI_Count *size);
 int MPI_Session_finalize(MPI_Session *session);
@@ -1128,7 +1116,6 @@ int MPI_Win_create(void *base, MPI_Aint size, int disp_unit, MPI_Info info, MPI_
 int MPI_Win_create_c(void *base, MPI_Aint size, MPI_Aint disp_unit, MPI_Info info, MPI_Comm comm, MPI_Win *win);
 int MPI_Win_create_dynamic(MPI_Info info, MPI_Comm comm, MPI_Win *win);
 int MPI_Win_create_errhandler(MPI_Win_errhandler_function *win_errhandler_fn, MPI_Errhandler *errhandler);
-int MPIX_Win_create_errhandler_x(MPIX_Win_errhandler_function_x *comm_errhandler_fn_x, MPIX_Destructor_function *destructor_fn, void *extra_state, MPI_Errhandler *errhandler);
 int MPI_Win_create_keyval(MPI_Win_copy_attr_function *win_copy_attr_fn, MPI_Win_delete_attr_function *win_delete_attr_fn, int *win_keyval, void *extra_state);
 int MPI_Win_delete_attr(MPI_Win win, int win_keyval);
 int MPI_Win_detach(MPI_Win win, const void *base);
@@ -1316,7 +1303,6 @@ int PMPI_Comm_compare(MPI_Comm comm1, MPI_Comm comm2, int *result);
 int PMPI_Comm_connect(const char *port_name, MPI_Info info, int root, MPI_Comm comm, MPI_Comm *newcomm);
 int PMPI_Comm_create(MPI_Comm comm, MPI_Group group, MPI_Comm *newcomm);
 int PMPI_Comm_create_errhandler(MPI_Comm_errhandler_function *comm_errhandler_fn, MPI_Errhandler *errhandler);
-int PMPIX_Comm_create_errhandler_x(MPIX_Comm_errhandler_function_x *comm_errhandler_fn_x, MPIX_Destructor_function *destructor_fn, void *extra_state, MPI_Errhandler *errhandler);
 int PMPI_Comm_create_from_group(MPI_Group group, const char *stringtag, MPI_Info info, MPI_Errhandler errhandler, MPI_Comm *newcomm);
 int PMPI_Comm_create_group(MPI_Comm comm, MPI_Group group, int tag, MPI_Comm *newcomm);
 int PMPI_Comm_create_keyval(MPI_Comm_copy_attr_function *comm_copy_attr_fn, MPI_Comm_delete_attr_function *comm_delete_attr_fn, int *comm_keyval, void *extra_state);
@@ -1369,7 +1355,6 @@ int PMPI_Fetch_and_op(const void *origin_addr, void *result_addr, MPI_Datatype d
 int PMPI_File_call_errhandler(MPI_File fh, int errorcode);
 int PMPI_File_close(MPI_File *fh);
 int PMPI_File_create_errhandler(MPI_File_errhandler_function *file_errhandler_fn, MPI_Errhandler *errhandler);
-int PMPIX_File_create_errhandler_x(MPIX_File_errhandler_function_x *comm_errhandler_fn_x, MPIX_Destructor_function *destructor_fn, void *extra_state, MPI_Errhandler *errhandler);
 int PMPI_File_delete(const char *filename, MPI_Info info);
 int PMPI_File_get_amode(MPI_File fh, int *amode);
 int PMPI_File_get_atomicity(MPI_File fh, int *flag);
@@ -1695,7 +1680,6 @@ int PMPI_Session_attach_buffer(MPI_Session session, void *buffer, int size);
 int PMPI_Session_attach_buffer_c(MPI_Session session, void *buffer, MPI_Count size);
 int PMPI_Session_call_errhandler(MPI_Session session, int errorcode);
 int PMPI_Session_create_errhandler(MPI_Session_errhandler_function *session_errhandler_fn, MPI_Errhandler *errhandler);
-int PMPIX_Session_create_errhandler_x(MPIX_Session_errhandler_function_x *comm_errhandler_fn_x, MPIX_Destructor_function *destructor_fn, void *extra_state, MPI_Errhandler *errhandler);
 int PMPI_Session_detach_buffer(MPI_Session session, void *buffer_addr, int *size);
 int PMPI_Session_detach_buffer_c(MPI_Session session, void *buffer_addr, MPI_Count *size);
 int PMPI_Session_finalize(MPI_Session *session);
@@ -1800,7 +1784,6 @@ int PMPI_Win_create(void *base, MPI_Aint size, int disp_unit, MPI_Info info, MPI
 int PMPI_Win_create_c(void *base, MPI_Aint size, MPI_Aint disp_unit, MPI_Info info, MPI_Comm comm, MPI_Win *win);
 int PMPI_Win_create_dynamic(MPI_Info info, MPI_Comm comm, MPI_Win *win);
 int PMPI_Win_create_errhandler(MPI_Win_errhandler_function *win_errhandler_fn, MPI_Errhandler *errhandler);
-int PMPIX_Win_create_errhandler_x(MPIX_Win_errhandler_function_x *comm_errhandler_fn_x, MPIX_Destructor_function *destructor_fn, void *extra_state, MPI_Errhandler *errhandler);
 int PMPI_Win_create_keyval(MPI_Win_copy_attr_function *win_copy_attr_fn, MPI_Win_delete_attr_function *win_delete_attr_fn, int *win_keyval, void *extra_state);
 int PMPI_Win_delete_attr(MPI_Win win, int win_keyval);
 int PMPI_Win_detach(MPI_Win win, const void *base);

--- a/src/include/Makefile.mk
+++ b/src/include/Makefile.mk
@@ -6,7 +6,7 @@
 # nodist_ b/c these are created by config.status and should not be distributed
 nodist_include_HEADERS += src/include/mpi.h
 
-include_HEADERS += src/include/mpi_proto.h
+include_HEADERS += src/include/mpi_proto.h src/include/mpix.h
 
 ## Internal headers that are created by config.status from a corresponding
 ## ".h.in" file.  This ensures that these files are _not_ distributed, which is

--- a/src/include/mpi.h.in
+++ b/src/include/mpi.h.in
@@ -5,6 +5,7 @@
 
 #ifdef MPI_ABI
 #include "mpi_abi.h"
+#include "mpix.h"
 #else
 
 /* @configure_input@ */
@@ -328,12 +329,6 @@ typedef int MPI_Request;
 
 /* MPI message objects for Mprobe and related functions */
 typedef int MPI_Message;
-
-/* Generalized requests extensions */
-typedef int MPIX_Grequest_class;
-
-/* MPI stream objects */
-typedef int MPIX_Stream;
 
 /* for info */
 typedef int MPI_Info;
@@ -789,11 +784,6 @@ enum MPIR_Combiner_enum {
 
 /* End of MPI's error classes */
 
-/* GPU extensions */
-#define MPIX_GPU_SUPPORT_CUDA  (0)
-#define MPIX_GPU_SUPPORT_ZE    (1)
-#define MPIX_GPU_SUPPORT_HIP   (2)
-
 /* feature advertisement */
 #define MPIIMPL_ADVERTISES_FEATURES 1
 #define MPIIMPL_HAVE_MPI_INFO 1
@@ -805,15 +795,6 @@ enum MPIR_Combiner_enum {
 #define MPIIMPL_HAVE_MPI_GREQUEST 1
 #define MPIIMPL_HAVE_STATUS_SET_BYTES 1
 #define MPIIMPL_HAVE_STATUS_SET_INFO 1
-
-/* MPIX Async extensions */
-/* poll_fn return following states. */
-enum {
-    MPIX_ASYNC_NOPROGRESS = 0,
-    MPIX_ASYNC_DONE = 1,
-};
-
-typedef struct MPIR_Async_thing * MPIX_Async_thing;
 
 #ifndef MPICH_BUILD_MPI_ABI
 /* C callback functions */
@@ -832,11 +813,6 @@ typedef void (MPI_Comm_errhandler_function)(MPI_Comm *, int *, ...);
 typedef void (MPI_File_errhandler_function)(MPI_File *, int *, ...);
 typedef void (MPI_Win_errhandler_function)(MPI_Win *, int *, ...);
 typedef void (MPI_Session_errhandler_function)(MPI_Session *, int *, ...);
-/* the _x callbacks accepts scalar inputs and an additional "void *" extra_state */
-typedef void (MPIX_Comm_errhandler_function_x)(MPI_Comm, int, void *);
-typedef void (MPIX_File_errhandler_function_x)(MPI_File, int, void *);
-typedef void (MPIX_Win_errhandler_function_x)(MPI_Win, int, void *);
-typedef void (MPIX_Session_errhandler_function_x)(MPI_Session, int, void *);
 /* names that were added in MPI-2.0 and deprecated in MPI-2.2 */
 typedef MPI_Comm_errhandler_function MPI_Comm_errhandler_fn;
 typedef MPI_File_errhandler_function MPI_File_errhandler_fn;
@@ -850,20 +826,12 @@ typedef int (MPI_Delete_function) ( MPI_Comm, int, void *, void * );
 /* User combination function */
 typedef void (MPI_User_function) ( void *, void *, int *, MPI_Datatype * );
 typedef void (MPI_User_function_c) ( void *, void *, MPI_Count *, MPI_Datatype * );
-/* the _x callbacks accepts scalar inputs and an additional "void *" extra_state */
-typedef void (MPIX_User_function_x) ( void *, void *, MPI_Count, MPI_Datatype, void *);
-
-/* User destructor */
-typedef void (MPIX_Destructor_function) (void *);
 
 /* Typedefs for generalized requests */
 typedef int (MPI_Grequest_cancel_function)(void *, int);
 typedef int (MPI_Grequest_free_function)(void *);
 typedef int (MPI_Grequest_query_function)(void *, MPI_Status *);
 #endif /* MPICH_BUILD_MPI_ABI */
-typedef int (MPIX_Grequest_poll_function)(void *, MPI_Status *);
-typedef int (MPIX_Grequest_wait_function)(int, void **, double, MPI_Status *);
-typedef int (MPIX_Async_poll_function)(MPIX_Async_thing);
 #ifndef MPICH_BUILD_MPI_ABI
 
 /* Function type defs */
@@ -1044,18 +1012,13 @@ int QMPI_Get_calling_address(QMPI_Context context, void **address) MPICH_API_PUB
 */
 /* --Insert Additional Definitions Here-- */
 
-/* same as struct iovec, provided to avoid header dependency */
-typedef struct MPIX_Iov {
-    void *iov_base;
-    MPI_Aint iov_len;
-} MPIX_Iov;
-
 /*
  * Normally, we provide prototypes for all MPI routines.  In a few weird
  * cases, we need to suppress the prototypes.
  */
 #ifndef MPICH_BUILD_MPI_ABI
 /* We require that the C compiler support prototypes */
+#include <mpix.h>
 #include <mpi_proto.h>
 
 /* The f2c and c2f APIs exist as real functions, but these macros allows

--- a/src/include/mpix.h
+++ b/src/include/mpix.h
@@ -11,6 +11,12 @@
 #define MPIX_GPU_SUPPORT_ZE    (1)
 #define MPIX_GPU_SUPPORT_HIP   (2)
 
+#ifndef MPICH
+#define MPIX_C_FLOAT16    ((MPI_Datatype)0x000002f0)
+#define MPIX_BFLOAT16     ((MPI_Datatype)0x000002f1)
+#define MPIX_EQUAL        ((MPI_Op)0x0000003e)
+#endif
+
 /* Generalized requests extensions */
 typedef int MPIX_Grequest_class;
 /* MPI stream objects */

--- a/src/include/mpix.h
+++ b/src/include/mpix.h
@@ -1,0 +1,333 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef MPIX_H_INCLUDED
+#define MPIX_H_INCLUDED
+
+/* GPU extensions */
+#define MPIX_GPU_SUPPORT_CUDA  (0)
+#define MPIX_GPU_SUPPORT_ZE    (1)
+#define MPIX_GPU_SUPPORT_HIP   (2)
+
+/* Generalized requests extensions */
+typedef int MPIX_Grequest_class;
+/* MPI stream objects */
+typedef int MPIX_Stream;
+
+/* MPIX Async extensions */
+/* poll_fn return following states. */
+enum {
+    MPIX_ASYNC_NOPROGRESS = 0,
+    MPIX_ASYNC_DONE = 1,
+};
+
+typedef struct MPIR_Async_thing *MPIX_Async_thing;
+
+/* same as struct iovec, provided to avoid header dependency */
+typedef struct MPIX_Iov {
+    void *iov_base;
+    MPI_Aint iov_len;
+} MPIX_Iov;
+
+/* the _x callbacks accepts scalar inputs and an additional "void *" extra_state */
+typedef void (MPIX_Comm_errhandler_function_x) (MPI_Comm, int, void *);
+typedef void (MPIX_File_errhandler_function_x) (MPI_File, int, void *);
+typedef void (MPIX_Win_errhandler_function_x) (MPI_Win, int, void *);
+typedef void (MPIX_Session_errhandler_function_x) (MPI_Session, int, void *);
+
+/* the _x callbacks accepts scalar inputs and an additional "void *" extra_state */
+typedef void (MPIX_User_function_x) (void *, void *, MPI_Count, MPI_Datatype, void *);
+
+/* User destructor */
+typedef void (MPIX_Destructor_function) (void *);
+
+typedef int (MPIX_Grequest_poll_function) (void *, MPI_Status *);
+typedef int (MPIX_Grequest_wait_function) (int, void **, double, MPI_Status *);
+typedef int (MPIX_Async_poll_function) (MPIX_Async_thing);
+
+
+int MPI_Address(void *location, MPI_Aint * address);
+int MPI_Type_hindexed(int count, int array_of_blocklengths[], MPI_Aint array_of_displacements[],
+                      MPI_Datatype oldtype, MPI_Datatype * newtype);
+int MPI_Type_hvector(int count, int blocklength, MPI_Aint stride, MPI_Datatype oldtype,
+                     MPI_Datatype * newtype);
+int MPI_Type_struct(int count, int array_of_blocklengths[], MPI_Aint array_of_displacements[],
+                    MPI_Datatype array_of_types[], MPI_Datatype * newtype);
+int MPI_Type_extent(MPI_Datatype datatype, MPI_Aint * extent);
+int MPI_Type_lb(MPI_Datatype datatype, MPI_Aint * displacement);
+int MPI_Type_ub(MPI_Datatype datatype, MPI_Aint * displacement);
+int MPI_Errhandler_create(MPI_Comm_errhandler_function * comm_errhandler_fn,
+                          MPI_Errhandler * errhandler);
+int MPI_Errhandler_get(MPI_Comm comm, MPI_Errhandler * errhandler);
+int MPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler errhandler);
+
+int MPIX_Async_start(MPIX_Async_poll_function * poll_fn, void *extra_state, MPIX_Stream stream);
+int MPIX_Async_spawn(MPIX_Async_thing async_thing, MPIX_Async_poll_function * poll_fn,
+                     void *extra_state, MPIX_Stream stream);
+int MPIX_Op_create_x(MPIX_User_function_x * user_fn_x, MPIX_Destructor_function * destructor_fn,
+                     int commute, void *extra_state, MPI_Op * op);
+int MPIX_Comm_create_errhandler_x(MPIX_Comm_errhandler_function_x * comm_errhandler_fn_x,
+                                  MPIX_Destructor_function * destructor_fn, void *extra_state,
+                                  MPI_Errhandler * errhandler);
+int MPIX_Win_create_errhandler_x(MPIX_Win_errhandler_function_x * comm_errhandler_fn_x,
+                                 MPIX_Destructor_function * destructor_fn, void *extra_state,
+                                 MPI_Errhandler * errhandler);
+int MPIX_File_create_errhandler_x(MPIX_File_errhandler_function_x * comm_errhandler_fn_x,
+                                  MPIX_Destructor_function * destructor_fn, void *extra_state,
+                                  MPI_Errhandler * errhandler);
+int MPIX_Session_create_errhandler_x(MPIX_Session_errhandler_function_x * comm_errhandler_fn_x,
+                                     MPIX_Destructor_function * destructor_fn, void *extra_state,
+                                     MPI_Errhandler * errhandler);
+int MPIX_Comm_create_keyval_x(MPI_Comm_copy_attr_function * comm_copy_attr_fn,
+                              MPI_Comm_delete_attr_function * comm_delete_attr_fn,
+                              MPIX_Destructor_function * destructor_fn, int *comm_keyval,
+                              void *extra_state);
+int MPIX_Type_create_keyval_x(MPI_Type_copy_attr_function * type_copy_attr_fn,
+                              MPI_Type_delete_attr_function * type_delete_attr_fn,
+                              MPIX_Destructor_function * destructor_fn, int *type_keyval,
+                              void *extra_state);
+int MPIX_Win_create_keyval_x(MPI_Win_copy_attr_function * win_copy_attr_fn,
+                             MPI_Win_delete_attr_function * win_delete_attr_fn,
+                             MPIX_Destructor_function * destructor_fn, int *win_keyval,
+                             void *extra_state);
+int MPIX_Comm_get_attr_as_fortran(MPI_Comm comm, int comm_keyval, void *attribute_val, int *flag);
+int MPIX_Comm_set_attr_as_fortran(MPI_Comm comm, int comm_keyval, void *attribute_val);
+int MPIX_Type_get_attr_as_fortran(MPI_Datatype datatype, int type_keyval, void *attribute_val,
+                                  int *flag);
+int MPIX_Type_set_attr_as_fortran(MPI_Datatype datatype, int type_keyval, void *attribute_val);
+int MPIX_Win_get_attr_as_fortran(MPI_Win win, int win_keyval, void *attribute_val, int *flag);
+int MPIX_Win_set_attr_as_fortran(MPI_Win win, int win_keyval, void *attribute_val);
+int MPIX_Comm_test_threadcomm(MPI_Comm comm, int *flag);
+int MPIX_Comm_revoke(MPI_Comm comm);
+int MPIX_Comm_shrink(MPI_Comm comm, MPI_Comm * newcomm);
+int MPIX_Comm_failure_ack(MPI_Comm comm);
+int MPIX_Comm_failure_get_acked(MPI_Comm comm, MPI_Group * failedgrp);
+int MPIX_Comm_agree(MPI_Comm comm, int *flag);
+int MPIX_Comm_get_failed(MPI_Comm comm, MPI_Group * failedgrp);
+int MPIX_Type_iov_len(MPI_Datatype datatype, MPI_Count max_iov_bytes, MPI_Count * iov_len,
+                      MPI_Count * actual_iov_bytes);
+int MPIX_Type_iov(MPI_Datatype datatype, MPI_Count iov_offset, MPIX_Iov * iov,
+                  MPI_Count max_iov_len, MPI_Count * actual_iov_len);
+int MPIX_Info_set_hex(MPI_Info info, const char *key, const void *value, int value_size);
+int MPIX_GPU_query_support(int gpu_type, int *is_supported);
+int MPIX_Query_cuda_support(void);
+int MPIX_Query_ze_support(void);
+int MPIX_Query_hip_support(void);
+int MPIX_Request_is_complete(MPI_Request request);
+int MPIX_Stream_create(MPI_Info info, MPIX_Stream * stream);
+int MPIX_Stream_free(MPIX_Stream * stream);
+int MPIX_Stream_comm_create(MPI_Comm comm, MPIX_Stream stream, MPI_Comm * newcomm);
+int MPIX_Stream_comm_create_multiplex(MPI_Comm comm, int count, MPIX_Stream array_of_streams[],
+                                      MPI_Comm * newcomm);
+int MPIX_Comm_get_stream(MPI_Comm comm, int idx, MPIX_Stream * stream);
+int MPIX_Stream_progress(MPIX_Stream stream);
+int MPIX_Start_progress_thread(MPIX_Stream stream);
+int MPIX_Stop_progress_thread(MPIX_Stream stream);
+int MPIX_Stream_send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
+                     MPI_Comm comm, int source_stream_index, int dest_stream_index);
+int MPIX_Stream_isend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
+                      MPI_Comm comm, int source_stream_index, int dest_stream_index,
+                      MPI_Request * request);
+int MPIX_Stream_recv(void *buf, int count, MPI_Datatype datatype, int source, int tag,
+                     MPI_Comm comm, int source_stream_index, int dest_stream_index,
+                     MPI_Status * status);
+int MPIX_Stream_irecv(void *buf, int count, MPI_Datatype datatype, int source, int tag,
+                      MPI_Comm comm, int source_stream_index, int dest_stream_index,
+                      MPI_Request * request);
+int MPIX_Send_enqueue(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
+                      MPI_Comm comm);
+int MPIX_Recv_enqueue(void *buf, int count, MPI_Datatype datatype, int source, int tag,
+                      MPI_Comm comm, MPI_Status * status);
+int MPIX_Isend_enqueue(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
+                       MPI_Comm comm, MPI_Request * request);
+int MPIX_Irecv_enqueue(void *buf, int count, MPI_Datatype datatype, int source, int tag,
+                       MPI_Comm comm, MPI_Request * request);
+int MPIX_Wait_enqueue(MPI_Request * request, MPI_Status * status);
+int MPIX_Waitall_enqueue(int count, MPI_Request array_of_requests[],
+                         MPI_Status * array_of_statuses);
+int MPIX_Allreduce_enqueue(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                           MPI_Op op, MPI_Comm comm);
+int MPIX_Threadcomm_init(MPI_Comm comm, int num_threads, MPI_Comm * newthreadcomm);
+int MPIX_Threadcomm_free(MPI_Comm * threadcomm);
+int MPIX_Threadcomm_start(MPI_Comm threadcomm);
+int MPIX_Threadcomm_finish(MPI_Comm threadcomm);
+int MPIX_Grequest_start(MPI_Grequest_query_function * query_fn,
+                        MPI_Grequest_free_function * free_fn,
+                        MPI_Grequest_cancel_function * cancel_fn,
+                        MPIX_Grequest_poll_function * poll_fn,
+                        MPIX_Grequest_wait_function * wait_fn, void *extra_state,
+                        MPI_Request * request);
+int MPIX_Grequest_class_create(MPI_Grequest_query_function * query_fn,
+                               MPI_Grequest_free_function * free_fn,
+                               MPI_Grequest_cancel_function * cancel_fn,
+                               MPIX_Grequest_poll_function * poll_fn,
+                               MPIX_Grequest_wait_function * wait_fn,
+                               MPIX_Grequest_class * greq_class);
+int MPIX_Grequest_class_allocate(MPIX_Grequest_class greq_class, void *extra_state,
+                                 MPI_Request * request);
+int MPIX_Stream_send_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag,
+                       MPI_Comm comm, int source_stream_index, int dest_stream_index);
+int MPIX_Stream_isend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag,
+                        MPI_Comm comm, int source_stream_index, int dest_stream_index,
+                        MPI_Request * request);
+int MPIX_Stream_recv_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag,
+                       MPI_Comm comm, int source_stream_index, int dest_stream_index,
+                       MPI_Status * status);
+int MPIX_Stream_irecv_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag,
+                        MPI_Comm comm, int source_stream_index, int dest_stream_index,
+                        MPI_Request * request);
+int MPIX_Send_enqueue_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag,
+                        MPI_Comm comm);
+int MPIX_Recv_enqueue_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag,
+                        MPI_Comm comm, MPI_Status * status);
+int MPIX_Isend_enqueue_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag,
+                         MPI_Comm comm, MPI_Request * request);
+int MPIX_Irecv_enqueue_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag,
+                         MPI_Comm comm, MPI_Request * request);
+int MPIX_Allreduce_enqueue_c(const void *sendbuf, void *recvbuf, MPI_Count count,
+                             MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+
+int PMPI_Address(void *location, MPI_Aint * address);
+int PMPI_Type_hindexed(int count, int array_of_blocklengths[], MPI_Aint array_of_displacements[],
+                       MPI_Datatype oldtype, MPI_Datatype * newtype);
+int PMPI_Type_hvector(int count, int blocklength, MPI_Aint stride, MPI_Datatype oldtype,
+                      MPI_Datatype * newtype);
+int PMPI_Type_struct(int count, int array_of_blocklengths[], MPI_Aint array_of_displacements[],
+                     MPI_Datatype array_of_types[], MPI_Datatype * newtype);
+int PMPI_Type_extent(MPI_Datatype datatype, MPI_Aint * extent);
+int PMPI_Type_lb(MPI_Datatype datatype, MPI_Aint * displacement);
+int PMPI_Type_ub(MPI_Datatype datatype, MPI_Aint * displacement);
+int PMPI_Errhandler_create(MPI_Comm_errhandler_function * comm_errhandler_fn,
+                           MPI_Errhandler * errhandler);
+int PMPI_Errhandler_get(MPI_Comm comm, MPI_Errhandler * errhandler);
+int PMPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler errhandler);
+
+int PMPIX_Async_start(MPIX_Async_poll_function * poll_fn, void *extra_state, MPIX_Stream stream);
+int PMPIX_Async_spawn(MPIX_Async_thing async_thing, MPIX_Async_poll_function * poll_fn,
+                      void *extra_state, MPIX_Stream stream);
+int PMPIX_Op_create_x(MPIX_User_function_x * user_fn_x, MPIX_Destructor_function * destructor_fn,
+                      int commute, void *extra_state, MPI_Op * op);
+int PMPIX_Comm_create_errhandler_x(MPIX_Comm_errhandler_function_x * comm_errhandler_fn_x,
+                                   MPIX_Destructor_function * destructor_fn, void *extra_state,
+                                   MPI_Errhandler * errhandler);
+int PMPIX_Win_create_errhandler_x(MPIX_Win_errhandler_function_x * comm_errhandler_fn_x,
+                                  MPIX_Destructor_function * destructor_fn, void *extra_state,
+                                  MPI_Errhandler * errhandler);
+int PMPIX_File_create_errhandler_x(MPIX_File_errhandler_function_x * comm_errhandler_fn_x,
+                                   MPIX_Destructor_function * destructor_fn, void *extra_state,
+                                   MPI_Errhandler * errhandler);
+int PMPIX_Session_create_errhandler_x(MPIX_Session_errhandler_function_x * comm_errhandler_fn_x,
+                                      MPIX_Destructor_function * destructor_fn, void *extra_state,
+                                      MPI_Errhandler * errhandler);
+int PMPIX_Comm_create_keyval_x(MPI_Comm_copy_attr_function * comm_copy_attr_fn,
+                               MPI_Comm_delete_attr_function * comm_delete_attr_fn,
+                               MPIX_Destructor_function * destructor_fn, int *comm_keyval,
+                               void *extra_state);
+int PMPIX_Type_create_keyval_x(MPI_Type_copy_attr_function * type_copy_attr_fn,
+                               MPI_Type_delete_attr_function * type_delete_attr_fn,
+                               MPIX_Destructor_function * destructor_fn, int *type_keyval,
+                               void *extra_state);
+int PMPIX_Win_create_keyval_x(MPI_Win_copy_attr_function * win_copy_attr_fn,
+                              MPI_Win_delete_attr_function * win_delete_attr_fn,
+                              MPIX_Destructor_function * destructor_fn, int *win_keyval,
+                              void *extra_state);
+int PMPIX_Comm_get_attr_as_fortran(MPI_Comm comm, int comm_keyval, void *attribute_val, int *flag);
+int PMPIX_Comm_set_attr_as_fortran(MPI_Comm comm, int comm_keyval, void *attribute_val);
+int PMPIX_Type_get_attr_as_fortran(MPI_Datatype datatype, int type_keyval, void *attribute_val,
+                                   int *flag);
+int PMPIX_Type_set_attr_as_fortran(MPI_Datatype datatype, int type_keyval, void *attribute_val);
+int PMPIX_Win_get_attr_as_fortran(MPI_Win win, int win_keyval, void *attribute_val, int *flag);
+int PMPIX_Win_set_attr_as_fortran(MPI_Win win, int win_keyval, void *attribute_val);
+int PMPIX_Comm_test_threadcomm(MPI_Comm comm, int *flag);
+int PMPIX_Comm_revoke(MPI_Comm comm);
+int PMPIX_Comm_shrink(MPI_Comm comm, MPI_Comm * newcomm);
+int PMPIX_Comm_failure_ack(MPI_Comm comm);
+int PMPIX_Comm_failure_get_acked(MPI_Comm comm, MPI_Group * failedgrp);
+int PMPIX_Comm_agree(MPI_Comm comm, int *flag);
+int PMPIX_Comm_get_failed(MPI_Comm comm, MPI_Group * failedgrp);
+int PMPIX_Type_iov_len(MPI_Datatype datatype, MPI_Count max_iov_bytes, MPI_Count * iov_len,
+                       MPI_Count * actual_iov_bytes);
+int PMPIX_Type_iov(MPI_Datatype datatype, MPI_Count iov_offset, MPIX_Iov * iov,
+                   MPI_Count max_iov_len, MPI_Count * actual_iov_len);
+int PMPIX_Info_set_hex(MPI_Info info, const char *key, const void *value, int value_size);
+int PMPIX_GPU_query_support(int gpu_type, int *is_supported);
+int PMPIX_Query_cuda_support(void);
+int PMPIX_Query_ze_support(void);
+int PMPIX_Query_hip_support(void);
+int PMPIX_Request_is_complete(MPI_Request request);
+int PMPIX_Stream_create(MPI_Info info, MPIX_Stream * stream);
+int PMPIX_Stream_free(MPIX_Stream * stream);
+int PMPIX_Stream_comm_create(MPI_Comm comm, MPIX_Stream stream, MPI_Comm * newcomm);
+int PMPIX_Stream_comm_create_multiplex(MPI_Comm comm, int count, MPIX_Stream array_of_streams[],
+                                       MPI_Comm * newcomm);
+int PMPIX_Comm_get_stream(MPI_Comm comm, int idx, MPIX_Stream * stream);
+int PMPIX_Stream_progress(MPIX_Stream stream);
+int PMPIX_Start_progress_thread(MPIX_Stream stream);
+int PMPIX_Stop_progress_thread(MPIX_Stream stream);
+int PMPIX_Stream_send(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
+                      MPI_Comm comm, int source_stream_index, int dest_stream_index);
+int PMPIX_Stream_isend(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
+                       MPI_Comm comm, int source_stream_index, int dest_stream_index,
+                       MPI_Request * request);
+int PMPIX_Stream_recv(void *buf, int count, MPI_Datatype datatype, int source, int tag,
+                      MPI_Comm comm, int source_stream_index, int dest_stream_index,
+                      MPI_Status * status);
+int PMPIX_Stream_irecv(void *buf, int count, MPI_Datatype datatype, int source, int tag,
+                       MPI_Comm comm, int source_stream_index, int dest_stream_index,
+                       MPI_Request * request);
+int PMPIX_Send_enqueue(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
+                       MPI_Comm comm);
+int PMPIX_Recv_enqueue(void *buf, int count, MPI_Datatype datatype, int source, int tag,
+                       MPI_Comm comm, MPI_Status * status);
+int PMPIX_Isend_enqueue(const void *buf, int count, MPI_Datatype datatype, int dest, int tag,
+                        MPI_Comm comm, MPI_Request * request);
+int PMPIX_Irecv_enqueue(void *buf, int count, MPI_Datatype datatype, int source, int tag,
+                        MPI_Comm comm, MPI_Request * request);
+int PMPIX_Wait_enqueue(MPI_Request * request, MPI_Status * status);
+int PMPIX_Waitall_enqueue(int count, MPI_Request array_of_requests[],
+                          MPI_Status * array_of_statuses);
+int PMPIX_Allreduce_enqueue(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
+                            MPI_Op op, MPI_Comm comm);
+int PMPIX_Threadcomm_init(MPI_Comm comm, int num_threads, MPI_Comm * newthreadcomm);
+int PMPIX_Threadcomm_free(MPI_Comm * threadcomm);
+int PMPIX_Threadcomm_start(MPI_Comm threadcomm);
+int PMPIX_Threadcomm_finish(MPI_Comm threadcomm);
+int PMPIX_Grequest_start(MPI_Grequest_query_function * query_fn,
+                         MPI_Grequest_free_function * free_fn,
+                         MPI_Grequest_cancel_function * cancel_fn,
+                         MPIX_Grequest_poll_function * poll_fn,
+                         MPIX_Grequest_wait_function * wait_fn, void *extra_state,
+                         MPI_Request * request);
+int PMPIX_Grequest_class_create(MPI_Grequest_query_function * query_fn,
+                                MPI_Grequest_free_function * free_fn,
+                                MPI_Grequest_cancel_function * cancel_fn,
+                                MPIX_Grequest_poll_function * poll_fn,
+                                MPIX_Grequest_wait_function * wait_fn,
+                                MPIX_Grequest_class * greq_class);
+int PMPIX_Grequest_class_allocate(MPIX_Grequest_class greq_class, void *extra_state,
+                                  MPI_Request * request);
+int PMPIX_Stream_send_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest,
+                        int tag, MPI_Comm comm, int source_stream_index, int dest_stream_index);
+int PMPIX_Stream_isend_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag,
+                         MPI_Comm comm, int source_stream_index, int dest_stream_index,
+                         MPI_Request * request);
+int PMPIX_Stream_recv_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag,
+                        MPI_Comm comm, int source_stream_index, int dest_stream_index,
+                        MPI_Status * status);
+int PMPIX_Stream_irecv_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag,
+                         MPI_Comm comm, int source_stream_index, int dest_stream_index,
+                         MPI_Request * request);
+int PMPIX_Send_enqueue_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest, int tag,
+                         MPI_Comm comm);
+int PMPIX_Recv_enqueue_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag,
+                         MPI_Comm comm, MPI_Status * status);
+int PMPIX_Isend_enqueue_c(const void *buf, MPI_Count count, MPI_Datatype datatype, int dest,
+                          int tag, MPI_Comm comm, MPI_Request * request);
+int PMPIX_Irecv_enqueue_c(void *buf, MPI_Count count, MPI_Datatype datatype, int source, int tag,
+                          MPI_Comm comm, MPI_Request * request);
+int PMPIX_Allreduce_enqueue_c(const void *sendbuf, void *recvbuf, MPI_Count count,
+                              MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
+
+#endif /* MPIX_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description
The binding layers will include legacy and MPIX functions, which are not declared in mpi_abi.h. This breaks the macos builds since we switched to support weak symbols without aliases. It currently require we predeclare PMPI prototypes as we call the PMPI function in the MPI stubs. Although we could fix it by changing the order of the function definitions, it is simpler and more robust to include mpix functions in the header.

This commit adds src/include/mpix.h, which lists all functions that are not included in a standard mpi_abi.h. In autogen, maint/gen_abi.py will load mpix.h and dump prototypes into mpi_abi_internal.h so MPICH can build.

In TODO, we will expose mpix.h so users can optionally access mpix functions even with a MPI ABI build.


[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
