### PR TITLE
ch4/ofi: fix msg descriptor passing for GPU RMA operations

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -114,7 +114,7 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, MPI_Aint origin_count,
 
         msg_len = MPL_MIN(origin_iov[origin_cur].iov_len, target_iov[target_cur].iov_len);
 
-        msg.desc = desc;
+        msg.desc = &desc;
         msg.addr = MPIDI_OFI_av_to_phys(addr, vci, 0, vci_target, nic_target);
         msg.context = NULL;
         msg.data = 0;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -271,7 +271,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         if (MPL_gpu_attr_is_strict_dev(&attr))
             MPIDI_OFI_gpu_rma_register(iov.iov_base, iov.iov_len, &attr, win, nic_target, &desc);
 
-        msg.desc = desc;
+        msg.desc = &desc;
         msg.addr = MPIDI_OFI_av_to_phys(addr, vci, 0, vci_target, nic_target);
         msg.context = NULL;
         msg.data = 0;
@@ -448,7 +448,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         if (MPL_gpu_attr_is_strict_dev(&attr))
             MPIDI_OFI_gpu_rma_register(iov.iov_base, iov.iov_len, NULL, win, nic_target, &desc);
 
-        msg.desc = desc;
+        msg.desc = &desc;
         msg.msg_iov = &iov;
         msg.iov_count = 1;
         msg.addr = MPIDI_OFI_av_to_phys(addr, vci, 0, vci_target, nic_target);
@@ -677,7 +677,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     MPIDI_OFI_gpu_rma_register(resultv.addr, dt_size, NULL, win, nic_target, &result_desc);
 
     msg.msg_iov = &originv;
-    msg.desc = desc;
+    msg.desc = &desc;
     msg.iov_count = 1;
     msg.addr = MPIDI_OFI_av_to_phys(av, vci, 0, vci_target, nic_target);
     msg.rma_iov = &targetv;
@@ -803,7 +803,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
                                    &desc);
 
         msg.msg_iov = &originv;
-        msg.desc = desc;
+        msg.desc = &desc;
         msg.iov_count = 1;
         msg.addr = MPIDI_OFI_av_to_phys(addr, vci, 0, vci_target, nic_target);
         msg.rma_iov = &targetv;
@@ -949,7 +949,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
                                    &result_desc);
 
         msg.msg_iov = &originv;
-        msg.desc = desc;
+        msg.desc = &desc;
         msg.iov_count = 1;
         msg.addr = MPIDI_OFI_av_to_phys(addr, vci, 0, vci_target, nic_target);
         msg.rma_iov = &targetv;


### PR DESCRIPTION
The fi_msg_rma and fi_msg_atomic structs declare their desc field as void** (pointer to an array of descriptors). The RMA code was assigning the descriptor value directly (void*) rather than a pointer to it, causing the provider to dereference the descriptor as if it were an array and read garbage from the internal MR struct.

This manifested as a SIGSEGV when using fi_readmsg or fi_writemsg with GPU memory buffers, since the provider would interpret the first bytes of the MR object as a descriptor pointer.

The bug was latent for host memory because desc is NULL in that case, and only triggered when HMEM memory registration produces a non-NULL descriptor. Point-to-point GPU operations were unaffected because they use fi_tsend/fi_trecv which take void* desc directly.

Fix by passing &desc instead of desc for all msg-based RMA and atomic operations.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
