### PR TITLE
ch4/ofi: skip inject path when memory registration is required

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -352,7 +352,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
     }
 
     if (MPIR_CVAR_CH4_OFI_ENABLE_INJECT && !syncflag && !is_init &&
-        (data_sz <= MPIDI_OFI_global.max_buffered_send)) {
+        (data_sz <= MPIDI_OFI_global.max_buffered_send) && !need_mr) {
         do_inject = true;
     }
 
@@ -386,7 +386,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
     match_bits = MPIDI_OFI_init_sendtag(comm->context_id + context_offset, comm->rank, tag);
 
     if (MPIR_CVAR_CH4_OFI_ENABLE_INJECT && !syncflag && !is_am &&
-        (data_sz <= MPIDI_OFI_global.max_buffered_send)) {
+        (data_sz <= MPIDI_OFI_global.max_buffered_send) && !need_mr) {
         /* inject path */
         void *pack_buf = NULL;
 #define MPIDI_OFI_LOCAL_PACK_BUF_SIZE 1024


### PR DESCRIPTION
The inject path (fi_tinject/fi_inject) does not accept a memory descriptor parameter. When HMEM memory registration is required (need_mr is set), the send must go through the regular fi_tsend path which can pass the descriptor for the registered device buffer.

Without this fix, GPU buffers small enough to fit within max_buffered_send would incorrectly take the inject path, bypassing the memory registration needed for device memory access.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
