### PR TITLE
ch4/ofi: update default capability based on fi_getinfo

### DIFF
--- a/src/mpid/ch4/netmod/ofi/init_provider.c
+++ b/src/mpid/ch4/netmod/ofi/init_provider.c
@@ -134,7 +134,7 @@ static int find_provider(struct fi_info **prov_out)
         const char *provname = NULL;
         provname = prov->fabric_attr->prov_name;
         /* Initialize MPIDI_OFI_global.settings */
-        MPIDI_OFI_init_settings(&MPIDI_OFI_global.settings, provname);
+        MPIDI_OFI_init_settings(&MPIDI_OFI_global.settings, provname, prov);
         /* The presets may have non-default minimum version requirement */
         required_version = MPIDI_OFI_get_required_version();
         if (MPIR_CVAR_DEBUG_SUMMARY && MPIR_Process.rank == 0) {
@@ -296,8 +296,8 @@ static int provider_preference(const char *prov_name)
 static struct fi_info *pick_provider_from_list(struct fi_info *list)
 {
     MPIDI_OFI_capabilities_t optimal_settings, minimal_settings;
-    MPIDI_OFI_init_settings(&optimal_settings, MPIDI_OFI_SET_NAME_DEFAULT);
-    MPIDI_OFI_init_settings(&minimal_settings, MPIDI_OFI_SET_NAME_MINIMAL);
+    MPIDI_OFI_init_settings(&optimal_settings, MPIDI_OFI_SET_NAME_DEFAULT, NULL);
+    MPIDI_OFI_init_settings(&minimal_settings, MPIDI_OFI_SET_NAME_MINIMAL, NULL);
 
     int best_score = INT_MIN;
     struct fi_info *best_prov = NULL;

--- a/src/mpid/ch4/netmod/ofi/init_provider.c
+++ b/src/mpid/ch4/netmod/ofi/init_provider.c
@@ -112,6 +112,12 @@ static int find_provider(struct fi_info **prov_out)
                 "instead\n");
     }
 
+    /* if we do runtime detection, initialize global settings.{major,minor}_version from CVARs */
+#ifdef MPIDI_CH4_OFI_USE_SET_RUNTIME
+    MPIDI_OFI_MAJOR_VERSION = MPIR_CVAR_CH4_OFI_MAJOR_VERSION;
+    MPIDI_OFI_MINOR_VERSION = MPIR_CVAR_CH4_OFI_MINOR_VERSION;
+#endif
+
     int required_version = MPIDI_OFI_get_required_version();
     if (MPIR_CVAR_DEBUG_SUMMARY && MPIR_Process.rank == 0) {
         printf("Required minimum FI_VERSION: %x, current version: %x\n", required_version,

--- a/src/mpid/ch4/netmod/ofi/init_settings.c
+++ b/src/mpid/ch4/netmod/ofi/init_settings.c
@@ -263,10 +263,18 @@ void MPIDI_OFI_set_auto_progress(struct fi_info *hints)
 #define UPDATE_SETTING_BY_CAP(cap, CVAR) \
     p_settings->cap = (CVAR != -1) ? CVAR : prov_caps->cap
 
-void MPIDI_OFI_init_settings(MPIDI_OFI_capabilities_t * p_settings, const char *prov_name)
+void MPIDI_OFI_init_settings(MPIDI_OFI_capabilities_t * p_settings, const char *prov_name,
+                             struct fi_info *prov)
 {
     int prov_idx = MPIDI_OFI_get_set_number(prov_name);
     MPIDI_OFI_capabilities_t *prov_caps = &MPIDI_OFI_caps_list[prov_idx];
+    if (prov_idx == MPIDI_OFI_SET_NUMBER_DEFAULT && prov) {
+        /* update some default settings based on capabilities provided by the provider */
+        prov_caps->enable_mr_virt_address = (prov->domain_attr->mr_mode & FI_MR_VIRT_ADDR) ? 1 : 0;
+        prov_caps->enable_mr_prov_key = (prov->domain_attr->mr_mode & FI_MR_PROV_KEY) ? 1 : 0;
+        prov_caps->enable_mr_allocated = (prov->domain_attr->mr_mode & FI_MR_ALLOCATED) ? 1 : 0;
+        prov_caps->enable_mr_hmem = (prov->domain_attr->mr_mode & FI_MR_HMEM) ? 1 : 0;
+    }
 
     memset(p_settings, 0, sizeof(MPIDI_OFI_capabilities_t));
 

--- a/src/mpid/ch4/netmod/ofi/init_settings.c
+++ b/src/mpid/ch4/netmod/ofi/init_settings.c
@@ -270,10 +270,21 @@ void MPIDI_OFI_init_settings(MPIDI_OFI_capabilities_t * p_settings, const char *
     MPIDI_OFI_capabilities_t *prov_caps = &MPIDI_OFI_caps_list[prov_idx];
     if (prov_idx == MPIDI_OFI_SET_NUMBER_DEFAULT && prov) {
         /* update some default settings based on capabilities provided by the provider */
-        prov_caps->enable_mr_virt_address = (prov->domain_attr->mr_mode & FI_MR_VIRT_ADDR) ? 1 : 0;
-        prov_caps->enable_mr_prov_key = (prov->domain_attr->mr_mode & FI_MR_PROV_KEY) ? 1 : 0;
-        prov_caps->enable_mr_allocated = (prov->domain_attr->mr_mode & FI_MR_ALLOCATED) ? 1 : 0;
-        prov_caps->enable_mr_hmem = (prov->domain_attr->mr_mode & FI_MR_HMEM) ? 1 : 0;
+        if (MPIDI_OFI_get_required_version() >= FI_VERSION(1, 5)) {
+#ifdef FI_MR_VIRT_ADDR
+            prov_caps->enable_mr_virt_address =
+                (prov->domain_attr->mr_mode & FI_MR_VIRT_ADDR) ? 1 : 0;
+            prov_caps->enable_mr_prov_key = (prov->domain_attr->mr_mode & FI_MR_PROV_KEY) ? 1 : 0;
+            prov_caps->enable_mr_allocated = (prov->domain_attr->mr_mode & FI_MR_ALLOCATED) ? 1 : 0;
+            prov_caps->enable_mr_hmem = (prov->domain_attr->mr_mode & FI_MR_HMEM) ? 1 : 0;
+#endif
+        } else {
+            if (prov->domain_attr->mr_mode & FI_MR_BASIC) {
+                prov_caps->enable_mr_virt_address = 1;
+                prov_caps->enable_mr_prov_key = 1;
+                prov_caps->enable_mr_allocated = 1;
+            }
+        }
     }
 
     memset(p_settings, 0, sizeof(MPIDI_OFI_capabilities_t));

--- a/src/mpid/ch4/netmod/ofi/init_settings.c
+++ b/src/mpid/ch4/netmod/ofi/init_settings.c
@@ -174,9 +174,9 @@ int MPIDI_OFI_init_hints(struct fi_info *hints)
         hints->domain_attr->mr_mode |= FI_MR_ENDPOINT;
 #endif
     } else {
-        /* In old versions FI_MR_BASIC is equivallent to set
+        /* In old versions FI_MR_BASIC is equivalent to set
          * FI_MR_VIRT_ADDR, FI_MR_PROV_KEY, and FI_MR_ALLOCATED on.
-         * FI_MR_SCALABLE is equivallent to all bits off in newer versions.
+         * FI_MR_SCALABLE is equivalent to all bits off in newer versions.
          */
         MPIR_Assert(MPIDI_OFI_ENABLE_MR_VIRT_ADDRESS == MPIDI_OFI_ENABLE_MR_PROV_KEY);
         MPIR_Assert(MPIDI_OFI_ENABLE_MR_VIRT_ADDRESS == MPIDI_OFI_ENABLE_MR_ALLOCATED);
@@ -387,7 +387,7 @@ void MPIDI_OFI_update_global_settings(struct fi_info *prov)
                            prov->domain_attr->max_ep_tx_ctx > 1 &&
                            (prov->caps & FI_NAMED_RX_CTX) == FI_NAMED_RX_CTX);
     /* NOTE: As of OFI version 1.5, FI_MR_SCALABLE and FI_MR_BASIC are deprecated.
-     * FI_MR_BASIC is equivallent to FI_MR_VIRT_ADDR|FI_MR_ALLOCATED|FI_MR_PROV_KEY */
+     * FI_MR_BASIC is equivalent to FI_MR_VIRT_ADDR|FI_MR_ALLOCATED|FI_MR_PROV_KEY */
 #if FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION) < FI_VERSION(1, 5)
     UPDATE_SETTING_BY_INFO_DIRECT(enable_mr_virt_address,
                                   prov->domain_attr->mr_mode & (FI_MR_VIRT_ADDR | FI_MR_BASIC));

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -20,7 +20,8 @@ int MPIDI_OFI_init_hints(struct fi_info *hints);
 void MPIDI_OFI_set_auto_progress(struct fi_info *hints);
 
 /* set settings based on provider-set */
-void MPIDI_OFI_init_settings(MPIDI_OFI_capabilities_t * p_settings, const char *prov_name);
+void MPIDI_OFI_init_settings(MPIDI_OFI_capabilities_t * p_settings, const char *prov_name,
+                             struct fi_info *prov);
 
 /* whether prov matches settings, return a score */
 int MPIDI_OFI_match_provider(struct fi_info *prov,


### PR DESCRIPTION
## Pull Request Description
Libfabric info hints works two ways. Some hints are from MPICH to tell libfabric what we need; some hints are provider telling us what they support. In particular, the mr capabilities are mostly provider telling us their requirement.

Traditionally we use hard-coded capability set. But when there is no hard-coded set, it falls back to the default set, which may not match provider requirement. In the long run, we want to deprecate hard coding capability set and rely on runtime checks.

When we fallback to default capability set, update the settings based on provider hints. For now, we just check mr capabilities. We can add more once we discover additional requirement-nature capabilites.

Fixes #7853
[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
