### PR TITLE
Fix bugs related to MR management

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -114,7 +114,7 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, MPI_Aint origin_count,
 
         msg_len = MPL_MIN(origin_iov[origin_cur].iov_len, target_iov[target_cur].iov_len);
 
-        msg.desc = desc;
+        msg.desc = &desc;
         msg.addr = MPIDI_OFI_av_to_phys(addr, vci, 0, vci_target, nic_target);
         msg.context = NULL;
         msg.data = 0;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -271,7 +271,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         if (MPL_gpu_attr_is_strict_dev(&attr))
             MPIDI_OFI_gpu_rma_register(iov.iov_base, iov.iov_len, &attr, win, nic_target, &desc);
 
-        msg.desc = desc;
+        msg.desc = &desc;
         msg.addr = MPIDI_OFI_av_to_phys(addr, vci, 0, vci_target, nic_target);
         msg.context = NULL;
         msg.data = 0;
@@ -448,7 +448,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         if (MPL_gpu_attr_is_strict_dev(&attr))
             MPIDI_OFI_gpu_rma_register(iov.iov_base, iov.iov_len, NULL, win, nic_target, &desc);
 
-        msg.desc = desc;
+        msg.desc = &desc;
         msg.msg_iov = &iov;
         msg.iov_count = 1;
         msg.addr = MPIDI_OFI_av_to_phys(addr, vci, 0, vci_target, nic_target);
@@ -677,7 +677,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_NM_mpi_compare_and_swap(const void *origin_ad
     MPIDI_OFI_gpu_rma_register(resultv.addr, dt_size, NULL, win, nic_target, &result_desc);
 
     msg.msg_iov = &originv;
-    msg.desc = desc;
+    msg.desc = &desc;
     msg.iov_count = 1;
     msg.addr = MPIDI_OFI_av_to_phys(av, vci, 0, vci_target, nic_target);
     msg.rma_iov = &targetv;
@@ -803,7 +803,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_accumulate(const void *origin_addr,
                                    &desc);
 
         msg.msg_iov = &originv;
-        msg.desc = desc;
+        msg.desc = &desc;
         msg.iov_count = 1;
         msg.addr = MPIDI_OFI_av_to_phys(addr, vci, 0, vci_target, nic_target);
         msg.rma_iov = &targetv;
@@ -949,7 +949,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get_accumulate(const void *origin_addr
                                    &result_desc);
 
         msg.msg_iov = &originv;
-        msg.desc = desc;
+        msg.desc = &desc;
         msg.iov_count = 1;
         msg.addr = MPIDI_OFI_av_to_phys(addr, vci, 0, vci_target, nic_target);
         msg.rma_iov = &targetv;

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -352,7 +352,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
     }
 
     if (MPIR_CVAR_CH4_OFI_ENABLE_INJECT && !syncflag && !is_init &&
-        (data_sz <= MPIDI_OFI_global.max_buffered_send)) {
+        (data_sz <= MPIDI_OFI_global.max_buffered_send) && !need_mr) {
         do_inject = true;
     }
 
@@ -386,7 +386,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
     match_bits = MPIDI_OFI_init_sendtag(comm->context_id + context_offset, comm->rank, tag);
 
     if (MPIR_CVAR_CH4_OFI_ENABLE_INJECT && !syncflag && !is_am &&
-        (data_sz <= MPIDI_OFI_global.max_buffered_send)) {
+        (data_sz <= MPIDI_OFI_global.max_buffered_send) && !need_mr) {
         /* inject path */
         void *pack_buf = NULL;
 #define MPIDI_OFI_LOCAL_PACK_BUF_SIZE 1024


### PR DESCRIPTION
## Pull Request Description
In testing against libfabric EFA provider, we hit several issues with HMEM:
 - Attempting inject path with HMEM buffers
 - Passing `void*` instead of `void**` as `desc` field
This fixes both issues.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
