### PR TITLE
configure: misc typo fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -54,9 +54,6 @@ external_subdirs = @mpl_srcdir@ @hwloc_srcdir@ @json_srcdir@ @yaksa_srcdir@ @pmi
 external_ldflags = @RPATHS@
 external_libs = @WRAPPER_LIBS@
 
-ROMIO_TEST_MPIEXEC = @ROMIO_TEST_MPIEXEC@
-export ROMIO_TEST_MPIEXEC
-
 # convenience libs that do not depend on MPI
 pmpi_convenience_libs = @mpl_lib@ @hwloc_lib@ @json_lib@ @yaksa_lib@ @pmi_lib@
 

--- a/configure.ac
+++ b/configure.ac
@@ -675,7 +675,8 @@ AC_PROG_CC
 
 # Modern autoconf aggressively probe gnu std support and will append (e.g.) -std=gnu23 to $CC
 # Since $CC will be used in mpicc and we don't want to force the gnu behavior on to user, let's strip it.
-CC=$(echo "$CC" | sed 's/ -std=[^ ]*//g')
+# NOTE: brackets are autoconf quotes, thus reqires quote protection.
+CC=$(echo "$CC" | sed 's/ -std=[[^ ]]*//g')
 
 AM_PROG_CC_C_O dnl needed for automake "silent-rules"
 PAC_PUSH_FLAG([CFLAGS])

--- a/configure.ac
+++ b/configure.ac
@@ -1412,16 +1412,6 @@ if test "$with_cross" != "no" ; then
     fi
 fi
 
-# This goes here because we need the top_srcdir
-if test "$enable_romio" = "yes" ; then
-    AC_DEFINE(HAVE_ROMIO,1,[Define if ROMIO is enabled])
-
-    m4_define([romio_embedded_dir], [src/mpi/romio])
-    PAC_CONFIG_ROMIO
-fi
-AC_SUBST(ROMIO_VERSION)
-
-AM_CONDITIONAL([BUILD_ROMIO], [test x$enable_romio = xyes])
 #
 # FIXME: If an external device, don't necessarily complain (e.g.,
 # if the device is already built)
@@ -1570,24 +1560,22 @@ fi
 pm_name=$first_pm_name
 AC_SUBST(pm_name)
 
-# Legacy ROMIO tests run before the configured installation prefix is
-# populated.  Use the primary process manager built in this tree instead of
-# the future $(bindir)/mpiexec path.
+# export TEST_MPIEXEC so subdirs (ROMIO) can run pre-install tests
 case "$pm_name" in
   hydra)
-    ROMIO_TEST_MPIEXEC="${main_top_builddir}/src/pm/hydra/mpiexec.hydra"
+    TEST_MPIEXEC="${main_top_builddir}/src/pm/hydra/mpiexec.hydra"
     ;;
   gforker)
-    ROMIO_TEST_MPIEXEC="${main_top_builddir}/src/pm/gforker/mpiexec"
+    TEST_MPIEXEC="${main_top_builddir}/src/pm/gforker/mpiexec"
     ;;
   remshell)
-    ROMIO_TEST_MPIEXEC="${main_top_builddir}/src/pm/remshell/mpiexec"
+    TEST_MPIEXEC="${main_top_builddir}/src/pm/remshell/mpiexec"
     ;;
   *)
-    ROMIO_TEST_MPIEXEC=""
+    TEST_MPIEXEC=
     ;;
 esac
-AC_SUBST(ROMIO_TEST_MPIEXEC)
+export TEST_MPIEXEC
 
 dnl
 dnl gforker and remshell does not use separate configure. 
@@ -1688,6 +1676,17 @@ fi
 if test "$enable_pmix" = "yes"; then
     AC_DEFINE([ENABLE_PMIX], 1, [Define to enable PMIX protocol])
 fi
+
+# -----------------------------------
+if test "$enable_romio" = "yes" ; then
+    AC_DEFINE(HAVE_ROMIO,1,[Define if ROMIO is enabled])
+
+    m4_define([romio_embedded_dir], [src/mpi/romio])
+    PAC_CONFIG_ROMIO
+fi
+AC_SUBST(ROMIO_VERSION)
+
+AM_CONDITIONAL([BUILD_ROMIO], [test x$enable_romio = xyes])
 
 # ---------------------------------------------------------------------------
 # Check for whether the compiler defines a symbol that contains the

--- a/src/include/mpir_comm.h
+++ b/src/include/mpir_comm.h
@@ -126,7 +126,7 @@ struct MPIR_Comm {
     const char *stringtag;      /* A string tag used to support multi-threaded MPI_Comm_create_from_group */
     struct MPIR_CCLcomm *cclcomm;       /* Not NULL only if CCL subcommunication is enabled */
 
-    /* -- unset unless (attr | MPIR_COMM_ATTR__HIERARCHY) -- */
+    /* -- unset unless (attr & MPIR_COMM_ATTR__HIERARCHY) -- */
     int hierarchy_flags;        /* bit flags for hierarchy characteristics. See bit definitions below. */
     int local_rank;
     int num_local;
@@ -344,7 +344,7 @@ MPL_STATIC_INLINE_PREFIX int MPIR_Stream_comm_set_attr(MPIR_Comm * comm, int src
 
 MPL_STATIC_INLINE_PREFIX int MPIR_Get_internode_rank(MPIR_Comm * comm, int r)
 {
-    MPIR_Assert(comm->attr | MPIR_COMM_ATTR__HIERARCHY);
+    MPIR_Assert(comm->attr & MPIR_COMM_ATTR__HIERARCHY);
     if (comm->internode_table) {
         return comm->internode_table[r];
     } else {
@@ -355,7 +355,7 @@ MPL_STATIC_INLINE_PREFIX int MPIR_Get_internode_rank(MPIR_Comm * comm, int r)
 
 MPL_STATIC_INLINE_PREFIX int MPIR_Get_intranode_rank(MPIR_Comm * comm, int r)
 {
-    MPIR_Assert(comm->attr | MPIR_COMM_ATTR__HIERARCHY);
+    MPIR_Assert(comm->attr & MPIR_COMM_ATTR__HIERARCHY);
     if (comm->intranode_table) {
         return comm->intranode_table[r];
     } else {

--- a/src/mpi/romio/configure.ac
+++ b/src/mpi/romio/configure.ac
@@ -1238,7 +1238,7 @@ elif test $FROM_MPICH = yes ; then
    MPI_H_INCLUDE="-I${main_top_builddir}/src/include -I${main_top_srcdir}/src/include"
    ROMIO_INCLUDE=""
    USER_CFLAGS=""
-   MPIRUN=""
+   MPIRUN="$TEST_MPIEXEC"
    #
    # Turn off the building of the Fortran interface and the Info routines
    EXTRA_DIRS=""

--- a/src/mpi/romio/test/parallel_run.sh.in
+++ b/src/mpi/romio/test/parallel_run.sh.in
@@ -12,14 +12,15 @@ set -e
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 bindir=@bindir@
-# MPICH exports ROMIO_TEST_MPIEXEC from the top-level Makefile.  It points
-# to the process manager built in this tree rather than the launcher that will
-# later be installed in $(bindir).
-mpirun="${ROMIO_TEST_MPIEXEC:-@MPIRUN@}"
+mpirun="@MPIRUN@"
 
 if test -z "$mpirun" ; then
-    echo "SKIP: no usable MPI launcher in the build tree" >&2
-    exit 77
+    if test -n "$MPIEXEC"; then
+        mpirun="$MPIEXEC"
+    else
+        echo "SKIP: mpi launcher not defined. Define MPIEXEC and rerun the test." >&2
+        exit 77
+    fi
 fi
 
 # valgrind_opt="libtool --mode=execute valgrind --quiet --leak-check=full"


### PR DESCRIPTION
## Pull Request Description
Fix issues pointed out by https://github.com/pmodels/mpich/issues/7845#issuecomment-4830462215. 
`[ ]` require double quotation in `autoconf`.

Fix stray error messages due to `if test $VAR = something`.

Fix a miss usage in testing a `comm->attr` bit.

[skip warnings]

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
