### PR TITLE
config: prevent AC_PROG_CC add -std=gnu23 to CC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -670,6 +670,11 @@ AC_CANONICAL_TARGET
 # We also need to do this before the F77 and FC test to ensure that we
 # find the C preprocessor reliably.
 AC_PROG_CC
+
+# Modern autoconf aggressively probe gnu std support and will append (e.g.) -std=gnu23 to $CC
+# Since $CC will be used in mpicc and we don't want to force the gnu behavior on to user, let's strip it.
+CC=$(echo "$CC" | sed 's/ -std=[^ ]*//g')
+
 AM_PROG_CC_C_O dnl needed for automake "silent-rules"
 PAC_PUSH_FLAG([CFLAGS])
 AC_PROG_CPP


### PR DESCRIPTION
## Pull Request Description
The modern autoconf aggressively probe in AC_PROG_CC and, if supported, will set e.g. CC=gcc -std=gnu23. This is annoying since we use $CC in mpicc, and user may not want to force the -std compliance in _their_ project.

Let's strip it for now.


Fixes #7845 
[skip warnings]



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
