### PR TITLE
autogen.sh: Use "command -v" instead of "which"

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -736,7 +736,7 @@ EOF
 
 fn_check_bash_find_patch_xargs() {
     echo_n "Checking for bash... "
-    if test "`which bash 2>&1 > /dev/null ; echo $?`" = "0" ;then
+    if test "`command -v bash 2>&1 > /dev/null ; echo $?`" = "0" ;then
         echo "done"
     else
         echo "bash not found" ;


### PR DESCRIPTION
## Pull Request Description

`which` is not a internal command so systems without `which` installed will report error when executing `./autogen.sh`.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
