### PR TITLE
config: fix libmpi_abi.so version-info so the intended SONAME is applied

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -504,13 +504,15 @@ AC_ARG_ENABLE(versioning,
 
 if test "$enable_versioning" = "yes" ; then
    ABIVERSIONFLAGS="-version-info \$(ABIVERSION)"
-   ABI_ABIVERSIONFLAGS="-version-info libmpi_abi_so_verion_m4"
+   ABI_ABIVERSIONFLAGS="-version-info libmpi_abi_so_version_m4"
 else
    ABIVERSIONFLAGS="-avoid-version"
    ABI_ABIVERSIONFLAGS="-avoid-version"
 fi
 export ABIVERSIONFLAGS
 AC_SUBST(ABIVERSIONFLAGS)
+export ABI_ABIVERSIONFLAGS
+AC_SUBST(ABI_ABIVERSIONFLAGS)
 
 
 dnl The environment variable MPICH_DEBUGLIBNAME may be used to


### PR DESCRIPTION
## Summary

`libmpi_abi` is currently installed with an SONAME of `libmpi_abi.so.0`
even though `maint/version.m4` sets `libmpi_abi_so_version_m4` to
`1:0:0` (which should yield `libmpi_abi.so.1`). The intended
`-version-info` never reaches libtool, so libtool falls back to its
`0:0:0` default. Two independent bugs cause this:

1. **Typo.** `configure.ac` referenced the macro as
   `libmpi_abi_so_verion_m4` (missing the `s` in `version`). That macro
   is undefined, so m4 passes the literal token through — you can see it
   survive verbatim into the generated `configure`:
   ```
   ABI_ABIVERSIONFLAGS="-version-info libmpi_abi_so_verion_m4"
   ```

2. **Missing `AC_SUBST`.** `ABI_ABIVERSIONFLAGS` was never `AC_SUBST`'d
   (unlike `ABIVERSIONFLAGS`), so even the bogus string never reached
   the Makefiles. In the generated `Makefile`, `$(ABI_ABIVERSIONFLAGS)`
   expands to empty on the `lib_libmpi_abi_la_LDFLAGS` line, and libtool
   applies no `-version-info` → default `0:0:0` → `libmpi_abi.so.0`.

## Fix

- Correct the macro name so it expands to the `1:0:0` already defined in
  `maint/version.m4`.
- `export` and `AC_SUBST` `ABI_ABIVERSIONFLAGS`, exactly as
  `ABIVERSIONFLAGS` already is, so the value flows to the link line.

With this change `libmpi_abi` installs with SONAME `libmpi_abi.so.1`,
matching the `1:0:0` intent already encoded in `maint/version.m4`.

## Why `libmpi_abi.so.1`

The point of the standard ABI is that an application can switch backends
without recompiling, which requires every implementation of a given ABI
version to expose the **same** SONAME. Setting the SONAME to match
`MPI_ABI_VERSION` (so ABI v1 → `libmpi_abi.so.1` everywhere) is what
`maint/version.m4`'s `1:0:0` already intends; this PR just makes it take
effect. See the versioning discussion in mpi-forum/mpi-abi-stubs#28 and
the Open MPI ABI work in open-mpi/ompi#13280. (Open MPI is setting its
`libmpi_abi` SONAME to `.so.1` to match.)

## Verification

Verified by structural analogy: the sibling `libmpi_so_version_m4` uses
the identical `m4_define` / expansion idiom in the same `version.m4` and
resolves correctly (`ABIVERSION = 0:0:0` in the generated `Makefile`);
this change makes `libmpi_abi_so_version_m4` flow the same way. A CI
build with `--enable-mpi-abi` should confirm the installed
`libmpi_abi.so.1` SONAME.

## Notes / possible follow-up

This PR intentionally keeps the hard-coded `1:0:0` in `maint/version.m4`
and only fixes the plumbing so it applies. Deriving the `c:r:a` triplet
programmatically from `MPI_ABI_VERSION`/`MPI_ABI_SUBVERSION` (per the
formula in mpi-abi-stubs#28) would be a larger, separate change and is
left out here.
