### PR TITLE
ch4/ofi: add mr cache for FI_HMEM_MR

### DIFF
--- a/src/mpid/ch4/netmod/ofi/Makefile.mk
+++ b/src/mpid/ch4/netmod/ofi/Makefile.mk
@@ -29,7 +29,9 @@ mpi_core_sources   += src/mpid/ch4/netmod/ofi/func_table.c \
                       src/mpid/ch4/netmod/ofi/init_provider.c \
                       src/mpid/ch4/netmod/ofi/init_settings.c \
                       src/mpid/ch4/netmod/ofi/init_addrxchg.c \
+                      src/mpid/ch4/netmod/ofi/mr_cache.c \
                       src/mpid/ch4/netmod/ofi/util.c
+
 errnames_txt_files += src/mpid/ch4/netmod/ofi/errnames.txt
 external_subdirs   += @ofisrcdir@
 pmpi_convenience_libs += @ofilib@

--- a/src/mpid/ch4/netmod/ofi/mr_cache.c
+++ b/src/mpid/ch4/netmod/ofi/mr_cache.c
@@ -1,0 +1,280 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <mpidimpl.h>
+#include "ofi_impl.h"
+
+/*
+=== BEGIN_MPI_T_CVAR_INFO_BLOCK ===
+cvars:
+    - name        : MPIR_CVAR_CH4_OFI_MR_CACHE_SIZE
+      category    : CH4_OFI
+      type        : int
+      default     : 16
+      class       : none
+      verbosity   : MPI_T_VERBOSITY_USER_BASIC
+      scope       : MPI_T_SCOPE_LOCAL
+      description : >-
+        The maximum number of entries to hold in the HMEM MR cache. When an entry
+        is evicted, the corresponding MR is unregistered.
+
+=== END_MPI_T_CVAR_INFO_BLOCK ===
+*/
+
+/* Use a simple array to manage HMEM mr cache. This is similar to the one used in IPC handle cache.
+ *   1. observes MPIR_CVAR_CH4_OFI_MR_CACHE_SIZE to avoid hoarding memory (an issue for Intel ZE).
+ *   2. checks for stale entries by checking for overlapping address ranges.
+ */
+
+#define MR_CACHE_MAX 1024
+/* assume stale entries (user frees the buffer but the mr still in cache) are harmless.
+ * otherwise, define MR_CACHE_CHECK_STALE_ENTRY.
+ */
+/* #define MR_CACHE_CHECK_STALE_ENTRY */
+
+struct mr_cache_entry {
+    const void *base_addr;
+    MPI_Aint len;
+    MPL_gpu_buffer_id_t buffer_id;
+    int ctx_idx;
+
+    int in_use;
+    unsigned long long usage_stamp;
+
+    struct fid_mr *mr;
+};
+
+static struct mr_cache_entry mr_cache[MR_CACHE_MAX];
+static int mr_cache_count = 0;
+
+static unsigned long long mr_cache_usage_counter;       /* for tracking LRU (Least Recently Used) */
+
+/* ipc handle cache utilities */
+static int mr_cache_free(int idx);
+static int mr_cache_delete(int idx);
+static struct mr_cache_entry *mr_cache_search(const void *addr, MPI_Aint len,
+                                              MPL_gpu_buffer_id_t buffer_id, int ctx_idx);
+static int mr_cache_check_limit(void);
+static int mr_cache_insert(const void *addr, MPI_Aint len,
+                           MPL_gpu_buffer_id_t buffer_id, int ctx_idx, struct fid_mr *mr);
+
+
+/* free the cache entry without updating mr_cache array */
+static int mr_cache_free(int idx)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    MPIR_Assert(mr_cache[idx].in_use == 0);
+    MPIDI_OFI_CALL(fi_close(&mr_cache[idx].mr->fid), mr_unreg);
+
+    /* The caller will take care of shifting mr_cache and updating mr_cache_count */
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+/* free the cache entry and shift mr_cache array */
+static int mr_cache_delete(int idx)
+{
+    int mpi_errno = MPI_SUCCESS;
+    MPIR_Assert(idx < mr_cache_count);
+
+    mpi_errno = mr_cache_free(idx);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    /* shift cache array and update mr_cache_count */
+    if (mr_cache_count - 1 > idx) {
+        memmove(mr_cache + idx, mr_cache + idx + 1,
+                (mr_cache_count - idx - 1) * sizeof(mr_cache[0]));
+    }
+    mr_cache_count -= 1;
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static struct mr_cache_entry *mr_cache_search(const void *addr, MPI_Aint len,
+                                              MPL_gpu_buffer_id_t buffer_id, int ctx_idx)
+{
+    struct mr_cache_entry *found = NULL;
+
+    for (int i = 0; i < mr_cache_count; i++) {
+        struct mr_cache_entry *entry = &mr_cache[i];
+        if (entry->base_addr == addr && entry->ctx_idx == ctx_idx && entry->buffer_id == buffer_id) {
+            found = entry;
+            goto fn_exit;
+        }
+#ifdef MR_CACHE_CHECK_STALE_ENTRY
+        /* check potential stale entry.
+         * Overlap condition between [a1, b1) and [a2, b2) is a1<b2 && b1>a2 */
+        if ((uintptr_t) entry->base_addr < (uintptr_t) addr + len &&
+            (uintptr_t) entry->base_addr + entry->len > (uintptr_t) addr) {
+            mr_cache_delete(i);
+            i--;        /* the cache array has been shifted up */
+            continue;
+        }
+#endif
+    }
+
+  fn_exit:
+    if (found) {
+        /* update usage_stamp for LRU */
+        found->usage_stamp = ++mr_cache_usage_counter;
+        found->in_use++;
+    }
+    return found;
+}
+
+static int mr_cache_check_limit(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    int cache_limit = MPL_MIN(MPIR_CVAR_CH4_OFI_MR_CACHE_SIZE, MR_CACHE_MAX);
+    if (mr_cache_count >= cache_limit) {
+        /* find LRU slot */
+        int min_idx = -1;
+        unsigned long long min_stamp = 0;
+        for (int i = 0; i < mr_cache_count; i++) {
+            if (mr_cache[i].in_use) {
+                continue;
+            }
+            if (min_idx == -1 || mr_cache[i].usage_stamp < min_stamp) {
+                min_stamp = mr_cache[i].usage_stamp;
+                min_idx = i;
+            }
+        }
+
+        if (min_idx != -1) {
+            mpi_errno = mr_cache_delete(min_idx);
+        }
+    }
+
+    return mpi_errno;
+}
+
+static int mr_cache_insert(const void *addr, MPI_Aint len, MPL_gpu_buffer_id_t buffer_id,
+                           int ctx_idx, struct fid_mr *mr)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    mpi_errno = mr_cache_check_limit();
+    MPIR_ERR_CHECK(mpi_errno);
+
+    int cache_limit = MPL_MIN(MPIR_CVAR_CH4_OFI_MR_CACHE_SIZE, MR_CACHE_MAX);
+    if (mr_cache_count < cache_limit) {
+        struct mr_cache_entry *entry = &mr_cache[mr_cache_count];
+        memset(entry, 0, sizeof(*entry));
+        entry->base_addr = addr;
+        entry->len = len;
+        entry->buffer_id = buffer_id;
+        entry->ctx_idx = ctx_idx;
+        entry->mr = mr;
+        entry->usage_stamp = ++mr_cache_usage_counter;
+        mr_cache_count++;
+
+        entry->in_use = 1;
+    }
+    /* NOTE: if we didn't cache due to cache limit, mr will be unregistered in MPIDI_OFI_mr_complete */
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+/* ---------------------------------------- */
+
+int MPIDI_OFI_register_memory_and_bind(char *buf, size_t data_sz,
+                                       MPL_pointer_attr_t * attr, int ctx_idx, struct fid_mr **mr)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    void *bounds_base;
+    uintptr_t bounds_len;
+    MPL_gpu_buffer_id_t buffer_id;
+    if (MPL_gpu_attr_is_dev(attr)) {
+        int mpl_err = MPL_gpu_get_buffer_bounds(buf, &bounds_base, &bounds_len);
+        MPIR_ERR_CHKANDJUMP(mpl_err != MPL_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                            "**gpu_get_buffer_info");
+        buffer_id = MPL_gpu_get_buffer_id(bounds_base);
+    } else {
+        bounds_base = buf;
+        bounds_len = data_sz;
+        buffer_id = 0;
+    }
+
+    struct mr_cache_entry *entry = mr_cache_search(bounds_base, bounds_len, buffer_id, ctx_idx);
+    if (entry) {
+        *mr = entry->mr;
+    } else {
+        mpi_errno = MPIDI_OFI_register_memory(bounds_base, bounds_len, attr, ctx_idx, 0, mr);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        if (*mr) {
+            mpi_errno = MPIDI_OFI_mr_bind(MPIDI_OFI_global.prov_use[0], *mr,
+                                          MPIDI_OFI_global.ctx[ctx_idx].ep, NULL);
+            MPIR_ERR_CHECK(mpi_errno);
+
+            mpi_errno = mr_cache_insert(bounds_base, bounds_len, buffer_id, ctx_idx, *mr);
+            MPIR_ERR_CHECK(mpi_errno);
+        }
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+
+int MPIDI_OFI_mr_complete(struct fid_mr *mr, bool keep_cache)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    bool found_in_cache = false;
+    for (int i = 0; i < mr_cache_count; i++) {
+        if (mr_cache[i].mr == mr) {
+            mr_cache[i].in_use--;
+            if (mr_cache[i].in_use <= 0) {
+                if (keep_cache) {
+                    mpi_errno = mr_cache_check_limit();
+                } else {
+                    mpi_errno = mr_cache_delete(i);
+                }
+                MPIR_ERR_CHECK(mpi_errno);
+            }
+
+            found_in_cache = true;
+            break;
+        }
+    }
+
+    if (!found_in_cache) {
+        /* unregister directly */
+        MPIDI_OFI_CALL(fi_close(&mr->fid), mr_unreg);
+    }
+
+  fn_exit:
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+int MPIDI_OFI_mr_cache_finalize(void)
+{
+    int mpi_errno = MPI_SUCCESS;
+
+    for (int i = 0; i < mr_cache_count; i++) {
+        mpi_errno = mr_cache_free(i);
+        MPIR_Assert(mpi_errno == MPI_SUCCESS);
+    }
+    mr_cache_count = 0;
+
+    return mpi_errno;
+}

--- a/src/mpid/ch4/netmod/ofi/ofi_events.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_events.h
@@ -53,6 +53,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_event(int vci,
         MPL_free(MPIDI_OFI_REQUEST(sreq, noncontig.nopack.iovs));
     }
 
+    if (MPIDI_OFI_REQUEST(sreq, mr)) {
+        mpi_errno = MPIDI_OFI_mr_complete(MPIDI_OFI_REQUEST(sreq, mr), true);
+        MPIR_ERR_CHECK(mpi_errno);
+    }
+
     if (MPIDI_OFI_REQUEST(sreq, am_req)) {
         MPIR_Request *am_sreq = MPIDI_OFI_REQUEST(sreq, am_req);
         int handler_id = MPIDI_OFI_REQUEST(sreq, am_handler_id);
@@ -108,6 +113,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_recv_complete(MPIR_Request * rreq, int ev
         }
 #endif
         MPL_free(MPIDI_OFI_REQUEST(rreq, noncontig.nopack.iovs));
+    }
+
+    if (MPIDI_OFI_REQUEST(rreq, mr)) {
+        mpi_errno = MPIDI_OFI_mr_complete(MPIDI_OFI_REQUEST(rreq, mr), true);
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     if (MPIDI_OFI_REQUEST(rreq, am_req) != NULL) {

--- a/src/mpid/ch4/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_impl.h
@@ -11,6 +11,7 @@
 #include "ofi_types.h"
 #include "mpidch4r.h"
 #include "ch4_impl.h"
+#include "utlist.h"
 
 extern unsigned long long PVAR_COUNTER_nic_sent_bytes_count[MPIDI_OFI_MAX_NICS] ATTRIBUTE((unused));
 extern unsigned long long PVAR_COUNTER_nic_recvd_bytes_count[MPIDI_OFI_MAX_NICS]
@@ -60,6 +61,11 @@ ATTRIBUTE((unused));
 
 int MPIDI_OFI_progress_uninlined(int vci);
 int MPIDI_OFI_handle_cq_error(int vci, int nic, ssize_t ret);
+
+int MPIDI_OFI_register_memory_and_bind(char *buf, size_t data_sz, MPL_pointer_attr_t * attr,
+                                       int ctx_idx, struct fid_mr **mr);
+int MPIDI_OFI_mr_complete(struct fid_mr *mr, bool keep_cache);
+int MPIDI_OFI_mr_cache_finalize(void);
 
 /*
  * Helper routines and macros for request completion
@@ -796,38 +802,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_register_memory(char *send_buf, size_t da
     goto fn_exit;
 }
 
-MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_register_memory_and_bind(char *send_buf, size_t data_sz,
-                                                                MPL_pointer_attr_t * attr,
-                                                                int ctx_idx, struct fid_mr **mr)
-{
-    int mpi_errno = MPI_SUCCESS;
-
-    MPIR_FUNC_ENTER;
-
-    mpi_errno = MPIDI_OFI_register_memory(send_buf, data_sz, attr, ctx_idx, 0, mr);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    if (*mr != NULL) {
-        mpi_errno = MPIDI_OFI_mr_bind(MPIDI_OFI_global.prov_use[0], *mr,
-                                      MPIDI_OFI_global.ctx[ctx_idx].ep, NULL);
-        MPIR_ERR_CHECK(mpi_errno);
-        /* Cache the mrs for closing during Finalize() */
-        struct MPIDI_GPU_RDMA_queue_t *new_mr =
-            MPL_malloc(sizeof(struct MPIDI_GPU_RDMA_queue_t), MPL_MEM_BUFFER);
-        MPIR_ERR_CHKANDJUMP1(new_mr == NULL, mpi_errno, MPI_ERR_OTHER, "**nomem", "**nomem %s",
-                             "GPU RDMA MR alloc");
-        new_mr->mr = *mr;
-        DL_APPEND(MPIDI_OFI_global.gdr_mrs, new_mr);
-    }
-
-  fn_exit:
-    MPIR_FUNC_EXIT;
-    return mpi_errno;
-
-  fn_fail:
-    goto fn_exit;
-}
-
 MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_register_am_bufs(void)
 {
     if (!MPIDI_OFI_global.am_bufs_registered) {
@@ -853,6 +827,7 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_gpu_rma_register(const void *buffer, siz
                                                          MPL_pointer_attr_t * attr, MPIR_Win * win,
                                                          int nic, void **desc)
 {
+    int mpi_errno = MPI_SUCCESS;
     struct fid_mr *mr = NULL;
     MPL_pointer_attr_t attr_tmp;
 
@@ -864,11 +839,22 @@ MPL_STATIC_INLINE_PREFIX void MPIDI_OFI_gpu_rma_register(const void *buffer, siz
         attr = &attr_tmp;
     }
     if (MPIDI_OFI_ENABLE_HMEM && MPIDI_OFI_ENABLE_MR_HMEM && MPL_gpu_attr_is_strict_dev(attr)) {
-        MPIDI_OFI_register_memory_and_bind((char *) buffer, size, attr, ctx_idx, &mr);
+        mpi_errno = MPIDI_OFI_register_memory_and_bind((char *) buffer, size, attr, ctx_idx, &mr);
+        MPIR_Assert(mpi_errno == MPI_SUCCESS);
         if (mr != NULL) {
             *desc = fi_mr_desc(mr);
+            MPIDI_OFI_mr_queue_t *elt = MPL_malloc(sizeof(MPIDI_OFI_mr_queue_t), MPL_MEM_OTHER);
+            MPIR_ERR_CHKANDJUMP(!elt, mpi_errno, MPI_ERR_OTHER, "**nomem");
+
+            elt->mr = mr;
+            LL_APPEND(MPIDI_OFI_WIN(win).pending_mr_queue.head,
+                      MPIDI_OFI_WIN(win).pending_mr_queue.tail, elt);
         }
     }
+
+    return;
+  fn_fail:
+    MPIR_Assertp(mpi_errno == MPI_SUCCESS);
 }
 
 #undef CQ_S_LIST

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -916,20 +916,8 @@ int MPIDI_OFI_mpi_finalize_hook(void)
             MPIR_Assert(MPIDI_OFI_global.per_vci[vci].am_inflight_inject_emus == 0);
         }
 
-        if (MPIDI_OFI_ENABLE_HMEM && MPIDI_OFI_ENABLE_MR_HMEM) {
-            MPIDI_GPU_RDMA_queue_t *queue_mr, *tmp;
-            DL_FOREACH_SAFE(MPIDI_OFI_global.gdr_mrs, queue_mr, tmp) {
-                if (queue_mr->mr) {
-                    struct fid_mr *mr = (struct fid_mr *) queue_mr->mr;
-                    if (mr != NULL) {
-                        MPIDI_OFI_CALL(fi_close(&mr->fid), mr_unreg);
-                    }
-
-                    DL_DELETE(MPIDI_OFI_global.gdr_mrs, queue_mr);
-                    MPL_free(queue_mr);
-                }
-            }
-        }
+        mpi_errno = MPIDI_OFI_mr_cache_finalize();
+        MPIR_ERR_CHECK(mpi_errno);
 
         /* Tearing down endpoints in reverse order they were created */
         for (int nic = MPIDI_OFI_global.num_nics - 1; nic >= 0; nic--) {

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -314,6 +314,7 @@ typedef struct {
             struct iovec *iovs;
         } nopack;
     } noncontig;
+    struct fid_mr *mr;
     union {
         struct iovec iov;
         void *inject_buf;       /* Internal buffer for inject emulation */
@@ -359,6 +360,12 @@ typedef struct {
     uintptr_t base;
 } MPIDI_OFI_win_targetinfo_t;
 
+/* Queue for storing pending memory registration handles, to be cleared at epoch synch */
+typedef struct MPIDI_OFI_mr_queue_t {
+    void *mr;
+    struct MPIDI_OFI_mr_queue_t *next;
+} MPIDI_OFI_mr_queue_t;
+
 typedef struct {
     struct fid_mr *mr;
     uint64_t mr_key;
@@ -382,6 +389,10 @@ typedef struct {
     struct MPIDI_OFI_win_request *syncQ;
     struct MPIDI_OFI_win_request *deferredQ;
     MPIDI_OFI_win_targetinfo_t *winfo;
+    struct {
+        MPIDI_OFI_mr_queue_t *head;
+        MPIDI_OFI_mr_queue_t *tail;
+    } pending_mr_queue;
 
     MPL_gavl_tree_t *dwin_target_mrs;   /* MR key and address pairs registered to remote processes.
                                          * One AVL tree per process. */

--- a/src/mpid/ch4/netmod/ofi/ofi_recv.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_recv.h
@@ -162,6 +162,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
     MPIDI_OFI_REQUEST(rreq, vci_remote) = vci_remote;
     MPIR_Datatype_add_ref_if_not_builtin(datatype);
 
+    MPIDI_OFI_REQUEST(rreq, mr) = NULL;
+
     if (rreq->comm == NULL) {
         rreq->comm = comm;
         MPIR_Comm_add_ref(comm);
@@ -200,6 +202,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_irecv(void *buf,
         MPIDI_OFI_register_memory_and_bind(recv_buf, data_sz, &attr, ctx_idx, &mr);
         if (mr != NULL) {
             desc = fi_mr_desc(mr);
+            MPIDI_OFI_REQUEST(rreq, mr) = mr;
         }
     }
 

--- a/src/mpid/ch4/netmod/ofi/ofi_send.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_send.h
@@ -200,6 +200,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_normal(const void *data, MPI_Aint da
         MPIDI_OFI_register_memory_and_bind((void *) data, data_sz, &attr, ctx_idx, &mr);
         if (mr != NULL) {
             desc = fi_mr_desc(mr);
+            MPIDI_OFI_REQUEST(sreq, mr) = mr;
         }
     }
 
@@ -238,6 +239,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send_fallback(const void *buf, MPI_Aint c
     MPIR_FUNC_ENTER;
 
     MPIDI_OFI_REQUEST_CREATE(*request, MPIR_REQUEST_KIND__SEND, vci_src);
+    MPIDI_OFI_REQUEST(*request, mr) = NULL;
     MPIDI_OFI_REQUEST(*request, am_req) = NULL;
 
     MPIR_Request *sreq = *request;
@@ -419,6 +421,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
         /* new pipeline send */
         MPIR_Request *sreq;
         MPIDI_OFI_REQUEST_CREATE(sreq, MPIR_REQUEST_KIND__SEND, vci_src);
+        MPIDI_OFI_REQUEST(sreq, mr) = NULL;
         *request = sreq;
         sreq->comm = comm;
         MPIR_Comm_add_ref(comm);
@@ -456,6 +459,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_send(const void *buf, MPI_Aint count, MPI
     } else {
         /* normal path */
         MPIDI_OFI_REQUEST_CREATE(*request, MPIR_REQUEST_KIND__SEND, vci_src);
+        MPIDI_OFI_REQUEST(*request, mr) = NULL;
         MPIDI_OFI_REQUEST(*request, am_req) = NULL;
         MPIR_Request *sreq = *request;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -439,13 +439,6 @@ typedef struct {
                                  * This is typically the socket above the NIC */
 } MPIDI_OFI_nic_info_t;
 
-/* Queue for storing the memory registration handles */
-typedef struct MPIDI_GPU_RDMA_queue_t {
-    void *mr;
-    struct MPIDI_GPU_RDMA_queue_t *next;
-    struct MPIDI_GPU_RDMA_queue_t *prev;
-} MPIDI_GPU_RDMA_queue_t;
-
 /* Global state data */
 #define MPIDI_KVSAPPSTRLEN 1024
 #define MPIDI_OFI_DT_MAX 30     /* must >= FI_DATATYPE_LAST */
@@ -494,9 +487,6 @@ typedef struct {
     /* OFI atomics limitation of each pair of <dtype, op> returned by the
      * OFI provider at MPI initialization.*/
     MPIDI_OFI_atomic_valid_t win_op_table[MPIDI_OFI_DT_MAX][MPIDI_OFI_OP_MAX];
-
-    /* Registration list for GPU RDMA */
-    MPIDI_GPU_RDMA_queue_t *gdr_mrs;
 
     /* stores the maximum of last recently used optimized memory region key */
     uint64_t global_max_optimized_mr_key;

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -77,6 +77,18 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_do_progress(MPIR_Win * win, int vci)
     MPIDI_OFI_WIN(win).syncQ = NULL;
     MPIDI_OFI_WIN(win).progress_counter = 1;
 
+    if (MPIDI_OFI_ENABLE_HMEM && MPIDI_OFI_ENABLE_MR_HMEM) {
+        MPIDI_OFI_mr_queue_t *elt, *tmp;
+        LL_FOREACH_SAFE(MPIDI_OFI_WIN(win).pending_mr_queue.head, elt, tmp) {
+            if (elt->mr) {
+                MPIDI_OFI_mr_complete(elt->mr, true);
+                LL_DELETE(MPIDI_OFI_WIN(win).pending_mr_queue.head,
+                          MPIDI_OFI_WIN(win).pending_mr_queue.tail, elt);
+                MPL_free(elt);
+            }
+        }
+    }
+
   fn_exit:
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpl/include/mpl_gpu.h
+++ b/src/mpl/include/mpl_gpu.h
@@ -119,6 +119,7 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
 int MPL_gpu_ipc_handle_destroy(const void *ptr, MPL_pointer_attr_t * gpu_attr);
 int MPL_gpu_ipc_handle_map(MPL_gpu_ipc_mem_handle_t * mpl_ipc_handle, int dev_id, void **ptr);
 int MPL_gpu_ipc_handle_unmap(void *ptr);
+MPL_gpu_buffer_id_t MPL_gpu_get_buffer_id(void *ptr);
 bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr);
 
 int MPL_gpu_malloc_host(void **ptr, size_t size);

--- a/src/mpl/include/mpl_gpu_cuda.h
+++ b/src/mpl/include/mpl_gpu_cuda.h
@@ -9,9 +9,10 @@
 #include "cuda.h"
 #include "cuda_runtime_api.h"
 
+typedef unsigned long long MPL_gpu_buffer_id_t;
 typedef struct {
     cudaIpcMemHandle_t handle;
-    unsigned long long id;
+    MPL_gpu_buffer_id_t id;
 } MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
 typedef struct cudaPointerAttributes MPL_gpu_device_attr;

--- a/src/mpl/include/mpl_gpu_fallback.h
+++ b/src/mpl/include/mpl_gpu_fallback.h
@@ -6,6 +6,7 @@
 #ifndef MPL_GPU_CUDA_H_INCLUDED
 #define MPL_GPU_CUDA_H_INCLUDED
 
+typedef int MPL_gpu_buffer_id_t;
 typedef int MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
 typedef int MPL_gpu_device_attr;        /* dummy type */

--- a/src/mpl/include/mpl_gpu_hip.h
+++ b/src/mpl/include/mpl_gpu_hip.h
@@ -13,9 +13,10 @@
 #include "hip/hip_runtime.h"
 #include "hip/hip_runtime_api.h"
 
+typedef uint32_t MPL_gpu_buffer_id_t;
 typedef struct {
     hipIpcMemHandle_t handle;
-    uint32_t id;
+    MPL_gpu_buffer_id_t id;
 } MPL_gpu_ipc_mem_handle_t;
 typedef int MPL_gpu_device_handle_t;
 typedef struct hipPointerAttribute_t MPL_gpu_device_attr;

--- a/src/mpl/include/mpl_gpu_ze.h
+++ b/src/mpl/include/mpl_gpu_ze.h
@@ -13,12 +13,13 @@ typedef struct {
     ze_device_handle_t device;
 } ze_alloc_attr_t;
 
+typedef uint64_t MPL_gpu_buffer_id_t;
 typedef struct {
     int fds[2];
     uint32_t nfds;
     pid_t pid;
     int dev_id;
-    uint64_t mem_id;
+    MPL_gpu_buffer_id_t mem_id;
 } fd_pid_t;
 
 typedef struct _MPL_gpu_ipc_mem_handle_t {

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -191,6 +191,17 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
     goto fn_exit;
 }
 
+MPL_gpu_buffer_id_t MPL_gpu_get_buffer_id(void *ptr)
+{
+    CUresult ret;
+    MPL_gpu_buffer_id_t buffer_id;
+
+    ret = cuPointerGetAttribute(&buffer_id, CU_POINTER_ATTRIBUTE_BUFFER_ID, (CUdeviceptr) ptr);
+    assert(ret == cudaSuccess);
+
+    return buffer_id;
+}
+
 bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr)
 {
     CUresult ret;

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -194,7 +194,7 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
 bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr)
 {
     CUresult ret;
-    unsigned long long buffer_id;
+    MPL_gpu_buffer_id_t buffer_id;
 
     ret = cuPointerGetAttribute(&buffer_id, CU_POINTER_ATTRIBUTE_BUFFER_ID, (CUdeviceptr) ptr);
     assert(ret == cudaSuccess);

--- a/src/mpl/src/gpu/mpl_gpu_fallback.c
+++ b/src/mpl/src/gpu/mpl_gpu_fallback.c
@@ -150,6 +150,11 @@ int MPL_gpu_launch_hostfn(int stream, MPL_gpu_hostfn fn, void *data)
     return -1;
 }
 
+MPL_gpu_buffer_id_t MPL_gpu_get_buffer_id(void *ptr)
+{
+    return 0;
+}
+
 bool MPL_gpu_stream_is_valid(MPL_gpu_stream_t stream)
 {
     return false;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -226,7 +226,7 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
 bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr)
 {
     hipError_t ret;
-    uint32_t buffer_id;
+    MPL_gpu_buffer_id_t buffer_id;
 
     ret = hipPointerGetAttribute(&buffer_id, HIP_POINTER_ATTRIBUTE_BUFFER_ID, (hipDeviceptr_t) ptr);
     assert(ret == hipSuccess);

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -223,6 +223,17 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
     goto fn_exit;
 }
 
+MPL_gpu_buffer_id_t MPL_gpu_get_buffer_id(void *ptr)
+{
+    hipError_t ret;
+    MPL_gpu_buffer_id_t buffer_id;
+
+    ret = hipPointerGetAttribute(&buffer_id, HIP_POINTER_ATTRIBUTE_BUFFER_ID, (hipDeviceptr_t) ptr);
+    assert(ret == hipSuccess);
+
+    return buffer_id;
+}
+
 bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr)
 {
     hipError_t ret;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -2091,6 +2091,24 @@ int MPL_gpu_ipc_handle_unmap(void *ptr)
     goto fn_exit;
 }
 
+MPL_gpu_buffer_id_t MPL_gpu_get_buffer_id(void *ptr)
+{
+    ze_result_t ret;
+    ze_device_handle_t device = NULL;
+    ze_memory_allocation_properties_t ptr_attr = {
+        .stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES,
+        .pNext = NULL,
+        .type = 0,
+        .id = 0,
+        .pageSize = 0,
+    };
+
+    ret = zeMemGetAllocProperties(ze_context, ptr, &ptr_attr, &device);
+    assert(ret == ZE_RESULT_SUCCESS);
+
+    return ptr_attr.id;
+}
+
 bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr)
 {
     ze_result_t ret;


### PR DESCRIPTION
## Pull Request Description

The provider (e.g. EFA) may not cache internally with mr registration.
Without caching, the overhead of mr registration will hurt performance.

Add MPIDI_OFI_mr_cache facility to cache mrs in MPICH. Use a simple
array-based cache for:
    1. simplicity
    2. cache size limit and LRU eviction
    3. stale cache entry detection (optional)

[skip warnings]
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
