### PR TITLE
doc/mansrc: Added semantic descriptions for functions

### DIFF
--- a/doc/mansrc/semantics.adoc
+++ b/doc/mansrc/semantics.adoc
@@ -6,3 +6,3505 @@ Use the following format to specify semantics or notes for an MPI Function
 Describe semantics for MPI_Func_name.
 // end:: MPI_Func_name[]
 
+//tag::MPI_Psend_init[]
+**MPI_Psend_init** creates a partitioned communication send request that enables multiple contributions from threads or tasks to a single message buffer.
+
+This initialization call is local and binds all arguments of a partitioned send operation to a persistent request. Matching with a corresponding MPI_PRECV_INIT follows standard point-to-point matching rules using communicator, tag, and destination; when these do not uniquely identify a message, the order of initialization calls determines match order. It is erroneous to provide a `partitions` value less than or equal to zero. Multiple threads or tasks may independently mark partitions as ready via MPI_PREADY calls after the operation is started. A smaller number of receiver-side partitions may provide higher performance as a large number may increase overheads.
+//end::MPI_Psend_init[]
+
+//tag::MPI_Precv_init[]
+**MPI_Precv_init** creates a partitioned communication receive request that binds all arguments of a partitioned receive operation to a persistent request.
+
+This initialization call is local and may return before the operation completes. Matching with a corresponding MPI_PSEND_INIT follows standard point-to-point matching rules using communicator, tag, and source; when these do not uniquely identify a message, the order of initialization calls determines match order. Wildcards for `source` and `tag` are not allowed. It is erroneous to provide a `partitions` value less than or equal to zero. Using a smaller number of receiver-side partitions may provide higher performance as a large number may increase overheads.
+//end::MPI_Precv_init[]
+
+//tag::MPI_Pready[]
+**MPI_Pready** is a send-side call that indicates a given `partition` is ready to be transferred.
+
+The partitioning is defined by the MPI_PSEND_INIT call, with partition numbering starting at zero and ranging to one less than the number of partitions declared. After a call to MPI_START or MPI_STARTALL, all partitions are inactive; a call to MPI_Pready marks the indicated partition as active. Multiple threads or tasks may independently call MPI_Pready to mark different partitions as ready. It is erroneous to use MPI_Pready on any request object that does not correspond to a partitioned send operation, to specify a partition number equal to or larger than the number of partitions, or to call MPI_Pready on an already active partition.
+//end::MPI_Pready[]
+
+//tag::MPI_Pready_range[]
+**MPI_Pready_range** is a send-side call that marks a contiguous range of partitions as ready to be transferred.
+A call to MPI_Pready_range has the same effect as calling MPI_PREADY for each partition from `partition_low` to `partition_high`, executed in arbitrary order. This function follows the same rules as MPI_PREADY, including that it is erroneous to use it on any request object that does not correspond to a partitioned send operation. It is erroneous to specify a partition number equal to or larger than the number of partitions or to mark an already active partition.
+//end::MPI_Pready_range[]
+
+//tag::MPI_Pready_list[]
+**MPI_Pready_list** is a send-side call that marks an array of partitions as ready to be transferred.
+
+A call to MPI_Pready_list has the same effect as calling MPI_PREADY for each partition specified in `array_of_partitions`, executed in arbitrary order. Multiple threads or tasks may independently call MPI_Pready_list to mark different partitions as ready. It is erroneous to use MPI_Pready_list on any request object that does not correspond to a partitioned send operation, to specify a partition number equal to or larger than the number of partitions, or to mark an already active partition.
+//end::MPI_Pready_list[]
+
+//tag::MPI_Parrived[]
+**MPI_Parrived** tests partial completion of partitioned receive operations.
+
+A call on an active partitioned communication request returns `flag` = true if the operation for the specified partition is complete. The request is not marked as complete or inactive by this procedure; a subsequent call to a completing procedure such as MPI_TEST or MPI_WAIT is required. MPI_Parrived may be called multiple times for a partition and returns `flag` = true when called with a null or inactive `request`. Multiple threads may independently call MPI_Parrived to test different partitions. Calling MPI_Parrived on a request that does not correspond to a partitioned receive operation is erroneous.
+//end::MPI_Parrived[]
+
+//tag::MPI_Comm_revoke[]
+**MPI_Comm_revoke** notifies all MPI processes in the groups associated with a communicator that the communicator is revoked.
+
+The revocation completes non-local MPI operations on `comm` at all MPI processes by raising an error of class MPI_ERR_REVOKED. This procedure is not collective and does not have a matching call on remote MPI processes. All non-failed MPI processes belonging to `comm` will be notified of the revocation despite failures. In a multithreaded application, a thread calling MPI_COMM_IS_REVOKED may return true before the operation that raises the first exception of class MPI_ERR_REVOKED has completed in a concurrent thread.
+//end::MPI_Comm_revoke[]
+
+//tag::MPI_Comm_is_revoked[]
+**MPI_Comm_is_revoked** returns whether a communicator is revoked at the calling process.
+
+This operation is local. It returns `flag` = true if the communicator is revoked and `flag` = false otherwise. In a multithreaded application, a thread calling MPI_COMM_IS_REVOKED may return `flag` = true before the operation that raises the first exception of class MPI_ERR_REVOKED has completed in a concurrent thread.
+//end::MPI_Comm_is_revoked[]
+
+//tag::MPI_Comm_get_failed[]
+**MPI_Comm_get_failed** returns the group of MPI processes from a communicator that are locally known to have failed.
+
+This local procedure returns `failedgrp` containing any MPI process whose failure caused an operation on `comm` to raise a process failure error at the calling process. The returned group may be MPI_GROUP_EMPTY. When an MPI process is a member of `failedgrp`, it is also a member with the same rank in any group produced by a subsequent call to MPI_COMM_GET_FAILED on `comm` at the same calling process. An implementation may update the group of locally known failed MPI processes only when entering a procedure that must raise a fault tolerance error. It is possible that only the calling MPI process has detected the reported failure.
+//end::MPI_Comm_get_failed[]
+
+//tag::MPI_Comm_ack_failed[]
+**MPI_Comm_ack_failed** acknowledges locally notified process failures on a communicator.
+
+This local procedure acknowledges the first `num_to_ack` process failures on `comm`, corresponding to members with ranks lower than `num_to_ack` in the group that would be produced by a concurrent call to MPI_COMM_GET_FAILED. The operation sets `num_acked` to the current number of acknowledged process failures, which may be larger than `num_to_ack` if failures were acknowledged in a prior call. After a process failure is acknowledged, unmatched MPI_ANY_SOURCE receive operations on `comm` that would have raised MPI_ERR_PROC_FAILED_PENDING proceed without raising errors due to that acknowledged failure. Users may query the number of currently acknowledged process failures without side effect by supplying 0 in `num_to_ack`, or may acknowledge all currently known failures by supplying the size of the group of `comm` in `num_to_ack`. Acknowledging failures on a communicator has no effect on collective operations; collective operations may continue to raise errors due to failed processes.
+//end::MPI_Comm_ack_failed[]
+
+//tag::MPI_T_init_thread[]
+**MPI_T_init_thread** initializes the MPI tool information interface and its thread environment.
+
+This routine has local semantics and may be called multiple times; subsequent calls increase a reference count without reinitializing the interface. The MPI tool information interface can be used independently from MPI communication functionality, meaning this routine may be called before MPI_INIT_THREAD or MPI_SESSION_INIT and after MPI_FINALIZE. Processes created by the MPI implementation during MPI initialization inherit the MPI tool information interface state from the process from which they are created. Processes created at runtime via dynamic process management require their own initialization before using the MPI tool information interface. The `required` and `provided` thread levels for MPI_T_INIT_THREAD may influence the behavior and return values of MPI_INIT_THREAD or MPI_SESSION_INIT, and vice versa.
+//end::MPI_T_init_thread[]
+
+//tag::MPI_T_finalize[]
+**MPI_T_finalize** finalizes the MPI tool information interface and decrements the reference count established by MPI_T_INIT_THREAD calls.
+
+This routine has local semantics and may be called as often as the corresponding MPI_T_INIT_THREAD routine up to the current point of execution. The MPI tool information interface remains initialized as long as the number of calls to MPI_T_FINALIZE is smaller than the number of calls to MPI_T_INIT_THREAD. Once MPI_T_FINALIZE is called the same number of times as MPI_T_INIT_THREAD, the interface is no longer initialized, but the user may reinitialize it with a subsequent call to MPI_T_INIT_THREAD. At the end of program execution, unless MPI_ABORT is called, an application must have called MPI_T_INIT_THREAD and MPI_T_FINALIZE an equal number of times.
+//end::MPI_T_finalize[]
+
+//tag::MPI_T_enum_get_info[]
+**MPI_T_enum_get_info** queries the number of discrete values and name associated with an enumeration type used in the MPI tool information interface.
+This routine has local semantics. If `enumtype` is a valid enumeration, the routine returns the number of items represented by the enumeration in `num` and the name of the enumeration in `name`. The enumeration must represent at least one value. The routine is required to return a name of at least length one, and this name must be unique with respect to all other enumeration names used by the MPI implementation.
+//end::MPI_T_enum_get_info[]
+
+//tag::MPI_T_enum_get_item[]
+**MPI_T_enum_get_item** retrieves the name and value pair for a specific item within an MPI tool information interface enumeration.
+
+This routine has local semantics. If completed successfully, the routine returns a name of at least length one in `name` and the corresponding value in `value`. The returned name must be unique with respect to all other item names within the same enumeration.
+//end::MPI_T_enum_get_item[]
+
+//tag::MPI_T_cvar_get_num[]
+**MPI_T_cvar_get_num** queries the number of control variables exported by the MPI implementation through the MPI tool information interface.
+
+This routine has local semantics. If the returned count is zero, the MPI implementation does not export any control variables; otherwise the provided control variables are indexed from 0 to `num_cvar`-1. The MPI implementation may increase the number of control variables during execution when new variables become available through dynamic loading. However, MPI implementations are not permitted to change the index of a control variable or delete a variable once it has been added. The number and indices of control variables are not guaranteed to be the same across MPI processes or between runs of an application. Applications relying on a particular control variable may not be portable across MPI implementations or platforms.
+//end::MPI_T_cvar_get_num[]
+
+//tag::MPI_T_cvar_get_info[]
+**MPI_T_cvar_get_info** queries metadata for a control variable exported through the MPI tool information interface.
+
+This routine has local semantics. After a successful call, subsequent calls querying the same variable must return identical information. If any output parameter is a NULL pointer, the implementation ignores that parameter and does not return a value. The `enumtype` parameter returns `MPI_T_ENUM_NULL` when the datatype is not `MPI_INT` or when no enumeration applies. The `bind` parameter returns `MPI_T_BIND_NO_OBJECT` when the variable does not require binding to an MPI object.
+//end::MPI_T_cvar_get_info[]
+
+//tag::MPI_T_cvar_get_index[]
+**MPI_T_cvar_get_index** retrieves the index of a control variable given a known variable name.
+
+This routine has local semantics. The `name` parameter is a null-terminated string provided by the caller, and `cvar_index` is returned by the MPI implementation. This routine enables fast retrieval of control variables by tools that know the variable name. The routine returns `MPI_T_ERR_INVALID_NAME` if `name` does not match the name of any control variable provided by the implementation at the time of the call.
+//end::MPI_T_cvar_get_index[]
+
+//tag::MPI_T_cvar_handle_alloc[]
+**MPI_T_cvar_handle_alloc** allocates a handle for a control variable and binds it to an MPI object.
+
+This routine has local semantics. The `obj_handle` argument is ignored if MPI_T_CVAR_GET_INFO returned `MPI_T_BIND_NO_OBJECT` for this control variable. Upon successful return, `count` contains the number of elements used to represent the variable. The `count` may differ based on the MPI object to which the control variable was bound. It is not portable to pass references to predefined MPI object handles such as `MPI_COMM_WORLD` directly; such handles are recommended to be stored in a local variable and the address of that local variable passed to this routine.
+//end::MPI_T_cvar_handle_alloc[]
+
+//tag::MPI_T_cvar_handle_free[]
+**MPI_T_cvar_handle_free** frees a control variable handle and releases associated resources in the MPI implementation.
+
+This routine has local semantics. On successful return, MPI sets `handle` to `MPI_T_CVAR_HANDLE_NULL`.
+//end::MPI_T_cvar_handle_free[]
+
+//tag::MPI_T_cvar_read[]
+**MPI_T_cvar_read** queries the value of a control variable and stores the result in a user-provided buffer.
+
+This routine has local semantics. The user must ensure that `buf` is of the appropriate size to hold the entire value of the control variable based on the datatype and count returned by prior calls to MPI_T_CVAR_GET_INFO and MPI_T_CVAR_HANDLE_ALLOC, respectively.
+//end::MPI_T_cvar_read[]
+
+//tag::MPI_T_cvar_write[]
+**MPI_T_cvar_write** sets the value of a control variable identified by `handle` using data from `buf`.
+
+This routine has local semantics. The user must ensure that `buf` is of the appropriate size based on the datatype and count returned by prior calls to MPI_T_CVAR_GET_INFO and MPI_T_CVAR_HANDLE_ALLOC. For variables with global or group scope, users must issue write calls in all participating MPI processes with consistent values. The function returns `MPI_T_ERR_CVAR_SET_NOT_NOW` if the variable cannot be changed at the time of the call but may be settable later. The function returns `MPI_T_ERR_CVAR_SET_NEVER` if the variable cannot be set for the remainder of the application execution.
+//end::MPI_T_cvar_write[]
+
+//tag::MPI_T_pvar_get_num[]
+**MPI_T_pvar_get_num** queries the number of performance variables exported by the MPI implementation through the MPI tool information interface.
+
+This routine has local semantics. If the returned count is zero, the MPI implementation does not export any performance variables; otherwise the provided performance variables are indexed from 0 to `num_pvar`-1. The MPI implementation may increase the number of performance variables during execution when new variables become available through dynamic loading, but is not permitted to change a variable's index or delete a variable once added. When a variable becomes inactive through dynamic unloading, accessing its value returns a corresponding return code. The number and indices of performance variables are not guaranteed to be the same across connected MPI processes or between runs; applications relying on particular variables may not be portable.
+//end::MPI_T_pvar_get_num[]
+
+//tag::MPI_T_pvar_get_info[]
+**MPI_T_pvar_get_info** queries metadata for a performance variable exported through the MPI tool information interface.
+
+This routine has local semantics and subsequent calls querying the same variable must return identical information. If any output parameter is a NULL pointer, the implementation ignores that parameter. The combination of `name` and `var_class` must be unique among all performance variables. The `enumtype` parameter returns `MPI_T_ENUM_NULL` when the datatype is not `MPI_INT` or when no enumeration applies; `bind` returns `MPI_T_BIND_NO_OBJECT` when the variable does not require binding to an MPI object. When maximum portability is desired, applications are recommended to avoid being dependent on the existence of a particular performance variable.
+//end::MPI_T_pvar_get_info[]
+
+//tag::MPI_T_pvar_get_index[]
+**MPI_T_pvar_get_index** retrieves the index of a performance variable given a known variable name and class.
+
+This routine has local semantics. The `name` parameter is a null-terminated string provided by the caller, and `pvar_index` is returned by the MPI implementation. This routine enables fast retrieval of performance variables by tools that know the variable name without iterating over all variables. The routine returns `MPI_T_ERR_INVALID_NAME` if `name` does not match the name of any performance variable of the specified `var_class` at the time of the call. Using MPI implementation specific variable names is not portable across MPI implementations, but may provide lower runtime overhead.
+//end::MPI_T_pvar_get_index[]
+
+//tag::MPI_T_pvar_session_create[]
+**MPI_T_pvar_session_create** creates a new performance experiment session for accessing performance variables.
+
+This routine has local semantics and returns a session handle of type `MPI_T_pvar_session` in `pe_session`. Within a single program, multiple components may use the MPI tool information interface; performance experiment sessions avoid collisions with respect to accesses to performance variables. Starting, stopping, reading, writing, or resetting a variable in one performance experiment session does not influence whether a variable is started, stopped, read, written, or reset in another session.
+//end::MPI_T_pvar_session_create[]
+
+//tag::MPI_T_pvar_session_free[]
+**MPI_T_pvar_session_free** frees an existing performance experiment session for accessing performance variables.
+
+This routine has local semantics. Calls to the MPI tool information interface can no longer be made within the context of a performance experiment session after it is freed. On successful return, MPI sets `pe_session` to `MPI_T_PVAR_SESSION_NULL`.
+//end::MPI_T_pvar_session_free[]
+
+//tag::MPI_T_pvar_handle_alloc[]
+**MPI_T_pvar_handle_alloc** allocates a handle for a performance variable and binds it to an MPI object within a performance experiment session.
+
+This routine has local semantics. The `obj_handle` argument is ignored if MPI_T_PVAR_GET_INFO returned `MPI_T_BIND_NO_OBJECT` for this performance variable. Upon successful return, `count` contains the number of elements used to represent the variable, which may differ based on the MPI object to which the variable was bound. The function returns `MPI_T_ERR_INVALID_HANDLE` if a `handle` is passed to subsequent routines that is not associated with the provided `pe_session`. Predefined MPI object handles such as `MPI_COMM_WORLD` are recommended to be stored in a local variable and the address of that local variable passed to this routine.
+//end::MPI_T_pvar_handle_alloc[]
+
+//tag::MPI_T_pvar_handle_free[]
+**MPI_T_pvar_handle_free** frees a performance variable handle and releases associated resources in the MPI implementation.
+
+This routine has local semantics. On successful return, MPI sets `handle` to `MPI_T_PVAR_HANDLE_NULL`. The function returns `MPI_T_ERR_INVALID_HANDLE` if `handle` is not associated with the provided `pe_session`.
+//end::MPI_T_pvar_handle_free[]
+
+//tag::MPI_T_pvar_start[]
+**MPI_T_pvar_start** starts a performance variable identified by `handle` within a performance experiment session.
+
+This routine has local semantics. If `MPI_T_PVAR_ALL_HANDLES` is passed in `handle`, the MPI implementation attempts to start all variables within the session for which handles have been allocated. When using `MPI_T_PVAR_ALL_HANDLES`, continuous variables and variables that are already started are ignored. The function returns `MPI_T_ERR_PVAR_NO_STARTSTOP` if it cannot start the specified variable or if any variable fails to start when using `MPI_T_PVAR_ALL_HANDLES`.
+//end::MPI_T_pvar_start[]
+
+//tag::MPI_T_pvar_stop[]
+**MPI_T_pvar_stop** stops a performance variable identified by `handle` within a performance experiment session.
+
+This routine has local semantics. If `MPI_T_PVAR_ALL_HANDLES` is passed in `handle`, the MPI implementation attempts to stop all variables within the session for which handles have been allocated. When using `MPI_T_PVAR_ALL_HANDLES`, continuous variables and variables that are already stopped are ignored. The function returns `MPI_T_ERR_PVAR_NO_STARTSTOP` if it cannot stop the specified variable or if any variable fails to stop when using `MPI_T_PVAR_ALL_HANDLES`.
+//end::MPI_T_pvar_stop[]
+
+//tag::MPI_T_pvar_read[]
+**MPI_T_pvar_read** queries the value of a performance variable and stores the result in a user-provided buffer.
+
+This routine has local semantics. The user must ensure that `buf` is of the appropriate size to hold the entire value of the performance variable based on the datatype and count returned by prior calls to MPI_T_PVAR_GET_INFO and MPI_T_PVAR_HANDLE_ALLOC, respectively. The constant `MPI_T_PVAR_ALL_HANDLES` cannot be used as an argument for this function.
+//end::MPI_T_pvar_read[]
+
+//tag::MPI_T_pvar_write[]
+**MPI_T_pvar_write** attempts to write the value of a performance variable identified by `handle` within a performance experiment session.
+
+This routine has local semantics. The user must ensure that `buf` is of the appropriate size to hold the entire value of the performance variable based on the datatype and count returned by prior calls to MPI_T_PVAR_GET_INFO and MPI_T_PVAR_HANDLE_ALLOC, respectively. The constant `MPI_T_PVAR_ALL_HANDLES` cannot be used as an argument for this function. The function returns `MPI_T_ERR_PVAR_NO_WRITE` if it is not possible to change the variable.
+//end::MPI_T_pvar_write[]
+
+//tag::MPI_T_pvar_reset[]
+**MPI_T_pvar_reset** sets a performance variable to its starting value as defined by the variable's class.
+
+This routine has local semantics. If the constant `MPI_T_PVAR_ALL_HANDLES` is passed in `handle`, the MPI implementation attempts to reset all variables within the performance experiment session for which handles have been allocated; read-only variables are ignored in this case. The function returns `MPI_T_ERR_PVAR_NO_WRITE` if the variable cannot be changed or if any writable variable fails to reset when using `MPI_T_PVAR_ALL_HANDLES`.
+//end::MPI_T_pvar_reset[]
+
+//tag::MPI_T_pvar_readreset[]
+**MPI_T_pvar_readreset** atomically reads and resets a performance variable within a performance experiment session.
+
+This routine has local semantics and combines the functionality of MPI_T_PVAR_READ and MPI_T_PVAR_RESET with the same semantics as if these two calls were invoked separately. The user must ensure that `buf` is of the appropriate size to hold the entire value of the performance variable based on the datatype and count returned by prior calls to MPI_T_PVAR_GET_INFO and MPI_T_PVAR_HANDLE_ALLOC, respectively. The function returns `MPI_T_ERR_PVAR_NO_ATOMIC` if the variable cannot be read and reset atomically. The constant `MPI_T_PVAR_ALL_HANDLES` cannot be used as an argument for this function.
+//end::MPI_T_pvar_readreset[]
+
+//tag::MPI_T_source_get_num[]
+**MPI_T_source_get_num** queries the number of event sources available through the MPI tool information interface.
+
+This routine has local semantics. Event sources are logical entities that raise events and are used to define partial ordering of events across different components. The MPI implementation may increase the number of sources during execution when new sources become available through dynamic loading. However, MPI implementations are not permitted to change the index of an event source or delete an event source once it has been made visible to the user.
+//end::MPI_T_source_get_num[]
+
+//tag::MPI_T_source_get_info[]
+**MPI_T_source_get_info** retrieves metadata for an event source in the MPI tool information interface.
+
+This routine has local semantics. The `ordering` parameter returns `MPI_T_SOURCE_ORDERED` if event callbacks from this source are invoked in chronological order with monotonically increasing timestamps, or `MPI_T_SOURCE_UNORDERED` otherwise. Users may use `max_ticks` to mitigate timestamp overflow problems resulting from the effective size of `MPI_Count`.
+//end::MPI_T_source_get_info[]
+
+//tag::MPI_T_source_get_timestamp[]
+**MPI_T_source_get_timestamp** obtains a current timestamp from a specified event source.
+
+This routine has local semantics. The `source_index` argument identifies the index of the source to query. The function returns `MPI_T_ERR_INVALID_INDEX` if the index does not identify a valid source. The function returns `MPI_T_ERR_NOT_SUPPORTED` if the source does not support ad-hoc generation of timestamps.
+//end::MPI_T_source_get_timestamp[]
+
+//tag::MPI_T_event_get_num[]
+**MPI_T_event_get_num** queries the number of event types exported by the MPI implementation through the MPI tool information interface.
+
+This routine has local semantics. If the returned count is zero, the MPI implementation does not export any event types; otherwise the provided event types are indexed from 0 to `num_events`-1. The MPI implementation may increase the number of event types during execution when new types become available through dynamic loading. However, MPI implementations are not permitted to change the index of an event type or delete an event type once it has been made visible to the user. The number and type of events may vary between MPI implementations, platforms, and different builds of the same implementation; applications relying on particular events are not portable.
+//end::MPI_T_event_get_num[]
+
+//tag::MPI_T_event_get_info[]
+**MPI_T_event_get_info** queries metadata for an event type exported through the MPI tool information interface.
+
+This routine has local semantics and after a successful call, subsequent calls for the same event type must return identical information. If any output parameter is a NULL pointer, the implementation ignores it and does not return a value. The `enumtype` parameter returns `MPI_T_ENUM_NULL` when no enumeration applies; the `bind` parameter returns `MPI_T_BIND_NO_OBJECT` when no MPI object binding is required. The function returns `MPI_T_ERR_INVALID_INDEX` if `event_index` does not match a valid event type index at the time of the call.
+//end::MPI_T_event_get_info[]
+
+//tag::MPI_T_event_get_index[]
+**MPI_T_event_get_index** retrieves the index of an event type given a known event type name.
+
+This routine has local semantics. The `name` parameter is a null-terminated string provided by the caller, and `event_index` is returned by the MPI implementation. This routine enables fast retrieval of event types by tools that know the event type name without iterating over all event types. The function returns `MPI_T_ERR_INVALID_NAME` if `name` does not match the name of any event type provided by the implementation at the time of the call. Using MPI implementation specific event type names is not portable across MPI implementations, but may provide lower runtime overhead.
+//end::MPI_T_event_get_index[]
+
+//tag::MPI_T_event_handle_alloc[]
+**MPI_T_event_handle_alloc** creates a registration handle for an event type and binds it to an MPI object if required.
+
+This routine has local semantics. The `obj_handle` argument is ignored if MPI_T_EVENT_GET_INFO returned `MPI_T_BIND_NO_OBJECT` for this event type. The user may pass hints for the handle allocation to the MPI implementation via the `info` argument. Predefined MPI object handles such as `MPI_COMM_WORLD` are recommended to be stored in a local variable and the address of that local variable passed to this routine.
+//end::MPI_T_event_handle_alloc[]
+
+//tag::MPI_T_event_handle_set_info[]
+**MPI_T_event_handle_set_info** updates the hints of an event-registration handle using the hints provided in `info`.
+
+This routine has local semantics. A call to this procedure has no effect on previously set or defaulted hints that are not specified by `info`. It also has no effect on previously set or defaulted hints that are specified by `info` but ignored by the MPI implementation. Some info items that an implementation uses when creating an event-registration handle may not be changeable after the handle is created, so an implementation may ignore hints in this call that it would have accepted in a handle allocation call. MPI_T_EVENT_HANDLE_GET_INFO may be used to determine whether info changes were ignored by the implementation.
+//end::MPI_T_event_handle_set_info[]
+
+//tag::MPI_T_event_handle_get_info[]
+**MPI_T_event_handle_get_info** returns a new info object containing the hints of an event-registration handle.
+
+This routine has local semantics. The current setting of all hints related to the registration handle is returned in `info_used`. An MPI implementation is required to return all hints that are supported by the implementation and have default values specified, any user-supplied hints that were not ignored by the implementation, and any additional hints that were set by the implementation. If no such hints exist, a handle to a newly created info object is returned that contains no key/value pairs. The user is responsible for freeing `info_used` via MPI_INFO_FREE.
+//end::MPI_T_event_handle_get_info[]
+
+//tag::MPI_T_event_register_callback[]
+**MPI_T_event_register_callback** associates a user-defined callback function with an allocated event-registration handle for a specified callback safety level.
+
+This routine has local semantics. Multiple callback functions may be registered for a given event-registration handle, one for each callback safety level. Registering a callback function for a specific callback safety level overwrites any previously-registered callback function and info object for that level; if `event_cb_function` is NULL, an existing association for that callback safety level is removed. When an event is triggered, the implementation selects the callback with the lowest safety level valid in the invocation context. If the required callback safety level exceeds the highest level for which a callback is registered, the event instance is dropped. To avoid dropped events, the callback with the highest safety guarantees is recommended to be registered before registering callbacks for lower safety levels.
+//end::MPI_T_event_register_callback[]
+
+//tag::MPI_T_event_callback_set_info[]
+**MPI_T_event_callback_set_info** updates the hints of a callback function registered for a specified callback safety level of an event-registration handle.
+
+This routine has local semantics. A call to this procedure has no effect on previously set or defaulted hints that are not specified by `info`. It also has no effect on previously set or defaulted hints that are specified by `info` but ignored by the MPI implementation in this call.
+//end::MPI_T_event_callback_set_info[]
+
+//tag::MPI_T_event_callback_get_info[]
+**MPI_T_event_callback_get_info** returns a new info object containing the hints of a callback function registered for a specified callback safety level of an event-registration handle.
+
+This routine has local semantics. The current set of all hints related to the specified `cb_safety` level of the event-registration handle is returned in `info_used`. An MPI implementation is required to return all hints that are supported by the implementation and have default values specified, any user-supplied hints that were not ignored by the implementation, and any additional hints that were set by the implementation. If no such hints exist, a handle to a newly created info object is returned that contains no key/value pairs. The user is responsible for freeing `info_used` via MPI_INFO_FREE.
+//end::MPI_T_event_callback_get_info[]
+
+//tag::MPI_T_event_handle_free[]
+**MPI_T_event_handle_free** initiates deallocation of an event-registration handle and stops the MPI implementation from raising events for that registration.
+
+This routine has local semantics. The `free_cb_function` callback is invoked by the MPI implementation when it can guarantee that no further event instances for the corresponding event-registration handle will be raised. If `free_cb_function` is NULL, no user function is invoked after successful deallocation. The `user_data` pointer is passed to `free_cb_function` upon invocation. The function returns `MPI_T_ERR_INVALID_HANDLE` if `event_registration` does not match a valid allocated event-registration handle at the time of the call. A free-callback function associated with a registration handle may need to postpone pending actions if the provided callback safety requirements exceed those required by the pending actions.
+//end::MPI_T_event_handle_free[]
+
+//tag::MPI_T_event_set_dropped_handler[]
+**MPI_T_event_set_dropped_handler** registers a callback function to be invoked when event information is dropped for a specified event-registration handle.
+
+This routine has local semantics. Subsequent calls with the same registration handle replace previously-registered callback functions for that handle. If `dropped_cb_function` is NULL, no data loss is recorded or reported until a new valid callback function is registered. The invocation of the dropped handler callback function may not necessarily occur close to the time the event was actually lost.
+//end::MPI_T_event_set_dropped_handler[]
+
+//tag::MPI_T_event_read[]
+**MPI_T_event_read** copies one element of event data to a user-specified buffer.
+
+This routine has local semantics and must be called from within an event callback function. The `event_instance` argument identifies the event instance to query; it is erroneous to provide any event-instance handle other than the one passed by the MPI implementation to the callback function. The `buffer` argument must point to a memory location where the MPI implementation can copy the element of event data identified by `element_index`. When called inside a callback, the actions permitted are restricted by callback safety levels such as `MPI_T_CB_REQUIRE_MPI_RESTRICTED` or `MPI_T_CB_REQUIRE_THREAD_SAFE`.
+//end::MPI_T_event_read[]
+
+//tag::MPI_T_event_copy[]
+**MPI_T_event_copy** copies event data as a whole into a user-provided buffer.
+
+This routine has local semantics and must be called from within an event callback function. The `buffer` must be at least the size of the extent of the event type, which may be computed from the type and displacement information returned by MPI_T_EVENT_GET_INFO. The data may include padding bytes between individual elements of the event data in the buffer. The location and size of data in the buffer may be reconstructed through information returned by MPI_T_EVENT_GET_INFO. When called inside a callback, actions permitted are restricted by callback safety levels.
+//end::MPI_T_event_copy[]
+
+//tag::MPI_T_event_get_timestamp[]
+**MPI_T_event_get_timestamp** returns the timestamp of when an event was initially observed by the MPI implementation.
+
+This routine has local semantics and must be called from within an event callback function. The `event_instance` argument identifies the event instance to query; it is erroneous to provide any event-instance handle other than the one passed by the MPI implementation to the callback function. An MPI implementation may postpone the callback function invocation; in this case, the returned timestamp may be in the past and closer to the time the event was initially observed, rather than a timestamp captured during callback invocation.
+//end::MPI_T_event_get_timestamp[]
+
+//tag::MPI_T_event_get_source[]
+**MPI_T_event_get_source** retrieves the index of the event source that raised a specific event instance.
+
+This routine has local semantics and must be called from within an event callback function. The `event_instance` argument identifies the event instance to query; it is erroneous to provide any event-instance handle other than the one passed by the MPI implementation to the callback function. The `source_index` may be used with MPI_T_SOURCE_GET_INFO to query additional information about the source.
+//end::MPI_T_event_get_source[]
+
+//tag::MPI_T_category_get_num[]
+**MPI_T_category_get_num** queries the number of categories exported by the MPI implementation through the MPI tool information interface.
+
+This routine has local semantics. If the returned count is zero, the MPI implementation does not export any categories; otherwise the provided categories are indexed from 0 to `num_cat`-1. The MPI implementation may increase the number of categories during execution when new categories become available through dynamic loading. However, MPI implementations are not permitted to change the index of a category or delete a category once it has been added.
+//end::MPI_T_category_get_num[]
+
+//tag::MPI_T_category_get_info[]
+**MPI_T_category_get_info** queries metadata for a category exported through the MPI tool information interface.
+
+This routine has local semantics. If any output parameter is a NULL pointer, the implementation ignores that parameter and does not return a value. The routine is required to return a `name` of at least length one, and this name must be unique with respect to all other category names used by the MPI implementation. The function returns the number of control variables, performance variables, and other categories contained in the queried category via `num_cvars`, `num_pvars`, and `num_categories`, respectively. If the name of a category is equivalent across connected MPI processes, the returned description must be equivalent.
+//end::MPI_T_category_get_info[]
+
+//tag::MPI_T_category_get_num_events[]
+**MPI_T_category_get_num_events** queries the number of event types contained in a category exported through the MPI tool information interface.
+
+This routine has local semantics. The `num_events` parameter returns the count of event types in the category identified by `cat_index`. Categories may contain zero or more event types.
+//end::MPI_T_category_get_num_events[]
+
+//tag::MPI_T_category_get_index[]
+**MPI_T_category_get_index** retrieves the index of a category given a known category name.
+
+This routine has local semantics. The `name` parameter is a null-terminated string provided by the caller, and `cat_index` is returned by the MPI implementation. This routine enables fast retrieval of categories by tools that know the category name without iterating over all categories. The function returns `MPI_T_ERR_INVALID_NAME` if `name` does not match the name of any category provided by the implementation at the time of the call. Using MPI implementation specific category names is not portable across MPI implementations, but may provide lower runtime overhead.
+//end::MPI_T_category_get_index[]
+
+//tag::MPI_T_category_get_cvars[]
+**MPI_T_category_get_cvars** queries which control variables are contained in a particular category.
+
+This routine has local semantics and a category contains zero or more control variables. The user is responsible for allocating the `indices` array. Starting from array index 0, the function writes up to `len` elements into the array. If the category contains more than `len` elements, the function returns an arbitrary subset of size `len`; otherwise, the entire set is returned in the beginning entries and remaining array entries are not modified. The returned index values may be used as input to MPI_T_CVAR_GET_INFO.
+//end::MPI_T_category_get_cvars[]
+
+//tag::MPI_T_category_get_pvars[]
+**MPI_T_category_get_pvars** queries which performance variables are contained in a particular category.
+
+This routine has local semantics. A category contains zero or more performance variables. The user is responsible for allocating the `indices` array. Starting from array index 0, the function writes up to `len` elements into the array. If the category contains more than `len` elements, the function returns an arbitrary subset of size `len`; otherwise, the entire set is returned in the beginning entries and remaining array entries are not modified. The returned index values may be used as input to MPI_T_PVAR_GET_INFO.
+//end::MPI_T_category_get_pvars[]
+
+//tag::MPI_T_category_get_events[]
+**MPI_T_category_get_events** queries which event types are contained in a particular category.
+
+This routine has local semantics and a category contains zero or more event types. The user is responsible for allocating the `indices` array. Starting from array index 0, the function writes up to `len` elements into the array. If the category contains more than `len` elements, the function returns an arbitrary subset of size `len`; otherwise, the entire set is returned in the beginning entries and remaining array entries are not modified. The returned index values may be used as input to MPI_T_EVENT_GET_INFO.
+//end::MPI_T_category_get_events[]
+
+//tag::MPI_T_category_get_categories[]
+**MPI_T_category_get_categories** queries which subcategories are contained in a particular category.
+
+This routine has local semantics and a category contains zero or more other categories. The user is responsible for allocating the `indices` array. Starting from array index 0, the function writes up to `len` elements into the array. If the category contains more than `len` elements, the function returns an arbitrary subset of size `len`; otherwise, the entire set is returned in the beginning entries and remaining array entries are not modified. The returned index values may be used as input to MPI_T_CATEGORY_GET_INFO.
+//end::MPI_T_category_get_categories[]
+
+//tag::MPI_T_category_changed[]
+**MPI_T_category_changed** returns an update number that indicates whether categories have been added or expanded since the last query.
+
+This routine has local semantics. If two calls to this routine return the same `update_number`, category information has not changed between the two calls. If the `update_number` from the second call is higher, categories have been added or expanded. If the number of changes exceeds the limit of `update_number`, the implementation sets `update_number` to the maximum possible value for its type.
+//end::MPI_T_category_changed[]
+
+//tag::MPI_Comm_create_keyval[]
+**MPI_Comm_create_keyval** generates a new attribute key for associating attributes with communicators.
+
+This operation is local. Keys are locally unique in an MPI process and opaque to the user, though stored in integers. Once allocated, the key value can be used to associate attributes and access them on any locally defined communicator. The `comm_copy_attr_fn` callback is invoked when a communicator is duplicated, and `comm_delete_attr_fn` is invoked when an attribute is deleted or when the communicator is freed. It is erroneous to use `MPI_KEYVAL_INVALID` as a key value.
+//end::MPI_Comm_create_keyval[]
+
+//tag::MPI_Comm_set_attr[]
+**MPI_Comm_set_attr** stores an attribute value on a communicator for subsequent retrieval by MPI_COMM_GET_ATTR.
+
+This operation is local. If an attribute value is already present for the key, the delete callback function `comm_delete_attr_fn` is executed before the new value is stored. The call fails if the delete callback returns an error code other than `MPI_SUCCESS`. It is erroneous to use `MPI_KEYVAL_INVALID` or a nonexistent key value; such errors may return error class `MPI_ERR_KEYVAL`.
+//end::MPI_Comm_set_attr[]
+
+//tag::MPI_Comm_get_attr[]
+**MPI_Comm_get_attr** retrieves an attribute value from a communicator by key.
+
+This operation is local. If the key exists but no attribute is attached to `comm` for that key, the call returns `flag` = false. It is erroneous to use `MPI_KEYVAL_INVALID` or a nonexistent key value; such errors may return error class `MPI_ERR_KEYVAL`.
+//end::MPI_Comm_get_attr[]
+
+//tag::MPI_Keyval_create[]
+**MPI_Keyval_create** is deprecated and superseded by MPI_COMM_CREATE_KEYVAL.
+
+This function generates a new attribute key value returned in `keyval`. The `copy_fn` callback is invoked when a communicator is duplicated by MPI_COMM_DUP. The `delete_fn` callback is invoked when an attribute is deleted. The `extra_state` argument is passed to callback functions.
+//end::MPI_Keyval_create[]
+
+//tag::MPI_Keyval_free[]
+**MPI_Keyval_free** is deprecated and superseded by MPI_COMM_FREE_KEYVAL.
+
+This function frees the integer key value in `keyval`. The function is local.
+//end::MPI_Keyval_free[]
+
+//tag::MPI_Attr_put[]
+**MPI_Attr_put** is deprecated and superseded by MPI_COMM_SET_ATTR.
+
+This function attaches an attribute value to a communicator using a key value created by MPI_KEYVAL_CREATE. The language independent definition is the same as MPI_COMM_SET_ATTR except for the function name. The language bindings are modified from those of the superseding function.
+//end::MPI_Attr_put[]
+
+//tag::MPI_Attr_get[]
+**MPI_Attr_get** is deprecated and superseded by MPI_COMM_GET_ATTR.
+
+This function retrieves the attribute value associated with a key on a communicator. If an attribute is associated with the key, `flag` is set to true and the value is returned in `attribute_val`. If no attribute is associated with the key, `flag` is set to false and `attribute_val` is unchanged. The language independent definition is the same as MPI_COMM_GET_ATTR except for the function name. The language bindings are modified from those of the superseding function.
+//end::MPI_Attr_get[]
+
+//tag::MPI_Attr_delete[]
+**MPI_Attr_delete** is deprecated and superseded by MPI_COMM_DELETE_ATTR.
+
+This function deletes an attribute from a communicator using the specified key value. The language independent definition is the same as MPI_COMM_DELETE_ATTR except for the function name. The language bindings are modified from those of the superseding function.
+//end::MPI_Attr_delete[]
+
+//tag::MPI_Alloc_mem[]
+**MPI_Alloc_mem** allocates memory that may be optimized for message-passing and remote-memory-access operations. Allocated memory may provide faster performance on systems where specially allocated memory improves communication, such as shared memory on an SMP. The use of such memory for communication is not mandatory and it may be used without restrictions as any other dynamically allocated memory. By default, the allocated memory is aligned to at least the alignment required for load/store accesses of any datatype corresponding to a predefined MPI datatype. The `info` argument may specify a desired alternative minimum alignment in bytes via the `mpi_minimum_memory_alignment` key set to an integral power of two, or provide directives controlling the desired location of the allocated memory; `MPI_INFO_NULL` is always valid.
+
+The function may raise an error of class `MPI_ERR_NO_MEM` if memory is exhausted.
+//end::MPI_Alloc_mem[]
+
+//tag::MPI_Free_mem[]
+**MPI_Free_mem** frees memory that was allocated by MPI_ALLOC_MEM.
+
+The function may raise an error of class `MPI_ERR_BASE` to indicate an invalid `base` argument.
+//end::MPI_Free_mem[]
+
+//tag::MPI_Info_dup[]
+**MPI_Info_dup** duplicates an existing info object, creating a new object with the same key/value pairs and the same ordering of keys.
+//end::MPI_Info_dup[]
+
+//tag::MPI_Info_create[]
+**MPI_Info_create** creates a new info object that contains no key/value pairs.
+
+The `info` object stores an unordered set of key/value pairs where keys and values are strings and a key may have only one value. The info object may be read, modified, or freed immediately after it is passed to any MPI procedure. Changes to an info object after return from a procedure do not affect that procedure's interpretation of the object.
+//end::MPI_Info_create[]
+
+//tag::MPI_Info_set[]
+**MPI_Info_set** adds a key/value pair to an info object, overriding the value if the same key was previously set. In C, both `key` and `value` are null-terminated strings. In Fortran, leading and trailing spaces in `key` and `value` are stripped.
+
+If `key` exceeds `MPI_MAX_INFO_KEY` or `value` exceeds `MPI_MAX_INFO_VAL`, the call raises an error of class `MPI_ERR_INFO_KEY` or `MPI_ERR_INFO_VALUE`, respectively.
+//end::MPI_Info_set[]
+
+//tag::MPI_Info_delete[]
+**MPI_Info_delete** deletes a key/value pair from an info object.
+
+If `key` is not defined in `info`, the call raises an error of class `MPI_ERR_INFO_NOKEY`.
+//end::MPI_Info_delete[]
+
+//tag::MPI_Info_get[]
+**MPI_Info_get** is deprecated and superseded by MPI_INFO_GET_STRING.
+
+This function retrieves the value associated with `key` in an info object. If the key exists, `flag` is set to true and the value is returned in `value`; otherwise `flag` is set to false and `value` is unchanged. If `valuelen` is less than the actual size of the value, the returned value is truncated. This function may be called at any time, including before MPI initialization and after MPI finalization. If `key` is larger than `MPI_MAX_INFO_KEY`, the call is erroneous.
+//end::MPI_Info_get[]
+
+//tag::MPI_Info_get_valuelen[]
+**MPI_Info_get_valuelen** is deprecated and superseded by MPI_INFO_GET_STRING.
+
+This function retrieves the length of the value associated with `key` in an info object. If `key` is defined, `valuelen` is set to the length of its associated value and `flag` is set to true; if `key` is not defined, `valuelen` is not touched and `flag` is set to false. The length returned in C does not include the end-of-string character. This function may be called at any time, including before MPI initialization and after MPI finalization. If `key` is larger than `MPI_MAX_INFO_KEY`, the call is erroneous.
+//end::MPI_Info_get_valuelen[]
+
+//tag::MPI_Info_get_string[]
+**MPI_Info_get_string** retrieves the value associated with a key from an info object. If the key exists, `flag` is set to true and the value is returned in `value`; otherwise `flag` is set to false and `value` is unchanged. If `buflen` is less than the required size including the null terminator, the value is truncated and `buflen` is set to the required buffer size. If `buflen` is set to 0, `value` is not changed.
+
+If `key` exceeds `MPI_MAX_INFO_KEY`, the call is erroneous. Users may obtain the required buffer size by setting `buflen` to 0, then use the returned `buflen` to allocate memory before calling MPI_INFO_GET_STRING again.
+//end::MPI_Info_get_string[]
+
+//tag::MPI_File_call_errhandler[]
+**MPI_File_call_errhandler** invokes the error handler assigned to the file with the supplied error code.
+This function is local.
+
+//tag::MPI_Session_call_errhandler[]
+**MPI_Session_call_errhandler** invokes the error handler assigned to `session` with the supplied `errorcode`.
+This function is local.
+Error handlers are not recommended to be called recursively with MPI_SESSION_CALL_ERRHANDLER, as this may create infinite recursion when called inside an error handler.
+//end::MPI_Session_call_errhandler[]
+
+Handlers are recommended to not be called recursively with MPI_FILE_CALL_ERRHANDLER, as this may create infinite recursion if MPI_FILE_CALL_ERRHANDLER is called inside an error handler.
+//end::MPI_File_call_errhandler[]
+
+//tag::MPI_Add_error_class[]
+**MPI_Add_error_class** creates a new error class and returns its value in `errorclass`.
+
+This operation is local. The value is set by the implementation to avoid conflicts with existing error codes and classes. This function is thread-safe and may be called before MPI is initialized or after MPI is finalized. The same `errorclass` value may not be returned on all processes that make this call; registering a new error class on multiple processes at the same time does not guarantee the same value on all processes. When using the World Process Model, the predefined attribute key `MPI_LASTUSEDCODE` associated with `MPI_COMM_WORLD` returns the current maximum error class including user-defined ones.
+//end::MPI_Add_error_class[]
+
+//tag::MPI_Add_error_code[]
+**MPI_Add_error_code** creates a new error code associated with an existing error class. This operation is local and the error code value is set by the implementation to avoid conflicts with existing error codes. This function is thread-safe and may be called before MPI is initialized or after MPI is finalized.
+
+Despite being thread-safe, concurrent calls that add and remove the same error class or code may result in undefined behavior; calls adding an error code must precede calls removing that error code even across different threads. Calling this function with different input values for the class or code parameters is always thread-safe.
+//end::MPI_Add_error_code[]
+
+//tag::MPI_Remove_error_class[]
+**MPI_Remove_error_class** removes a user-created error class.
+
+This operation is local and thread-safe. The value of the predefined attribute key `MPI_LASTUSEDCODE` associated with `MPI_COMM_WORLD` is updated to reflect the maximum error class value. This function may be called before MPI is initialized or after MPI is finalized. It is erroneous to call this function with a value for `errorclass` that was not added by a call to MPI_ADD_ERROR_CLASS, to remove an `errorclass` again without first obtaining a new value from another call to MPI_ADD_ERROR_CLASS, or to remove an error class when its associated error codes have not been removed.
+//end::MPI_Remove_error_class[]
+
+//tag::MPI_Remove_error_code[]
+**MPI_Remove_error_code** removes a user-created error code and all its associations with any error class.
+
+This operation is local and thread-safe. This function may be called before MPI is initialized or after MPI is finalized. It is erroneous to call this function with a value for `errorcode` that was not added by a call to MPI_ADD_ERROR_CODE, to remove an `errorcode` again without first obtaining a new value from another call to MPI_ADD_ERROR_CODE, or to remove an error code when its associated error string has not been removed.
+
+Despite being thread-safe, concurrent calls that add and remove the same error code may result in undefined behavior; calls adding an error code must precede calls removing that error code even across different threads.
+//end::MPI_Remove_error_code[]
+
+//tag::MPI_Add_error_string[]
+**MPI_Add_error_string** associates a user-defined error string with an error code or class. This operation is local and thread-safe. The `string` must be no more than `MPI_MAX_ERROR_STRING` characters long. Calling this function for an `errorcode` that already has a string replaces the old string with the new string. This function may be called before MPI is initialized or after MPI is finalized. It is erroneous to call this function for an error code or class with a value less than or equal to `MPI_ERR_LASTCODE`.
+//end::MPI_Add_error_string[]
+
+//tag::MPI_Comm_get_errhandler[]
+**MPI_Comm_get_errhandler** retrieves the error handler currently associated with a communicator.
+
+This operation is local and behaves as if a new error handler object is created. Once the error handler is no longer needed, MPI_ERRHANDLER_FREE is recommended to be called with the returned `errhandler` to mark it for deallocation. A library function may register at its entry point the current error handler for a communicator, set its own private error handler for that communicator, and restore the previous error handler before exiting.
+//end::MPI_Comm_get_errhandler[]
+
+//tag::MPI_Comm_call_errhandler[]
+**MPI_Comm_call_errhandler** invokes the error handler assigned to a communicator with a user-supplied error code.
+
+This function allows users to explicitly call an error handler associated with a communicator. Error codes and classes are associated with a process and may be used in any error handler. Error handlers are not recommended to be called recursively as this may create an infinite recursion situation.
+//end::MPI_Comm_call_errhandler[]
+
+//tag::MPI_Info_get_nthkey[]
+**MPI_Info_get_nthkey** returns the `n`th defined key in an info object. Keys are numbered 0 to N-1 where N is the value returned by MPI_INFO_GET_NKEYS. All keys between 0 and N-1 are guaranteed to be defined. The number of a given key does not change as long as `info` is not modified with MPI_INFO_SET or MPI_INFO_DELETE.
+//end::MPI_Info_get_nthkey[]
+
+//tag::MPI_Pack[]
+**MPI_Pack** packs a message into a contiguous buffer space for subsequent transmission. The input buffer specified by `inbuf`, `incount`, and `datatype` is packed into the output buffer starting at the location indicated by `position`. The `position` parameter is incremented by the size of the packed message. Multiple messages may be packed into one packing unit via successive related calls where each call inputs the `position` value output by the previous call. A packing unit may be sent using the datatype `MPI_PACKED`, for which type matching rules are relaxed. Each packing unit must be unpacked as a unit by a sequence of related unpack calls.
+//end::MPI_Pack[]
+
+//tag::MPI_Get_library_version[]
+**MPI_Get_library_version** returns a string representing the version of the MPI library. The `version` argument must represent storage that is `MPI_MAX_LIBRARY_VERSION_STRING` characters long. MPI_Get_library_version may write up to this many characters into `version`. The number of characters written is returned in `resultlen`. This function may be called at any time in an MPI program.
+//end::MPI_Get_library_version[]
+
+//tag::MPI_Get_hw_resource_info[]
+**MPI_Get_hw_resource_info** is a local procedure that returns an info object containing hardware platform information for the calling MPI process. The info object stores (key, value) pairs where each key is a hardware resource type name and its value is true if the process is restricted to a single instance of that resource type, false otherwise. The order of keys in `hw_info` is unspecified, and subsequent calls may return different information if the process is relocated or has its hardware restrictions changed. The user is responsible for freeing `hw_info` via MPI_INFO_FREE.
+
+The returned information may reflect virtualized hardware resources and may be restricted by access permissions or other constraints. Keys have a Uniform Resource Identifier format where the key provider mpi:// is reserved for exclusive use by the MPI standard; users are recommended to be cautious when comparing keys from different providers as the same hardware resource may be listed under different names, and keys returned by this procedure may be used in MPI_COMM_SPLIT_TYPE with `split_type` value `MPI_COMM_TYPE_HW_GUIDED` or `MPI_COMM_TYPE_RESOURCE_GUIDED` as key values for info key mpi_hw_resource_type.
+//end::MPI_Get_hw_resource_info[]
+
+//tag::MPI_Lookup_name[]
+**MPI_Lookup_name** retrieves a `port_name` published by MPI_PUBLISH_NAME using the specified `service_name`.
+
+If `service_name` has not been published, the function raises an error of class `MPI_ERR_NAME`. The application must supply a `port_name` buffer large enough to hold the largest possible port name. If an implementation allows multiple entries with the same `service_name` within the same scope, a particular `port_name` is chosen in an implementation-defined manner. If the `info` argument was used with MPI_PUBLISH_NAME to specify how names are published, a similar `info` argument may be required for MPI_LOOKUP_NAME.
+//end::MPI_Lookup_name[]
+
+//tag::MPI_Session_get_pset_info[]
+**MPI_Session_get_pset_info** queries properties of a specific process set associated with a session. The returned `info` object can be queried with existing MPI info object query functions. The `mpi_size` key/value pair must be defined for the returned info object, specifying the number of MPI processes in the process set. The user is responsible for freeing the returned `MPI_Info` object.
+//end::MPI_Session_get_pset_info[]
+
+//tag::MPI_Session_get_nth_pset[]
+**MPI_Session_get_nth_pset** returns the name of the `n`th process set in the supplied `pset_name` buffer. If `pset_len` is less than the required buffer size, the returned string is truncated; if `pset_len` is 0, `pset_name` is not changed. On return, `pset_len` is set to the required buffer size including the null terminator in C, where a null-terminated string is returned when `pset_len` input is greater than 0. After a successful call, subsequent queries for the same process set name and session handle must return identical information.
+
+If two MPI processes obtain the same process set name, the intersection of the two process sets is either the empty set or identical to the union. Process set names have a maximum length of `MPI_MAX_PSET_NAME_LEN` characters; users may call this function with `pset_len` set to 0 to obtain the required buffer size before allocating memory.
+//end::MPI_Session_get_nth_pset[]
+
+//tag::MPI_Session_finalize[]
+**MPI_Session_finalize** cleans up all MPI state associated with a session and sets the `session` handle to `MPI_SESSION_NULL`.
+
+Before invoking this routine, an MPI process must locally complete all MPI operations it initiated and execute matching calls needed to complete MPI communications initiated by other processes. All message handles associated with the session must be received and all request handles must be freed for nonblocking operations, or be inactive or freed for persistent or partitioned operations. This routine does not free objects created by MPI calls; these objects are freed using MPI_XXX_FREE, MPI_COMM_DISCONNECT, or MPI_FILE_CLOSE calls. After this routine returns, no MPI procedure related to this session may be called except for those listed as callable before initialization. MPI_Session_finalize may be synchronizing on any or all of the groups associated with communicators, windows, or files derived from the session and not disconnected, freed, or closed before the call. Opaque objects and their handles may bind internal resources; therefore, explicitly freeing handles associated with a session before finalizing it is recommended.
+//end::MPI_Session_finalize[]
+
+//tag::MPI_Initialized[]
+**MPI_Initialized** determines whether MPI has been initialized using the World Process Model.
+This routine returns `flag` = true if MPI_INIT or MPI_INIT_THREAD has been called and `flag` = false otherwise. It is valid to call MPI_INITIALIZED before MPI_INIT or MPI_INIT_THREAD and after MPI_FINALIZE. Whether MPI_FINALIZE has been called does not affect the behavior of MPI_INITIALIZED. This function returns `flag` = false for applications using the Session Process Model exclusively. This function must always be thread-safe.
+//end::MPI_Initialized[]
+
+//tag::MPI_Init_thread[]
+**MPI_Init_thread** initializes MPI and the thread environment in the World Process Model.
+
+The `required` parameter specifies the desired level of thread support: `MPI_THREAD_SINGLE` (only one thread executes), `MPI_THREAD_FUNNELED` (multithreaded but only the main thread makes MPI calls), `MPI_THREAD_SERIALIZED` (multiple threads may make MPI calls but not concurrently), or `MPI_THREAD_MULTIPLE` (multiple threads may call MPI with no restrictions). These thread support levels are monotonic. The `provided` parameter returns the actual thread support level; if possible, `provided` equals `required`, otherwise the least level greater than `required` is returned, or if the requirement cannot be satisfied, the highest supported level is returned. A thread-compliant MPI implementation returns `MPI_THREAD_MULTIPLE` in `provided`. A call to MPI_INIT is equivalent to MPI_INIT_THREAD with `required` equal to `MPI_THREAD_SINGLE`. Different processes in `MPI_COMM_WORLD` may request different levels of thread support.
+//end::MPI_Init_thread[]
+
+//tag::MPI_Pack_size[]
+**MPI_Pack_size** returns an upper bound on the space needed to pack a message. The returned `size` is an upper bound on the increment in `position` that would be effected by a corresponding call to MPI_PACK. This allows users to manage space allocation for buffers. The returned value is an upper bound rather than an exact bound since the exact space may depend on context.
+
+If the packed size cannot be expressed by the `size` output parameter, it is set to `MPI_UNDEFINED`.
+//end::MPI_Pack_size[]
+
+//tag::MPI_Sizeof[]
+**MPI_Sizeof** is deprecated and superseded by Fortran intrinsic functions `storage_size()` and `c_sizeof()`.
+
+This function returns the size in bytes of the machine representation of a given variable. It is a generic Fortran routine and has a Fortran binding only. If given an array argument, it returns the size of the base element, not the size of the whole array.
+//end::MPI_Sizeof[]
+
+//tag::MPI_Type_get_extent_x[]
+**MPI_Type_get_extent_x** is deprecated and may be removed in a future version of the MPI specification.
+
+This function returns the lower bound and extent of a datatype. The description of MPI_TYPE_GET_EXTENT is applicable to this deprecated function. For C and Fortran `mpi_f08` module bindings, it is superseded by the large count and large byte displacement bindings of MPI_TYPE_GET_EXTENT.
+//end::MPI_Type_get_extent_x[]
+
+//tag::MPI_Type_get_true_extent_x[]
+**MPI_Type_get_true_extent_x** is deprecated and may be removed in a future version of the MPI specification.
+
+This function returns the true lower bound and true extent of a datatype. The description of MPI_TYPE_GET_TRUE_EXTENT is applicable to this deprecated function. For C and Fortran `mpi_f08` module bindings, it is superseded by the large count and large byte displacement bindings of MPI_TYPE_GET_TRUE_EXTENT.
+//end::MPI_Type_get_true_extent_x[]
+
+//tag::MPI_Barrier[]
+**MPI_Barrier** performs barrier synchronization across all members of a group. If `comm` is an intra-communicator, the call blocks the caller until all group members have called it, returning at any process only after all group members have entered the call. If `comm` is an inter-communicator, the call involves two groups and returns at processes in one group only after all members of the other group have entered the call, and vice versa. A process may return from the call before all processes in its own group have entered when using an inter-communicator. MPI_Barrier is classified as an All-To-All collective operation.
+
+In multithreaded implementations, it is the user's responsibility to ensure that the same communicator is not used concurrently by two different collective communication initialization calls at the same process. A collective communication may or may not have the effect of synchronizing all participating processes; programs are recommended to avoid relying on synchronization side-effects for correctness. Programs must allow for the fact that a collective call may be synchronizing.
+//end::MPI_Barrier[]
+
+//tag::MPI_Comm_get_name[]
+**MPI_Comm_get_name** returns the name previously associated with a communicator.
+This operation is local. If no name has been associated with the communicator, an empty string is returned. The predefined communicators `MPI_COMM_WORLD`, `MPI_COMM_SELF`, and the communicator returned by MPI_COMM_GET_PARENT have default names of "MPI_COMM_WORLD", "MPI_COMM_SELF", and "MPI_COMM_PARENT" respectively. Passing `MPI_COMM_NULL` returns the string "MPI_COMM_NULL".
+//end::MPI_Comm_get_name[]
+
+//tag::MPI_Type_get_name[]
+**MPI_Type_get_name** returns the name previously associated with a datatype.
+This operation is local. If no name has been associated with the datatype, an empty string is returned. Named predefined datatypes have default names matching the datatype name. Passing `MPI_DATATYPE_NULL` as `datatype` returns the string "MPI_DATATYPE_NULL". The name may be set and retrieved from any language, returning the same name regardless of the language used.
+//end::MPI_Type_get_name[]
+
+//tag::MPI_Type_get_contents[]
+**MPI_Type_get_contents** retrieves the actual arguments used in the constructor call that created a datatype. The `datatype` must be a predefined unnamed or derived datatype; calling with a predefined named datatype is erroneous. The values for `max_integers`, `max_addresses`, `max_large_counts`, and `max_datatypes` must be at least as large as the corresponding values returned by MPI_TYPE_GET_ENVELOPE. Datatypes returned in `array_of_datatypes` are handles equivalent to those used in the original construction; derived datatypes are new objects the user is responsible for freeing with MPI_TYPE_FREE, while predefined datatypes cannot be freed. The committed state and attribute content of returned derived datatypes is undefined.
+
+If the variant without `max_large_counts` is invoked with a `datatype` requiring values in `array_of_large_counts`, an error of class `MPI_ERR_TYPE` is raised.
+//end::MPI_Type_get_contents[]
+
+//tag::MPI_Type_get_envelope[]
+**MPI_Type_get_envelope** returns information on the number and type of input arguments used in the call that created a datatype. The returned `combiner` reflects the MPI datatype constructor call used to create the datatype. The number-of-arguments values returned can be used to provide sufficiently large arrays in the decoding procedure MPI_TYPE_GET_CONTENTS.
+
+If `combiner` is `MPI_COMBINER_NAMED`, then `datatype` is a named predefined datatype. If the variant without `num_large_counts` is invoked with a datatype that requires an output value of `num_large_counts` greater than zero, an error of class `MPI_ERR_TYPE` is raised.
+//end::MPI_Type_get_envelope[]
+
+//tag::MPI_Get_elements[]
+**MPI_Get_elements** returns the number of basic elements received in a message by querying a status object.
+
+This operation is local. The `datatype` argument must match the datatype used in the receive call that set the `status` variable. This function may also be used after a probe to find the number of elements in the probed message. If the `count` output parameter cannot express the value to be returned, it is set to `MPI_UNDEFINED`. MPI_Get_elements and MPI_GET_COUNT return the same values when used with basic datatypes as long as the limits of their respective `count` arguments are not exceeded.
+//end::MPI_Get_elements[]
+
+//tag::MPI_Type_free[]
+**MPI_Type_free** marks a datatype object for deallocation and sets `datatype` to `MPI_DATATYPE_NULL`. Any communication currently using the datatype will complete normally. Freeing a datatype does not affect any other datatype that was built from the freed datatype.
+//end::MPI_Type_free[]
+
+//tag::MPI_Type_get_true_extent[]
+**MPI_Type_get_true_extent** returns the true lower bound and true extent of a datatype. The `true_lb` output returns the offset of the lowest unit of storage addressed by the datatype, ignoring explicit lower bound markers. The `true_extent` output returns the true size of the datatype, ignoring explicit lower bound and upper bound markers, and performing no rounding for alignment. The true extent is the minimum number of bytes of memory necessary to hold the datatype uncompressed.
+
+If either output parameter cannot express the value to be returned, it is set to `MPI_UNDEFINED`.
+//end::MPI_Type_get_true_extent[]
+
+//tag::MPI_Type_create_resized[]
+**MPI_Type_create_resized** creates a new datatype that is identical to `oldtype` except that the lower bound is set to `lb` and the upper bound is set to `lb` + `extent`. Any previous lower bound and upper bound markers are erased, and a new pair of markers are placed at the positions indicated by the `lb` and `extent` arguments. This affects the behavior of the datatype when used in communication operations with count greater than one and when used in the construction of new derived datatypes.
+
+In Fortran, it is recommended to use MPI_TYPE_CREATE_RESIZED for arrays of structures if an alignment may cause an alignment-gap at the end of a structure.
+//end::MPI_Type_create_resized[]
+
+//tag::MPI_Aint_add[]
+**MPI_Aint_add** produces a new `MPI_Aint` value equivalent to the sum of the `base` and `disp` arguments.
+
+The `base` argument represents a base address returned by a call to MPI_GET_ADDRESS. The resulting address is valid only at the process that generated `base` and must correspond to a location in the same object referenced by `base`. The addition is performed in a manner that results in the correct `MPI_Aint` representation of the output address. To ensure portability, arithmetic on MPI addresses are recommended to be performed using MPI_AINT_ADD and MPI_AINT_DIFF rather than intrinsic operators.
+//end::MPI_Aint_add[]
+
+//tag::MPI_Aint_diff[]
+**MPI_Aint_diff** produces a new `MPI_Aint` value equivalent to the difference between `addr1` and `addr2`.
+
+The `addr1` and `addr2` arguments represent addresses returned by calls to MPI_GET_ADDRESS. The resulting address is valid only at the process that generated `addr1` and `addr2`, and both addresses must correspond to locations in the same object in the same process. The difference is calculated in a manner that results in the signed difference from `addr1` to `addr2`. To ensure portability, arithmetic on MPI addresses are recommended to be performed using MPI_AINT_ADD and MPI_AINT_DIFF rather than intrinsic operators.
+//end::MPI_Aint_diff[]
+
+//tag::MPI_Get_address[]
+**MPI_Get_address** returns the byte address of a memory location.
+
+This operation is local and returns a valid address when passed a variable of the calling program. The returned address may be used to compute relative displacements between variables in the same sequential storage using MPI_AINT_DIFF or to compute new addresses using MPI_AINT_ADD. The C address operator `&` is not portable for this purpose on machines with a segmented address space. Arithmetic on MPI addresses using intrinsic operators is not recommended; the procedures MPI_AINT_ADD and MPI_AINT_DIFF are recommended for portability.
+//end::MPI_Get_address[]
+
+//tag::MPI_Type_create_subarray[]
+**MPI_Type_create_subarray** creates an MPI datatype describing an n-dimensional subarray of an n-dimensional array.
+The subarray may be situated anywhere within the full array and may be of any nonzero size up to the size of the larger array as long as it is confined within this array. This type constructor handles arrays with an arbitrary number of dimensions and works for both C-ordered (row-major) and Fortran-ordered (column-major) matrices. The `order` parameter must be set to `MPI_ORDER_C` or `MPI_ORDER_FORTRAN`. Arrays are assumed to be indexed starting from zero. In a Fortran program with arrays indexed starting from 1, if the starting coordinate of a particular dimension of the subarray is n, then the entry in `array_of_starts` for that dimension is n-1.
+//end::MPI_Type_create_subarray[]
+
+//tag::MPI_Type_create_hindexed_block[]
+**MPI_Type_create_hindexed_block** creates a derived datatype representing a sequence of blocks of replicated elements, where all blocks have the same length and byte displacements are specified for each block.
+
+This operation is local and is identical to MPI_TYPE_CREATE_INDEXED_BLOCK except that block displacements in `array_of_displacements` are specified in bytes rather than in multiples of the `oldtype` extent. The newly created datatype specifies a type map derived from `count` blocks, each containing `blocklength` copies of `oldtype`.
+//end::MPI_Type_create_hindexed_block[]
+
+//tag::MPI_Type_create_hindexed[]
+**MPI_Type_create_hindexed** creates a derived datatype representing a sequence of blocks of replicated elements, where each block can have a different length and byte displacement.
+
+This operation is local and is identical to MPI_TYPE_INDEXED except that block displacements in `array_of_displacements` are specified in bytes rather than in multiples of the `oldtype` extent. The newly created datatype has a type map with entries defined by summing the products of each block length with the number of entries in the old datatype's type map. A call to MPI_TYPE_CREATE_HINDEXED is equivalent to a call to MPI_TYPE_CREATE_STRUCT where each entry of the array of types is equal to `oldtype`.
+//end::MPI_Type_create_hindexed[]
+
+//tag::MPI_Type_indexed[]
+**MPI_Type_indexed** creates a derived datatype representing a sequence of blocks of replicated elements, where each block can have a different length and displacement.
+
+This operation is local and does not require communication with other processes. Block displacements are specified as multiples of the old datatype extent. The newly created datatype has a type map with entries defined by summing the products of each block length with the number of entries in the old datatype's type map. A call to MPI_TYPE_VECTOR(`count`, `blocklength`, `stride`, `oldtype`, `newtype`) is equivalent to a call to MPI_TYPE_INDEXED where all block lengths equal `blocklength` and displacements are computed as `stride` * j for each block j. If any block length is zero, that block generates no elements in the type map.
+//end::MPI_Type_indexed[]
+
+//tag::MPI_Type_create_hvector[]
+**MPI_Type_create_hvector** creates a derived datatype representing equally spaced blocks of replicated elements, where the spacing between blocks is specified in bytes. This operation is local and does not require communication with other processes. The constructor is identical to MPI_TYPE_VECTOR except that `stride` is given in bytes rather than in multiples of the old datatype extent. If `count` or `blocklength` is zero, no elements are generated in the type map.
+//end::MPI_Type_create_hvector[]
+
+//tag::MPI_Type_vector[]
+**MPI_Type_vector** is a datatype constructor that allows replication of a datatype into locations consisting of equally spaced blocks. Each block is obtained by concatenating the same number of copies of the old datatype. The spacing between blocks is a multiple of the extent of the old datatype. The newly created datatype has a type map with `count` * `blocklength` * n entries, where n is the number of entries in the old datatype's type map. A call to MPI_TYPE_CONTIGUOUS(`count`, `oldtype`, `newtype`) is equivalent to a call to MPI_TYPE_VECTOR(`count`, 1, 1, `oldtype`, `newtype`). If `count` or `blocklength` is zero, no elements are generated in the type map and there is no effect on datatype bounds or extent.
+//end::MPI_Type_vector[]
+
+//tag::MPI_Type_contiguous[]
+**MPI_Type_contiguous** is the simplest datatype constructor, creating a new datatype by replicating an existing datatype into contiguous locations.
+The `newtype` is obtained by concatenating `count` copies of `oldtype`, where concatenation is defined using extent as the size of the concatenated copies. The resulting type map contains `count` times the number of entries in `oldtype`. A replication count of zero generates an empty type map with no effect on datatype bounds or extent.
+//end::MPI_Type_contiguous[]
+
+//tag::MPI_Ineighbor_alltoall[]
+**MPI_Ineighbor_alltoall** starts a nonblocking neighborhood alltoall operation on a communicator with an associated virtual topology. Each process sends distinct data blocks to its outgoing neighbors and receives data blocks from its incoming neighbors. The k-th block in the send buffer is sent to the k-th outgoing neighbor and the l-th block in the receive buffer is received from the l-th incoming neighbor. This function is collective and must be called by all processes in the communicator. The communicator must have an associated Cartesian, graph, or distributed graph topology. The type signature at a sending process must equal the type signature at the corresponding receiving process. The amount of data sent must equal the amount of data received pairwise between every pair of communicating processes.
+
+If a neighbor is `MPI_PROC_NULL`, the buffer is still part of the sequence of neighbors but is neither communicated nor updated.
+//end::MPI_Ineighbor_alltoall[]
+
+//tag::MPI_Ineighbor_allgather[]
+**MPI_Ineighbor_allgather** starts a nonblocking neighborhood gather operation on a communicator with an associated virtual topology. Each process gathers data items from its incoming neighbors and sends the same data to all outgoing neighbors. This collective operation supports Cartesian, graph, and distributed graph communicators. Nonblocking variants allow relaxed synchronization and overlapping of computation and communication.
+
+All arguments are significant on all processes and `comm` must have identical values on all processes. The type signature associated with `sendcount` and `sendtype` at a process must be equal to the type signature associated with `recvcount` and `recvtype` at all other processes. If a neighbor is `MPI_PROC_NULL`, the buffer is still part of the sequence but is neither communicated nor updated.
+//end::MPI_Ineighbor_allgather[]
+
+//tag::MPI_Ineighbor_allgatherv[]
+**MPI_Ineighbor_allgatherv** starts a nonblocking neighborhood gather operation with varying receive counts on a communicator with an associated virtual topology. This collective operation gathers data from incoming neighbors and sends the same data to all outgoing neighbors. The procedure supports Cartesian, graph, and distributed graph communicators. Nonblocking variants allow relaxed synchronization and overlapping of computation and communication. For distributed graph topologies, the sequence of neighbors in send and receive buffers is defined by MPI_DIST_GRAPH_NEIGHBORS. For Cartesian topologies, the sequence of neighbors follows dimension order with negative direction first, then positive direction with displacement 1.
+
+All arguments are significant on all processes and `comm` must have identical values on all processes. The type signature associated with `sendcount` and `sendtype` at one process must equal the type signature associated with `recvcounts[l]` and `recvtype` at any other process where `srcs[l]` equals that process. If a neighbor is `MPI_PROC_NULL`, the buffer is still part of the sequence but is neither communicated nor updated. The in-place option is not meaningful for this operation.
+//end::MPI_Ineighbor_allgatherv[]
+
+//tag::MPI_Neighbor_alltoallw[]
+**MPI_Neighbor_alltoallw** performs an all-to-all communication with different datatypes to and from each neighbor on a virtual topology.
+
+This operation is collective and must be called by all MPI processes in the communicator. It supports Cartesian, graph, and distributed graph communicators. Each process sends data to its outgoing neighbors and receives data from its incoming neighbors as defined by the topology. The type signature of data sent must match the type signature of data received pairwise between every pair of communicating processes. The "in place" option is not meaningful for this operation. If a neighbor is `MPI_PROC_NULL`, the buffer is still part of the sequence of neighbors but is neither communicated nor updated.
+//end::MPI_Neighbor_alltoallw[]
+
+//tag::MPI_Neighbor_alltoallv[]
+**MPI_Neighbor_alltoallv** performs a neighborhood collective alltoallv operation on a communicator with an associated virtual topology.
+
+This collective operation supports Cartesian, graph, and distributed graph communicators. Each process sends data to each outgoing neighbor starting at an offset of `sdispls[k]` elements and receives data from each incoming neighbor into an offset of `rdispls[l]` elements. For distributed graph topologies, the sequence of neighbors is defined by MPI_DIST_GRAPH_NEIGHBORS. The type signature at the sender must equal the type signature at the receiver for each communicating pair. If a neighbor is `MPI_PROC_NULL`, the buffer position is neither communicated nor updated. All arguments are significant on all processes and `comm` must have identical values on all processes. The in-place option is not meaningful for this operation.
+//end::MPI_Neighbor_alltoallv[]
+
+//tag::MPI_Neighbor_alltoall[]
+**MPI_Neighbor_alltoall** performs a neighborhood collective alltoall operation on a communicator with an associated virtual topology.
+
+This collective operation supports Cartesian, graph, and distributed graph communicators. Each process i receives data from each process j if an edge (j,i) exists in the topology graph, and sends data to each process j where an edge (i,j) exists. The k-th block in the send buffer is sent to the k-th outgoing neighbor and the l-th block in the receive buffer is received from the l-th incoming neighbor. The type signature at a process must equal the type signature at any other process for each communicating pair. If a neighbor is `MPI_PROC_NULL`, the buffer position is neither communicated nor updated. All arguments are significant on all processes and `comm` must have identical values on all processes. The in-place option is not meaningful for this operation.
+//end::MPI_Neighbor_alltoall[]
+
+//tag::MPI_Neighbor_allgatherv[]
+**MPI_Neighbor_allgatherv** performs a neighborhood gather operation with varying receive counts on a communicator with an associated virtual topology.
+
+This collective operation gathers data items from each incoming neighbor and sends the same data to all outgoing neighbors. The procedure supports Cartesian, graph, and distributed graph communicators. For distributed graph topologies, the sequence of neighbors in send and receive buffers is defined by MPI_DIST_GRAPH_NEIGHBORS. For Cartesian topologies, the sequence of neighbors follows dimension order with negative direction first, then positive direction with displacement 1. If a neighbor is `MPI_PROC_NULL`, the buffer position is neither communicated nor updated. The type signature at the sending process must equal the type signature at the receiving process for each communicating pair. The "in place" option is not meaningful for this operation.
+//end::MPI_Neighbor_allgatherv[]
+
+//tag::MPI_Neighbor_allgather[]
+**MPI_Neighbor_allgather** performs a neighborhood gather operation on a communicator with an associated virtual topology.
+
+This collective operation supports Cartesian, graph, and distributed graph communicators. Each process sends its send buffer to all outgoing neighbors and receives data from all incoming neighbors into separate locations of the receive buffer. The sequence of neighbors is determined by the topology type: for distributed graphs, by MPI_DIST_GRAPH_NEIGHBORS; for graphs, by MPI_GRAPH_NEIGHBORS; for Cartesian topologies, by dimension order with negative then positive direction. All arguments are significant on all processes and `comm` must have identical values on all processes. The type signature of send data at one process must equal the type signature of corresponding receive data at all neighboring processes. If a neighbor is `MPI_PROC_NULL`, the buffer position is neither communicated nor updated. The in-place option is not meaningful for this operation.
+//end::MPI_Neighbor_allgather[]
+
+//tag::MPI_Cart_sub[]
+**MPI_Cart_sub** partitions a communicator with an associated Cartesian topology into subgroups that form lower-dimensional Cartesian subgrids.
+
+This function is collective over the input communicator's group. The new communicator `newcomm` is associated with a subgrid Cartesian topology containing the calling process. The number of dimensions in the subgrid is the count of true values in `remain_dims`. The periodicity for remaining dimensions is preserved from the original communicator. If all entries in `remain_dims` are false or if `comm` is already associated with a zero-dimensional Cartesian topology, `newcomm` is associated with a zero-dimensional Cartesian topology.
+//end::MPI_Cart_sub[]
+
+//tag::MPI_Cart_shift[]
+**MPI_Cart_shift** provides source and destination ranks for performing a shift of data along a Cartesian dimension using MPI_SENDRECV.
+This function is local. Depending on the periodicity of the Cartesian topology in the specified coordinate direction, the function provides identifiers for either a circular or an end-off shift. In the case of an end-off shift, the value `MPI_PROC_NULL` is returned in `rank_source` or `rank_dest` indicating that the source or destination for the shift is out of range. In Fortran, the dimension indicated by DIRECTION = i has DIMS(i+1) nodes; in C, the dimension indicated by direction = i is specified by dims[i].
+//end::MPI_Cart_shift[]
+
+//tag::MPI_Cart_rank[]
+**MPI_Cart_rank** translates the logical Cartesian coordinates of an MPI process to the corresponding rank in the group of the communicator.
+This operation is local. For periodic dimensions, out-of-range coordinates are automatically shifted back to the valid interval. Out-of-range coordinates are erroneous for nonperiodic dimensions. If `comm` is associated with a zero-dimensional Cartesian topology, `coords` is not significant and 0 is returned in `rank`.
+//end::MPI_Cart_rank[]
+
+//tag::MPI_Cart_get[]
+**MPI_Cart_get** retrieves the Cartesian topology information associated with a communicator.
+
+This operation is local. If `comm` is associated with a zero-dimensional Cartesian topology, all output arguments are unchanged. If `maxdims` is less than the number of dimensions of the Cartesian topology associated with `comm`, the outcome is unspecified.
+//end::MPI_Cart_get[]
+
+//tag::MPI_Graph_get[]
+**MPI_Graph_get** retrieves graph topology information associated with a communicator.
+This operation is local. The `index` and `edges` arrays are populated with the graph structure as originally specified in MPI_GRAPH_CREATE. MPI_GRAPHDIMS_GET may be used to determine the appropriate sizes for the `index` and `edges` arrays before calling this function.
+//end::MPI_Graph_get[]
+
+//tag::MPI_Topo_test[]
+**MPI_Topo_test** returns the type of topology associated with a communicator. This operation is local. The output `status` is one of `MPI_GRAPH` for graph topology, `MPI_CART` for Cartesian topology, `MPI_DIST_GRAPH` for distributed graph topology, or `MPI_UNDEFINED` for no topology.
+//end::MPI_Topo_test[]
+
+//tag::MPI_Dist_graph_create[]
+**MPI_Dist_graph_create** creates a new communicator with distributed graph topology information attached. This collective operation allows each MPI process to specify a subset of the communication graph edges, enabling a fully distributed specification. The number of MPI processes in the output communicator is identical to the number in the input communicator. If `reorder` is false, all processes retain their ranks; if true, the library may remap processes to improve communication on graph edges. Isolated processes with no incoming or outgoing edges are allowed. Different processes may specify different numbers of source and destination nodes and different edges.
+
+It is erroneous to supply `MPI_UNWEIGHTED` for `weights` on some but not all MPI processes of `comm_old`. When constructing a weighted graph with `n` = 0, `MPI_WEIGHTS_EMPTY` or any arbitrary array may be passed to `weights`. All MPI processes must specify the same set of (`key`,`value`) `info` pairs.
+//end::MPI_Dist_graph_create[]
+
+//tag::MPI_Graph_create[]
+**MPI_Graph_create** creates a new communicator with graph topology information attached.
+
+This collective operation returns a handle to a new communicator to which the graph topology information is attached. If `reorder` = false, the rank of each process in the new communicator is identical to its rank in `comm_old`; if `reorder` = true, the function may reorder the ranks. If `nnodes` is smaller than the size of the group of `comm_old`, some processes return `MPI_COMM_NULL`; if `nnodes` = 0, `MPI_COMM_NULL` is returned in all processes. Each process specifies all nodes and edges in the graph, and all input arguments must have identical values on all processes. The call is erroneous if the specified graph is larger than the group size. A process may be defined multiple times in the list of neighbors of a process, and a process may be a neighbor to itself. Performance implications of using multiple edges or a nonsymmetric adjacency matrix are not defined, and the definition of a node-neighbor edge does not imply a direction of communication.
+//end::MPI_Graph_create[]
+
+//tag::MPI_Cart_create[]
+**MPI_Cart_create** creates a new communicator with Cartesian topology information attached.
+
+This collective operation returns a handle to a new communicator to which the Cartesian topology information is attached. If `reorder` = false, the rank of each process in the new communicator is identical to its rank in `comm_old`; if `reorder` = true, the function may reorder the ranks to achieve a better mapping of the virtual topology onto the physical machine. If the total size of the Cartesian grid is smaller than the size of the group of `comm_old`, some processes return `MPI_COMM_NULL`. If `ndims` is zero, a zero-dimensional Cartesian topology is created. All input arguments must have identical values on all processes of `comm_old`. The call is erroneous if the specified grid is larger than the group size or if `ndims` is negative. As with other collective calls, programs must be written to work correctly whether the call synchronizes or not.
+//end::MPI_Cart_create[]
+
+//tag::MPI_Bcast[]
+**MPI_Bcast** broadcasts a message from the process with rank `root` to all processes of the group, including itself.
+
+If `comm` is an intra-communicator, all members of the group call the routine using the same arguments for `comm` and `root`, and on return, the content of the root's buffer is copied to all other processes. If `comm` is an inter-communicator, all processes in the inter-communicator participate, with one group defining the root; processes in the other group pass the rank of the root in their `root` argument, the root passes `MPI_ROOT`, and all other processes in the root's group pass `MPI_PROC_NULL`. The type signature of `count` and `datatype` on any process must be equal to the type signature at the root. Distinct type maps between sender and receiver are allowed. MPI_Bcast is a collective operation that may or may not have the effect of synchronizing all participating processes; programs are recommended to avoid relying on synchronization side-effects for correctness, while allowing for the fact that a collective call may be synchronizing.
+//end::MPI_Bcast[]
+
+//tag::MPI_Get_elements_x[]
+**MPI_Get_elements_x** is deprecated and may be removed in a future version of the MPI specification.
+
+This function returns the number of received basic elements from a completed receive operation. The description of MPI_GET_ELEMENTS is applicable to this deprecated function. For C and Fortran `mpi_f08` module bindings, it is superseded by the large count bindings of MPI_GET_ELEMENTS.
+//end::MPI_Get_elements_x[]
+
+//tag::MPI_Comm_free_keyval[]
+**MPI_Comm_free_keyval** frees an extant communicator attribute key.
+
+This operation is local and sets `comm_keyval` to `MPI_KEYVAL_INVALID`. It is not erroneous to free an attribute key that is in use because the actual free does not occur until after all references to the key have been freed. These references must be explicitly freed by the program via calls to MPI_COMM_DELETE_ATTR that free one attribute instance, or via calls to MPI_COMM_FREE that free all attribute instances associated with the freed communicator.
+//end::MPI_Comm_free_keyval[]
+
+//tag::MPI_Status_set_elements[]
+**MPI_Status_set_elements** modifies the opaque part of a `status` object so that subsequent calls to MPI_GET_ELEMENTS return `count`. Calls to MPI_GET_COUNT will return a compatible value. A subsequent call to MPI_GET_COUNT or MPI_GET_ELEMENTS must use a `datatype` argument with the same type signature as used in the call to MPI_STATUS_SET_ELEMENTS.
+
+Users are advised not to reuse status fields for values other than those for which they were intended, as calling MPI_GET_ELEMENTS may cause an error if the value is out of range.
+//end::MPI_Status_set_elements[]
+
+//tag::MPI_Status_set_elements_x[]
+**MPI_Status_set_elements_x** is deprecated and may be removed in a future version of the MPI specification.
+
+This function sets the element count in a `status` object to associate with a specified `datatype`. The description of MPI_STATUS_SET_ELEMENTS is applicable to this deprecated function. For C and Fortran `mpi_f08` module bindings, it is superseded by the large count bindings of MPI_STATUS_SET_ELEMENTS.
+//end::MPI_Status_set_elements_x[]
+
+//tag::MPI_Comm_remote_size[]
+**MPI_Comm_remote_size** returns the number of MPI processes in the remote group of an inter-communicator.
+
+This operation is local. In inter-communication, the remote group refers to the group containing the target process: the receiver in a send operation and the sender in a receive operation. Symmetric access to both the local and remote groups of an inter-communicator is provided through this function and MPI_COMM_REMOTE_GROUP.
+//end::MPI_Comm_remote_size[]
+
+//tag::MPI_Comm_remote_group[]
+**MPI_Comm_remote_group** returns a handle to the remote group of an inter-communicator.
+
+This operation is local. In inter-communication, the remote group refers to the group containing the target process: the receiver in a send operation and the sender in a receive operation. Symmetric access to both the local and remote groups of an inter-communicator is provided through this function and MPI_COMM_REMOTE_SIZE. The returned `group` handle may be used with group manipulation functions. Groups are opaque objects that cannot be directly transferred between MPI processes.
+//end::MPI_Comm_remote_group[]
+
+//tag::MPI_Comm_test_inter[]
+**MPI_Comm_test_inter** determines whether a communicator is an inter-communicator or an intra-communicator. This operation is local. The function returns `flag` = true if `comm` is an inter-communicator, and `flag` = false otherwise.
+//end::MPI_Comm_test_inter[]
+
+//tag::MPI_Comm_free[]
+**MPI_Comm_free** marks a communicator for deallocation.
+
+This collective operation applies to both intra-communicators and inter-communicators. Any operations using the communicator, whether active or inactive at the time of the call, will continue to work normally. The communicator is actually deallocated only when there are no other active references to it. Delete callback functions for all cached attributes are invoked in arbitrary order.
+
+The function sets `comm` to `MPI_COMM_NULL` upon return.
+//end::MPI_Comm_free[]
+
+//tag::MPI_Comm_create_from_group[]
+**MPI_Comm_create_from_group** creates a new intra-communicator from a specified group without requiring an existing communicator as input.
+All MPI processes in the nonempty `group` must call the function with identical arguments, including the same members in the same order and identical `stringtag` values. The `stringtag` argument differentiates concurrent communicator creation operations in a multithreaded environment. If `MPI_GROUP_EMPTY` is supplied as the `group` argument, the call is a local operation and `MPI_COMM_NULL` is returned as `newcomm`. No cached information or virtual topology information is propagated to the new communicator. The `errhandler` argument specifies an error handler to be attached to the new intra-communicator. The `info` argument provides hints and assertions to guide communicator creation.
+
+If multiple threads at a given MPI process perform concurrent MPI_COMM_CREATE_FROM_GROUP operations, users must distinguish these operations by providing different `stringtag` arguments. The `stringtag` shall not exceed `MPI_MAX_STRINGTAG_LEN` characters in length.
+//end::MPI_Comm_create_from_group[]
+
+//tag::MPI_Comm_split_type[]
+**MPI_Comm_split_type** partitions the group associated with a communicator into disjoint subgroups based on a specified `split_type` criterion.
+
+This is a collective call where all MPI processes in the group must participate and provide the same `split_type`, with each process permitted to provide different values for `key`. The function returns `MPI_COMM_NULL` in `newcomm` when a process supplies `MPI_UNDEFINED` as `split_type`. For `MPI_COMM_TYPE_HW_GUIDED` and `MPI_COMM_TYPE_RESOURCE_GUIDED`, `MPI_COMM_NULL` is returned when `MPI_INFO_NULL` is provided, when the `info` handle lacks required keys, when the implementation does not recognize or support the specified info keys, or when the implementation does not recognize the value associated with the info key. For `MPI_COMM_TYPE_HW_UNGUIDED`, `MPI_COMM_NULL` is returned when a process cannot be a member of a communicator that forms a strict subset or does not meet the hardware resource criteria. No cached information propagates from `comm` to `newcomm` and no virtual topology information is added to the created communicators.
+//end::MPI_Comm_split_type[]
+
+//tag::MPI_Comm_split[]
+**MPI_Comm_split** partitions the group associated with a communicator into disjoint subgroups based on `color` and creates a new communicator for each subgroup.
+
+This is a collective operation over the group or groups associated with `comm`. Each subgroup contains all MPI processes of the same `color`, ranked in the order defined by `key` with ties broken according to rank in the old group. An MPI process may supply `MPI_UNDEFINED` as `color`, in which case `MPI_COMM_NULL` is returned in `newcomm`. Each MPI process is permitted to provide different values for `color` and `key`. No cached information propagates from `comm` to `newcomm` and no virtual topology information is added to the created communicators. The value of `color` must be nonnegative or `MPI_UNDEFINED`. For inter-communicators, MPI processes on the left with the same `color` as those on the right combine to create a new inter-communicator; colors specified only on one side result in `MPI_COMM_NULL`. Multiple calls to MPI_COMM_SPLIT may be used to create overlapping communication structures.
+//end::MPI_Comm_split[]
+
+//tag::MPI_Comm_dup_with_info[]
+**MPI_Comm_dup_with_info** duplicates an existing communicator with associated key values, topology information, and error handlers, while associating hints provided by the `info` argument with the output communicator.
+
+This is a collective operation and all MPI processes in the group or groups associated with `comm` must call it. For each key value, the respective copy callback function determines the attribute value associated with this key in the new communicator. The call returns in `newcomm` a new communicator with the same group or groups, same topology, same error handlers, and any copied cached information, but a new context. The newly created communicator will have no buffer attached. This call is valid even if there are pending point-to-point communication operations or decoupled MPI activities involving `comm`. The call applies to both intra-communicators and inter-communicators.
+//end::MPI_Comm_dup_with_info[]
+
+//tag::MPI_Comm_idup_with_info[]
+**MPI_Comm_idup_with_info** is a nonblocking variant of MPI_COMM_DUP_WITH_INFO that duplicates a communicator with associated info hints.
+
+This is a collective operation over the group or groups associated with `comm`. The semantics are as if MPI_COMM_DUP_WITH_INFO was executed at the time that MPI_Comm_idup_with_info is called. Attributes or info hints changed after MPI_Comm_idup_with_info will not be copied to the new communicator. All restrictions and assumptions for nonblocking collective operations apply to MPI_Comm_idup_with_info and the returned `request`. This call applies to both intra-communicators and inter-communicators.
+
+It is erroneous to use `newcomm` as an input argument to other MPI functions before the MPI_Comm_idup_with_info operation completes.
+//end::MPI_Comm_idup_with_info[]
+
+//tag::MPI_Comm_group[]
+**MPI_Comm_group** returns a handle to the group associated with a communicator.
+
+This operation is local. Groups are opaque objects that define an ordered collection of MPI processes, each identified by a rank starting from zero. The returned `group` handle may be used with group manipulation functions but cannot be directly transferred between MPI processes. Only communicators, not groups, can be used in communication operations.
+//end::MPI_Comm_group[]
+
+//tag::MPI_Comm_create_errhandler[]
+**MPI_Comm_create_errhandler** creates an error handler that can be attached to communicators. The user routine `comm_errhandler_fn` defines the error handling procedure to be invoked when errors occur on the associated communicator. The created error handler is returned in `errhandler`. A newly created communicator inherits the error handler associated with the parent communicator. In the World Process Model, users may specify an error handler for all communicators by associating this handler with the predefined communicators `MPI_COMM_WORLD` and `MPI_COMM_SELF` before creating other communicators.
+//end::MPI_Comm_create_errhandler[]
+
+//tag::MPI_Errhandler_c2f[]
+**MPI_Errhandler_c2f** translates a C error handler handle into a Fortran error handler handle.
+
+This function is local and available only in C. It maps a null C handle to a null Fortran handle and an invalid C handle to an invalid Fortran handle. With the Fortran `mpi` module or the deprecated `mpif.h` include file, the returned Fortran handle is an `INTEGER` value. With the Fortran `mpi_f08` module, the returned handle is a `BIND(C)` derived type containing an `INTEGER` component named `MPI_VAL`.
+//end::MPI_Errhandler_c2f[]
+
+//tag::MPI_Comm_c2f[]
+**MPI_Comm_c2f** translates a C communicator handle into a Fortran handle to the same communicator. It maps a null handle into a null handle and an invalid handle into an invalid handle.
+//end::MPI_Comm_c2f[]
+
+//tag::MPI_Type_create_keyval[]
+**MPI_Type_create_keyval** generates a new attribute key for associating attributes with datatypes.
+
+This operation is local. Keys are locally unique in an MPI process and opaque to the user, though stored in integers. Once allocated, the key value can be used to associate attributes and access them on any locally defined datatype. The `type_copy_attr_fn` callback is invoked when a datatype is duplicated, and `type_delete_attr_fn` is invoked when an attribute is deleted or when the datatype is freed. The predefined callbacks `MPI_TYPE_NULL_COPY_FN` and `MPI_TYPE_DUP_FN` may be used from either C or Fortran. Invalid key values may return error class `MPI_ERR_KEYVAL`.
+//end::MPI_Type_create_keyval[]
+
+//tag::MPI_Type_c2f[]
+**MPI_Type_c2f** translates a C datatype handle into a Fortran handle to the same datatype. It maps a null handle into a null handle and an invalid handle into an invalid handle.
+//end::MPI_Type_c2f[]
+
+//tag::MPI_Win_c2f[]
+**MPI_Win_c2f** translates a C window handle into a Fortran handle to the same window. It maps a null handle into a null handle and an invalid handle into an invalid handle. This function is provided only in C to support interlanguage operability when C wrappers are used to allow Fortran code to call C libraries or vice versa.
+//end::MPI_Win_c2f[]
+
+//tag::MPI_Group_f2c[]
+**MPI_Group_f2c** converts a Fortran group handle to a C group handle. If `group` is a valid Fortran handle to a group, the function returns a valid C handle to that same group. If `group` equals `MPI_GROUP_NULL` (Fortran value), the function returns a null C handle. If `group` is an invalid Fortran handle, the function returns an invalid C handle.
+//end::MPI_Group_f2c[]
+
+//tag::MPI_Type_create_f90_real[]
+**MPI_Type_create_f90_real** returns a predefined MPI datatype that matches a Fortran REAL variable of KIND `selected_real_kind(p, r)`.
+
+Either `p` or `r` may be set to `MPI_UNDEFINED`, but not both. A datatype returned by this function matches another datatype if and only if both were created with the same `p` and `r` values, or one is a duplicate of such a datatype. The returned datatype is predefined, cannot be freed, does not need to be committed, and can be used with predefined reduction operations. Restrictions apply when using the returned datatype with the `external32` data representation. It is erroneous to supply values for `p` and `r` not supported by the compiler.
+//end::MPI_Type_create_f90_real[]
+
+//tag::MPI_Type_create_f90_integer[]
+**MPI_Type_create_f90_integer** returns a predefined MPI datatype that matches a Fortran INTEGER variable of KIND `selected_int_kind(r)`. A datatype returned by this function matches another datatype if and only if both were created with the same `r` value, or one is a duplicate of such a datatype. The returned datatype is predefined, cannot be freed, does not need to be committed, and can be used with predefined reduction operations. Restrictions apply when using the returned datatype with the `external32` data representation. It is erroneous to supply a value for `r` not supported by the compiler.
+//end::MPI_Type_create_f90_integer[]
+
+//tag::MPI_Comm_toint[]
+**MPI_Comm_toint** translates a C communicator handle into a C integer. For predefined handles, the integer value matches the values specified by the MPI ABI. For user-defined handles, the implementation returns the same integer for every call with the same handle, which does not conflict with the reserved range for predefined handles.
+
+It is erroneous to call this function with an invalid `comm` argument.
+//end::MPI_Comm_toint[]
+
+//tag::MPI_Grequest_start[]
+**MPI_Grequest_start** creates a generalized request that allows users to define new nonblocking operations with an interface similar to standard MPI operations.
+
+The call is local and returns a handle in `request`. Progress toward completion of generalized requests occurs asynchronously and may require concurrent execution via threads or signal handlers provided by the operating system. Callback functions `query_fn`, `free_fn`, and `cancel_fn` may invoke blocking MPI communication calls only if guaranteed to return in finite time. MPI maintains only the completion status of generalized requests; all other state must be maintained by the user. Users are advised not to reuse status fields for unintended values, as doing so may lead to unexpected results; the `extra_state` argument may be used to return information that does not logically belong in status.
+//end::MPI_Grequest_start[]
+
+//tag::MPI_Grequest_complete[]
+**MPI_Grequest_complete** notifies MPI that the operations represented by a generalized `request` are complete.
+
+A call to MPI_WAIT on the request will return and MPI_TEST will return `flag` = true only after MPI_Grequest_complete has declared that operations are complete. Progress toward completion of generalized requests occurs asynchronously and may require concurrent execution via threads or signal handlers provided by the underlying operating system. Callback functions `query_fn`, `free_fn`, and `cancel_fn` may invoke blocking MPI communication calls only if guaranteed to return in finite time. Once MPI_CANCEL is invoked, the cancelled operation may complete in finite time irrespective of the state of other MPI processes; it may either succeed or fail without side-effects.
+//end::MPI_Grequest_complete[]
+
+//tag::MPI_Mrecv[]
+**MPI_Mrecv** receives a message that was previously matched by a matching probe operation. The receive buffer must be large enough to hold the incoming message; an overflow error occurs if the data does not fit without truncation. On return, the `message` handle is set to `MPI_MESSAGE_NULL`. Errors during execution are handled according to the error handler set for the communicator used in the matching probe call. Calling MPI_Mrecv with `MPI_MESSAGE_NULL` is erroneous.
+
+If `message` is `MPI_MESSAGE_NO_PROC`, the call returns immediately with `status` set to `source` = `MPI_PROC_NULL`, `tag` = `MPI_ANY_TAG`, and `count` = 0.
+//end::MPI_Mrecv[]
+
+//tag::MPI_Request_get_status_some[]
+**MPI_Request_get_status_some** returns the number of completed requests from an array, along with their indices and statuses, without deallocating or inactivating any request. If no operation completes, `outcount` is set to 0. If all requests in `array_of_requests` are either `MPI_REQUEST_NULL` or inactive, `outcount` is set to `MPI_UNDEFINED`.
+
+The progress rule for MPI_TEST applies. This function fulfills a fairness requirement: if a request for a receive repeatedly appears in a list of requests passed to MPI_REQUEST_GET_STATUS_SOME, MPI_WAITSOME, or MPI_TESTSOME and a matching send has been started, then the receive will eventually succeed unless the send is satisfied by another receive. Nonblocking communication operations are nonovertaking.
+//end::MPI_Request_get_status_some[]
+
+//tag::MPI_Request_get_status_any[]
+**MPI_Request_get_status_any** tests for completion of either one or none of the operations associated with active handles in an array without deallocating or inactivating any request. If one operation completes, the function returns `flag` = true, the index of the completed request, and its status. If no operation completes, the function returns `flag` = false, `index` = `MPI_UNDEFINED`, and an undefined status. If the array contains no active handles, the function returns immediately with `flag` = true, `index` = `MPI_UNDEFINED`, and an empty status.
+
+The array may contain null or inactive handles. The progress rule for MPI_TEST applies, and nonblocking communication operations are nonovertaking.
+//end::MPI_Request_get_status_any[]
+
+//tag::MPI_Request_get_status_all[]
+**MPI_Request_get_status_all** returns `flag` = true if all communication operations associated with active handles in the array have completed, including the case where all handles are inactive or `MPI_REQUEST_NULL`. Each status entry corresponding to an active request is set to the status of the corresponding operation. Unlike test or wait, it does not deallocate or inactivate the requests; a subsequent call to test, wait, or free is required for each request. Each status entry corresponding to a null or inactive handle is set to empty. If `flag` = false is returned, the values of the status entries are undefined.
+
+The progress rule for MPI_TEST applies.
+//end::MPI_Request_get_status_all[]
+
+//tag::MPI_Request_free[]
+**MPI_Request_free** marks a request object for deallocation and sets `request` to `MPI_REQUEST_NULL`.
+
+This procedure is local. For an inactive request, the freeing stage executes immediately; for an active nonblocking or persistent point-to-point request, the request is marked for freeing and MPI performs the actual freeing later. Calling this function with an active request representing any other operation type, such as partitioned, collective, I/O, or RMA operations, is erroneous. Once freed, the associated communication cannot be checked for completion via MPI_WAIT or MPI_TEST, and subsequent errors are treated as fatal. An active receive request is not recommended to be freed as the receiver has no way to verify completion and buffer reuse.
+//end::MPI_Request_free[]
+
+//tag::MPI_Issend[]
+**MPI_Issend** initiates a synchronous mode nonblocking send operation. The call is local and returns immediately, regardless of the status of other MPI processes. The send completes successfully only if a matching receive is started and has begun to receive the message. The sender must not modify the send buffer after the call until the operation completes via MPI_WAIT or MPI_TEST. Nonblocking sends can be matched with blocking receives.
+
+Nonblocking communication operations are nonovertaking and ordered according to the execution order of the calls that initiate them. In a multithreaded environment, users are responsible for not modifying the communication buffer until the communication completes.
+//end::MPI_Issend[]
+
+//tag::MPI_Isend[]
+**MPI_Isend** initiates a standard mode nonblocking send operation. The call is local and returns immediately, regardless of the status of other MPI processes. The send buffer may not be modified until the operation completes via MPI_WAIT or MPI_TEST. Message data may be copied directly into the matching receive buffer or buffered by the communication subsystem. Nonblocking sends can be matched with blocking receives.
+
+Nonblocking communication operations are nonovertaking and messages are ordered according to the execution order of the calls that initiate them.
+//end::MPI_Isend[]
+
+//tag::MPI_Ibsend[]
+**MPI_Ibsend** initiates a buffered mode nonblocking send operation. The call is local and returns immediately, regardless of whether a matching receive has been started. Completion does not depend on the occurrence of a matching receive; if no matching receive is started, the message is buffered. The sender must not modify the send buffer after the call until the operation completes via MPI_WAIT or MPI_TEST.
+
+Nonblocking communication operations are nonovertaking and ordered according to the execution order of the calls that initiate them. In a multithreaded environment, users are responsible for not modifying the communication buffer until the communication completes.
+//end::MPI_Ibsend[]
+
+//tag::MPI_Comm_detach_buffer[]
+**MPI_Comm_detach_buffer** detaches the communicator-specific buffer currently attached to the communicator. This procedure is nonlocal and will delay return until all messages currently in the buffer have been transmitted, returning the address and size of the detached buffer. Upon return, the user may reuse or deallocate the buffer space. If `MPI_BUFFER_AUTOMATIC` was used in the corresponding attach procedure, `MPI_BUFFER_AUTOMATIC` is returned in `buffer_addr`, the value in `size` is undefined, and automatic buffering is disabled. If the size of the detached buffer cannot be represented in `size`, it is set to `MPI_UNDEFINED`.
+
+The procedure must eventually return when all corresponding receive operations are started, provided that none are cancelled.
+//end::MPI_Comm_detach_buffer[]
+
+//tag::MPI_Session_detach_buffer[]
+**MPI_Session_detach_buffer** detaches the session-specific buffer currently attached to a session and returns the address and size of the detached buffer. This procedure is nonlocal and will delay return until all messages currently in the buffer have been transmitted, after which the user may reuse or deallocate the buffer space.
+
+If `MPI_BUFFER_AUTOMATIC` was used in the corresponding attach procedure, `MPI_BUFFER_AUTOMATIC` is returned in `buffer_addr`, the value in `size` is undefined, and automatic buffering is disabled. If the size of the detached buffer cannot be represented in `size`, it is set to `MPI_UNDEFINED`. It is erroneous to detach a buffer if no buffer was attached using a corresponding attach procedure. For libraries and programs using the Sessions Model, using only communicator-specific or session-specific buffers is recommended.
+//end::MPI_Session_detach_buffer[]
+
+//tag::MPI_Comm_attach_buffer[]
+**MPI_Comm_attach_buffer** provides a communicator-specific buffer for buffered mode send operations.
+
+This procedure is local. The buffer is used for outgoing messages sent when a buffered mode send uses the communicator `comm`. If `MPI_BUFFER_AUTOMATIC` is passed as `buffer`, automatic buffering is enabled for all buffered mode communication associated with the communicator and `size` is ignored. Only one buffer may be attached to a communicator at a time. It is erroneous to attach a buffer to a communicator that already has an attached buffer.
+//end::MPI_Comm_attach_buffer[]
+
+//tag::MPI_Comm_flush_buffer[]
+**MPI_Comm_flush_buffer** blocks until all messages in the communicator-specific buffer of the calling MPI process have been transmitted without detaching the buffer.
+This procedure is nonlocal. It must eventually return when all corresponding receive operations are started, provided that none are cancelled. It is erroneous to call this procedure if no buffer is attached to the communicator, including automatic buffering.
+//end::MPI_Comm_flush_buffer[]
+
+//tag::MPI_Ssend[]
+**MPI_Ssend** performs a blocking synchronous mode point-to-point send operation. The send may be started whether or not a matching receive has been started. The send completes successfully only if a matching receive is started and has begun to receive the message sent by the synchronous send. Completion indicates that the send buffer can be reused and that the receiver has reached a certain point in its execution, namely that it has started executing the matching receive. A synchronous mode send is nonlocal.
+
+Sends are nonovertaking; if a sender sends two messages in succession to the same destination, and both match the same receive, the receive operation cannot receive the second message if the first is still pending. In a multithreaded implementation, the user is responsible not to modify the communication buffer until the communication completes.
+//end::MPI_Ssend[]
+
+//tag::MPI_Bsend[]
+**MPI_Bsend** performs a blocking buffered mode send operation.
+
+The send operation is local and completes without depending on the occurrence of a matching receive. If a send is executed and no matching receive is started, MPI buffers the outgoing message, and an error occurs if there is insufficient buffer space. Buffer allocation by the user via MPI_BUFFER_ATTACH, MPI_COMM_ATTACH_BUFFER, or MPI_SESSION_ATTACH_BUFFER may be required for the buffered mode to be effective. Sends are nonovertaking: if a sender sends two messages in succession to the same destination, and both match the same receive, the receive operation cannot receive the second message if the first is still pending. In a multithreaded implementation, the user is responsible not to modify the communication buffer until the communication completes. For libraries and programs using the Sessions Model, using only communicator-specific or session-specific buffers is recommended.
+//end::MPI_Bsend[]
+
+//tag::MPI_Bsend_init[]
+**MPI_Bsend_init** creates a persistent communication request for a buffered mode send operation.
+
+This initialization call is local and binds all arguments to an inactive persistent request without initiating communication. A call to MPI_START with the returned `request` has the same effect as MPI_IBSEND. The request may be started and completed repeatedly using MPI_START and completion procedures such as MPI_WAIT or MPI_TEST. Communication operations started from persistent requests are nonovertaking: if a sender sends two messages in succession to the same destination and both match the same receive, the receive operation cannot receive the second message if the first is still pending. Freeing inactive persistent request handles explicitly via MPI_REQUEST_FREE before freeing or disconnecting the associated communicator is recommended.
+//end::MPI_Bsend_init[]
+
+//tag::MPI_Ssend_init[]
+**MPI_Ssend_init** creates a persistent communication request for a synchronous mode send operation.
+
+This initialization call is local and binds all arguments to an inactive persistent request without initiating communication. A call to MPI_START with the returned `request` has the same effect as MPI_ISSEND, and the started send completes successfully only if a matching receive is started and has begun to receive the message. The request may be started and completed repeatedly using MPI_START and completion procedures such as MPI_WAIT or MPI_TEST. Communication operations started from persistent requests are nonovertaking: if a sender sends two messages in succession to the same destination and both match the same receive, the receive operation cannot receive the second message if the first is still pending. Freeing inactive persistent request handles explicitly via MPI_REQUEST_FREE before freeing or disconnecting the associated communicator is recommended.
+//end::MPI_Ssend_init[]
+
+//tag::MPI_Status_get_source[]
+**MPI_Status_get_source** returns the source rank from a `status` object. The function retrieves the value stored in the `MPI_SOURCE` field of the `status` argument and returns it in `source`. This is a local procedure that provides a convenience interface for accessing status information that is also directly accessible in the status structure. The `status` object is typically set by a receive operation, probe, or wait/test function.
+//end::MPI_Status_get_source[]
+
+//tag::MPI_Send[]
+**MPI_Send** performs a blocking standard mode point-to-point send operation. The call does not return until the message data has been safely stored, allowing the sender to modify the send buffer. The message may be copied directly to the matching receive buffer or buffered by the system. A standard mode send is nonlocal; successful completion may depend on the occurrence of a matching receive.
+
+If `dest` is `MPI_PROC_NULL`, the call returns immediately with no operation performed. Messages are nonovertaking; if a sender sends two messages to the same destination with the same communicator, the receive order matches the send order. In a multithreaded implementation, users must not modify the send buffer until the communication completes. Sending a message to oneself using blocking send and receive operations may lead to deadlock.
+//end::MPI_Send[]
+
+//tag::MPI_Get_accumulate[]
+**MPI_Get_accumulate** is a nonblocking RMA operation that atomically retrieves data from a target window into the result buffer and then accumulates data from the origin buffer to the target using a specified reduction operator. The get and accumulate steps are executed atomically for each basic element in the datatype. The origin and result buffers must be disjoint. Each datatype argument must be a predefined datatype or a derived datatype where all basic components are of the same predefined type, and all datatype arguments must be constructed from the same predefined datatype. The `target_datatype` may not specify overlapping entries, and the target buffer must fit in the target window or in attached memory for a dynamic window. Any predefined operator for MPI_REDUCE, as well as `MPI_NO_OP` or `MPI_REPLACE`, may be specified as `op`. When `MPI_NO_OP` is specified, the `origin_addr`, `origin_count`, and `origin_datatype` arguments are ignored and the target buffer is not updated. `MPI_PROC_NULL` is a valid `target_rank`, resulting in no operation.
+//end::MPI_Get_accumulate[]
+
+//tag::MPI_Accumulate[]
+**MPI_Accumulate** is a nonblocking RMA operation that combines data from the origin buffer with data at a target process window using a specified reduction operator. The operation accumulates `origin_count` elements from the origin buffer to the target buffer at an offset computed from `target_disp` and `disp_unit`. Any predefined operator for MPI_REDUCE may be used, plus `MPI_REPLACE` which sets the target value to the origin value. Each datatype argument must be a predefined datatype or a derived datatype where all basic components are of the same predefined type, and the `target_datatype` may not specify overlapping entries. Concurrent accumulate operations to the same location with the same predefined datatype execute atomically per element, as if serialized in some order. `MPI_PROC_NULL` is a valid `target_rank`, resulting in no operation.
+
+The operation completes at the origin when a subsequent synchronization call such as MPI_WIN_FENCE, MPI_WIN_UNLOCK, MPI_WIN_FLUSH, or MPI_WIN_COMPLETE is invoked on the window. Ordering between accumulate operations from the same origin to the same target may be controlled via the `accumulate_ordering` info key, with the default guaranteeing strict ordering.
+//end::MPI_Accumulate[]
+
+//tag::MPI_Get[]
+**MPI_Get** is a nonblocking RMA operation that transfers data from a target process's window to the origin process's memory. Data is copied from the target memory at an address computed from `target_disp` and `disp_unit` to the origin buffer. The `origin_datatype` may not specify overlapping entries in the origin buffer. The target buffer must be contained within the target window or within attached memory in a dynamic window, and the copied data must fit without truncation in the origin buffer. `MPI_PROC_NULL` is a valid `target_rank`, resulting in no operation.
+
+The operation completes at the origin when a subsequent synchronization call such as MPI_WIN_FENCE, MPI_WIN_UNLOCK, MPI_WIN_FLUSH, or MPI_WIN_COMPLETE is invoked on the window.
+//end::MPI_Get[]
+
+//tag::MPI_File_write_ordered_begin[]
+**MPI_File_write_ordered_begin** begins a split collective write operation using the shared file pointer with accesses ordered by process rank. This operation is collective over the group of processes that participated in the collective open and is nonlocal. The call may or may not return before it is called by all MPI processes in the group. File accesses occur in the order determined by process ranks, where each process writes at the position following the data written by all lower-ranked processes. The user must not use the buffer passed to this routine until the matching MPI_FILE_WRITE_ORDERED_END completes. On any MPI process, each file handle may have at most one active split collective operation at any time. No collective I/O operations are permitted on a file handle between the begin and end of a split collective access. In a multithreaded implementation, the begin and end operations must be called from the same thread. All processes using the shared file pointer routines must use the same file view.
+//end::MPI_File_write_ordered_begin[]
+
+//tag::MPI_File_iread_shared[]
+**MPI_File_iread_shared** is a nonblocking version of MPI_FILE_READ_SHARED that initiates a read operation using the shared file pointer. The shared file pointer is maintained by MPI and shared among all processes in the communicator group that opened the file. All processes must use the same file view when using shared file pointer routines. Upon initiation, the shared file pointer is updated to point to the next etype after the last one that will be accessed. For noncollective shared file pointer routines, the serialization ordering of accesses is not deterministic. The buffer passed to this routine must not be accessed until the operation completes via MPI_WAIT, MPI_TEST, or their variants. The effect of multiple calls to shared file pointer routines behaves as if the calls were serialized, though the user must use other synchronization means to enforce a specific order.
+//end::MPI_File_iread_shared[]
+
+//tag::MPI_File_iwrite_shared[]
+**MPI_File_iwrite_shared** is a nonblocking version of MPI_FILE_WRITE_SHARED that initiates a write operation using the shared file pointer. The shared file pointer is maintained by MPI and shared among all processes in the communicator group that opened the file. All processes must use the same file view when using shared file pointer routines. Upon initiation, the shared file pointer is updated to point to the next etype after the last one that will be accessed. For noncollective shared file pointer routines, the serialization ordering of accesses is not deterministic. The buffer passed to this routine must not be modified until the operation completes via MPI_WAIT, MPI_TEST, or their variants, and other synchronization means may be used to enforce a specific access order.
+//end::MPI_File_iwrite_shared[]
+
+//tag::MPI_File_iwrite_all[]
+**MPI_File_iwrite_all** is a nonblocking collective version of MPI_FILE_WRITE_ALL that initiates a write operation using individual file pointers.
+
+This operation is collective over the group of processes that opened the file and must be called by all processes in that group. The call initiates the I/O operation and returns a `request` handle that must be completed via MPI_WAIT, MPI_TEST, or their variants. All nonblocking collective I/O calls are local; the call returns before the operation completes. Multiple nonblocking collective I/O operations may be outstanding on a single file handle. After the operation is initiated, the individual file pointer is updated to point to the next etype after the last one that will be accessed. In multithreaded implementations, the begin and end operations for split collective I/O on the same file handle must be called from the same thread. The buffer passed to the routine must not be accessed until the operation completes.
+//end::MPI_File_iwrite_all[]
+
+//tag::MPI_Comm_fromint[]
+**MPI_Comm_fromint** translates a C integer to the appropriate C communicator handle. Only an integer obtained from a previous call to MPI_COMM_TOINT may be passed to this function.
+
+It is erroneous to pass an integer associated with a handle that has been freed, disconnected, or aborted, or that was derived from a session that has been finalized.
+//end::MPI_Comm_fromint[]
+
+//tag::MPI_Session_fromint[]
+**MPI_Session_fromint** translates a C integer to the appropriate C session handle. This function is part of handle serialization functionality that supports language bindings and other use cases requiring integer representations of handles. Only an integer obtained from a previous call to MPI_SESSION_TOINT may be passed to this function.
+
+It is erroneous to pass an integer associated with a `session` that has been freed or finalized.
+//end::MPI_Session_fromint[]
+
+//tag::MPI_Errhandler_toint[]
+**MPI_Errhandler_toint** translates a C error handler handle into a C integer.
+For predefined handles, the integer value matches the values specified by the MPI ABI.
+For user-defined handles, the implementation returns the same integer for every call with the same handle, which does not conflict with the reserved range for predefined handles.
+It is erroneous to call this function with an invalid `errhandler` argument.
+//end::MPI_Errhandler_toint[]
+
+//tag::MPI_Errhandler_fromint[]
+**MPI_Errhandler_fromint** translates a C integer to the appropriate C error handler handle. This function is part of handle serialization functionality that supports language bindings and other use cases requiring integer representations of handles. Only an integer obtained from a previous call to MPI_ERRHANDLER_TOINT may be passed to this function.
+
+It is erroneous to pass an integer associated with an `errhandler` that has been freed.
+//end::MPI_Errhandler_fromint[]
+
+//tag::MPI_Errhandler_f2c[]
+**MPI_Errhandler_f2c** converts a Fortran error handler handle to a C error handler handle. If `errhandler` is a valid Fortran handle, the function returns a valid C handle to the same error handler. If `errhandler` equals `MPI_ERRHANDLER_NULL` (Fortran value), the function returns a null C handle. If `errhandler` is an invalid Fortran handle, the function returns an invalid C handle.
+//end::MPI_Errhandler_f2c[]
+
+//tag::MPI_Group_toint[]
+**MPI_Group_toint** translates a C group handle into a C integer. For predefined handles, the integer value matches the values specified by the MPI ABI. For user-defined handles, the implementation returns the same integer for every call with the same handle, which does not conflict with the reserved range for predefined handles.
+
+It is erroneous to call this function with an invalid `group` argument.
+//end::MPI_Group_toint[]
+
+//tag::MPI_Abi_get_fortran_booleans[]
+**MPI_Abi_get_fortran_booleans** retrieves the literal values of Fortran booleans from the MPI implementation. This function returns the size of Fortran LOGICAL in bytes, the literal values for `.TRUE.` and `.FALSE.`, and a flag indicating whether these values were previously set. When `is_set` is false, the implementation does not know the Fortran compiler properties and they must be set by the application using MPI_ABI_SET_FORTRAN_BOOLEANS. When `is_set` is true, the implementation already knows the Fortran boolean literal values.
+
+This function is thread-safe.
+//end::MPI_Abi_get_fortran_booleans[]
+
+//tag::MPI_Abi_set_fortran_booleans[]
+**MPI_Abi_set_fortran_booleans** allows the application to inform the implementation of the literal values of the Fortran booleans. Boolean literals must be passed directly so that they can be observed by the implementation, since it may not be possible to obtain their literal values directly. This function has a `logical_size` argument to allow it to be called before MPI_ABI_SET_FORTRAN_INFO. Before setting this information, the application may check if the logical values are already set using MPI_ABI_GET_FORTRAN_BOOLEANS. Only the first call to this function affects the state of the MPI library.
+
+Subsequent calls return the error code `MPI_ERR_ABI`.
+//end::MPI_Abi_set_fortran_booleans[]
+
+//tag::MPI_Reduce_scatter_init[]
+**MPI_Reduce_scatter_init** creates a persistent collective communication request for a combined reduction and scatter operation.
+
+This All-To-All collective operation performs a global element-wise reduction on data from all processes and then scatters the resulting blocks to each process according to `recvcounts`. The initialization call is nonlocal and follows collective ordering rules; all processes in the communicator must call persistent collective initializations in the same order. Once initialized, the persistent request can be started with MPI_START or MPI_STARTALL and may be reused. After initialization, arrays associated with input arguments must not be modified until the request is freed with MPI_REQUEST_FREE. Started operations must be completed, and all other processes in the communicator must eventually start and complete the same persistent collective operation. In multithreaded implementations, it is the user's responsibility to ensure that the same communicator is not used concurrently by two different collective communication initialization calls at the same process.
+//end::MPI_Reduce_scatter_init[]
+
+//tag::MPI_Ireduce[]
+**MPI_Ireduce** initiates a nonblocking collective reduction that combines elements from all processes using a specified operation and returns the combined value to the root process. This All-To-One collective operation returns a request handle that must be passed to a completion call. All processes in the group must call collective operations in the same order per communicator. Completion indicates the local part of the operation is finished; it does not indicate that other processes have completed or started the operation.
+
+The operation `op` is assumed to be associative, and predefined operations are also assumed to be commutative. For operations that are not truly associative, the result upon completion may differ from the blocking reduction. In multithreaded implementations, the same communicator is not to be used concurrently by two different collective communication initialization calls at the same process. The `MPI_IN_PLACE` option may be specified by passing `MPI_IN_PLACE` as the value of `sendbuf` at the root when using an intra-communicator. It is erroneous to call MPI_REQUEST_FREE or MPI_CANCEL on a nonblocking collective request.
+//end::MPI_Ireduce[]
+
+//tag::MPI_Dist_graph_neighbors[]
+**MPI_Dist_graph_neighbors** returns adjacency information for a distributed graph topology associated with a communicator.
+
+This operation is local. The `sources` and `destinations` arrays are populated with the ranks of incoming and outgoing neighbor processes, and multiply-defined edges are all counted and returned in some order. If `MPI_UNWEIGHTED` is supplied for `sourceweights` or `destweights`, or if the graph was created with `MPI_UNWEIGHTED`, no weight information is returned in those arrays. If `maxindegree` or `maxoutdegree` is smaller than the values returned by MPI_DIST_GRAPH_NEIGHBORS_COUNT, only the first part of the full list is returned. If the communicator was created with MPI_DIST_GRAPH_CREATE_ADJACENT, the order of values in `sources` and `destinations` is identical to the input used by the process with the same rank during creation; if created with MPI_DIST_GRAPH_CREATE, the only requirement is that two calls with the same `comm` return the same sequence of edges.
+//end::MPI_Dist_graph_neighbors[]
+
+//tag::MPI_Scatterv[]
+**MPI_Scatterv** is a collective operation that distributes varying amounts of data from a root process to all processes in a group, acting as the inverse of MPI_GATHERV. If `comm` is an intra-communicator, the root sends data from locations specified by `displs` to each process, with each process receiving `sendcounts[i]` elements. The type signature implied by `sendcounts[i]` and `sendtype` at the root must equal the type signature implied by `recvcount` and `recvtype` at process i. If `comm` is an inter-communicator, all processes in both groups participate; processes in the remote group pass the root's rank, the root passes `MPI_ROOT`, and other processes in the root's group pass `MPI_PROC_NULL`. The send buffer is ignored for all nonroot processes, and the arguments `root` and `comm` must have identical values on all processes. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` as `recvbuf` at the root, in which case the root sends no data to itself.
+
+Collective operations may or may not have the effect of synchronizing all participating processes, and programs are recommended to avoid relying on synchronization side-effects for correctness while allowing for the fact that a collective call may be synchronizing.
+//end::MPI_Scatterv[]
+
+//tag::MPI_Gatherv[]
+**MPI_Gatherv** is a collective operation that gathers varying amounts of data from all processes in a group to the root process. Each process sends the contents of its send buffer to the root, which receives the data and places it at offsets specified by the `displs` array. For intra-communicators, the type signature implied by `sendcount` and `sendtype` on process i must equal the type signature implied by `recvcounts[i]` and `recvtype` at the root. For inter-communicators, all processes in one group define the root while processes in the other group pass the root's rank, the root passes `MPI_ROOT`, and all other processes in the root's group pass `MPI_PROC_NULL`. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` as `sendbuf` at the root. The specification of counts, types, and displacements may not cause any location on the root to be written more than once.
+
+Collective operations may or may not have the effect of synchronizing all participating processes. Programs are recommended to avoid relying on synchronization side-effects for correctness while allowing for the fact that a collective call may be synchronizing.
+//end::MPI_Gatherv[]
+
+//tag::MPI_Gather[]
+**MPI_Gather** is a collective operation where each process sends the contents of its send buffer to the root, which receives the messages and stores them in rank order.
+
+If `comm` is an intra-communicator, all processes including the root send data, and the root receives from all group members. If `comm` is an inter-communicator, all processes in the inter-communicator participate, with one group defining the root; processes in the other group pass the rank of the root, the root passes `MPI_ROOT`, and other processes in the root's group pass `MPI_PROC_NULL`. The type signature of `sendcount` and `sendtype` on each process must equal the type signature of `recvcount` and `recvtype` at the root. The receive buffer is ignored for all nonroot processes. On the root, specifying counts and types that cause any location to be written more than once is erroneous. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` as `sendbuf` at the root, in which case `sendcount` and `sendtype` are ignored and the root's contribution is assumed to be in the correct place in the receive buffer. In multithreaded implementations, users must ensure the same communicator is not used concurrently by two different collective communication initialization calls at the same process.
+//end::MPI_Gather[]
+
+//tag::MPI_Scatter[]
+**MPI_Scatter** is a collective operation that distributes data from one root process to all processes in a group, acting as the inverse of MPI_GATHER. If `comm` is an intra-communicator, the root sends distinct segments of the send buffer to each process including itself, with each process receiving data in its receive buffer. If `comm` is an inter-communicator, all processes in both groups participate; processes in the remote group pass the root's rank, the root passes `MPI_ROOT`, and other processes in the root's group pass `MPI_PROC_NULL`. The type signature associated with `sendcount` and `sendtype` at the root must equal the type signature associated with `recvcount` and `recvtype` at all processes. The send buffer is ignored for all nonroot processes, and the arguments `root` and `comm` must have identical values on all processes. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` as `recvbuf` at the root, in which case the root sends no data to itself.
+
+Collective operations may or may not have the effect of synchronizing all participating processes, and programs are recommended to avoid relying on synchronization side-effects for correctness while allowing for the fact that a collective call may be synchronizing.
+//end::MPI_Scatter[]
+
+//tag::MPI_Allgather[]
+**MPI_Allgather** is a collective All-To-All operation where all processes contribute data and all processes receive the concatenated result.
+
+If `comm` is an intra-communicator, the block of data sent from the j-th process is received by every process and placed in the j-th block of `recvbuf`. The type signature associated with `sendcount` and `sendtype` at a process must equal the type signature associated with `recvcount` and `recvtype` at any other process. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes, in which case `sendcount` and `sendtype` are ignored. If `comm` is an inter-communicator, each process in one group contributes `sendcount` data items that are concatenated and stored at each process in the other group, and vice versa. Collective operations may or may not have the effect of synchronizing all participating processes. Programs are recommended to avoid relying on synchronization side-effects for correctness while allowing for the fact that a collective call may be synchronizing. In multithreaded implementations, users must ensure the same communicator is not used concurrently by two different collective communication calls at the same process.
+//end::MPI_Allgather[]
+
+//tag::MPI_Allgatherv[]
+**MPI_Allgatherv** is a collective All-To-All operation that gathers varying amounts of data from all processes and distributes the concatenated result to all processes.
+
+If `comm` is an intra-communicator, the block of data sent from the j-th process is received by every process and placed in the j-th block of `recvbuf` at the displacement specified by `displs`. These blocks need not all be the same size. The type signature associated with `sendcount` and `sendtype` at process j must equal the type signature associated with `recvcounts[j]` and `recvtype` at any other process. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes, in which case `sendcount` and `sendtype` are ignored. If `comm` is an inter-communicator, each process in one group contributes `sendcount` data items that are concatenated and stored at each process in the other group, and vice versa. Collective operations may or may not have the effect of synchronizing all participating processes. Programs are recommended to avoid relying on synchronization side-effects for correctness while allowing for the fact that a collective call may be synchronizing.
+//end::MPI_Allgatherv[]
+
+//tag::MPI_Alltoall[]
+**MPI_Alltoall** is a collective All-To-All operation that performs a complete exchange where each process sends distinct data to every other process. If `comm` is an intra-communicator, the j-th block sent from process i is received by process j and placed in the i-th block of `recvbuf`. The type signature associated with `sendcount` and `sendtype` at a process must equal the type signature associated with `recvcount` and `recvtype` at any other process, implying the amount of data sent equals the amount received pairwise between every pair of processes. If `comm` is an inter-communicator, each process in group A sends a message to each process in group B and vice versa. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes, in which case `sendcount` and `sendtype` are ignored and data is taken from and replaced in `recvbuf`. Completion indicates the calling process may access buffers but does not indicate that other processes have completed or started the operation. In multithreaded implementations, users must ensure the same communicator is not used concurrently by two different collective communication initialization calls at the same process. Collective operations may or may not have the effect of synchronizing all participating processes. Programs are recommended to avoid relying on synchronization side-effects for correctness while allowing for the fact that a collective call may be synchronizing.
+//end::MPI_Alltoall[]
+
+//tag::MPI_Alltoallv[]
+**MPI_Alltoallv** is a collective All-To-All operation that performs a complete exchange where each process sends and receives variable-sized blocks to and from every other process. If `comm` is an intra-communicator, the j-th block sent from process i is received by process j and placed in the i-th block of `recvbuf` at the location specified by `rdispls`. The type signature associated with `sendcounts[j]` and `sendtype` at process i must equal the type signature associated with `recvcounts[i]` and `recvtype` at process j. All arguments on all processes are significant and `comm` must have identical values on all processes. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes, in which case `sendcounts`, `sdispls`, and `sendtype` are ignored. When using the in-place option, symmetric data exchange is implied such that `recvcounts[j]` and `recvtype` on process i must match `recvcounts[i]` and `recvtype` on process j. If `comm` is an inter-communicator, each process in group A sends a message to each process in group B and vice versa. Collective operations may or may not have the effect of synchronizing all participating processes.
+//end::MPI_Alltoallv[]
+
+//tag::MPI_File_read_at[]
+**MPI_File_read_at** reads a file beginning at the position specified by `offset`. This is a blocking, noncollective explicit offset operation that performs data access at the file position given directly as an argument. No file pointer is used nor updated. The type signature of `datatype` must match the type signature of some number of contiguous copies of the etype of the current view. Upon completion, the amount of data accessed is returned in `status`, and reading less data than requested indicates end of file.
+
+It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened, or to provide a negative `offset` value.
+//end::MPI_File_read_at[]
+
+//tag::MPI_File_open[]
+**MPI_File_open** collectively opens a file identified by `filename` on all processes in the `comm` communicator group and returns a file handle in `fh`.
+
+This is a collective routine requiring all processes to provide the same value for `amode` and filenames that reference the same file; `comm` must be an intra-communicator. The returned file handle can be used to access the file until it is closed with MPI_FILE_CLOSE, and all files opened with MPI_FILE_OPEN must be closed before calling MPI_FINALIZE. Initially, all processes view the file as a linear byte stream with displacement zero and etype and filetype equal to `MPI_BYTE`, and files are opened using nonatomic mode file consistency semantics by default. Errors are raised using the default file error handler, and errors related to access mode are raised in the class `MPI_ERR_AMODE`. It is erroneous to specify `MPI_MODE_CREATE` or `MPI_MODE_EXCL` with `MPI_MODE_RDONLY`, and erroneous to specify `MPI_MODE_SEQUENTIAL` with `MPI_MODE_RDWR`. Specifying `MPI_MODE_APPEND` only guarantees that all shared and individual file pointers are positioned at the initial end of file when MPI_FILE_OPEN returns. In multithreaded programs, any split collective begin and end operation called by a process on a file handle must be called from the same thread. On some implementations the file namespace may not be identical from all processes, so users are responsible for ensuring that a single file is referenced by the `filename` argument.
+//end::MPI_File_open[]
+
+//tag::MPI_File_close[]
+**MPI_File_close** synchronizes file state and closes the file associated with `fh`. This call first performs the equivalent of MPI_FILE_SYNC before closing the file. If the file was opened with access mode `MPI_MODE_DELETE_ON_CLOSE`, the file is deleted. MPI_File_close is a collective routine over the group associated with the file. All outstanding nonblocking requests and split collective operations associated with `fh` must be completed before calling this routine. Upon completion, the file handle object is deallocated and `fh` is set to `MPI_FILE_NULL`.
+
+If the file is deleted on close and other processes are currently accessing the file, the status of the file and the behavior of future accesses by these processes are implementation dependent.
+//end::MPI_File_close[]
+
+//tag::MPI_Alltoallw[]
+**MPI_Alltoallw** is the most general form of complete exchange, allowing separate specification of count, displacement, and datatype for each process pair. If `comm` is an intra-communicator, the j-th block sent from process i is received by process j and placed in the i-th block of `recvbuf`. Displacements within the send and receive buffers are specified in bytes, unlike other all-to-all variants. The type signature associated with `sendcounts[j]` and `sendtypes[j]` at process i must equal the type signature associated with `recvcounts[i]` and `recvtypes[i]` at process j. All arguments on all processes are significant and `comm` must describe the same communicator on all processes. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes, in which case `sendcounts`, `sdispls`, and `sendtypes` are ignored. If `comm` is an inter-communicator, each process in group A sends a message to each process in group B and vice versa. Collective operations may or may not have the effect of synchronizing all participating processes, and programs are recommended to avoid relying on synchronization side-effects for correctness.
+//end::MPI_Alltoallw[]
+
+//tag::MPI_Reduce[]
+**MPI_Reduce** is a collective All-To-One operation that combines elements from all processes using a specified operation and returns the result to a designated root process. If `comm` is an intra-communicator, each process provides an input buffer and the root receives the combined result in its output buffer. If `comm` is an inter-communicator, processes in the remote group pass the root's rank, the root passes `MPI_ROOT`, and other processes in the root's group pass `MPI_PROC_NULL`. The operation `op` is assumed to be associative, and predefined operations are also commutative; user-defined operations may be non-commutative. The canonical evaluation order is determined by process ranks, but the implementation may reorder evaluation based on associativity or commutativity. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at the root, and overlapping datatypes in receive buffers are erroneous.
+
+Applications requiring a specific evaluation order may gather all operands at a single process using MPI_GATHER, apply the reduction locally using MPI_REDUCE_LOCAL, and broadcast or scatter the result if needed. Collective operations may or may not have the effect of synchronizing all participating processes.
+//end::MPI_Reduce[]
+
+//tag::MPI_Op_create[]
+**MPI_Op_create** binds a user-defined reduction operation to an `op` handle for use in MPI_REDUCE, MPI_ALLREDUCE, MPI_REDUCE_SCATTER, MPI_REDUCE_SCATTER_BLOCK, MPI_SCAN, MPI_EXSCAN, their nonblocking and persistent variants, and MPI_REDUCE_LOCAL. The user-defined operation is assumed to be associative. If `commute` is true, the operation is both commutative and associative; if `commute` is false, operand order is fixed in ascending process rank order beginning with rank 0. The `user_fn` must have four arguments: `invec`, `inoutvec`, `len`, and `datatype`. In Fortran when using `USE mpi_f08`, the large count variant must be called explicitly as MPI_Op_create_c.
+//end::MPI_Op_create[]
+
+//tag::MPI_Type_get_value_index[]
+**MPI_Type_get_value_index** returns a handle to a predefined datatype suitable for use with MPI_MINLOC and MPI_MAXLOC. The function queries for a predefined pair datatype matching the provided `value_type` and `index_type`. The returned type is not a duplicate and cannot be freed.
+
+If the provided combination of `value_type` and `index_type` does not match a predefined pair datatype, `pair_type` is set to `MPI_DATATYPE_NULL`. A named type handle returned by this function yields combiner value `MPI_COMBINER_NAMED` when queried with MPI_TYPE_GET_ENVELOPE, whereas unnamed type handles yield `MPI_COMBINER_VALUE_INDEX`. Code evaluating the combiner of type handles returned from this function must handle both `MPI_COMBINER_NAMED` and `MPI_COMBINER_VALUE_INDEX`.
+//end::MPI_Type_get_value_index[]
+
+//tag::MPI_Op_free[]
+**MPI_Op_free** marks a user-defined reduction operation for deallocation and sets `op` to `MPI_OP_NULL`.
+//end::MPI_Op_free[]
+
+//tag::MPI_Allreduce[]
+**MPI_Allreduce** is a collective All-To-All operation that combines elements from all processes using a specified operation and returns the result to all group members.
+
+If `comm` is an intra-communicator, MPI_Allreduce behaves the same as MPI_REDUCE except that the result appears in the receive buffer of all group members. MPI requires that all processes from the same group participating in these operations receive identical results. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes, in which case input data is taken from the receive buffer and replaced by the output data. If `comm` is an inter-communicator, the result of the reduction of the data provided by processes in group A is stored at each process in group B and vice versa, and both groups must provide `count` and `datatype` arguments that specify the same type signature. Collective operations may or may not have the effect of synchronizing all participating processes. Programs are recommended to avoid relying on synchronization side-effects for correctness while allowing for the fact that a collective call may be synchronizing.
+//end::MPI_Allreduce[]
+
+//tag::MPI_Reduce_local[]
+**MPI_Reduce_local** applies a reduction operation to local arguments without communication. This function applies the operation given by `op` element-wise to the elements of `inbuf` and `inoutbuf`, with the result stored element-wise in `inoutbuf`. Both buffers must have the same number of elements given by `count` and the same datatype given by `datatype`. The `MPI_IN_PLACE` option is not allowed. This function is intended for library implementors who may want to implement special reduction patterns not easily covered by standard MPI operations.
+//end::MPI_Reduce_local[]
+
+//tag::MPI_Op_commutative[]
+**MPI_Op_commutative** queries whether a reduction operation is commutative. This is a local operation that returns true in `commute` if `op` is commutative and false otherwise. All predefined reduction operations are commutative. User-defined operations created with MPI_OP_CREATE have their commutativity determined by the `commute` argument provided at creation time.
+//end::MPI_Op_commutative[]
+
+//tag::MPI_Reduce_scatter[]
+**MPI_Reduce_scatter** is a collective All-To-All operation that combines a global element-wise reduction with a scatter of variable-sized blocks to all processes.
+
+If `comm` is an intra-communicator, the function first performs a global reduction on vectors of count elements using `op`, where count is the sum of all `recvcounts` entries. The resulting vector is divided into n consecutive blocks, with the i-th block containing `recvcounts[i]` elements and sent to process i. All group members must call the routine using the same arguments for `recvcounts`, `datatype`, `op`, and `comm`. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` in `sendbuf`, in which case input data is taken from the receive buffer. If `comm` is an inter-communicator, the result of the reduction of data provided by processes in one group is scattered among processes in the other group and vice versa, and the number of elements must be the same for the two groups. Collective operations may or may not have the effect of synchronizing all participating processes. Programs are recommended to avoid relying on synchronization side-effects for correctness while allowing for the fact that a collective call may be synchronizing.
+//end::MPI_Reduce_scatter[]
+
+//tag::MPI_Reduce_scatter_block[]
+**MPI_Reduce_scatter_block** is a collective All-To-All operation that combines a global element-wise reduction with a scatter of equal-sized blocks to all processes.
+
+If `comm` is an intra-communicator, the function first performs a global reduction on vectors of n*`recvcount` elements using `op`, where n is the number of processes in the group. The resulting vector is divided into n consecutive blocks of `recvcount` elements each, and the i-th block is sent to process i. All group members must call the routine using the same arguments for `recvcount`, `datatype`, `op`, and `comm`. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` in `sendbuf` on all processes, in which case input data is taken from the receive buffer. If `comm` is an inter-communicator, the result of the reduction of data provided by processes in one group is scattered among processes in the other group and vice versa, and the number of elements must be the same for the two groups. Collective operations may or may not have the effect of synchronizing all participating processes. Programs are recommended to avoid relying on synchronization side-effects for correctness while allowing for the fact that a collective call may be synchronizing.
+//end::MPI_Reduce_scatter_block[]
+
+//tag::MPI_Scan[]
+**MPI_Scan** is a collective operation that performs an inclusive prefix reduction on data distributed across the group.
+
+If `comm` is an intra-communicator, the operation returns in the receive buffer of the process with rank i the reduction of the values in the send buffers of processes with ranks 0 through i, inclusive. All group members must call the routine using the same arguments for `count`, `datatype`, `op`, and `comm`. The type of operations supported, their semantics, and the constraints on send and receive buffers are as for MPI_REDUCE. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` in `sendbuf`, in which case input data is taken from the receive buffer and replaced by the output data. This operation is invalid for inter-communicators. Collective operations may or may not have the effect of synchronizing all participating processes, and programs are recommended to avoid relying on synchronization side-effects for correctness while allowing for the fact that a collective call may be synchronizing.
+//end::MPI_Scan[]
+
+//tag::MPI_Exscan[]
+**MPI_Exscan** is a collective operation that performs an exclusive prefix reduction on data distributed across the group.
+
+If `comm` is an intra-communicator, the value in `recvbuf` on rank 0 is undefined and `recvbuf` is not significant on that process. The value in `recvbuf` on rank 1 equals the value in `sendbuf` on rank 0. For processes with rank i > 1, the operation returns the reduction of values in send buffers of processes with ranks 0 through i-1, inclusive. All group members must call the routine using the same arguments for `count`, `datatype`, `op`, and `comm`. The type of operations supported, their semantics, and the constraints on send and receive buffers are as for MPI_REDUCE. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` in `sendbuf`, in which case input data is taken from the receive buffer and replaced by the output data; the receive buffer on rank 0 is not changed by this operation. This operation is invalid for inter-communicators.
+//end::MPI_Exscan[]
+
+//tag::MPI_Test_cancelled[]
+**MPI_Test_cancelled** determines whether a communication operation was successfully cancelled. The function returns `flag` = true if the communication associated with the `status` object was cancelled. When `flag` = true, all other fields of `status` such as `count` or `tag` are undefined. If a receive operation might be cancelled, MPI_TEST_CANCELLED may be called first to check whether the operation was cancelled before examining other fields of the return status. Cancel operations are expensive and are recommended to be used only exceptionally.
+//end::MPI_Test_cancelled[]
+
+//tag::MPI_Ibarrier[]
+**MPI_Ibarrier** starts a nonblocking barrier synchronization across all members of a group.
+
+The call returns immediately, independent of whether other processes have called MPI_IBARRIER. If `comm` is an intra-communicator, the corresponding completion operation completes only after all other processes in the communicator have called MPI_IBARRIER. If `comm` is an inter-communicator, the completion operation completes when all processes in the remote group have called MPI_IBARRIER. All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations. A nonblocking barrier may be used to hide latency by moving independent computations between the MPI_IBARRIER call and the subsequent completion call. The semantic properties are useful when mixing collective operations and point-to-point messages.
+//end::MPI_Ibarrier[]
+
+//tag::MPI_Ibcast[]
+**MPI_Ibcast** starts a nonblocking broadcast from the process with rank `root` to all processes of the group.
+
+This call initiates a nonblocking variant of MPI_BCAST and returns immediately. If `comm` is an intra-communicator, all members of the group call the routine using the same arguments for `comm` and `root`, and upon completion, the content of the root's buffer is copied to all other processes. If `comm` is an inter-communicator, all processes in both groups participate; processes in the remote group pass the root's rank, the root passes `MPI_ROOT`, and other processes in the root's group pass `MPI_PROC_NULL`. All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations. Once initiated, send buffers must not be modified and receive buffers must not be accessed until the operation completes. Completion indicates the caller may access buffers but does not indicate that other processes have completed or started the operation. Collective operations may or may not have the effect of synchronizing all participating processes. Programs are recommended to avoid relying on synchronization side-effects for correctness while allowing for the fact that a collective call may be synchronizing.
+//end::MPI_Ibcast[]
+
+//tag::MPI_Igather[]
+**MPI_Igather** starts a nonblocking gather operation where each process sends data to the root, which receives and stores messages in rank order.
+
+If `comm` is an intra-communicator, each process including the root sends the contents of its send buffer to the root upon completion. If `comm` is an inter-communicator, processes in the remote group pass the root's rank, the root passes `MPI_ROOT`, and other processes in the root's group pass `MPI_PROC_NULL`. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` as `sendbuf` at the root, in which case `sendcount` and `sendtype` are ignored. All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations. Once initiated, send buffers must not be modified and receive buffers must not be accessed until the operation completes. Completion indicates the caller may access buffers but does not indicate that other processes have completed or started the operation. In multithreaded implementations, users must ensure the same communicator is not used concurrently by two different collective communication initialization calls at the same process.
+//end::MPI_Igather[]
+
+//tag::MPI_Igatherv[]
+**MPI_Igatherv** starts a nonblocking gather operation that collects varying amounts of data from all processes to the root. If `comm` is an intra-communicator, each process sends data to the root, which places incoming data at offsets specified by `displs`. If `comm` is an inter-communicator, processes in the remote group pass the root's rank, the root passes `MPI_ROOT`, and other processes in the root's group pass `MPI_PROC_NULL`. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` as `sendbuf` at the root. Once initiated, send buffers and input argument arrays must not be modified and receive buffers must not be accessed until the operation completes. Completion indicates the caller may access buffers but does not indicate that other processes have completed or started the operation.
+
+All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations. In multithreaded implementations, users must ensure the same communicator is not used concurrently by two different collective communication initialization calls at the same process. Calling MPI_REQUEST_FREE or MPI_CANCEL on the returned request is erroneous.
+//end::MPI_Igatherv[]
+
+//tag::MPI_Irsend[]
+**MPI_Irsend** initiates a ready mode nonblocking send operation. The call is local and returns immediately, regardless of the status of other MPI processes. A ready mode send may be started only if the matching receive is already started; otherwise the operation is erroneous and its outcome is undefined. The sender must not modify the send buffer after the call until the operation completes via MPI_WAIT or MPI_TEST. Nonblocking sends can be matched with blocking receives.
+
+Nonblocking communication operations are nonovertaking and ordered according to the execution order of the calls that initiate them.
+//end::MPI_Irsend[]
+
+//tag::MPI_Iscatter[]
+**MPI_Iscatter** starts a nonblocking scatter operation that distributes data from a root process to all processes in a group, acting as the inverse of MPI_IGATHER.
+
+If `comm` is an intra-communicator, the root sends distinct segments of the send buffer to each process including itself. If `comm` is an inter-communicator, processes in the remote group pass the root's rank, the root passes `MPI_ROOT`, and other processes in the root's group pass `MPI_PROC_NULL`. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` as `recvbuf` at the root, in which case the root sends no data to itself. All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations. Once initiated, send buffers must not be modified and receive buffers must not be accessed until the operation completes. Completion indicates the caller may access buffers but does not indicate that other processes have completed or started the operation. In multithreaded implementations, users must ensure the same communicator is not used concurrently by two different collective communication initialization calls at the same process, and calling MPI_REQUEST_FREE or MPI_CANCEL on a nonblocking collective request is erroneous.
+//end::MPI_Iscatter[]
+
+//tag::MPI_Iscatterv[]
+**MPI_Iscatterv** starts a nonblocking scatter operation that distributes varying amounts of data from a root process to all processes in a group.
+
+If `comm` is an intra-communicator, the root sends `sendcounts[i]` elements from locations specified by `displs` to each process i. If `comm` is an inter-communicator, processes in the remote group pass the root's rank, the root passes `MPI_ROOT`, and other processes in the root's group pass `MPI_PROC_NULL`. The type signature implied by `sendcounts[i]` and `sendtype` at the root must equal the type signature implied by `recvcount` and `recvtype` at process i. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` as `recvbuf` at the root, in which case the root sends no data to itself. Once initiated, send buffers and input argument arrays must not be modified and receive buffers must not be accessed until the operation completes. Completion indicates the caller may access buffers but does not indicate that other processes have completed or started the operation. All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations. In multithreaded implementations, users must ensure the same communicator is not used concurrently by two different collective communication initialization calls at the same process. Calling MPI_REQUEST_FREE or MPI_CANCEL on a nonblocking collective request is erroneous.
+//end::MPI_Iscatterv[]
+
+//tag::MPI_Iallgather[]
+**MPI_Iallgather** starts a nonblocking All-To-All gather operation where all processes contribute data and all processes receive the concatenated result.
+
+If `comm` is an intra-communicator, the block of data sent from the j-th process is received by every process and placed in the j-th block of `recvbuf`. If `comm` is an inter-communicator, each process in one group contributes `sendcount` data items that are concatenated and stored at each process in the other group, and vice versa. The type signature associated with `sendcount` and `sendtype` at a process must equal the type signature associated with `recvcount` and `recvtype` at any other process. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes. All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations. Upon completion, the `MPI_SOURCE` and `MPI_TAG` fields in the associated status object are undefined. Calling MPI_REQUEST_FREE or MPI_CANCEL on a nonblocking collective request is erroneous.
+//end::MPI_Iallgather[]
+
+//tag::MPI_Iallgatherv[]
+**MPI_Iallgatherv** starts a nonblocking collective All-To-All operation that gathers varying amounts of data from all processes and distributes the concatenated result to all processes.
+
+If `comm` is an intra-communicator, the block of data sent from the j-th process is received by every process and placed in the j-th block of `recvbuf` at the displacement specified by `displs`. The type signature associated with `sendcount` and `sendtype` at process j must equal the type signature associated with `recvcounts[j]` and `recvtype` at any other process. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes. If `comm` is an inter-communicator, each process in one group contributes `sendcount` data items that are concatenated and stored at each process in the other group, and vice versa. All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations. Once initiated, send buffers and input argument arrays must not be modified and receive buffers must not be accessed until the operation completes. Upon completion, the `MPI_SOURCE` and `MPI_TAG` fields in the associated status object are undefined, and calling MPI_REQUEST_FREE or MPI_CANCEL on a nonblocking collective request is erroneous.
+//end::MPI_Iallgatherv[]
+
+//tag::MPI_Ialltoall[]
+**MPI_Ialltoall** starts a nonblocking All-To-All collective operation that performs a complete exchange where each process sends distinct data to every other process. If `comm` is an intra-communicator, the j-th block sent from process i is received by process j and placed in the i-th block of `recvbuf`. The type signature associated with `sendcount` and `sendtype` at a process must equal the type signature associated with `recvcount` and `recvtype` at any other process. If `comm` is an inter-communicator, each process in group A sends a message to each process in group B and vice versa. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes, in which case `sendcount` and `sendtype` are ignored. All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations. Once initiated, send buffers must not be modified and receive buffers must not be accessed until the operation completes. Calling MPI_REQUEST_FREE or MPI_CANCEL on a nonblocking collective request is erroneous.
+//end::MPI_Ialltoall[]
+
+//tag::MPI_Ialltoallv[]
+**MPI_Ialltoallv** starts a nonblocking All-To-All collective operation that performs a complete exchange with variable-sized blocks between all processes.
+
+If `comm` is an intra-communicator, the j-th block sent from process i is received by process j and placed in the i-th block of `recvbuf` at the location specified by `rdispls`. The type signature associated with `sendcounts[j]` and `sendtype` at process i must equal the type signature associated with `recvcounts[i]` and `recvtype` at process j. If `comm` is an inter-communicator, each process in group A sends a message to each process in group B and vice versa. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes, in which case `sendcounts`, `sdispls`, and `sendtype` are ignored. All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations. Once initiated, send buffers and input argument arrays must not be modified and receive buffers must not be accessed until the operation completes. In multithreaded implementations, users must ensure the same communicator is not used concurrently by two different collective communication initialization calls at the same process, and calling MPI_REQUEST_FREE or MPI_CANCEL on a nonblocking collective request is erroneous.
+//end::MPI_Ialltoallv[]
+
+//tag::MPI_Ialltoallw[]
+**MPI_Ialltoallw** starts a nonblocking All-To-All collective operation that is the most general form of complete exchange, allowing separate specification of count, displacement, and datatype for each process pair.
+
+If `comm` is an intra-communicator, the j-th block sent from process i is received by process j and placed in the i-th block of `recvbuf`, with displacements specified in bytes. The type signature associated with `sendcounts[j]` and `sendtypes[j]` at process i must equal the type signature associated with `recvcounts[i]` and `recvtypes[i]` at process j. If `comm` is an inter-communicator, each process in group A sends a message to each process in group B and vice versa. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes, in which case `sendcounts`, `sdispls`, and `sendtypes` are ignored. All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations. Once initiated, send buffers and input argument arrays must not be modified and receive buffers must not be accessed until the operation completes. In multithreaded implementations, users must ensure the same communicator is not used concurrently by two different collective communication initialization calls at the same process.
+//end::MPI_Ialltoallw[]
+
+//tag::MPI_Iallreduce[]
+**MPI_Iallreduce** starts a nonblocking All-To-All collective reduction that combines elements from all processes using a specified operation and returns the result to all group members. If `comm` is an intra-communicator, the operation behaves the same as MPI_REDUCE except that the result appears in the receive buffer of all group members, and MPI requires that all processes receive identical results. If `comm` is an inter-communicator, the result of the reduction of data provided by processes in group A is stored at each process in group B and vice versa. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes, in which case input data is taken from the receive buffer and replaced by the output data. Once initiated, send buffers must not be modified and receive buffers must not be accessed until the operation completes. Completion indicates the caller may access buffers but does not indicate that other processes have completed or started the operation.
+
+All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations. In multithreaded implementations, users must ensure the same communicator is not used concurrently by two different collective communication initialization calls at the same process. Calling MPI_REQUEST_FREE or MPI_CANCEL on a nonblocking collective request is erroneous.
+//end::MPI_Iallreduce[]
+
+//tag::MPI_Ireduce_scatter[]
+**MPI_Ireduce_scatter** starts a nonblocking All-To-All collective operation that combines a reduction with a scatter of variable-sized blocks. If `comm` is an intra-communicator, the operation first performs a global element-wise reduction on vectors using operation `op`, then scatters the resulting vector as n consecutive blocks where the i-th block contains `recvcounts[i]` elements. If `comm` is an inter-communicator, the result of the reduction from one group is scattered among processes in the other group and vice versa. The `recvcounts` array argument must be identical on all calling processes. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` in `sendbuf`. All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations. Calling MPI_REQUEST_FREE or MPI_CANCEL on a nonblocking collective request is erroneous.
+
+Upon completion, the values of `MPI_SOURCE` and `MPI_TAG` in any associated status object are undefined.
+//end::MPI_Ireduce_scatter[]
+
+//tag::MPI_Ireduce_scatter_block[]
+**MPI_Ireduce_scatter_block** starts a nonblocking All-To-All collective operation that combines a reduction with a scatter of equal-sized blocks. If `comm` is an intra-communicator, the operation first performs a global element-wise reduction on vectors of `n*recvcount` elements using operation `op`, then scatters the resulting vector as n consecutive blocks of `recvcount` elements to each process. If `comm` is an inter-communicator, the result of the reduction from one group is scattered among processes in the other group and vice versa. The in-place option for intra-communicators is specified by passing `MPI_IN_PLACE` in `sendbuf` at all processes, in which case the input data is taken from the receive buffer. All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations. Once initiated, send buffers must not be modified and receive buffers must not be accessed until the operation completes. Calling MPI_REQUEST_FREE or MPI_CANCEL on a nonblocking collective request is erroneous.
+
+Upon completion, the values of `MPI_SOURCE` and `MPI_TAG` in any associated status object are undefined.
+//end::MPI_Ireduce_scatter_block[]
+
+//tag::MPI_Iscan[]
+**MPI_Iscan** starts a nonblocking collective inclusive prefix reduction on data distributed across the group.
+
+If `comm` is an intra-communicator, the operation returns in the receive buffer of the process with rank i the reduction of the values in the send buffers of processes with ranks 0 through i, inclusive. All group members must call the routine using the same arguments for `count`, `datatype`, `op`, and `comm`. The type of operations supported, their semantics, and the constraints on send and receive buffers are as for MPI_REDUCE. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` in `sendbuf`, in which case input data is taken from the receive buffer and replaced by the output data. This operation is invalid for inter-communicators. All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations.
+//end::MPI_Iscan[]
+
+//tag::MPI_Iexscan[]
+**MPI_Iexscan** starts a nonblocking collective exclusive prefix reduction on data distributed across the group.
+
+If `comm` is an intra-communicator, the value in `recvbuf` on rank 0 is undefined and `recvbuf` is not significant on that process. The value in `recvbuf` on rank 1 equals the value in `sendbuf` on rank 0. For processes with rank i > 1, the operation returns the reduction of values in send buffers of processes with ranks 0 through i-1, inclusive. All group members must call the routine using the same arguments for `count`, `datatype`, `op`, and `comm`. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` in `sendbuf`, in which case input data is taken from the receive buffer and replaced by output data; the receive buffer on rank 0 is not changed by this operation. This operation is invalid for inter-communicators. All processes must call collective operations in the same order per communicator, and nonblocking collective operations do not match with blocking collective operations. In multithreaded implementations, the same communicator is not to be used concurrently by two different collective communication initialization calls at the same process. Calling MPI_REQUEST_FREE or MPI_CANCEL on the returned request is erroneous.
+//end::MPI_Iexscan[]
+
+//tag::MPI_Barrier_init[]
+**MPI_Barrier_init** creates a persistent collective communication request for barrier synchronization across all members of a group.
+
+This initialization call is nonlocal and follows the ordering rules for collective operations. All processes in the group identified by the communicator must call collective routines in the same order. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL. Once started, the operation must be completed by all processes in the communicator, and persistent collective operations cannot be matched with blocking or nonblocking collective operations. Arrays associated with input arguments must not be modified until the persistent request is freed with MPI_REQUEST_FREE. In multithreaded implementations, the same communicator is not to be used concurrently by two different collective communication initialization calls at the same process. Persistent collective requests cannot be canceled, and it is erroneous to use MPI_CANCEL on a persistent collective request.
+//end::MPI_Barrier_init[]
+
+//tag::MPI_Bcast_init[]
+**MPI_Bcast_init** creates a persistent collective communication request for broadcasting a message from the process with rank `root` to all processes of the group.
+
+This initialization call is nonlocal and follows the ordering rules for collective operations. All processes in the group identified by the communicator must call collective routines in the same order. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL. Once initialized, persistent collective operations may be started in any order across processes in the communicator. For inter-communicators, processes in the remote group pass the root's rank, the root passes `MPI_ROOT`, and other processes in the root's group pass `MPI_PROC_NULL`. Persistent collective operations cannot be matched with blocking or nonblocking collective operations. Arrays associated with input arguments must not be modified until the persistent request is freed with MPI_REQUEST_FREE, and it is erroneous to use MPI_CANCEL on a persistent collective request.
+//end::MPI_Bcast_init[]
+
+//tag::MPI_Gather_init[]
+**MPI_Gather_init** creates a persistent collective communication request for the gather operation, an All-To-One collective where each process sends data to the root.
+
+This initialization call is nonlocal and follows the ordering rules for collective operations. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL. For inter-communicators, processes in the remote group pass the root's rank, the root passes `MPI_ROOT`, and other processes in the root's group pass `MPI_PROC_NULL`. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` as `sendbuf` at the root. Persistent collective operations cannot be matched with blocking or nonblocking collective operations. Arrays associated with input arguments must not be modified until the persistent request is freed with MPI_REQUEST_FREE, and it is erroneous to use MPI_CANCEL on a persistent collective request.
+//end::MPI_Gather_init[]
+
+//tag::MPI_Gatherv_init[]
+**MPI_Gatherv_init** creates a persistent collective communication request for the gatherv operation, an All-To-One collective that gathers varying amounts of data from all processes to the root.
+
+This initialization call is nonlocal and follows the ordering rules for collective operations. All processes in the group identified by the communicator must call collective routines in the same order. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL. Once initialized, persistent collective operations may be started in any order across processes in the communicator. For inter-communicators, processes in the remote group pass the root's rank, the root passes `MPI_ROOT`, and other processes in the root's group pass `MPI_PROC_NULL`. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` as `sendbuf` at the root. Persistent collective operations cannot be matched with blocking or nonblocking collective operations. Arrays associated with input arguments must not be modified until the persistent request is freed with MPI_REQUEST_FREE, and it is erroneous to use MPI_CANCEL on a persistent collective request. In multithreaded implementations, the same communicator is not to be used concurrently by two different collective communication initialization calls at the same process.
+//end::MPI_Gatherv_init[]
+
+//tag::MPI_Scatter_init[]
+**MPI_Scatter_init** creates a persistent collective communication request for the scatter operation, a One-To-All collective that distributes data from a root process to all processes in a group. This initialization call is nonlocal and follows the ordering rules for collective operations. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL. Once initialized, persistent collective operations may be started in any order across processes in the communicator. For inter-communicators, processes in the remote group pass the root's rank, the root passes `MPI_ROOT`, and other processes in the root's group pass `MPI_PROC_NULL`. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` as `recvbuf` at the root. Persistent collective operations cannot be matched with blocking or nonblocking collective operations. Arrays associated with input arguments must not be modified until the persistent request is freed with MPI_REQUEST_FREE, and it is erroneous to use MPI_CANCEL on a persistent collective request.
+//end::MPI_Scatter_init[]
+
+//tag::MPI_Scatterv_init[]
+**MPI_Scatterv_init** creates a persistent collective communication request for the scatterv operation, a One-To-All collective that scatters varying amounts of data from a root process to all processes in a group.
+
+This initialization call is nonlocal and follows the ordering rules for collective operations. All processes in the group identified by the communicator must call collective routines in the same order. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL. Once initialized, persistent collective operations may be started in any order across processes in the communicator. For inter-communicators, processes in the remote group pass the root's rank, the root passes `MPI_ROOT`, and other processes in the root's group pass `MPI_PROC_NULL`. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` as `recvbuf` at the root. Persistent collective operations cannot be matched with blocking or nonblocking collective operations. Arrays associated with input arguments must not be modified until the persistent request is freed with MPI_REQUEST_FREE, and it is erroneous to use MPI_CANCEL on a persistent collective request. In multithreaded implementations, the same communicator is not to be used concurrently by two different collective communication initialization calls at the same process.
+//end::MPI_Scatterv_init[]
+
+//tag::MPI_Allgather_init[]
+**MPI_Allgather_init** creates a persistent collective communication request for the allgather operation, an All-To-All collective where all processes contribute data and all receive the concatenated result.
+
+This initialization call is nonlocal and all processes in the group must call collective routines in the same order. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL; once initialized, persistent collective operations may be started in any order across processes. For inter-communicators, each process in one group contributes data that is concatenated and stored at each process in the other group, and vice versa. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes. Persistent collective operations cannot be matched with blocking or nonblocking collective operations; it is erroneous to use MPI_CANCEL on a persistent collective request. Arrays associated with input arguments must not be modified until the persistent request is freed with MPI_REQUEST_FREE. In multithreaded implementations, the same communicator is not to be used concurrently by two different collective communication initialization calls at the same process.
+//end::MPI_Allgather_init[]
+
+//tag::MPI_Allgatherv_init[]
+**MPI_Allgatherv_init** creates a persistent collective communication request for the allgatherv operation, an All-To-All collective that gathers varying amounts of data from all processes and distributes the concatenated result to all processes.
+
+This initialization call is nonlocal and all processes in the group must call collective routines in the same order. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL; once initialized, persistent collective operations may be started in any order across processes. For inter-communicators, each process in one group contributes data that is concatenated and stored at each process in the other group, and vice versa. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes. Persistent collective operations cannot be matched with blocking or nonblocking collective operations; it is erroneous to use MPI_CANCEL on a persistent collective request. Arrays associated with input arguments must not be modified until the persistent request is freed with MPI_REQUEST_FREE. In multithreaded implementations, the same communicator is not to be used concurrently by two different collective communication initialization calls at the same process.
+//end::MPI_Allgatherv_init[]
+
+//tag::MPI_Alltoall_init[]
+**MPI_Alltoall_init** creates a persistent collective communication request for the alltoall operation, an All-To-All collective that performs a complete exchange where each process sends distinct data to every other process.
+
+This initialization call is nonlocal and all processes in the group must call collective routines in the same order. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL; once initialized, persistent collective operations may be started in any order across processes. For inter-communicators, each process in group A sends a message to each process in group B and vice versa. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes. Persistent collective operations cannot be matched with blocking or nonblocking collective operations; it is erroneous to use MPI_CANCEL on a persistent collective request. Arrays associated with input arguments must not be modified until the persistent request is freed with MPI_REQUEST_FREE.
+//end::MPI_Alltoall_init[]
+
+//tag::MPI_Alltoallv_init[]
+**MPI_Alltoallv_init** creates a persistent collective communication request for the alltoallv operation, an All-To-All collective that performs a complete exchange with variable-sized blocks between all processes.
+
+This initialization call is nonlocal and all processes in the group must call collective routines in the same order. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL; once initialized, persistent collective operations may be started in any order across processes. For inter-communicators, each process in group A sends a message to each process in group B and vice versa. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes, in which case `sendcounts`, `sdispls`, and `sendtype` are ignored. Persistent collective operations cannot be matched with blocking or nonblocking collective operations. Arrays associated with input arguments must not be modified until the persistent request is freed with MPI_REQUEST_FREE, and it is erroneous to use MPI_CANCEL on a persistent collective request. In multithreaded implementations, the same communicator is not to be used concurrently by two different collective communication initialization calls at the same process.
+//end::MPI_Alltoallv_init[]
+
+//tag::MPI_Alltoallw_init[]
+**MPI_Alltoallw_init** creates a persistent collective communication request for the alltoallw operation, the most general form of complete exchange allowing separate specification of count, displacement, and datatype for each process pair.
+
+This initialization call is nonlocal and all processes in the group must call collective routines in the same order. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL; once initialized, persistent collective operations may be started in any order across processes. For intra-communicators, the j-th block sent from process i is received by process j and placed in the i-th block of `recvbuf`, with displacements specified in bytes. For inter-communicators, each process in group A sends a message to each process in group B and vice versa. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` to `sendbuf` at all processes, in which case `sendcounts`, `sdispls`, and `sendtypes` are ignored. Persistent collective operations cannot be matched with blocking or nonblocking collective operations. Arrays associated with input arguments must not be modified until the persistent request is freed with MPI_REQUEST_FREE, and it is erroneous to use MPI_CANCEL on a persistent collective request. In multithreaded implementations, the same communicator is not to be used concurrently by two different collective communication initialization calls at the same process.
+//end::MPI_Alltoallw_init[]
+
+//tag::MPI_Reduce_init[]
+**MPI_Reduce_init** creates a persistent collective communication request for the reduce operation, an All-To-One collective that combines elements from all processes using a specified operation and returns the result to the root process.
+
+This initialization call is nonlocal and all processes in the group must call collective routines in the same order. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL. Once initialized, persistent collective operations may be started in any order across processes in the communicator. For inter-communicators, processes in the remote group pass the root's rank, the root passes `MPI_ROOT`, and other processes in the root's group pass `MPI_PROC_NULL`. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` as `sendbuf` at the root. Persistent collective operations cannot be matched with blocking or nonblocking collective operations. Arrays associated with input arguments must not be modified until the persistent request is freed with MPI_REQUEST_FREE, and it is erroneous to use MPI_CANCEL on a persistent collective request. In multithreaded implementations, the same communicator is not to be used concurrently by two different collective communication initialization calls at the same process.
+//end::MPI_Reduce_init[]
+
+//tag::MPI_Allreduce_init[]
+**MPI_Allreduce_init** creates a persistent collective communication request for the allreduce operation, an All-To-All collective that combines elements from all processes using a specified operation and returns the result to all group members.
+
+This initialization call is nonlocal and all processes in the group must call collective routines in the same order. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL. Once initialized, persistent collective operations may be started in any order across processes in the communicator. For inter-communicators, the result of the reduction of data provided by processes in one group is stored at each process in the other group, and vice versa. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` as `sendbuf` at all processes. Persistent collective operations cannot be matched with blocking or nonblocking collective operations, and it is erroneous to use MPI_CANCEL on a persistent collective request. In multithreaded implementations, the same communicator is not to be used concurrently by two different collective communication initialization calls at the same process.
+//end::MPI_Allreduce_init[]
+
+//tag::MPI_Reduce_scatter_block_init[]
+**MPI_Reduce_scatter_block_init** creates a persistent collective communication request for the reduce-scatter operation with equal-sized blocks, an All-To-All collective that performs a global element-wise reduction and scatters the result in equal blocks to all processes.
+
+This initialization call is nonlocal and all processes in the group must call collective routines in the same order. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL. Once initialized, persistent collective operations may be started in any order across processes in the communicator. For inter-communicators, the result of the reduction of data provided by processes in one group is scattered among processes in the other group, and vice versa. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` as `sendbuf` at all processes. Persistent collective operations cannot be matched with blocking or nonblocking collective operations, and it is erroneous to use MPI_CANCEL on a persistent collective request. In multithreaded implementations, the same communicator is not to be used concurrently by two different collective communication initialization calls at the same process.
+//end::MPI_Reduce_scatter_block_init[]
+
+//tag::MPI_Scan_init[]
+**MPI_Scan_init** creates a persistent collective communication request for the inclusive scan operation, a prefix reduction on data distributed across the group.
+
+This initialization call is nonlocal and all processes in the group must call collective routines in the same order. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL. Once initialized, persistent collective operations may be started in any order across processes in the communicator. Upon completion, the receive buffer of the process with rank i contains the reduction of the values in the send buffers of processes with ranks 0 through i, inclusive. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` in `sendbuf`, in which case input data is taken from the receive buffer and replaced by the output data. This operation is invalid for inter-communicators. Persistent collective operations cannot be matched with blocking or nonblocking collective operations, and it is erroneous to use MPI_CANCEL on a persistent collective request. In multithreaded implementations, the same communicator is not to be used concurrently by two different collective communication initialization calls at the same process.
+//end::MPI_Scan_init[]
+
+//tag::MPI_Exscan_init[]
+**MPI_Exscan_init** creates a persistent collective communication request for the exclusive scan operation, a prefix reduction on data distributed across the group.
+
+This initialization call is nonlocal and all processes in the group must call collective routines in the same order. The returned `request` is initially inactive and may be started zero or more times using MPI_START or MPI_STARTALL; once initialized, persistent collective operations may be started in any order across processes. Upon completion, the value in `recvbuf` on rank 0 is undefined and `recvbuf` is not significant on that process; the value in `recvbuf` on rank 1 equals the value in `sendbuf` on rank 0; for processes with rank i > 1, the receive buffer contains the reduction of values in send buffers of processes with ranks 0 through i-1. The `MPI_IN_PLACE` option for intra-communicators is specified by passing `MPI_IN_PLACE` in `sendbuf`, in which case input data is taken from the receive buffer and replaced by output data, and the receive buffer on rank 0 is not changed. This operation is invalid for inter-communicators. Persistent collective operations cannot be matched with blocking or nonblocking collective operations, and it is erroneous to use MPI_CANCEL on a persistent collective request. In multithreaded implementations, the same communicator is not to be used concurrently by two different collective communication initialization calls at the same process.
+//end::MPI_Exscan_init[]
+
+//tag::MPI_Abi_get_version[]
+**MPI_Abi_get_version** queries the standard ABI version supported by the MPI implementation.
+
+This function may be called at any time during an MPI program. It is always thread-safe. If the implementation supports the standard ABI, `abi_major` and `abi_minor` contain the version numbers; otherwise both are set to -1. The ABI version is independent of the MPI specification version.
+//end::MPI_Abi_get_version[]
+
+//tag::MPI_Abi_get_info[]
+**MPI_Abi_get_info** queries implementation-specific ABI information via an info object.
+
+This function may be called at any time during an MPI program. It is always thread-safe. Predefined keys include `mpi_aint_size`, `mpi_count_size`, and `mpi_offset_size`, which provide the sizes in bytes of `MPI_Aint`, `MPI_Count`, and `MPI_Offset`, respectively.
+//end::MPI_Abi_get_info[]
+
+//tag::MPI_Abi_set_fortran_info[]
+**MPI_Abi_set_fortran_info** allows an application to inform the MPI implementation of Fortran type sizes and optional type support.
+
+This function decouples MPI Fortran support from the rest of the implementation by providing a mechanism to set Fortran compiler properties. Before calling this function, the application may call MPI_ABI_GET_FORTRAN_INFO to obtain the current info object; if `MPI_INFO_NULL` is returned, the properties must be set by the application. Only the first call affects the state of the MPI library; all subsequent calls return the error code `MPI_ERR_ABI`. If a call is not successful, the user may call MPI_ABI_GET_FORTRAN_INFO to determine what properties were set.
+//end::MPI_Abi_set_fortran_info[]
+
+//tag::MPI_Abi_get_fortran_info[]
+**MPI_Abi_get_fortran_info** retrieves the current Fortran ABI properties known to the MPI implementation via an info object.
+
+This function returns an `info` object containing Fortran type sizes and optional type support information. When `MPI_INFO_NULL` is returned, the implementation does not know the properties of the Fortran compiler and they must be set by the application via MPI_ABI_SET_FORTRAN_INFO. Before setting Fortran info properties, applications may call this function to check current settings. If a call to MPI_ABI_SET_FORTRAN_INFO is not successful, this function may be called to determine what Fortran compiler properties were set.
+//end::MPI_Abi_get_fortran_info[]
+
+//tag::MPI_Type_toint[]
+**MPI_Type_toint** translates a C datatype handle into a C integer. For predefined handles, the integer value matches the values specified by the MPI ABI. For user-defined handles, the implementation returns the same integer for every call with the same handle, which does not conflict with the reserved range for predefined handles. It is erroneous to call this function with an invalid `datatype` argument.
+//end::MPI_Type_toint[]
+
+//tag::MPI_Type_fromint[]
+**MPI_Type_fromint** translates a C integer to the appropriate C datatype handle. Only an integer obtained from a previous call to MPI_TYPE_TOINT may be passed to this function. It is erroneous to pass an integer associated with a handle that has been freed.
+//end::MPI_Type_fromint[]
+
+//tag::MPI_Group_fromint[]
+**MPI_Group_fromint** translates a C integer to the appropriate C group handle. This function is part of the MPI ABI handle serialization interface, which provides handle conversion without depending on Fortran compiler properties. Only an integer obtained from a previous call to MPI_GROUP_TOINT may be passed to this function. It is erroneous to pass an integer associated with a handle that has been freed or that was derived from a session that has been finalized.
+//end::MPI_Group_fromint[]
+
+//tag::MPI_Request_toint[]
+**MPI_Request_toint** translates a C request handle into a C integer. For predefined handles, the integer value matches the values specified by the MPI ABI. For user-defined handles, the implementation returns the same integer for every call with the same handle, which does not conflict with the reserved range for predefined handles. It is erroneous to call this function with an invalid `request` argument.
+//end::MPI_Request_toint[]
+
+//tag::MPI_Request_fromint[]
+**MPI_Request_fromint** translates a C integer to the appropriate C request handle. This function is part of the MPI ABI handle serialization interface, which provides handle conversion without depending on Fortran compiler properties. Only an integer obtained from a previous call to MPI_REQUEST_TOINT may be passed to this function.
+
+It is erroneous to pass an integer associated with a handle that has been freed, disconnected, or aborted, or that was derived from a session that has been finalized.
+//end::MPI_Request_fromint[]
+
+//tag::MPI_File_toint[]
+**MPI_File_toint** translates a C file handle into a C integer. For predefined handles, the integer value matches the values specified by the MPI ABI. For user-defined handles, the implementation returns the same integer for every call with the same handle, which does not conflict with the reserved range for predefined handles.
+
+It is erroneous to call this function with an invalid `file` argument.
+//end::MPI_File_toint[]
+
+//tag::MPI_File_fromint[]
+**MPI_File_fromint** translates a C integer to the appropriate C file handle. This function is part of the MPI ABI handle serialization interface, which provides handle conversion without depending on Fortran compiler properties. Only an integer obtained from a previous call to MPI_FILE_TOINT may be passed to this function.
+
+It is erroneous to pass an integer associated with a handle that has been freed or that was derived from a session that has been finalized.
+//end::MPI_File_fromint[]
+
+//tag::MPI_Win_toint[]
+**MPI_Win_toint** translates a C window handle into a C integer. For predefined handles, the integer value matches the values specified by the MPI ABI. For user-defined handles, the implementation returns the same integer for every call with the same handle, which does not conflict with the reserved range for predefined handles. This function is thread-safe. It is erroneous to call this function with an invalid `win` argument.
+//end::MPI_Win_toint[]
+
+//tag::MPI_Win_fromint[]
+**MPI_Win_fromint** translates a C integer to the appropriate C window handle. This function is part of the MPI ABI handle serialization interface, which provides handle conversion without depending on Fortran compiler properties. Only an integer obtained from a previous call to MPI_WIN_TOINT may be passed to this function. It is erroneous to pass an integer associated with a handle that has been freed or that was derived from a session that has been finalized.
+//end::MPI_Win_fromint[]
+
+//tag::MPI_Op_toint[]
+**MPI_Op_toint** translates a C operation handle into a C integer. For predefined handles, the integer value matches the values specified by the MPI ABI. For user-defined handles, the implementation returns the same integer for every call with the same handle, which does not conflict with the reserved range for predefined handles. It is erroneous to call this function with an invalid `op` argument.
+//end::MPI_Op_toint[]
+
+//tag::MPI_Op_fromint[]
+**MPI_Op_fromint** translates a C integer to the appropriate C operation handle. This function is part of the MPI ABI handle serialization interface, which provides handle conversion without depending on Fortran compiler properties. Only an integer obtained from a previous call to MPI_OP_TOINT may be passed to this function. It is erroneous to pass an integer associated with a handle that has been freed.
+//end::MPI_Op_fromint[]
+
+//tag::MPI_Info_toint[]
+**MPI_Info_toint** translates a C info handle into a C integer. For predefined handles, the integer value matches the values specified by the MPI ABI. For user-defined handles, the implementation returns the same integer for every call with the same handle, which does not conflict with the reserved range for predefined handles. It is erroneous to call this function with an invalid `info` argument.
+//end::MPI_Info_toint[]
+
+//tag::MPI_Info_fromint[]
+**MPI_Info_fromint** translates a C integer to the appropriate C info handle. This function is part of the MPI ABI handle serialization interface, which provides handle conversion without depending on Fortran compiler properties. Only an integer obtained from a previous call to MPI_INFO_TOINT may be passed to this function. It is erroneous to pass an integer associated with a handle that has been freed.
+//end::MPI_Info_fromint[]
+
+//tag::MPI_Message_toint[]
+**MPI_Message_toint** translates a C message handle into a C integer. For predefined handles, the integer value matches the values specified by the MPI ABI. For user-defined handles, the implementation returns the same integer for every call with the same handle, which does not conflict with the reserved range for predefined handles. It is erroneous to call this function with an invalid `message` argument.
+//end::MPI_Message_toint[]
+
+//tag::MPI_Message_fromint[]
+**MPI_Message_fromint** translates a C integer to the appropriate C message handle. This function is part of the MPI ABI handle serialization interface, which provides handle conversion without depending on Fortran compiler properties. Only an integer obtained from a previous call to MPI_MESSAGE_TOINT may be passed to this function. It is erroneous to pass an integer associated with a handle that has been freed.
+//end::MPI_Message_fromint[]
+
+//tag::MPI_Session_toint[]
+**MPI_Session_toint** translates a C session handle into a C integer. For predefined handles, the integer value matches the values specified by the MPI ABI. For user-defined handles, the implementation returns the same integer for every call with the same handle, which does not conflict with the reserved range for predefined handles. It is erroneous to call this function with an invalid `session` argument.
+//end::MPI_Session_toint[]
+
+//tag::MPI_File_delete[]
+**MPI_File_delete** deletes the file identified by `filename`. The `info` argument may provide file system specifics, and `MPI_INFO_NULL` may be used when no info is needed. If the file does not exist, an error of class `MPI_ERR_NO_SUCH_FILE` is raised. If a process currently has the file open, the behavior of any access to the file and whether an open file is deleted is implementation dependent. If the file is not deleted, an error of class `MPI_ERR_FILE_IN_USE` or `MPI_ERR_ACCESS` is raised. Errors are raised using the default file error handler.
+//end::MPI_File_delete[]
+
+//tag::MPI_File_set_size[]
+**MPI_File_set_size** resizes the file associated with the file handle `fh`.
+
+This is a collective operation over the group associated with the file, and all processes must pass identical values for `size`. If `size` is smaller than the current file size, the file is truncated; if `size` is larger, the values in newly accessible regions are undefined. It is implementation dependent whether MPI_FILE_SET_SIZE allocates file space. This operation does not affect individual file pointers or the shared file pointer, and file pointers may point beyond end of file after truncation. All nonblocking requests and split collective operations on `fh` must be completed before calling this routine. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened. For consistency semantics, MPI_FILE_SET_SIZE is a write operation that conflicts with operations accessing bytes between the old and new file sizes.
+//end::MPI_File_set_size[]
+
+
+//tag::MPI_File_get_size[]
+**MPI_File_get_size** returns the current size in bytes of the file associated with `fh`. The size is returned in the `size` parameter. For consistency semantics, this operation is classified as a data access operation.
+//end::MPI_File_get_size[]
+
+//tag::MPI_File_preallocate[]
+**MPI_File_preallocate** ensures that storage space is allocated for the first `size` bytes of the file associated with `fh`.
+
+This is a collective operation over the group associated with the file, and all processes must pass identical values for `size`. Regions of the file that have previously been written are unaffected, and for newly allocated regions the effect is the same as writing undefined data. If `size` is larger than the current file size, the file size increases to `size`; if `size` is less than or equal to the current file size, the file size is unchanged. The treatment of file pointers, nonblocking accesses, and file consistency is the same as with MPI_FILE_SET_SIZE. All nonblocking requests and split collective operations on `fh` must be completed before calling this routine. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened. In some implementations, file preallocation may be time-consuming.
+//end::MPI_File_preallocate[]
+
+//tag::MPI_File_get_group[]
+**MPI_File_get_group** returns a duplicate of the group of the communicator used to open the file associated with `fh`. The group is returned in `group`. The user is responsible for freeing `group`.
+//end::MPI_File_get_group[]
+
+//tag::MPI_File_get_amode[]
+**MPI_File_get_amode** returns the access mode associated with the file handle `fh`. The access mode is returned in `amode` and corresponds to the value specified when the file was opened with MPI_FILE_OPEN.
+//end::MPI_File_get_amode[]
+
+//tag::MPI_File_set_info[]
+**MPI_File_set_info** updates the hints of the file associated with `fh` using the hints provided in `info`.
+
+This is a collective routine over the group associated with the file. The operation has no effect on previously set or defaulted hints that are not specified by `info`. It also has no effect on hints that are specified by `info` but ignored by the MPI implementation. The `info` object may differ on each process, but any info entries that the implementation requires to be the same on all processes must appear with the same value in each process's `info` object. Many info items that an implementation can use when creating or opening a file may not be easily changed afterward, so an implementation may ignore hints in this call that it would have accepted in an open call. MPI_FILE_GET_INFO may be used to determine whether info changes were ignored by the implementation.
+//end::MPI_File_set_info[]
+
+//tag::MPI_File_get_info[]
+**MPI_File_get_info** returns a new info object containing the hints of the file associated with `fh`. The current setting of all hints related to this file is returned in `info_used`. An MPI implementation is required to return all hints that are supported by the implementation and have default values specified, any user-supplied hints that were not ignored by the implementation, and any additional hints that were set by the implementation. If no such hints exist, a handle to a newly created info object is returned that contains no key/value pairs. The user is responsible for freeing `info_used` via MPI_INFO_FREE.
+//end::MPI_File_get_info[]
+
+//tag::MPI_File_set_view[]
+**MPI_File_set_view** changes the process's view of the data in the file, setting the displacement, elementary datatype, filetype, and data representation.
+
+This is a collective operation over the group of processes that opened the file. The values for `datarep` and the extent of `etype` in the file data representation must be identical on all processes, while values for `disp`, `filetype`, and `info` may vary. The datatypes passed in `etype` and `filetype` must be committed. This routine resets both the individual file pointers and the shared file pointer to zero. All nonblocking requests and split collective operations on `fh` must be completed before calling this routine. It is erroneous to use absolute addresses in the construction of `etype` and `filetype`. If `MPI_MODE_SEQUENTIAL` was specified when the file was opened, the special displacement `MPI_DISPLACEMENT_CURRENT` must be passed in `disp`. In multithreaded implementations, any split collective begin and end operation called by a process on a file handle must be called from the same thread.
+//end::MPI_File_set_view[]
+
+//tag::MPI_File_get_view[]
+**MPI_File_get_view** returns the process's view of the data in the file associated with the file handle. The current displacement is returned in `disp`, and the data representation is returned in `datarep`. The `etype` and `filetype` are new datatypes with typemaps equal to the typemaps of the current elementary datatype and filetype, respectively, and both are returned in a committed state. If a portable datatype was used to set the current view, the corresponding datatype returned is also portable.
+
+The length of a data representation string is limited to `MPI_MAX_DATAREP_STRING`, and users are responsible for ensuring that `datarep` is large enough. If `etype` or `filetype` are derived datatypes, users are responsible for freeing them.
+//end::MPI_File_get_view[]
+
+//tag::MPI_File_read_at_all[]
+**MPI_File_read_at_all** is a collective version of the blocking MPI_FILE_READ_AT interface. This routine reads a file beginning at the position specified by `offset`, which is expressed in etype units relative to the current view. No file pointer is used nor updated by this explicit offset operation. The type signature of `datatype` must match the type signature of some number of contiguous copies of the etype of the current view. Upon completion, the amount of data accessed is returned in `status`, and reading less data than requested indicates end of file.
+
+Completion of a collective call may depend on the activity of other processes participating in the collective call. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened, or to provide a negative `offset` value.
+//end::MPI_File_read_at_all[]
+
+//tag::MPI_File_write_at[]
+**MPI_File_write_at** writes a file beginning at the position specified by `offset`. This is a blocking, noncollective explicit offset operation that performs data access at the file position given directly as an argument. No file pointer is used nor updated. The type signature of `datatype` must match the type signature of some number of contiguous copies of the etype of the current view. Writing past the end of file increases the file size, and the amount of data accessed is returned in `status`.
+
+It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened, or to provide a negative `offset` value.
+//end::MPI_File_write_at[]
+
+//tag::MPI_File_write_at_all[]
+**MPI_File_write_at_all** is a collective version of the blocking MPI_FILE_WRITE_AT interface. This routine writes a file beginning at the position specified by `offset`, which is expressed in etype units relative to the current view. No file pointer is used nor updated by this explicit offset operation. The type signature of `datatype` must match the type signature of some number of contiguous copies of the etype of the current view. Writing past the end of file increases the file size, and the amount of data accessed is returned in `status`.
+
+Completion of a collective call may depend on the activity of other processes participating in the collective call. All processes in the group must call collective I/O operations in the same order. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened, or to provide a negative `offset` value.
+//end::MPI_File_write_at_all[]
+
+//tag::MPI_File_iread_at[]
+**MPI_File_iread_at** is a nonblocking version of the MPI_FILE_READ_AT interface. This routine initiates reading a file beginning at the position specified by `offset`. No file pointer is used nor updated by this explicit offset operation. The nonblocking call returns a `request` handle that must be passed to a completion call such as MPI_WAIT or MPI_TEST. It is erroneous to access the buffer passed to this routine between initiation and completion of the operation.
+
+It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+//end::MPI_File_iread_at[]
+
+//tag::MPI_File_iread_at_all[]
+**MPI_File_iread_at_all** is a nonblocking collective version of MPI_FILE_READ_AT_ALL. This routine initiates reading a file beginning at the position specified by `offset`, which is expressed in etype units relative to the current view. No file pointer is used nor updated by this explicit offset operation. The nonblocking collective call is local and returns a `request` handle that must be passed to a completion call. It is erroneous to access the buffer passed to this routine between initiation and completion of the operation.
+
+All processes in the group must call collective I/O operations in the same order. Nonblocking collective I/O operations do not match with blocking collective I/O operations. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened, or to provide a negative `offset` value.
+//end::MPI_File_iread_at_all[]
+
+//tag::MPI_File_iwrite_at[]
+**MPI_File_iwrite_at** is a nonblocking version of the MPI_FILE_WRITE_AT interface. This routine initiates writing to a file beginning at the position specified by `offset`, which is expressed in etype units relative to the current view. No file pointer is used nor updated by this explicit offset operation. The nonblocking call returns a `request` handle that must be passed to a completion call such as MPI_WAIT or MPI_TEST. It is erroneous to access or modify the buffer passed to this routine between initiation and completion of the operation.
+
+It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+//end::MPI_File_iwrite_at[]
+
+//tag::MPI_File_iwrite_at_all[]
+**MPI_File_iwrite_at_all** is a nonblocking collective version of MPI_FILE_WRITE_AT_ALL. This routine initiates writing to a file beginning at the position specified by `offset`, which is expressed in etype units relative to the current view. No file pointer is used nor updated by this explicit offset operation. The nonblocking collective call is local and returns a `request` handle that must be passed to a completion call. It is erroneous to access or modify the buffer passed to this routine between initiation and completion of the operation.
+
+All processes in the group must call collective I/O operations in the same order, and nonblocking collective I/O operations do not match with blocking collective I/O operations. In multithreaded implementations, any split collective begin and end operation called by a process on a file handle must be called from the same thread. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+//end::MPI_File_iwrite_at_all[]
+
+//tag::MPI_File_write_at_all_begin[]
+**MPI_File_write_at_all_begin** initiates a split collective write operation at an explicit offset. This is a collective call over the group of processes that opened the file and follows the ordering rules for collective calls. The begin procedure is nonlocal and may or may not return before it is called by all processes in the group. A file handle may have at most one active split collective operation at any time. The buffer must not be accessed or modified until the matching MPI_FILE_WRITE_AT_ALL_END completes the operation. No collective I/O operations are permitted on the file handle concurrently with a split collective access. In multithreaded implementations, the begin and end operations on the same file handle must be called from the same thread. Split collective operations do not match with regular collective operations.
+//end::MPI_File_write_at_all_begin[]
+
+//tag::MPI_File_read[]
+**MPI_File_read** reads a file using the individual file pointer. This is a blocking, noncollective operation where completion depends only on the calling process. After the operation completes, the individual file pointer is updated to point to the next etype after the last one accessed. The type signature of `datatype` must match the type signature of some number of contiguous copies of the etype of the current view. Upon completion, the amount of data accessed is returned in `status`, and reading less data than requested indicates end of file. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+//end::MPI_File_read[]
+
+//tag::MPI_File_read_all[]
+**MPI_File_read_all** is a collective version of the blocking MPI_FILE_READ interface. This operation reads a file using the individual file pointer and must be called by all processes in the group that collectively opened the file. Completion of this collective call may depend on the activity of other participating processes. After the operation completes, the individual file pointer is updated to point to the next etype after the last one accessed. Upon completion, the amount of data accessed is returned in `status`, and reading less data than requested indicates end of file.
+
+All processes in the group must call collective I/O operations in the same order. In multithreaded implementations, any split collective begin and end operation called by a process on a file handle must be called from the same thread. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+//end::MPI_File_read_all[]
+
+//tag::MPI_File_write[]
+**MPI_File_write** writes a file using the individual file pointer. This is a blocking, noncollective operation where completion depends only on the calling process. After the operation completes, the individual file pointer is updated to point to the next etype after the last one accessed. The type signature of `datatype` must match the type signature of some number of contiguous copies of the etype of the current view. Writing past the end of file increases the file size. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+//end::MPI_File_write[]
+
+//tag::MPI_File_write_all[]
+**MPI_File_write_all** is a collective version of the blocking MPI_FILE_WRITE interface that writes a file using the individual file pointer. This operation must be called by all processes in the group that collectively opened the file. Completion of this collective call may depend on the activity of other participating processes. After the operation completes, the individual file pointer is updated to point to the next etype after the last one accessed. The type signature of `datatype` must match the type signature of some number of contiguous copies of the etype of the current view. Writing past the end of file increases the file size.
+
+All processes in the group must call collective I/O operations in the same order. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+//end::MPI_File_write_all[]
+
+//tag::MPI_File_iread[]
+**MPI_File_iread** is a nonblocking version of the MPI_FILE_READ interface. This routine initiates a read using the individual file pointer and returns a `request` handle that must be passed to a completion call such as MPI_WAIT or MPI_TEST. After initiation, the individual file pointer is updated to point to the next etype after the last one to be accessed. It is erroneous to access the buffer passed to this routine between initiation and completion of the operation. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+//end::MPI_File_iread[]
+
+
+//tag::MPI_File_iread_all[]
+**MPI_File_iread_all** is a nonblocking collective version of MPI_FILE_READ_ALL. This routine initiates a read using the individual file pointer and returns a `request` handle that must be passed to a completion call. After initiation, the individual file pointer is updated to point to the next etype after the last one to be accessed. The nonblocking collective call is local and may progress independently of communication, computation, or I/O. It is erroneous to access the buffer passed to this routine between initiation and completion of the operation, or to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+
+All processes in the group must call collective I/O operations in the same order, and nonblocking collective I/O operations do not match with blocking collective I/O operations. In multithreaded implementations, any split collective begin and end operation called by a process on a file handle must be called from the same thread.
+//end::MPI_File_iread_all[]
+
+//tag::MPI_File_iwrite[]
+**MPI_File_iwrite** is a nonblocking version of MPI_FILE_WRITE that initiates a write using the individual file pointer. After initiation, the individual file pointer is updated to point to the next etype after the last one to be accessed. The routine returns a `request` handle that must be passed to a completion call such as MPI_WAIT or MPI_TEST. It is erroneous to access or modify the buffer passed to this routine between initiation and completion of the operation. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+//end::MPI_File_iwrite[]
+
+//tag::MPI_File_seek[]
+**MPI_File_seek** updates the individual file pointer according to `whence`. The `whence` argument accepts `MPI_SEEK_SET` to set the pointer to `offset`, `MPI_SEEK_CUR` to set the pointer to the current position plus `offset`, or `MPI_SEEK_END` to set the pointer to end of file plus `offset`. The `offset` can be negative, allowing seeking backwards. It is erroneous to seek to a negative position in the view or to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+//end::MPI_File_seek[]
+
+//tag::MPI_File_get_position[]
+**MPI_File_get_position** returns the current position of the individual file pointer in etype units relative to the current view. The returned `offset` may be used in a future call to MPI_FILE_SEEK with `whence` = `MPI_SEEK_SET` to return to the current position. To set the displacement to the current file pointer position, the `offset` may be converted to an absolute byte position using MPI_FILE_GET_BYTE_OFFSET and then passed to MPI_FILE_SET_VIEW. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+//end::MPI_File_get_position[]
+
+//tag::MPI_File_get_byte_offset[]
+**MPI_File_get_byte_offset** converts a view-relative offset into an absolute byte position. The absolute byte position from the beginning of the file corresponding to `offset` relative to the current view of `fh` is returned in `disp`. To set the displacement to the current file pointer position, the `offset` may first be converted to an absolute byte position using this routine, then passed to MPI_FILE_SET_VIEW.
+//end::MPI_File_get_byte_offset[]
+
+//tag::MPI_File_read_shared[]
+**MPI_File_read_shared** reads a file using the shared file pointer, which is maintained by MPI and shared among all processes in the group that collectively opened the file. This is a blocking, noncollective operation. The effect of multiple calls to shared file pointer routines is defined to behave as if the calls were serialized, but the serialization ordering is not deterministic. User synchronization is required to enforce a specific access order. All processes must use the same file view for shared file pointer routines. After the operation completes, the shared file pointer is updated to point to the next etype after the last one accessed relative to the current view. Upon completion, the amount of data accessed is returned in `status`, and reading less data than requested indicates end of file.
+//end::MPI_File_read_shared[]
+
+//tag::MPI_File_write_shared[]
+**MPI_File_write_shared** writes a file using the shared file pointer, which is maintained by MPI and shared among all processes in the group that collectively opened the file. This is a blocking, noncollective operation. The effect of multiple calls to shared file pointer routines behaves as if the calls were serialized, but for noncollective routines the serialization ordering is not deterministic. User synchronization is required to enforce a specific access order. All processes must use the same file view for shared file pointer routines. After the operation completes, the shared file pointer is updated to point to the next etype after the last one accessed relative to the current view. Upon completion, the amount of data accessed is returned in `status`.
+//end::MPI_File_write_shared[]
+
+//tag::MPI_File_read_ordered[]
+**MPI_File_read_ordered** is a collective version of MPI_FILE_READ_SHARED that reads a file using the shared file pointer with accesses ordered by process rank.
+
+All processes in the group that collectively opened the file must call this routine, and all processes must use the same file view. Accesses to the file occur in the order determined by the ranks of the processes within the group. For each process, the location in the file at which data is accessed is the position at which the shared file pointer would be after all processes with lower ranks had accessed their data. The call may return only after all processes in the group have initiated their accesses. When the call returns, the shared file pointer points to the next etype after the last one requested, according to the file view used by all processes. In multithreaded implementations, any split collective begin and end operation called by a process on a file handle must be called from the same thread. Collective operations may perform better than their noncollective counterparts when data access order is not strictly required by the program.
+//end::MPI_File_read_ordered[]
+
+//tag::MPI_File_write_ordered[]
+**MPI_File_write_ordered** is a collective version of MPI_FILE_WRITE_SHARED that writes to a file using the shared file pointer with accesses ordered by process rank.
+
+All processes in the group that collectively opened the file must call this routine, and all processes must use the same file view. Accesses to the file occur in the order determined by the ranks of the processes within the group. For each process, the location in the file at which data is written is the position at which the shared file pointer would be after all processes with lower ranks had written their data. The call may return only after all processes in the group have initiated their accesses. When the call returns, the shared file pointer points to the next etype after the last one requested, according to the file view used by all processes. Upon completion, the amount of data accessed is returned in `status`. In multithreaded implementations, any split collective begin and end operation called by a process on a file handle must be called from the same thread. Using ordered routines may enable an implementation to optimize access when data access need not occur strictly in process rank order, improving performance.
+//end::MPI_File_write_ordered[]
+
+//tag::MPI_File_seek_shared[]
+**MPI_File_seek_shared** is a collective operation that updates the shared file pointer according to the `whence` parameter. All processes in the communicator group associated with the file handle must call this routine with identical values for `offset` and `whence`. The `whence` parameter accepts `MPI_SEEK_SET` to set the pointer to `offset`, `MPI_SEEK_CUR` to set it to the current position plus `offset`, or `MPI_SEEK_END` to set it to end of file plus `offset`. The `offset` may be negative for seeking backwards. All processes must use the same file view when using shared file pointer routines. It is erroneous to seek to a negative position in the view or to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+//end::MPI_File_seek_shared[]
+
+//tag::MPI_File_get_position_shared[]
+**MPI_File_get_position_shared** returns the current position of the shared file pointer in etype units relative to the current view. The shared file pointer is maintained by MPI and shared among all processes in the communicator group that collectively opened the file. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+
+The returned `offset` may be used in a future call to MPI_FILE_SEEK_SHARED with `MPI_SEEK_SET` to return to the current position. To set the displacement to the current shared file pointer position, `offset` may first be converted into an absolute byte position using MPI_FILE_GET_BYTE_OFFSET, then MPI_FILE_SET_VIEW may be called with the resulting displacement.
+//end::MPI_File_get_position_shared[]
+
+//tag::MPI_File_read_at_all_begin[]
+**MPI_File_read_at_all_begin** begins a split collective read operation at an explicit `offset` in the file. This is the begin routine of a split collective pair that, when completed with MPI_FILE_READ_AT_ALL_END, produces results equivalent to MPI_FILE_READ_AT_ALL. Begin calls are collective over the group of processes that participated in the collective open and follow the ordering rules for collective calls. The begin routine is a nonlocal, incomplete procedure that may or may not return before it is called in all MPI processes of the group. Each file handle may have at most one active split collective operation at any time.
+
+In a multithreaded implementation, the split collective begin and end operations called by a process must be called from the same thread. It is erroneous to access the buffer passed to a begin routine or to perform any collective I/O operation on the file handle between the begin and end calls. An implementation may implement the split collective using the corresponding blocking collective routine when either the begin or end call is issued. Split collective operations do not match regular collective operations; an MPI_FILE_READ_AT_ALL on one process does not match an MPI_FILE_READ_AT_ALL_BEGIN/MPI_FILE_READ_AT_ALL_END pair on another process. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+//end::MPI_File_read_at_all_begin[]
+
+//tag::MPI_File_read_at_all_end[]
+**MPI_File_read_at_all_end** completes a split collective read operation initiated by MPI_FILE_READ_AT_ALL_BEGIN. This is the end routine of a split collective pair that, when combined with the matching begin call, produces results equivalent to MPI_FILE_READ_AT_ALL. End calls are collective over the group of processes that participated in the collective open and follow the ordering rules for collective calls. Each end call matches the preceding begin call for the same operation, and exactly one unmatched begin call must precede the end call. A matched pair of split collective data access operations composes a single data access for the purpose of consistency semantics.
+
+In multithreaded implementations, the split collective begin and end operations called by a process must be called from the same thread. An implementation may perform the read operation when either the begin or end call is issued.
+//end::MPI_File_read_at_all_end[]
+
+//tag::MPI_File_write_at_all_end[]
+**MPI_File_write_at_all_end** completes a split collective write operation initiated by MPI_FILE_WRITE_AT_ALL_BEGIN. This is the end routine of a split collective pair that, when combined with the matching begin call, produces results equivalent to MPI_FILE_WRITE_AT_ALL. End calls are collective over the group of processes that participated in the collective open and follow the ordering rules for collective calls. Each end call matches the preceding begin call for the same operation, and exactly one unmatched begin call must precede the end call. A matched pair of split collective data access operations composes a single data access for the purpose of consistency semantics. An implementation may perform the write operation when either the begin or end call is issued.
+
+In multithreaded implementations, the split collective begin and end operations called by a process must be called from the same thread.
+//end::MPI_File_write_at_all_end[]
+
+//tag::MPI_File_read_all_begin[]
+**MPI_File_read_all_begin** begins a split collective read operation using the individual file pointer. This is the begin routine of a split collective pair that, when completed with MPI_FILE_READ_ALL_END, produces results equivalent to MPI_FILE_READ_ALL. Begin calls are collective over the group of processes that participated in the collective open and follow the ordering rules for collective calls. The begin routine is a nonlocal, incomplete procedure that may or may not return before it is called in all MPI processes of the group. After the begin call is initiated, the individual file pointer is updated to point to the next etype after the last one that will be accessed.
+
+Each file handle may have at most one active split collective operation at any time. In a multithreaded implementation, the split collective begin and end operations called by a process must be called from the same thread. It is erroneous to access the `buf` passed to a begin routine or to perform any collective I/O operation on the file handle between the begin and end calls. Split collective operations do not match regular collective operations. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+//end::MPI_File_read_all_begin[]
+
+//tag::MPI_File_read_all_end[]
+**MPI_File_read_all_end** completes a split collective read operation initiated by MPI_FILE_READ_ALL_BEGIN.
+
+This is the end routine of a split collective pair that, when combined with the matching begin call, produces results equivalent to MPI_FILE_READ_ALL. End calls are collective over the group of processes that participated in the collective open and follow the ordering rules for collective calls. Each end call matches the preceding begin call for the same operation, and exactly one unmatched begin call must precede the end call. A matched pair of split collective data access operations composes a single data access for the purpose of consistency semantics. In multithreaded implementations, the split collective begin and end operations called by a process must be called from the same thread. An implementation may perform the read operation when either the begin or end call is issued.
+//end::MPI_File_read_all_end[]
+
+//tag::MPI_File_write_all_begin[]
+**MPI_File_write_all_begin** begins a split collective write operation using the individual file pointer. This is the begin routine of a split collective pair that, when completed with MPI_FILE_WRITE_ALL_END, produces results equivalent to MPI_FILE_WRITE_ALL. Begin calls are collective over the group of processes that participated in the collective open and follow the ordering rules for collective calls. The begin routine is a nonlocal, incomplete procedure that may or may not return before it is called in all MPI processes of the group. After the begin call is initiated, the individual file pointer is updated to point to the next etype after the last one that will be accessed.
+
+Each file handle may have at most one active split collective operation at any time. In a multithreaded implementation, the split collective begin and end operations called by a process must be called from the same thread. It is erroneous to access the `buf` passed to a begin routine or to perform any collective I/O operation on the file handle between the begin and end calls. Split collective operations do not match regular collective operations. It is erroneous to call this routine if `MPI_MODE_SEQUENTIAL` was specified when the file was opened.
+//end::MPI_File_write_all_begin[]
+
+//tag::MPI_File_write_all_end[]
+**MPI_File_write_all_end** completes a split collective write operation initiated by MPI_FILE_WRITE_ALL_BEGIN using the individual file pointer. This is the end routine of a split collective pair that, when combined with the matching begin call, produces results equivalent to MPI_FILE_WRITE_ALL. End calls are collective over the group of processes that participated in the collective open and follow the ordering rules for collective calls. Each end call matches the preceding begin call for the same operation, and exactly one unmatched begin call must precede the end call. A matched pair of split collective data access operations composes a single data access for the purpose of consistency semantics. An implementation may perform the write operation when either the begin or end call is issued.
+
+In multithreaded implementations, the split collective begin and end operations called by a process must be called from the same thread. No collective I/O operations are permitted on the file handle concurrently with a split collective access.
+//end::MPI_File_write_all_end[]
+
+//tag::MPI_File_read_ordered_begin[]
+**MPI_File_read_ordered_begin** begins a split collective read operation using the shared file pointer with accesses ordered by process rank. This is the begin routine of a split collective pair that, when completed with MPI_FILE_READ_ORDERED_END, produces results equivalent to MPI_FILE_READ_ORDERED. Begin calls are collective over the group of processes that participated in the collective open and follow the ordering rules for collective calls. The begin routine is a nonlocal, incomplete procedure that may or may not return before it is called in all MPI processes of the group.
+
+Each file handle may have at most one active split collective operation at any time. In a multithreaded implementation, the split collective begin and end operations called by a process must be called from the same thread. It is erroneous to access `buf` passed to a begin routine or to perform any collective I/O operation on the file handle between the begin and end calls. A matched pair of split collective data access operations composes a single data access for the purpose of consistency semantics.
+//end::MPI_File_read_ordered_begin[]
+
+//tag::MPI_File_read_ordered_end[]
+**MPI_File_read_ordered_end** completes a split collective read operation initiated by MPI_FILE_READ_ORDERED_BEGIN using the shared file pointer with accesses ordered by process rank. This is the end routine of a split collective pair that, when combined with the matching begin call, produces results equivalent to MPI_FILE_READ_ORDERED. End calls are collective over the group of processes that participated in the collective open and follow the ordering rules for collective calls. Each end call matches the preceding begin call for the same operation, and exactly one unmatched begin call must precede the end call. A matched pair of split collective data access operations composes a single data access for the purpose of consistency semantics. An implementation may perform the read operation when either the begin or end call is issued.
+
+In multithreaded implementations, the split collective begin and end operations called by a process must be called from the same thread. No collective I/O operations are permitted on the file handle concurrently with a split collective access.
+//end::MPI_File_read_ordered_end[]
+
+//tag::MPI_File_write_ordered_end[]
+**MPI_File_write_ordered_end** completes a split collective write operation initiated by MPI_FILE_WRITE_ORDERED_BEGIN using the shared file pointer with accesses ordered by process rank. This is the end routine of a split collective pair that, when combined with the matching begin call, produces results equivalent to MPI_FILE_WRITE_ORDERED. End calls are collective over the group of processes that participated in the collective open and follow the ordering rules for collective calls. Each end call matches the preceding begin call for the same operation, and exactly one unmatched begin call must precede the end call. A matched pair of split collective data access operations composes a single data access for the purpose of consistency semantics. An implementation may perform the write operation when either the begin or end call is issued.
+
+In multithreaded implementations, the split collective begin and end operations called by a process must be called from the same thread. No collective I/O operations are permitted on the file handle concurrently with a split collective access.
+//end::MPI_File_write_ordered_end[]
+
+//tag::MPI_File_get_type_extent[]
+**MPI_File_get_type_extent** returns the extent of `datatype` in the file `fh`. This extent will be the same for all processes accessing the file. If the current view uses a user-defined data representation, MPI uses the `dtype_file_extent_fn` callback to calculate the extent.
+
+If the `datatype` extent cannot be represented in `extent`, it is set to `MPI_UNDEFINED`.
+//end::MPI_File_get_type_extent[]
+
+//tag::MPI_Register_datarep[]
+**MPI_Register_datarep** associates user-defined conversion functions with a data representation identifier for use with MPI_FILE_SET_VIEW.
+
+This is a local operation that only registers the data representation for the calling MPI process. The `datarep` identifier can then be passed to MPI_FILE_SET_VIEW, causing subsequent data access operations to call the conversion functions for converting data between file and native representations. If `datarep` is already defined, an error of class `MPI_ERR_DUP_DATAREP` is raised using the default file error handler. The length of a data representation string is limited to `MPI_MAX_DATAREP_STRING`. The conversion functions must be reentrant, are restricted to use byte alignment for all types, and cannot call collective routines or free `datatype`.
+//end::MPI_Register_datarep[]
+
+//tag::MPI_CONVERSION_FN_NULL[]
+**MPI_CONVERSION_FN_NULL** is a predefined constant function pointer that may be passed as either the `read_conversion_fn` or `write_conversion_fn` argument to MPI_REGISTER_DATAREP. When used, MPI will not invoke the corresponding conversion function but will instead perform the requested data access using the native data representation. The large count variant `MPI_CONVERSION_FN_NULL_C` is available for use with MPI_Register_datarep_c.
+//end::MPI_CONVERSION_FN_NULL[]
+
+//tag::MPI_File_set_atomicity[]
+**MPI_File_set_atomicity** sets the consistency semantics for data access operations on file handles created from one collective open.
+
+This is a collective operation over the group of processes that opened the file. All processes in the group must pass identical values for `fh` and `flag`. If `flag` is true, atomic mode is set; if `flag` is false, nonatomic mode is set. Atomic mode guarantees sequential consistency for conflicting accesses from file handles created by the same collective open. Changing the consistency semantics only affects new data accesses. Nonblocking data accesses and split collective operations that have not completed are only guaranteed to abide by nonatomic mode consistency semantics. In multithreaded implementations, any split collective begin and end operation called by a process on the file handle must be called from the same thread.
+//end::MPI_File_set_atomicity[]
+
+//tag::MPI_File_get_atomicity[]
+**MPI_File_get_atomicity** returns the current consistency semantics for data access operations on the set of file handles created by one collective open. If `flag` is true, atomic mode is enabled. If `flag` is false, nonatomic mode is enabled.
+//end::MPI_File_get_atomicity[]
+
+//tag::MPI_File_sync[]
+**MPI_File_sync** causes all previous writes to `fh` by the calling process to be transferred to the storage device. If other processes have made updates to the storage device, all such updates become visible to subsequent reads of `fh` by the calling process. MPI_File_sync may be necessary to ensure sequential consistency when accessing a file through file handles from different collective opens. MPI_File_sync is a collective operation. Both opening and closing a file implicitly perform an MPI_FILE_SYNC.
+
+All nonblocking requests and split collective operations on `fh` are required to be completed before calling MPI_File_sync.
+//end::MPI_File_sync[]
+
+//tag::MPI_Win_create[]
+**MPI_Win_create** is a collective operation over the group of `comm` that creates a window object for remote memory access operations. Each process specifies a region of existing memory starting at `base` of `size` bytes that is exposed for RMA accesses by other processes in the group. The call returns an opaque window handle that represents the group of processes and the attributes of each window. A process may expose no memory by specifying `size` = 0. The `disp_unit` argument facilitates address arithmetic in RMA operations by scaling target displacement arguments. The `info` argument provides optimization hints including `no_locks`, `accumulate_ordering`, `accumulate_ops`, `same_size`, and `same_disp_unit`. Concurrent communications to distinct overlapping windows may lead to undefined results. Implementations may make the provided memory available for load/store accesses by processes in the same shared memory domain.
+//end::MPI_Win_create[]
+
+//tag::MPI_Win_allocate[]
+**MPI_Win_allocate** is a collective operation over the group of `comm` that allocates memory and creates a window for remote memory access operations. On each process, the call allocates at least `size` bytes and returns a pointer in `baseptr` along with a window handle usable by all processes in the group. The `size` argument may differ at each process and `size` = 0 is valid. A library may allocate and expose more memory to create a fast, globally symmetric allocation. The `disp_unit` argument facilitates address arithmetic in RMA operations by scaling target displacement arguments. The `info` argument provides optimization hints similar to MPI_WIN_CREATE and MPI_ALLOC_MEM. Implementations may make allocated memory available for load/store accesses by processes in the same shared memory domain. Default memory alignment requirements apply to all processes with nonzero `size` argument.
+//end::MPI_Win_allocate[]
+
+//tag::MPI_Win_allocate_shared[]
+**MPI_Win_allocate_shared** is a collective operation over the group of `comm` that allocates shared memory accessible by all processes in the group and creates a window for remote memory access operations. On each process, the call allocates at least `size` bytes of shared memory and returns a pointer in `baseptr` to the locally allocated segment. The locally allocated memory can be the target of load/store accesses by remote processes, with base pointers for other processes queryable using MPI_WIN_SHARED_QUERY. The `size` argument may differ at each process and `size` = 0 is valid. It is the user's responsibility to ensure that `comm` represents a group of processes in the same shared memory domain. The allocated memory is contiguous across processes in rank order unless the info key `alloc_shared_noncontig` is specified. The `info` argument provides optimization hints similar to MPI_WIN_CREATE, MPI_WIN_ALLOCATE, and MPI_ALLOC_MEM.
+
+If the `alloc_shared_noncontig` info key is not set to true, users are responsible for controlling alignment of contiguous memory for processes other than the first by ensuring each process provides a `size` argument that is an integral multiple of the required alignment.
+//end::MPI_Win_allocate_shared[]
+
+//tag::MPI_Win_shared_query[]
+**MPI_Win_shared_query** queries the process-local address for remote memory segments created with MPI_WIN_ALLOCATE_SHARED, MPI_WIN_ALLOCATE, or MPI_WIN_CREATE. This function can return different process-local addresses for the same physical memory when called by different processes. Only MPI_WIN_ALLOCATE_SHARED is guaranteed to allocate shared memory; implementations may provide shared memory for windows created with MPI_WIN_CREATE and MPI_WIN_ALLOCATE where possible.
+
+When `rank` is `MPI_PROC_NULL`, the returned `baseptr`, `disp_unit`, and `size` are for the process with the lowest rank that specified `size` > 0. When the remote memory segment cannot be accessed directly, returns `size` = 0 and a `baseptr` as if MPI_ALLOC_MEM was called with `size` = 0. A consistent view in the unified memory model may be created by utilizing window synchronization functions or by completing outstanding store accesses via MPI_WIN_FLUSH.
+//end::MPI_Win_shared_query[]
+
+//tag::MPI_Win_create_dynamic[]
+**MPI_Win_create_dynamic** is a collective operation over the group of `comm` that creates a window without memory attached for remote memory access operations. Existing process memory can be attached using MPI_WIN_ATTACH and detached using MPI_WIN_DETACH. For dynamic windows, the `target_disp` for all RMA functions is the address at the target; the effective `window_base` is `MPI_BOTTOM` and the `disp_unit` is one. For dynamic windows, the `target_disp` argument to RMA communication operations is not restricted to nonnegative values. Memory at the target cannot be accessed until that memory has been attached using MPI_WIN_ATTACH. The `info` argument provides optimization hints similar to MPI_WIN_CREATE.
+
+Users may use MPI_GET_ADDRESS at the target process to determine the address of a target memory location and communicate this address to the origin process. The MPI_AINT_ADD and MPI_AINT_DIFF functions may be used to safely perform address arithmetic with `MPI_Aint` displacements.
+//end::MPI_Win_create_dynamic[]
+
+//tag::MPI_Win_attach[]
+**MPI_Win_attach** attaches a local memory region for remote access within a dynamic window created with MPI_WIN_CREATE_DYNAMIC. This is a local procedure that is not collective, and multiple non-overlapping memory regions may be attached to the same window. The memory region must not contain any part already attached to the window `win`.
+
+Attaching overlapping memory concurrently within the same window is erroneous, and performing an RMA operation on memory that has not been attached to a dynamic window is erroneous. Users are responsible for ensuring that MPI_Win_attach at the target has returned before an MPI process attempts to target that memory with an RMA operation. Attaching large regions of memory is not recommended in portable programs because attaching memory may require the use of scarce resources.
+//end::MPI_Win_attach[]
+
+//tag::MPI_Win_detach[]
+**MPI_Win_detach** detaches a previously attached memory region beginning at `base` from a dynamic window. This is a local procedure that is not collective. The arguments `base` and `win` must match the arguments passed to a previous call to MPI_WIN_ATTACH. After memory has been detached, it may not be the target of an RMA operation on that window unless the memory is re-attached with MPI_WIN_ATTACH. Memory becomes detached when the associated dynamic memory window is freed.
+
+Memory is recommended to be detached before it is freed by the user, and detaching memory that is no longer needed may permit the implementation to make more efficient use of resources.
+//end::MPI_Win_detach[]
+
+//tag::MPI_Win_free[]
+**MPI_Win_free** frees a window object and returns a null handle equal to `MPI_WIN_NULL`.
+
+This procedure is collective over the group associated with `win`. MPI_Win_free may be invoked by a process only after it has completed its involvement in RMA communications on the window, such as calling MPI_WIN_FENCE, MPI_WIN_WAIT to match a previous MPI_WIN_POST, MPI_WIN_COMPLETE to match a previous MPI_WIN_START, or MPI_WIN_UNLOCK to match a previous MPI_WIN_LOCK. For windows created with MPI_WIN_CREATE, the associated memory may be freed after the call returns. For windows created with MPI_WIN_ALLOCATE or MPI_WIN_ALLOCATE_SHARED, MPI_Win_free will free the memory that was allocated in those calls. Freeing a window created with MPI_WIN_CREATE_DYNAMIC detaches all associated memory. MPI_Win_free is required to delay its return until all accesses to the local window using passive target synchronization have completed, making it synchronizing unless the window was created with the `no_locks` info key set to true.
+//end::MPI_Win_free[]
+
+//tag::MPI_Win_get_group[]
+**MPI_Win_get_group** returns in `group` a duplicate of the group of the communicator used to create the window associated with `win`. The returned group can be used to query ranks or compare with other groups for applications that need to identify which processes share access to the window.
+//end::MPI_Win_get_group[]
+
+//tag::MPI_Win_set_info[]
+**MPI_Win_set_info** updates the hints of a window using the hints provided in `info`.
+
+This procedure is collective over the group of `win`. The operation has no effect on previously set or defaulted hints that are not specified by `info`. It also has no effect on previously set or defaulted hints that are specified by `info` but are ignored by the MPI implementation in this call. The entries in `info` may be different on each process, but any info entries that an implementation requires to be the same on all processes must appear with the same value in each process's `info` object. Some info items that an implementation uses when creating a window may not be changeable after the window is created. MPI_WIN_GET_INFO may be used to determine whether info changes were ignored by the implementation.
+//end::MPI_Win_set_info[]
+
+//tag::MPI_Win_get_info[]
+**MPI_Win_get_info** returns a new info object containing the hints of the window associated with `win`. The current setting of all hints related to the window is returned in `info_used`. An MPI implementation is required to return all hints that are supported by the implementation and have default values specified, any user-supplied hints that were not ignored by the implementation, and any additional hints that were set by the implementation. If no such hints exist, a handle to a newly created info object is returned that contains no key/value pair. The user is responsible for freeing `info_used` via MPI_INFO_FREE. MPI_Win_get_info may be used to determine whether info changes from a prior MPI_WIN_SET_INFO call were ignored by the implementation.
+//end::MPI_Win_get_info[]
+
+//tag::MPI_Put[]
+**MPI_Put** is a nonblocking one-sided communication operation that transfers data from the origin process memory to the target process window. The operation is similar to a send by the origin and a matching receive by the target, except all arguments are provided by the origin. The `target_datatype` may not specify overlapping entries in the target buffer, and the message must fit without truncation in the target buffer. The target buffer must fit within the target window or attached memory in a dynamic window. `MPI_PROC_NULL` is a valid `target_rank`, with the same effect as in point-to-point communication.
+
+Transfers to a target window in memory allocated by MPI_ALLOC_MEM or MPI_WIN_ALLOCATE may be faster on shared memory systems, and transfers from contiguous buffers are faster on most systems.
+//end::MPI_Put[]
+
+//tag::MPI_Fetch_and_op[]
+**MPI_Fetch_and_op** is a nonblocking RMA operation that atomically accumulates one element from the origin buffer to the target buffer and returns the target buffer content before the accumulation in the result buffer. The origin and result buffers must be disjoint. Any predefined operator for MPI_REDUCE, as well as `MPI_NO_OP` or `MPI_REPLACE`, may be specified as the operator. The `datatype` argument must be a predefined datatype. `MPI_PROC_NULL` is a valid `target_rank`, resulting in no operation.
+//end::MPI_Fetch_and_op[]
+
+//tag::MPI_Compare_and_swap[]
+**MPI_Compare_and_swap** is a nonblocking RMA operation that atomically compares one element in the `compare_addr` buffer with an element in the target window and conditionally replaces the target value. If the compare buffer and target buffer values are identical, the target is replaced with the value from `origin_addr`. The original target value is returned in `result_addr` regardless of whether the swap occurred. The `origin_addr` and `result_addr` buffers must be disjoint. The `datatype` argument must be a predefined datatype belonging to C integer, Fortran integer, Logical, Multi-language types, or Byte categories. `MPI_PROC_NULL` is a valid `target_rank`, resulting in no operation.
+//end::MPI_Compare_and_swap[]
+
+//tag::MPI_Rput[]
+**MPI_Rput** is a nonblocking RMA operation that transfers data from the origin process to the target process window, similar to MPI_PUT, but allocates a communication request object associated with the `request` handle. Request-based RMA operations are only valid within a passive target epoch and are not persistent. Completion of the operation at the origin via MPI_TEST or MPI_WAIT indicates the sender may update the origin buffer, but does not indicate that data is available at the target window. For remote completion, MPI_WIN_FLUSH, MPI_WIN_FLUSH_ALL, MPI_WIN_UNLOCK, or MPI_WIN_UNLOCK_ALL may be used. `MPI_PROC_NULL` is a valid `target_rank`, resulting in no operation, but the RMA epoch must still be closed with the appropriate synchronization call. It is erroneous to call MPI_REQUEST_FREE or MPI_CANCEL for a request associated with an RMA operation.
+//end::MPI_Rput[]
+
+//tag::MPI_Rget[]
+**MPI_Rget** is a nonblocking RMA operation that transfers data from the target process window to the origin process memory, similar to MPI_GET, but allocates a communication request object associated with the `request` handle. Completion of the operation at the origin via MPI_TEST or MPI_WAIT indicates that data is available in the origin buffer. Request-based RMA operations are only valid within a passive target epoch and are not persistent. The `origin_datatype` may not specify overlapping entries in the origin buffer, and the target buffer must be contained within the target window or attached memory in a dynamic window. `MPI_PROC_NULL` is a valid `target_rank`, resulting in no operation.
+
+It is erroneous to call MPI_REQUEST_FREE or MPI_CANCEL for a request associated with an RMA operation.
+//end::MPI_Rget[]
+
+//tag::MPI_Raccumulate[]
+**MPI_Raccumulate** is a nonblocking RMA operation that accumulates data from the origin buffer to the target window using a specified reduction operator and allocates a communication request object associated with the `request` handle. Request-based RMA operations are only valid within a passive target epoch and are not persistent. Completion of the operation at the origin via MPI_TEST or MPI_WAIT indicates the origin buffer is free to be updated, but does not indicate the operation has completed at the target window. Each datatype argument must be a predefined datatype or a derived datatype where all basic components are of the same predefined type, and both datatype arguments must be constructed from the same predefined datatype. The `target_datatype` may not specify overlapping entries, and the target buffer must fit in the target window. Any predefined operator for MPI_REDUCE or `MPI_REPLACE` may be specified as `op`; `MPI_NO_OP` cannot be used. `MPI_PROC_NULL` is a valid `target_rank`, resulting in no operation.
+
+It is erroneous to call MPI_REQUEST_FREE or MPI_CANCEL for a request associated with an RMA operation.
+//end::MPI_Raccumulate[]
+
+//tag::MPI_Rget_accumulate[]
+**MPI_Rget_accumulate** is a nonblocking RMA operation that atomically retrieves data from a target window into the result buffer and accumulates data from the origin buffer to the target using a specified reduction operator, allocating a communication request object associated with the `request` handle. Request-based RMA operations are only valid within a passive target epoch and are not persistent. Completion at the origin via MPI_TEST or MPI_WAIT indicates that data is available in the result buffer and the origin buffer is free to be updated, but does not indicate completion at the target window. Each datatype argument must be a predefined datatype or a derived datatype where all basic components are of the same predefined type, and all datatype arguments must be constructed from the same predefined datatype. Any predefined operator for MPI_REDUCE, as well as `MPI_NO_OP` or `MPI_REPLACE`, may be specified as `op`. When `MPI_NO_OP` is specified, the `origin_addr`, `origin_count`, and `origin_datatype` arguments are ignored and the target buffer is not updated. `MPI_PROC_NULL` is a valid `target_rank`, resulting in no operation, but the RMA epoch must still be closed with the appropriate synchronization call.
+
+It is erroneous to call MPI_REQUEST_FREE or MPI_CANCEL for a request associated with an RMA operation.
+//end::MPI_Rget_accumulate[]
+
+//tag::MPI_Win_fence[]
+**MPI_Win_fence** synchronizes RMA operations on `win` and is collective over the group of `win`. All RMA operations on `win` originating at a given process and started before the fence call complete at that process before the fence returns, and complete at their target before the fence returns at the target. Store accesses to shared memory of `win` become visible before the fence call returns at the target. RMA operations on `win` started after the fence call returns access their target window only after MPI_WIN_FENCE has been called by the target process. The call may close an RMA access or exposure epoch if preceded by another fence with intervening RMA communication. A call to MPI_WIN_FENCE is usually synchronizing; however, a call known not to close any epoch is not necessarily synchronizing.
+
+The `assert` argument accepts constants `MPI_MODE_NOSTORE`, `MPI_MODE_NOPUT`, `MPI_MODE_NOPRECEDE`, and `MPI_MODE_NOSUCCEED` for optimization hints; if `MPI_MODE_NOPRECEDE` or `MPI_MODE_NOSUCCEED` is given by any process in the window group, it must be given by all processes. Calls to MPI_WIN_FENCE are recommended to both precede and follow RMA communication calls synchronized with fence calls.
+//end::MPI_Win_fence[]
+
+//tag::MPI_Win_start[]
+**MPI_Win_start** opens an RMA access epoch for `win`. RMA calls issued on `win` during this epoch must access only windows at processes in `group`. Each process in `group` must issue a matching call to MPI_WIN_POST. RMA accesses to each target window are delayed until the target process executes the matching call to MPI_WIN_POST. MPI_Win_start is allowed to delay its return until the corresponding calls to MPI_WIN_POST have occurred, but is not required to do so. The `assert` argument provides optimization hints.
+
+To ensure a portable deadlock-free program, users must assume that MPI_WIN_START may delay its return until the corresponding call to MPI_WIN_POST has occurred.
+//end::MPI_Win_start[]
+
+//tag::MPI_Win_complete[]
+**MPI_Win_complete** closes an RMA access epoch on `win` opened by a call to MPI_WIN_START. All RMA communication operations initiated on `win` during this epoch complete at the origin when the call returns. All updates to shared memory in `win` through load/store accesses executed during this epoch become visible at the target when the call returns. MPI_Win_complete enforces completion of preceding RMA operations and visibility of load/store accesses at the origin, but not at the target. A put or accumulate operation may not have completed at the target when it has completed at the origin. This call must match calls to MPI_WIN_WAIT issued by each of the origin processes that were granted access to the window during the preceding MPI_WIN_START epoch. If an RMA operation is completed at the origin by a call to MPI_WIN_COMPLETE, then the operation is completed at the target by the matching call to MPI_WIN_WAIT by the target process.
+//end::MPI_Win_complete[]
+
+//tag::MPI_Win_post[]
+**MPI_Win_post** opens an RMA exposure epoch for the local window associated with `win`. Only processes in `group` may access the window with RMA calls on `win` during this epoch. Each process in `group` must issue a matching call to MPI_WIN_START. MPI_Win_post is a local procedure.
+
+The `assert` argument provides optimization hints and a value of `assert` = 0 is always valid.
+//end::MPI_Win_post[]
+
+//tag::MPI_Win_wait[]
+**MPI_Win_wait** closes an RMA exposure epoch opened by a call to MPI_WIN_POST on `win`. This call matches calls to MPI_WIN_COMPLETE on `win` issued by each of the origin processes that were granted access to the window during this epoch. The call returns only after all matching calls to MPI_WIN_COMPLETE have occurred. This guarantees that all origin processes have completed their RMA operations and shared-memory load/store accesses have become visible on the local window. When the call returns, all RMA accesses will have completed at the target window.
+
+MPI_Win_wait is nonlocal as it waits for remote process completions.
+//end::MPI_Win_wait[]
+
+//tag::MPI_Win_test[]
+**MPI_Win_test** is a local procedure that tests for completion of an RMA exposure epoch opened by MPI_WIN_POST. Repeated calls with the same `win` argument will eventually return `flag` = true once all accesses to the local window by the group to which it was exposed have been completed as indicated by matching MPI_WIN_COMPLETE calls. If `flag` = false is returned, the call has no visible effect. When `flag` = true, the effect is the same as a return of MPI_WIN_WAIT. MPI_Win_test may only be called where MPI_WIN_WAIT can be called. Once the call has returned `flag` = true, it must not be called again until the window is posted again.
+//end::MPI_Win_test[]
+
+//tag::MPI_Win_lock[]
+**MPI_Win_lock** opens an RMA access epoch for passive target communication, enabling the origin process to access the window at the target process specified by `rank` in the group of `win`. Accesses protected by an exclusive lock (`MPI_LOCK_EXCLUSIVE`) will not be concurrent at the window site with other lock-protected accesses to the same window. Accesses protected by a shared lock (`MPI_LOCK_SHARED`) will not be concurrent at the window site with accesses protected by an exclusive lock. Multiple RMA access epochs with calls to MPI_WIN_LOCK may occur simultaneously; however, each access epoch must target a different process. It is erroneous to have a window locked and exposed in an exposure epoch concurrently. Locks may be used portably only in memory allocated by MPI_ALLOC_MEM, MPI_WIN_ALLOCATE, MPI_WIN_ALLOCATE_SHARED, or attached with MPI_WIN_ATTACH.
+
+The `assert` argument `MPI_MODE_NOCHECK` indicates that no other process holds or will attempt to acquire a conflicting lock, which is useful when mutual exclusion is achieved by other means but coherence operations attached to the lock and unlock calls are still required. To ensure a portable deadlock-free program, users must assume that MPI_WIN_LOCK may delay its return until the desired lock on the window has been acquired.
+//end::MPI_Win_lock[]
+
+//tag::MPI_Win_lock_all[]
+**MPI_Win_lock_all** opens an RMA access epoch to all processes in `win` with a lock type of `MPI_LOCK_SHARED`. During this epoch, the calling process can access the window memory on all processes in `win` using RMA operations. A window locked with MPI_WIN_LOCK_ALL must be unlocked with MPI_WIN_UNLOCK_ALL. This routine is not collective; the ALL refers to a lock on all members of the group of the window. Accesses protected by a shared lock will not be concurrent at the window site with accesses protected by an exclusive lock to the same window. Locks may be used portably only in memory allocated by MPI_ALLOC_MEM, MPI_WIN_ALLOCATE, MPI_WIN_ALLOCATE_SHARED, or attached with MPI_WIN_ATTACH.
+
+The `assert` argument `MPI_MODE_NOCHECK` indicates that no other process holds or will attempt to acquire a conflicting lock, which is useful when mutual exclusion is achieved by other means but coherence operations attached to the lock and unlock calls are still required. There may be additional overheads associated with using MPI_WIN_LOCK and MPI_WIN_LOCK_ALL concurrently on the same window; these overheads may be avoided by specifying the assertion `MPI_MODE_NOCHECK` when possible.
+//end::MPI_Win_lock_all[]
+
+//tag::MPI_Win_unlock[]
+**MPI_Win_unlock** closes an RMA access epoch opened by a call to MPI_WIN_LOCK on window `win`. RMA operations issued during this epoch will have completed both at the origin and at the target when the call returns. This function is used for passive target synchronization where the target process is not explicitly involved in the synchronization. An update of a location in a private window copy in process memory becomes visible in the public window copy at the latest when a call to MPI_WIN_UNLOCK is executed on that window by the window owner.
+
+Locks may be used portably only in memory allocated by MPI_ALLOC_MEM, MPI_WIN_ALLOCATE, MPI_WIN_ALLOCATE_SHARED, or attached with MPI_WIN_ATTACH. It is erroneous to have a window locked and exposed in an exposure epoch concurrently.
+//end::MPI_Win_unlock[]
+
+//tag::MPI_Win_unlock_all[]
+**MPI_Win_unlock_all** closes a shared RMA access epoch opened by a call to MPI_WIN_LOCK_ALL on window `win`. RMA operations issued during this epoch will have completed both at the origin and at the target when the call returns. This routine is not collective. An update of a location in a private window copy in process memory becomes visible in the public window copy at the latest when MPI_WIN_UNLOCK_ALL is executed on that window by the window owner. If an RMA operation is completed at the origin by a call to MPI_WIN_UNLOCK_ALL, then the operation is also completed at the target by that same call.
+
+It is erroneous to have a window locked and exposed in an exposure epoch concurrently. Locks may be used portably only in memory allocated by MPI_ALLOC_MEM, MPI_WIN_ALLOCATE, MPI_WIN_ALLOCATE_SHARED, or attached with MPI_WIN_ATTACH.
+//end::MPI_Win_unlock_all[]
+
+//tag::MPI_Win_flush[]
+**MPI_Win_flush** completes all outstanding RMA operations initiated by the calling process to a specified target on the given window. This function may only be called within a passive target epoch. When the call returns, the operations are completed both at the origin and at the target.
+//end::MPI_Win_flush[]
+
+//tag::MPI_Win_flush_all[]
+**MPI_Win_flush_all** completes all RMA operations initiated by the calling process to any target on the specified window. This function may only be called within a passive target epoch. When the call returns, all operations are completed both at the origin and at the target. An RMA operation is completed at the origin by an ensuing call to MPI_WIN_FLUSH_ALL that synchronizes that access. If an RMA operation is completed at the origin by a call to MPI_WIN_FLUSH_ALL, the operation is also completed at the target by that same call.
+//end::MPI_Win_flush_all[]
+
+//tag::MPI_Win_flush_local[]
+**MPI_Win_flush_local** completes all outstanding RMA operations initiated by the calling process to a specified target on the given window at the origin only. This function may only be called within a passive target epoch. When the call returns, the user may reuse any buffers provided to put, get, or accumulate operations. The operations are not guaranteed to have completed at the target. If remote completion is required, MPI_WIN_FLUSH, MPI_WIN_FLUSH_ALL, MPI_WIN_UNLOCK, or MPI_WIN_UNLOCK_ALL may be used instead.
+//end::MPI_Win_flush_local[]
+
+//tag::MPI_Win_flush_local_all[]
+**MPI_Win_flush_local_all** completes all RMA operations initiated by the calling process to any target on the specified window at the origin only. This function may only be called within a passive target epoch. When the call returns, the user may reuse any buffers provided to put, get, or accumulate operations. The operations are not guaranteed to have completed at the target.
+//end::MPI_Win_flush_local_all[]
+
+//tag::MPI_Win_sync[]
+**MPI_Win_sync** synchronizes the private and public window copies of `win` at the calling MPI process for windows in the separate memory model. In the unified memory model, MPI_WIN_SYNC may be used to order load and store accesses to shared memory and to ensure visibility of store updates for other threads and MPI processes. A call to MPI_WIN_SYNC does not open or close an epoch, does not complete any pending RMA operations, and does not guarantee progress of any pending MPI operation. This function may only be called within a passive target epoch.
+
+MPI_WIN_SYNC may be called by both the reader and the writer of a shared memory variable between any non-RMA synchronization and access to that variable.
+//end::MPI_Win_sync[]
+
+//tag::MPI_Recv[]
+**MPI_Recv** performs a blocking point-to-point receive operation that returns only after the message data has been stored into the receive buffer. The receiver may specify `MPI_ANY_SOURCE` for `source` and `MPI_ANY_TAG` for `tag` to accept messages from any source or with any tag; a wildcard value cannot be specified for `comm`. Messages are nonovertaking; if a sender sends two messages to the same destination with the same communicator, the receive order matches the send order. If `source` is `MPI_PROC_NULL`, the call returns immediately with `status` set to `source` = `MPI_PROC_NULL`, `tag` = `MPI_ANY_TAG`, and `count` = 0. In a multithreaded implementation, users are responsible for not accessing the receive buffer until the communication completes. MPI_GET_COUNT returns `MPI_UNDEFINED` in `count` if the number of received entries exceeds the limits of the `count` parameter. An overflow error occurs if all incoming data does not fit, without truncation, into the receive buffer.
+//end::MPI_Recv[]
+
+//tag::MPI_Get_count[]
+**MPI_Get_count** returns the number of entries received from a completed receive operation. The `datatype` argument may match the argument provided by the receive call that set the `status` variable. If the number of entries received exceeds the limits of the `count` parameter, `count` is set to `MPI_UNDEFINED`. For a datatype of length zero where zero bytes have been transferred, the returned `count` is zero; if the number of bytes transferred is greater than zero, `MPI_UNDEFINED` is returned. The safest approach is to use the same datatype with MPI_GET_COUNT and the receive.
+//end::MPI_Get_count[]
+
+//tag::MPI_Status_get_tag[]
+**MPI_Status_get_tag** returns the message tag from a `status` object. The function retrieves the value stored in the `MPI_TAG` field of the `status` argument and returns it in `tag`. This is a local procedure that provides a convenience interface for accessing status information that is also directly accessible in the status structure. The `status` object is typically set by a receive operation, probe, or wait/test function.
+//end::MPI_Status_get_tag[]
+
+//tag::MPI_Status_get_error[]
+**MPI_Status_get_error** returns the error code from a `status` object. The function retrieves the value stored in the `MPI_ERROR` field of the `status` argument and returns it in `err`. This is a local procedure that provides a convenience interface for accessing status information that is also directly accessible in the status structure. The `status` object is typically set by a receive operation, probe, or wait/test function.
+//end::MPI_Status_get_error[]
+
+//tag::MPI_Sendrecv[]
+**MPI_Sendrecv** executes a blocking send and receive operation using the same communicator. The send buffer and receive buffer must be disjoint, and may have different lengths and datatypes. The semantics are equivalent to forking two concurrent threads, one to execute the send and one to execute the receive, followed by a join of these two threads. A message sent by this operation can be received by a regular receive or probed by a probe operation, and this operation can receive a message sent by a regular send.
+
+The receiver may specify `MPI_ANY_SOURCE` for `source` and `MPI_ANY_TAG` for `recvtag` to accept messages from any source or with any tag. If `dest` or `source` is `MPI_PROC_NULL`, the respective send or receive is a no-op. Messages are nonovertaking; nonblocking communication operations are ordered according to the execution order of the calls that initiate the communication. In a multithreaded implementation, users are responsible for not modifying the send buffer or accessing the receive buffer until the communication completes.
+//end::MPI_Sendrecv[]
+
+//tag::MPI_Sendrecv_replace[]
+**MPI_Sendrecv_replace** executes a blocking send and receive operation using the same buffer for both operations. The message sent is replaced by the message received. Both send and receive use the same communicator. The semantics are equivalent to forking two concurrent threads, one to execute the send and one to execute the receive, followed by a join of these two threads.
+
+The receiver may specify `MPI_ANY_SOURCE` for `source` and `MPI_ANY_TAG` for `recvtag` to accept messages from any source or with any tag. If `dest` or `source` is `MPI_PROC_NULL`, the respective send or receive is a no-op. Messages are nonovertaking; nonblocking communication operations are ordered according to the execution order of the calls that initiate the communication. In a multithreaded implementation, users are responsible for not modifying the communication buffer until the operation completes.
+//end::MPI_Sendrecv_replace[]
+
+//tag::MPI_Rsend[]
+**MPI_Rsend** performs a blocking ready mode point-to-point send operation. The send may be started only if the matching receive is already started; otherwise, the operation is erroneous and its outcome is undefined. Completion of the send does not depend on the status of a matching receive, and merely indicates that the send buffer can be reused. A ready send has the same semantics as a standard send operation; the sender provides additional information to the system that may save overhead.
+
+Sends are nonovertaking; if a sender sends two messages in succession to the same destination, and both match the same receive, the receive operation cannot receive the second message if the first is still pending. In a multithreaded implementation, the user is responsible not to modify the communication buffer until the communication completes.
+//end::MPI_Rsend[]
+
+//tag::MPI_Session_attach_buffer[]
+**MPI_Session_attach_buffer** provides a session-specific buffer for buffered mode send operations.
+
+This procedure is local. The buffer is used for outgoing messages sent when a buffered mode send uses a communicator derived from `session`, unless a communicator-specific buffer is attached to that communicator. If `MPI_BUFFER_AUTOMATIC` is passed as `buffer`, automatic buffering is enabled and `size` is ignored. Only one buffer may be attached to a session at a time, and a particular memory region may only be used in one buffer. It is erroneous to attach a buffer to a session that already has an attached buffer.
+//end::MPI_Session_attach_buffer[]
+
+//tag::MPI_Buffer_attach[]
+**MPI_Buffer_attach** provides an MPI process-specific buffer for buffered mode send operations.
+
+This procedure is local. The buffer is used for outgoing messages sent when a buffered mode send uses a communicator to which no communicator-specific buffer is attached and which is not derived from a session with a session-specific buffer. If `MPI_BUFFER_AUTOMATIC` is passed as `buffer`, automatic buffering is enabled and `size` is ignored. Only one buffer may be attached to an MPI process at a time, and a particular memory region may only be used in one buffer. It is erroneous to attach a buffer if one is already attached. For libraries and programs using the Sessions Model, using only communicator-specific or session-specific buffers is recommended.
+//end::MPI_Buffer_attach[]
+
+//tag::MPI_Buffer_detach[]
+**MPI_Buffer_detach** detaches the MPI process-specific buffer currently attached to MPI and returns the address and size of the detached buffer. This procedure is nonlocal and will delay return until all messages currently in the buffer have been transmitted. Upon return, the user may reuse or deallocate the buffer space. If `MPI_BUFFER_AUTOMATIC` was used in the corresponding attach procedure, `MPI_BUFFER_AUTOMATIC` is returned in `buffer_addr`, the value in `size` is undefined, and automatic buffering is disabled. If the size of the detached buffer cannot be represented in `size`, it is set to `MPI_UNDEFINED`. The procedure must eventually return when all corresponding receive operations are started, provided that none are cancelled.
+//end::MPI_Buffer_detach[]
+
+//tag::MPI_Session_flush_buffer[]
+**MPI_Session_flush_buffer** blocks until all messages currently in the session-specific buffer of the calling MPI process have been transmitted without detaching the buffer.
+
+This procedure is nonlocal. It must eventually return when all corresponding receive operations are started, provided that none are cancelled. It is erroneous to call this procedure if no buffer is attached to the session, including automatic buffering.
+//end::MPI_Session_flush_buffer[]
+
+//tag::MPI_Buffer_flush[]
+**MPI_Buffer_flush** blocks until all messages currently in the MPI process-specific buffer of the calling MPI process have been transmitted without detaching the buffer.
+
+This procedure is nonlocal. It must eventually return when all corresponding receive operations are started, provided that none are cancelled. It is erroneous to call this procedure if no buffer is attached to the MPI process, including automatic buffering.
+//end::MPI_Buffer_flush[]
+
+//tag::MPI_Comm_iflush_buffer[]
+**MPI_Comm_iflush_buffer** initiates a nonblocking flush of the communicator-specific buffer for the calling MPI process. The operation will not complete until all messages currently in the buffer have been transmitted. A `request` handle is returned that must be completed via MPI_WAIT, MPI_TEST, or their variants. This procedure is nonlocal and must eventually complete when all corresponding receive operations are started, provided that none are cancelled. It is erroneous to call this procedure if no buffer is attached to the communicator, including automatic buffering.
+//end::MPI_Comm_iflush_buffer[]
+
+//tag::MPI_Session_iflush_buffer[]
+**MPI_Session_iflush_buffer** initiates a nonblocking flush of the session-specific buffer for the calling MPI process. The operation will not complete until all messages currently in the buffer have been transmitted. A `request` handle is returned that must be completed via MPI_WAIT, MPI_TEST, or their variants. This procedure is nonlocal and must eventually complete when all corresponding receive operations are started, provided that none are cancelled. It is erroneous to call this procedure if no buffer is attached to the `session`, including automatic buffering.
+//end::MPI_Session_iflush_buffer[]
+
+//tag::MPI_Buffer_iflush[]
+**MPI_Buffer_iflush** initiates a nonblocking flush of the MPI process-specific buffer for the calling MPI process. The operation will not complete until all messages currently in the buffer have been transmitted. A `request` handle is returned that must be completed via MPI_WAIT, MPI_TEST, or their variants. This procedure is nonlocal and must eventually complete when all corresponding receive operations are started, provided that none are cancelled. It is erroneous to call this procedure if no buffer is attached to the MPI process, including automatic buffering.
+//end::MPI_Buffer_iflush[]
+
+//tag::MPI_Irecv[]
+**MPI_Irecv** initiates a nonblocking receive operation. The call is local and returns immediately, allocating a request object to track the pending operation. The receive buffer must not be accessed until the operation completes via MPI_WAIT, MPI_TEST, or their variants. Completion indicates the receive buffer contains the received message and the status object is set. Nonblocking receives can be matched with blocking sends.
+
+Nonblocking communication operations are nonovertaking and ordered according to the execution order of the calls that initiate the communication. The receiver may specify `MPI_ANY_SOURCE` for `source` and `MPI_ANY_TAG` for `tag` to accept messages from any source or with any tag. In a multithreaded implementation, users are responsible for not accessing the receive buffer until the communication completes.
+//end::MPI_Irecv[]
+
+//tag::MPI_Isendrecv[]
+**MPI_Isendrecv** initiates a nonblocking send-receive operation that combines sending a message to one destination and receiving a message from another source using the same communicator. The semantics are equivalent to concurrently executing a nonblocking send and a nonblocking receive, followed by completion of both operations. The send and receive buffers must be disjoint and may have different lengths and datatypes. Nonblocking communication operations are nonovertaking and ordered according to the execution order of the calls that initiate them.
+
+The receiver may specify `MPI_ANY_SOURCE` for `source` and `MPI_ANY_TAG` for `recvtag` to accept messages from any source or with any tag.
+//end::MPI_Isendrecv[]
+
+//tag::MPI_Isendrecv_replace[]
+**MPI_Isendrecv_replace** initiates a nonblocking send-receive operation using the same buffer for both send and receive. The message sent is replaced by the message received upon completion. The semantics are equivalent to concurrently executing a nonblocking send and a nonblocking receive, followed by completion of both operations. Nonblocking communication operations are nonovertaking and ordered according to the execution order of the calls that initiate them.
+
+The receiver may specify `MPI_ANY_SOURCE` for `source` and `MPI_ANY_TAG` for `recvtag` to accept messages from any source or with any tag.
+//end::MPI_Isendrecv_replace[]
+
+//tag::MPI_Wait[]
+**MPI_Wait** blocks until the operation identified by `request` completes. If the request is an active persistent communication request, it is marked inactive; any other type of request is deallocated and the handle is set to `MPI_REQUEST_NULL`. MPI_Wait is in general a nonlocal procedure, though it is local when the operation represented by the request is enabled. Calling MPI_Wait with a null or inactive request returns immediately with empty status.
+
+A call to MPI_Wait that completes a receive will eventually terminate if a matching send has been started, unless the send is satisfied by another receive. Nonblocking communication operations are nonovertaking and ordered according to the execution order of the calls that initiate the communication. In a multithreaded environment, users are responsible for not modifying the communication buffer until the communication completes.
+//end::MPI_Wait[]
+
+//tag::MPI_Test[]
+**MPI_Test** is a local procedure that tests for completion of a nonblocking operation identified by `request`. If the operation is complete, `flag` is set to true and the `status` object is set to contain information on the completed operation; otherwise `flag` is set to false and `status` is undefined. For a completed active persistent communication request, the request is marked inactive; for any other completed request type, the request is deallocated and set to `MPI_REQUEST_NULL`. Calling MPI_Test with a null or inactive `request` returns `flag` = true with empty `status`.
+
+If MPI_Test is repeatedly called with a matching send or receive started, the call will eventually return `flag` = true, unless the operation is satisfied by another matching operation. Nonblocking communication operations are nonovertaking and ordered according to the execution order of the calls that initiate the communication.
+//end::MPI_Test[]
+
+//tag::MPI_Waitany[]
+**MPI_Waitany** blocks until one of the operations associated with active requests in the array completes. If more than one operation can complete, one is arbitrarily chosen. The `array_of_requests` may contain null or inactive handles. If the request that completes is an active persistent communication request, it is marked inactive; any other type of request is deallocated and set to `MPI_REQUEST_NULL`.
+
+Nonblocking communication operations are nonovertaking and ordered according to the execution order of the calls that initiate them. If the array contains no active handles, the call returns immediately with `index` = `MPI_UNDEFINED` and empty `status`.
+//end::MPI_Waitany[]
+
+//tag::MPI_Testany[]
+**MPI_Testany** is a local procedure that tests for completion of one or none of the operations associated with active handles in an array of requests. If an operation completes, `flag` is set to true, `index` is set to the array position of the completed request, and `status` contains completion information; if no operation completes, `flag` is set to false, `index` is set to `MPI_UNDEFINED`, and `status` is undefined. For a completed active persistent communication request, the request is marked inactive; for any other completed request type, the request is deallocated and set to `MPI_REQUEST_NULL`. The `array_of_requests` may contain null or inactive handles.
+
+Nonblocking communication operations are nonovertaking and ordered according to the execution order of the calls that initiate them. If the array contains no active handles, the call returns immediately with `flag` = true, `index` = `MPI_UNDEFINED`, and empty `status`.
+//end::MPI_Testany[]
+
+//tag::MPI_Waitall[]
+**MPI_Waitall** blocks until all communication operations associated with active handles in the `array_of_requests` complete. The i-th entry in `array_of_statuses` is set to the return status of the i-th operation; null or inactive handles have their status set to empty. Active persistent communication requests are marked inactive; other request types are deallocated and set to `MPI_REQUEST_NULL`.
+
+When one or more operations fail, the function returns `MPI_ERR_IN_STATUS` and sets each status error field to `MPI_SUCCESS` if the operation completed, to a specific error code if it failed, or to `MPI_ERR_PENDING` if it has neither failed nor completed. Nonblocking communication operations are nonovertaking and ordered according to the execution order of the calls that initiate them.
+//end::MPI_Waitall[]
+
+//tag::MPI_Testall[]
+**MPI_Testall** is a local procedure that tests for completion of all communication operations associated with active handles in an array of requests. If all operations complete, `flag` is set to true and each status entry for an active request is set to the corresponding operation's status; active persistent communication requests are marked inactive, other request types are deallocated and set to `MPI_REQUEST_NULL`. Null or inactive handles have their status set to empty. If not all operations complete, `flag` is set to false, no request is modified, and the status entry values are undefined.
+
+When one or more operations fail, the function returns `MPI_ERR_IN_STATUS` and sets each status error field to `MPI_SUCCESS` if the operation completed, to a specific error code if it failed, or to `MPI_ERR_PENDING` if it has neither failed nor completed.
+//end::MPI_Testall[]
+
+//tag::MPI_Waitsome[]
+**MPI_Waitsome** blocks until at least one of the operations associated with active handles in `array_of_requests` completes. The `outcount` parameter returns the number of completed requests, with their indices and statuses stored in the first `outcount` locations of `array_of_indices` and `array_of_statuses`. Active persistent requests that complete are marked inactive; other completed request types are deallocated and set to `MPI_REQUEST_NULL`. If the list contains no active handles, the call returns immediately with `outcount` = `MPI_UNDEFINED`.
+
+MPI_Waitsome fulfills a fairness requirement: if a request for a receive repeatedly appears in a list passed to MPI_Waitsome, and a matching send has been started, then the receive will eventually succeed unless satisfied by another receive. When one or more operations fail, the function returns `MPI_ERR_IN_STATUS` and sets each completed status error field to `MPI_SUCCESS` or a specific error code.
+//end::MPI_Waitsome[]
+
+//tag::MPI_Testsome[]
+**MPI_Testsome** is a local procedure that tests for completion of some operations associated with active handles in `array_of_requests` and returns immediately. The `outcount` parameter returns the number of completed requests, with their indices and statuses stored in the first `outcount` locations of `array_of_indices` and `array_of_statuses`; if no operation has completed, `outcount` is set to 0, and if no active handle exists, `outcount` is set to `MPI_UNDEFINED`. Active persistent requests that complete are marked inactive; other completed request types are deallocated and set to `MPI_REQUEST_NULL`.
+
+MPI_Testsome fulfills a fairness requirement: if a request for a receive repeatedly appears in a list passed to MPI_Testsome or MPI_Waitsome, and a matching send has been started, then the receive will eventually succeed unless satisfied by another receive. Nonblocking communication operations are nonovertaking and ordered according to the execution order of the calls that initiate them. When one or more operations fail, the function returns `MPI_ERR_IN_STATUS` and sets each completed status error field to `MPI_SUCCESS` or a specific error code.
+//end::MPI_Testsome[]
+
+//tag::MPI_Request_get_status[]
+**MPI_Request_get_status** queries completion status of a request without deallocating or inactivating the request.
+
+If the operation is complete, `flag` is set to true and the request status is returned in `status`; otherwise `flag` is set to false. Unlike MPI_TEST or MPI_WAIT, a subsequent call to test, wait, or free must be executed with the request. A call with a null or inactive `request` argument returns `flag` = true and empty `status`. The progress rule for MPI_TEST applies to this function. Nonblocking communication operations are nonovertaking and ordered according to the execution order of the calls that initiate them.
+//end::MPI_Request_get_status[]
+
+//tag::MPI_Iprobe[]
+**MPI_Iprobe** is a local procedure that tests for an incoming message matching a specified pattern without receiving it.
+
+The call returns `flag` = true if a matching message is available, with `status` set as it would be by MPI_RECV; otherwise `flag` = false and `status` is undefined. A subsequent receive using the `source` and `tag` returned in `status` will receive the matched message, provided no other intervening receive occurs and the send is not successfully cancelled. The wildcards `MPI_ANY_SOURCE` and `MPI_ANY_TAG` may be specified for `source` and `tag`, and a probe with `source` = `MPI_PROC_NULL` returns `flag` = true with `source` = `MPI_PROC_NULL`, `tag` = `MPI_ANY_TAG`, and `count` = 0. If MPI_IPROBE is repeatedly called and a matching send has been initiated, the call will eventually return `flag` = true unless the message is received by another concurrent receive operation or matched by a concurrent matching probe. In a multithreaded MPI program, if a thread probes for a message and then immediately posts a matching receive, the receive may match a different message because another thread could concurrently receive the original message.
+//end::MPI_Iprobe[]
+
+//tag::MPI_Probe[]
+**MPI_Probe** is a blocking, nonlocal procedure that checks for an incoming message matching a specified pattern without receiving it and returns only after a matching message has been found. The `status` object is set as it would be by MPI_RECV, allowing the source, tag, and length of the probed message to be determined. The wildcards `MPI_ANY_SOURCE` and `MPI_ANY_TAG` may be specified for `source` and `tag`.
+
+If a call to MPI_PROBE has been issued and a matching send has been initiated, the call will return unless the message is received by another concurrent receive operation. A probe with `source` = `MPI_PROC_NULL` returns immediately with `source` = `MPI_PROC_NULL`, `tag` = `MPI_ANY_TAG`, and `count` = 0. Point-to-point communication operations are nonovertaking.
+//end::MPI_Probe[]
+
+//tag::MPI_Improbe[]
+**MPI_Improbe** is a local, nonblocking matching probe that tests for an incoming message and returns a message handle that can only be received by MPI_MRECV or MPI_IMRECV.
+
+If a matching message is available, `flag` is set to true, `status` is set as it would be by MPI_RECV, and `message` returns a handle to the matched message. Otherwise, `flag` is set to false and `status` and `message` are undefined. The wildcards `MPI_ANY_SOURCE` and `MPI_ANY_TAG` may be specified for `source` and `tag`. A matching probe with `source` = `MPI_PROC_NULL` returns `flag` = true, `message` = `MPI_MESSAGE_NO_PROC`, `source` = `MPI_PROC_NULL`, `tag` = `MPI_ANY_TAG`, and `count` = 0. In multithreaded programs, MPI_IMPROBE provides thread-safe probing by preventing other probe or receive operations from matching the returned message; this addresses the race condition where a thread probes for a message and another thread receives it before the probing thread can post a matching receive.
+//end::MPI_Improbe[]
+
+//tag::MPI_Mprobe[]
+**MPI_Mprobe** is a blocking, nonlocal matching probe that returns only after a matching message has been found, providing a message handle that can only be received by MPI_MRECV or MPI_IMRECV. The `status` object is set as it would be by MPI_RECV, and the `message` handle ensures that no other probe or receive operation can match the message. The wildcards `MPI_ANY_SOURCE` and `MPI_ANY_TAG` may be specified for `source` and `tag`.
+
+If a call to MPI_Mprobe has been issued and a matching send has been initiated, the call will return unless the message is received by another concurrent receive operation. A matching probe with `source` = `MPI_PROC_NULL` returns `flag` = true, `message` = `MPI_MESSAGE_NO_PROC`, `source` = `MPI_PROC_NULL`, `tag` = `MPI_ANY_TAG`, and `count` = 0. In multithreaded programs, MPI_Mprobe provides thread-safe probing by preventing the matched message from being intercepted by other threads. Point-to-point communication operations are nonovertaking.
+//end::MPI_Mprobe[]
+
+//tag::MPI_Imrecv[]
+**MPI_Imrecv** is the nonblocking variant of MPI_MRECV that starts a nonblocking receive of a message previously matched by a matching probe operation. On return, the `message` handle is set to `MPI_MESSAGE_NULL`. Errors during execution are handled according to the error handler set for the communicator used in the matching probe call that produced the message handle.
+
+If `message` is `MPI_MESSAGE_NO_PROC`, the call returns immediately with a request that yields `source` = `MPI_PROC_NULL`, `tag` = `MPI_ANY_TAG`, and `count` = 0. A call with `MPI_MESSAGE_NULL` is erroneous. Nonblocking communication operations are nonovertaking.
+//end::MPI_Imrecv[]
+
+//tag::MPI_Cancel[]
+**MPI_Cancel** marks a pending nonblocking communication operation for cancellation. This procedure is local and returns immediately, possibly before the communication is actually cancelled. A call to MPI_REQUEST_FREE, MPI_WAIT, or MPI_TEST is still required after MPI_Cancel; if marked for cancellation, MPI_WAIT is guaranteed to return regardless of other MPI processes. Either the cancellation succeeds or the communication succeeds, but not both.
+
+Nonblocking communication operations are nonovertaking. Cancelling a send request is deprecated, and cancel may be an expensive operation that is recommended to be used only exceptionally.
+//end::MPI_Cancel[]
+
+//tag::MPI_Send_init[]
+**MPI_Send_init** creates a persistent communication request for a standard mode send operation. This initialization call is local and involves no communication. The request is inactive after creation and is activated by calling MPI_START, which has the same semantics as MPI_ISEND. After a successful completion via MPI_WAIT or MPI_TEST, the request becomes inactive and may be activated again.
+
+Point-to-point communication operations are nonovertaking. Explicitly freeing inactive persistent request handles using MPI_REQUEST_FREE before disconnecting the associated communicator or finalizing the associated session is recommended.
+//end::MPI_Send_init[]
+
+//tag::MPI_Rsend_init[]
+**MPI_Rsend_init** creates a persistent communication request for a ready mode send operation. This initialization call is local and binds all arguments to an inactive persistent request without initiating communication. A call to MPI_START with the returned `request` has the same effect as MPI_IRSEND, and a ready mode send may be started only if the matching receive is already started; otherwise the operation is erroneous and its outcome is undefined. The request may be started and completed repeatedly using MPI_START and completion procedures such as MPI_WAIT or MPI_TEST.
+
+Communication operations started from persistent requests are nonovertaking. Freeing inactive persistent request handles explicitly via MPI_REQUEST_FREE before freeing or disconnecting the associated communicator is recommended.
+//end::MPI_Rsend_init[]
+
+//tag::MPI_Recv_init[]
+**MPI_Recv_init** creates a persistent communication request for a receive operation. This initialization call is local and binds all arguments to an inactive persistent request without initiating communication. A call to MPI_START with the returned `request` has the same effect as MPI_IRECV, and the request may be started and completed repeatedly using MPI_START and completion procedures such as MPI_WAIT or MPI_TEST.
+
+The wildcards `MPI_ANY_SOURCE` and `MPI_ANY_TAG` may be specified for `source` and `tag`. Communication operations started from persistent requests are nonovertaking, and if the same request is used in concurrent threads, coordinating calls so that the correct sequence is obeyed is the user's responsibility. Freeing inactive persistent request handles explicitly via MPI_REQUEST_FREE before freeing or disconnecting the associated communicator is recommended.
+//end::MPI_Recv_init[]
+
+//tag::MPI_Start[]
+**MPI_Start** activates a persistent communication request that was created by an initialization procedure. The `request` argument is a handle returned by initialization procedures for persistent point-to-point, partitioned point-to-point, or persistent collective communication, and the associated request must be inactive. For a ready mode send request, a matching receive operation must be started before the call is made. The communication buffer must not be modified after the call until the operation completes. This call is local with semantics similar to the corresponding nonblocking communication operations.
+
+A send operation started with MPI_Start can be matched with any receive operation, and a receive operation started with MPI_Start can receive messages generated by any send operation. Communication operations started from persistent requests are nonovertaking. If the same persistent communication request is used in concurrent threads, coordinating calls to ensure the correct sequence of Create, Start, Complete, and Free is the user's responsibility.
+//end::MPI_Start[]
+
+//tag::MPI_Startall[]
+**MPI_Startall** activates an array of persistent communication requests that were created by initialization procedures for persistent point-to-point, partitioned point-to-point, or persistent collective communication. The execution has the same effect as calling MPI_START for each array element in arbitrary order. All associated requests in `array_of_requests` must be inactive. This call is local and the communication buffers must not be modified after the call until the operations complete.
+
+Communication operations started from persistent requests are nonovertaking. If the same persistent communication request is used in concurrent threads, coordinating calls to ensure the correct sequence of Create, Start, Complete, and Free is the user's responsibility.
+//end::MPI_Startall[]
+
+//tag::MPI_Status_set_cancelled[]
+**MPI_Status_set_cancelled** sets the cancellation flag in a `status` object. If `flag` is set to true, a subsequent call to MPI_TEST_CANCELLED will return `flag` = true; otherwise it will return false. This functionality is needed for generalized requests. Users are advised not to reuse status fields for values other than those for which they were intended; the `extra_state` argument provided with a generalized request may be used to return information that does not logically belong in status. Modifying values in a status set internally by MPI may lead to unpredictable results and is strongly discouraged.
+//end::MPI_Status_set_cancelled[]
+
+//tag::MPI_Status_set_source[]
+**MPI_Status_set_source** sets the `MPI_SOURCE` field in a `status` object to a specified `source` rank. This procedure provides a convenience interface for setting status information that is also directly accessible in the status structure. This functionality is needed for generalized requests.
+
+Users are advised not to reuse status fields for values other than those for which they were intended, as doing so may lead to unexpected results. Modifying values in a status set internally by MPI may lead to unpredictable results and is strongly discouraged.
+//end::MPI_Status_set_source[]
+
+//tag::MPI_Status_set_tag[]
+**MPI_Status_set_tag** sets the `MPI_TAG` field in a `status` object to a specified `tag` value. This procedure provides a convenience interface for setting status information that is also directly accessible in the status structure. This functionality is needed for generalized requests.
+
+Users are advised not to reuse status fields for values other than those for which they were intended, as doing so may lead to unexpected results. Modifying values in a status set internally by MPI may lead to unpredictable results and is strongly discouraged.
+//end::MPI_Status_set_tag[]
+
+//tag::MPI_Status_set_error[]
+**MPI_Status_set_error** sets the `MPI_ERROR` field in a `status` object to a specified `err` error code. This procedure provides a convenience interface for setting status information that is also directly accessible in the status structure. This functionality is needed for generalized requests.
+
+Users are advised not to reuse status fields for values other than those for which they were intended, as doing so may lead to unexpected results. The `extra_state` argument provided with a generalized request may be used to return information that does not logically belong in status. Modifying values in a status set internally by MPI may lead to unpredictable results and is strongly discouraged.
+//end::MPI_Status_set_error[]
+
+//tag::MPI_F_sync_reg[]
+**MPI_F_sync_reg** is a Fortran-only routine that forces the compiler to flush a cached register value of `buf` back to memory or invalidate the register value.
+
+This routine has no executable statements and is compiled in the MPI library so that a Fortran compiler cannot detect that the routine has an empty body. It has no `ierror` return argument because there is no operation that can fail. This routine may be used to prevent code movement and register optimization problems when using nonblocking operations, one-sided communication, or MPI_BOTTOM with absolute displacements. If only a part of an array is used in a nonblocking routine, passing the whole array to MPI_F_sync_reg is recommended to minimize overhead. This routine need not be called if `MPI_ASYNC_PROTECTS_NONBLOCKING` is `.TRUE.` and the application fully uses the facilities of `ASYNCHRONOUS` arrays.
+//end::MPI_F_sync_reg[]
+
+//tag::MPI_Type_create_f90_complex[]
+**MPI_Type_create_f90_complex** returns a predefined MPI datatype that matches a Fortran COMPLEX variable of KIND `selected_real_kind(p, r)`.
+
+Either `p` or `r` may be set to `MPI_UNDEFINED`, but not both. A datatype returned by this function matches another datatype if and only if both were created with the same `p` and `r` values, or one is a duplicate of such a datatype. The returned datatype is predefined, cannot be freed, does not need to be committed, and can be used with predefined reduction operations. Restrictions apply when using the returned datatype with the `external32` data representation. It is erroneous to supply values for `p` and `r` not supported by the compiler.
+//end::MPI_Type_create_f90_complex[]
+
+//tag::MPI_Type_match_size[]
+**MPI_Type_match_size** returns a predefined MPI datatype that matches a local variable of a specified `typeclass` and `size` in bytes.
+
+The `typeclass` argument is one of `MPI_TYPECLASS_REAL`, `MPI_TYPECLASS_INTEGER`, or `MPI_TYPECLASS_COMPLEX`. This function returns a reference to one of the predefined named datatypes, not a duplicate. The returned datatype cannot be freed. It is erroneous to specify a `size` not supported by the compiler.
+//end::MPI_Type_match_size[]
+
+//tag::MPI_Comm_f2c[]
+**MPI_Comm_f2c** converts a Fortran communicator handle to a C communicator handle. If `comm` is a valid Fortran handle, the function returns a valid C handle to the same communicator. If `comm` equals `MPI_COMM_NULL` (Fortran value), the function returns a null C handle. If `comm` is an invalid Fortran handle, the function returns an invalid C handle.
+//end::MPI_Comm_f2c[]
+
+//tag::MPI_Type_f2c[]
+**MPI_Type_f2c** converts a Fortran datatype handle to a C datatype handle. If `datatype` is a valid Fortran handle, the function returns a valid C handle to the same datatype. If `datatype` equals `MPI_DATATYPE_NULL` (Fortran value), the function returns a null C handle. If `datatype` is an invalid Fortran handle, the function returns an invalid C handle.
+//end::MPI_Type_f2c[]
+
+//tag::MPI_Group_c2f[]
+**MPI_Group_c2f** translates a C group handle into a Fortran handle to the same group. It maps a null handle into a null handle and an invalid handle into an invalid handle.
+//end::MPI_Group_c2f[]
+
+//tag::MPI_Request_f2c[]
+**MPI_Request_f2c** converts a Fortran request handle to a C request handle. If `request` is a valid Fortran handle, the function returns a valid C handle to the same request. If `request` equals `MPI_REQUEST_NULL` (Fortran value), the function returns a null C handle. If `request` is an invalid Fortran handle, the function returns an invalid C handle.
+//end::MPI_Request_f2c[]
+
+//tag::MPI_Request_c2f[]
+**MPI_Request_c2f** translates a C request handle into a Fortran handle to the same request. It maps a null handle into a null handle and an invalid handle into an invalid handle.
+//end::MPI_Request_c2f[]
+
+//tag::MPI_File_f2c[]
+**MPI_File_f2c** converts a Fortran file handle to a C file handle. If `file` is a valid Fortran handle, the function returns a valid C handle to the same file. If `file` equals `MPI_FILE_NULL` (Fortran value), the function returns a null C handle. If `file` is an invalid Fortran handle, the function returns an invalid C handle.
+//end::MPI_File_f2c[]
+
+//tag::MPI_File_c2f[]
+**MPI_File_c2f** translates a C file handle into a Fortran handle to the same file. It maps a null handle into a null handle and an invalid handle into an invalid handle.
+//end::MPI_File_c2f[]
+
+//tag::MPI_Win_f2c[]
+**MPI_Win_f2c** converts a Fortran window handle to a C window handle. If `win` is a valid Fortran handle, the function returns a valid C handle to the same window. If `win` equals `MPI_WIN_NULL` (Fortran value), the function returns a null C handle. If `win` is an invalid Fortran handle, the function returns an invalid C handle.
+//end::MPI_Win_f2c[]
+
+//tag::MPI_Op_f2c[]
+**MPI_Op_f2c** converts a Fortran operation handle to a C operation handle. If `op` is a valid Fortran handle, the function returns a valid C handle to the same operation. If `op` equals `MPI_OP_NULL` (Fortran value), the function returns a null C handle. If `op` is an invalid Fortran handle, the function returns an invalid C handle.
+//end::MPI_Op_f2c[]
+
+//tag::MPI_Op_c2f[]
+**MPI_Op_c2f** translates a C operation handle into a Fortran handle to the same operation. It maps a null handle into a null handle and an invalid handle into an invalid handle. This function is provided only in C to support interlanguage operability.
+//end::MPI_Op_c2f[]
+
+//tag::MPI_Info_f2c[]
+**MPI_Info_f2c** converts a Fortran info handle to a C info handle. If `info` is a valid Fortran handle, the function returns a valid C handle to the same info object. If `info` equals `MPI_INFO_NULL` (Fortran value), the function returns a null C handle. If `info` is an invalid Fortran handle, the function returns an invalid C handle. This function is provided only in C to support interlanguage operability when C wrappers are used.
+//end::MPI_Info_f2c[]
+
+//tag::MPI_Info_c2f[]
+**MPI_Info_c2f** translates a C info handle into a Fortran handle to the same info object. It maps a null handle into a null handle and an invalid handle into an invalid handle. This function is provided only in C to support interlanguage operability when C wrappers are used.
+//end::MPI_Info_c2f[]
+
+//tag::MPI_Message_f2c[]
+**MPI_Message_f2c** converts a Fortran message handle to a C message handle. If `message` is a valid Fortran handle, the function returns a valid C handle to the same message. If `message` equals `MPI_MESSAGE_NULL` (Fortran value), the function returns a null C handle. If `message` is an invalid Fortran handle, the function returns an invalid C handle.
+//end::MPI_Message_f2c[]
+
+//tag::MPI_Message_c2f[]
+**MPI_Message_c2f** translates a C message handle into a Fortran handle to the same message. It maps a null handle into a null handle and an invalid handle into an invalid handle. This function is local and available only in C. With the Fortran `mpi` module or the deprecated `mpif.h` include file, the returned Fortran handle is an `INTEGER` value. With the Fortran `mpi_f08` module, the returned handle is a `BIND(C)` derived type containing an `INTEGER` component named `MPI_VAL`.
+//end::MPI_Message_c2f[]
+
+//tag::MPI_Session_f2c[]
+**MPI_Session_f2c** converts a Fortran session handle to a C session handle. If `session` is a valid Fortran handle, the function returns a valid C handle to the same session. If `session` equals `MPI_SESSION_NULL` (Fortran value), the function returns a null C handle. If `session` is an invalid Fortran handle, the function returns an invalid C handle.
+//end::MPI_Session_f2c[]
+
+//tag::MPI_Session_c2f[]
+**MPI_Session_c2f** translates a C session handle into a Fortran handle to the same session. This function is local and available only in C. It maps a null handle into a null handle and an invalid handle into an invalid handle. With the Fortran `mpi` module or the deprecated `mpif.h` include file, the returned Fortran handle is an `INTEGER` value. With the Fortran `mpi_f08` module, the returned handle is a `BIND(C)` derived type containing an `INTEGER` component named `MPI_VAL`.
+//end::MPI_Session_c2f[]
+
+//tag::MPI_Status_f2c[]
+**MPI_Status_f2c** converts a Fortran status (an array of integers) to a C status (a structure). The conversion preserves all status information including hidden fields. The C status has the same source, tag, and error code values as the Fortran status and returns the same answers when queried for count, elements, and cancellation. The conversion function may be called with a Fortran status argument that has an undefined error field, in which case the error field in the C status is undefined. If `f_status` is `MPI_STATUS_IGNORE`, `MPI_STATUSES_IGNORE`, or an invalid Fortran status, the call is erroneous.
+//end::MPI_Status_f2c[]
+
+//tag::MPI_Status_c2f[]
+**MPI_Status_c2f** converts a C status structure into a Fortran status array. This function is local and available only in C. The conversion preserves all status information including hidden fields, and the Fortran status has the same source, tag, and error code values as the C status and returns the same answers when queried for count, elements, and cancellation. If `c_status` is `MPI_STATUS_IGNORE` or `MPI_STATUSES_IGNORE`, the call is erroneous.
+//end::MPI_Status_c2f[]
+
+//tag::MPI_Status_f082c[]
+**MPI_Status_f082c** converts a Fortran `mpi_f08` module `TYPE(MPI_Status)` into a C `MPI_Status` structure. This function is local and available only in C. The C type `MPI_F08_status` can be used to pass a Fortran `mpi_f08` status argument into a C routine. The conversion preserves all status information, and the resulting C status has the same source, tag, and error code values and returns the same answers when queried for count, elements, and cancellation.
+//end::MPI_Status_f082c[]
+
+
+//tag::MPI_Status_c2f08[]
+**MPI_Status_c2f08** converts a C `MPI_Status` structure into a Fortran `mpi_f08` module `TYPE(MPI_Status)`. This function is local and available only in C. The C type `MPI_F08_status` can be used to pass a Fortran `mpi_f08` status to and from a C routine. The conversion preserves all status information, and the resulting Fortran status has the same source, tag, and error code values and returns the same answers when queried for count, elements, and cancellation. If `c_status` is `MPI_STATUS_IGNORE` or `MPI_STATUSES_IGNORE`, the call is erroneous.
+//end::MPI_Status_c2f08[]
+
+//tag::MPI_Status_f2f08[]
+**MPI_Status_f2f08** converts a Fortran `INTEGER, DIMENSION(MPI_STATUS_SIZE)` status array into a Fortran `mpi_f08` module `TYPE(MPI_Status)`. This routine is local and available in both C and the `mpi` and `mpi_f08` Fortran modules, but not with the deprecated `mpif.h` include file. The conversion preserves all status information including hidden fields.
+//end::MPI_Status_f2f08[]
+
+//tag::MPI_Status_f082f[]
+**MPI_Status_f082f** converts a Fortran `mpi_f08` module `TYPE(MPI_Status)` into a Fortran `INTEGER, DIMENSION(MPI_STATUS_SIZE)` status array. This routine is local and available in both C and the `mpi` and `mpi_f08` Fortran modules, but not with the deprecated `mpif.h` include file. The conversion preserves all status information including hidden fields.
+//end::MPI_Status_f082f[]
+
+//tag::MPI_Group_size[]
+**MPI_Group_size** returns the number of MPI processes in a group.
+
+This operation is local. Groups are represented by opaque group objects. The predefined group `MPI_GROUP_EMPTY` contains no members.
+//end::MPI_Group_size[]
+
+//tag::MPI_Group_rank[]
+**MPI_Group_rank** returns the rank of the calling MPI process in a group.
+
+This operation is local. If the calling MPI process is not a member of the group, `MPI_UNDEFINED` is returned in `rank`.
+//end::MPI_Group_rank[]
+
+//tag::MPI_Group_translate_ranks[]
+**MPI_Group_translate_ranks** translates the ranks of MPI processes in one group to their corresponding ranks in another group.
+
+This operation is local. The function determines the relative numbering of the same MPI processes in two different groups. `MPI_PROC_NULL` is a valid rank for input and returns `MPI_PROC_NULL` as the translated rank. `MPI_UNDEFINED` is returned when no correspondence exists between a rank in `group1` and any rank in `group2`.
+//end::MPI_Group_translate_ranks[]
+
+//tag::MPI_Group_compare[]
+**MPI_Group_compare** compares two groups and returns an integer indicating their relationship.
+
+This operation is local. The function returns `MPI_IDENT` if the group members and group order are exactly the same in both groups, including when `group1` and `group2` are the same handle. The function returns `MPI_SIMILAR` if the group members are the same but the order is different. The function returns `MPI_UNEQUAL` otherwise.
+//end::MPI_Group_compare[]
+
+//tag::MPI_Group_union[]
+**MPI_Group_union** creates a new group from the union of two existing groups.
+
+This operation is local. The resulting `newgroup` contains all elements of `group1`, followed by all elements of `group2` not in `group1`. The order of MPI processes in the output group is determined primarily by order in the first group, and then by order in the second group when necessary. The union operation is not commutative but is associative. The new group may be empty, equal to `MPI_GROUP_EMPTY`.
+//end::MPI_Group_union[]
+
+//tag::MPI_Group_intersection[]
+**MPI_Group_intersection** creates a new group from the intersection of two existing groups.
+
+This operation is local. The resulting `newgroup` contains all elements of `group1` that are also in `group2`, ordered as in `group1`. The intersection operation is not commutative but is associative. The new group may be empty, equal to `MPI_GROUP_EMPTY`.
+//end::MPI_Group_intersection[]
+
+//tag::MPI_Group_difference[]
+**MPI_Group_difference** creates a new group from the set difference of two existing groups.
+
+This operation is local. The resulting `newgroup` contains all elements of `group1` that are not in `group2`, ordered as in `group1`. The new group may be empty, equal to `MPI_GROUP_EMPTY`.
+//end::MPI_Group_difference[]
+
+//tag::MPI_Group_incl[]
+**MPI_Group_incl** creates a new group from a subset of an existing group with a specified ordering.
+
+This operation is local. The resulting `newgroup` consists of `n` MPI processes from `group` with ranks defined by the `ranks` array, where the MPI process with rank i in `newgroup` is the MPI process with rank `ranks[i]` in `group`. Each element of `ranks` must be a valid rank in `group` and all elements must be distinct, or the program is erroneous. This function may be used to reorder the elements of a group. If `n` equals zero, `newgroup` is `MPI_GROUP_EMPTY`.
+//end::MPI_Group_incl[]
+
+//tag::MPI_Group_excl[]
+**MPI_Group_excl** creates a new group by excluding specified MPI processes from an existing group.
+
+This operation is local. The resulting `newgroup` is obtained by deleting from `group` those MPI processes with ranks specified in the `ranks` array. The ordering of MPI processes in `newgroup` is identical to the ordering in `group`. Each element of `ranks` must be a valid rank in `group` and all elements must be distinct, or the program is erroneous. If `n` equals zero, `newgroup` is identical to `group`.
+//end::MPI_Group_excl[]
+
+//tag::MPI_Group_range_incl[]
+**MPI_Group_range_incl** creates a new group from an existing group using an array of range triplets specifying MPI processes to include.
+
+This operation is local. Each triplet in `ranges` specifies a first rank, last rank, and stride, and `newgroup` consists of the sequence of MPI processes in `group` computed from these ranges in the order defined by `ranges`. Each computed rank must be a valid rank in `group` and all computed ranks must be distinct, or the program is erroneous. The stride may be negative but cannot be zero, and first may be greater than last. MPI programmers are recommended to use range operations when possible, as high-quality implementations may take advantage of their scalability.
+//end::MPI_Group_range_incl[]
+
+//tag::MPI_Group_range_excl[]
+**MPI_Group_range_excl** creates a new group by excluding MPI processes from an existing group using an array of range triplets.
+
+This operation is local. Each triplet in `ranges` specifies a first rank, last rank, and stride, and `newgroup` is obtained by deleting from `group` those MPI processes with ranks computed from these ranges, preserving the order in `group`. Each computed rank must be a valid rank in `group` and all computed ranks must be distinct, or the program is erroneous. The stride may be negative but cannot be zero. MPI programmers are recommended to use range operations when possible, as high-quality implementations may take advantage of their scalability.
+//end::MPI_Group_range_excl[]
+
+//tag::MPI_Group_from_session_pset[]
+**MPI_Group_from_session_pset** creates a group using the provided session handle and process set name.
+
+This operation is local. Process set names returned from MPI_SESSION_GET_NTH_PSET for the supplied `session` are considered valid by MPI. If `pset_name` is not valid at the time of the call, `MPI_GROUP_NULL` is returned in `newgroup`.
+//end::MPI_Group_from_session_pset[]
+
+//tag::MPI_Group_free[]
+**MPI_Group_free** marks a group object for deallocation.
+
+This operation is local. The handle `group` is set to `MPI_GROUP_NULL` by the call. Any ongoing operation using this group will complete normally.
+//end::MPI_Group_free[]
+
+//tag::MPI_Comm_size[]
+**MPI_Comm_size** returns the number of MPI processes in the group of a communicator.
+
+This operation is local. For `MPI_COMM_WORLD`, the function indicates the total number of MPI processes available; the number of processes in `MPI_COMM_WORLD` does not change during the life of an MPI program. This function is often used with MPI_COMM_RANK to determine the amount of concurrency available for a library or program.
+//end::MPI_Comm_size[]
+
+//tag::MPI_Comm_rank[]
+**MPI_Comm_rank** returns the rank of the calling MPI process in the group of a communicator.
+
+This operation is local. The returned `rank` is in the range from 0 to size-1, where size is the return value of MPI_COMM_SIZE. This function is often used with MPI_COMM_SIZE to determine roles of MPI processes, such as in supervisor/executor or manager/worker models.
+//end::MPI_Comm_rank[]
+
+//tag::MPI_Comm_compare[]
+**MPI_Comm_compare** compares two communicators and returns a result indicating their relationship.
+
+This operation is local. The function returns `MPI_IDENT` if `comm1` and `comm2` are handles for the same object with identical groups and same contexts, `MPI_CONGRUENT` if the underlying groups are identical in constituents and rank order but the communicators differ only by context, `MPI_SIMILAR` if the group members are the same but the rank order differs, and `MPI_UNEQUAL` otherwise. For inter-communicators, both communicators must be either intra- or inter-communicators, and both corresponding local and remote groups must compare correctly to obtain `MPI_CONGRUENT` or `MPI_SIMILAR`.
+//end::MPI_Comm_compare[]
+
+//tag::MPI_Comm_dup[]
+**MPI_Comm_dup** duplicates an existing communicator with associated key values, topology information, and error handlers.
+
+This operation is collective over all MPI processes in the group of `comm` and applies to both intra-communicators and inter-communicators. The function returns in `newcomm` a new communicator with the same group or groups, same topology, same error handlers, and copied cached information, but a new context. For each key value, the respective copy callback function determines the attribute value associated with this key in the new communicator. The newly created communicator will have no buffer attached. The call is valid even if there are pending point-to-point communication operations or decoupled MPI activities involving `comm`. This operation may be used to provide a parallel library with a duplicate communication space that has the same properties as the original communicator.
+//end::MPI_Comm_dup[]
+
+//tag::MPI_Comm_idup[]
+**MPI_Comm_idup** is a nonblocking variant of MPI_COMM_DUP that duplicates an existing communicator. The semantics are as if MPI_COMM_DUP was executed at the time MPI_COMM_IDUP is called. Attributes changed after MPI_COMM_IDUP will not be copied to the new communicator. All restrictions and assumptions for nonblocking collective operations apply to this function and the returned `request`. The call applies to both intra-communicators and inter-communicators.
+
+It is erroneous to use `newcomm` as an input argument to other MPI functions before the MPI_COMM_IDUP operation completes.
+//end::MPI_Comm_idup[]
+
+//tag::MPI_Comm_create[]
+**MPI_Comm_create** creates a new communicator from an existing communicator using a specified group.
+
+This operation is collective over all MPI processes in the group of `comm`. For an intra-communicator, each MPI process must provide a `group` argument that is a subgroup of `comm`; processes may specify different values, but if a process specifies a nonempty group then all processes in that group must specify the same group. The specified groups across processes must be disjoint. If the calling process is a member of `group`, `newcomm` is a communicator with `group` as its associated group; otherwise `MPI_COMM_NULL` is returned. For an inter-communicator, the output is also an inter-communicator where the local group consists only of processes contained in `group`; all processes in the same local group must specify the same `group` value. No cached information or virtual topology information propagates from `comm` to `newcomm`. This function may be used to subset a group of MPI processes for separate MIMD computation with separate communication space.
+//end::MPI_Comm_create[]
+
+//tag::MPI_Comm_create_group[]
+**MPI_Comm_create_group** creates a new intra-communicator from a subgroup of an existing intra-communicator, with participation limited to processes in the subgroup.
+
+This function is collective over all MPI processes in `group`, not over all processes in `comm`. Each MPI process must provide a `group` argument that is a subgroup of the group associated with `comm`. If a nonempty `group` is specified, then all MPI processes in that group must call the function with the same arguments, including a `group` that contains the same members with the same ordering. If the calling MPI process is a member of the group given as the `group` argument, then `newcomm` is a communicator with `group` as its associated group. No cached information or virtual topology information propagates from `comm` to `newcomm`.
+
+If the calling MPI process is not a member of `group`, including when `group` is `MPI_GROUP_EMPTY`, then the call is local and `MPI_COMM_NULL` is returned as `newcomm`. The `tag` argument does not conflict with tags used in point-to-point communication and wildcards are not permitted for `tag`. If multiple threads at a given MPI process perform concurrent MPI_COMM_CREATE_GROUP operations, they must distinguish these operations by providing different `tag` or `comm` arguments. MPI_COMM_CREATE may provide lower overhead than MPI_COMM_CREATE_GROUP because it may use collective communication on `comm` when constructing `newcomm`.
+//end::MPI_Comm_create_group[]
+
+//tag::MPI_Comm_set_info[]
+**MPI_Comm_set_info** updates the hints of a communicator using the hints provided in the `info` argument.
+
+This is a collective routine. The `info` object may be different on each MPI process, but any info entries that an implementation requires to be the same on all MPI processes must appear with the same value in each process's `info` object. The operation has no effect on previously set or defaulted hints that are not specified by `info`. It also has no effect on previously set or defaulted hints that are specified by `info` but are ignored by the MPI implementation. MPI_COMM_GET_INFO may be used to determine whether updates to existing info hints were ignored by the implementation. Setting info hints on `MPI_COMM_WORLD` and `MPI_COMM_SELF` may have unintended effects, as changes to these global objects may affect all components of the application including libraries and tools. Users are recommended to ensure that all components of the application that use a given communicator may comply with any info hints associated with that communicator.
+//end::MPI_Comm_set_info[]
+
+//tag::MPI_Comm_get_info[]
+**MPI_Comm_get_info** returns a new info object containing the hints of the communicator associated with `comm`.
+
+This operation is local. The current setting of all hints related to the communicator is returned in `info_used`. An MPI implementation is required to return all hints that are supported by the implementation and have default values specified, any user-supplied hints that were not ignored by the implementation, and any additional hints that were set by the implementation. If no such hints exist, a handle to a newly created info object is returned that contains no key/value pair. The user is responsible for freeing `info_used` via MPI_INFO_FREE.
+//end::MPI_Comm_get_info[]
+
+//tag::MPI_Intercomm_create[]
+**MPI_Intercomm_create** creates an inter-communicator from two existing intra-communicators.
+
+This call is collective over the union of the local and remote groups. All MPI processes within each group must provide identical `local_comm` and `local_leader` arguments. The local and remote groups must be disjoint; overlap is erroneous and may cause deadlock. Wildcards are not permitted for `remote_leader`, `local_leader`, and `tag`. At least one selected member from each group must be able to communicate with the selected member from the other group via a peer communicator. The peer communicator argument is significant only at the `local_leader`.
+//end::MPI_Intercomm_create[]
+
+//tag::MPI_Intercomm_create_from_groups[]
+**MPI_Intercomm_create_from_groups** creates an inter-communicator from two previously defined, disjoint groups.
+
+This call is collective over the union of the local and remote groups. The calling MPI process must be a member of `local_group`. All involved MPI processes must provide an identical `stringtag` argument. Within each group, all MPI processes must provide identical `local_group` and `local_leader` arguments. If `MPI_GROUP_EMPTY` is supplied as `local_group` or `remote_group` or both, the call is a local operation and `MPI_COMM_NULL` is returned as `newintercomm`. Wildcards are not permitted for `remote_leader` or `local_leader`. If multiple threads at a given MPI process perform concurrent MPI_INTERCOMM_CREATE_FROM_GROUPS operations, users must distinguish these operations by providing different `stringtag` arguments.
+//end::MPI_Intercomm_create_from_groups[]
+
+//tag::MPI_Intercomm_merge[]
+**MPI_Intercomm_merge** creates an intra-communicator from the union of the two groups associated with an inter-communicator.
+
+This call is blocking and collective within the union of the two groups. All MPI processes within each group are recommended to provide the same `high` value. If MPI processes in one group provide `high` = false and MPI processes in the other group provide `high` = true, the union orders the low group before the high group. If all MPI processes provide the same `high` argument, the order of the union is arbitrary. The two groups of the inter-communicator must be disjoint. The error handler on the new intra-communicator in each MPI process is inherited from the communicator that contributes the local group.
+//end::MPI_Intercomm_merge[]
+
+//tag::MPI_Comm_delete_attr[]
+**MPI_Comm_delete_attr** deletes an attribute from a communicator's cache by key.
+
+This operation is local. The function invokes the attribute delete callback function `comm_delete_attr_fn` specified when `comm_keyval` was created. The call will fail if the `comm_delete_attr_fn` function returns an error code other than `MPI_SUCCESS`. Attributes are local to the MPI process and specific to the communicator to which they are attached.
+//end::MPI_Comm_delete_attr[]
+
+//tag::MPI_Win_create_keyval[]
+**MPI_Win_create_keyval** generates a new attribute key for associating attributes with windows.
+
+This operation is local. Keys are locally unique in an MPI process and opaque to the user, though stored in integers. Once allocated, the key value can be used to associate attributes and access them on any locally defined window. The `win_copy_attr_fn` callback is invoked when a window is duplicated, and `win_delete_attr_fn` is invoked when an attribute is deleted or when the window is freed. It is erroneous to use `MPI_KEYVAL_INVALID` as a key value; such errors may return error class `MPI_ERR_KEYVAL`.
+//end::MPI_Win_create_keyval[]
+
+//tag::MPI_Win_free_keyval[]
+**MPI_Win_free_keyval** frees an attribute key for window objects and sets `win_keyval` to `MPI_KEYVAL_INVALID`.
+
+This operation is local. It is not erroneous to free an attribute key that is in use, because the actual free does not occur until all references to the key have been freed. References are freed explicitly via calls to MPI_WIN_DELETE_ATTR or by calls to MPI_WIN_FREE that free all attribute instances associated with the freed window. Erroneous key values may return error class `MPI_ERR_KEYVAL`.
+//end::MPI_Win_free_keyval[]
+
+//tag::MPI_Win_set_attr[]
+**MPI_Win_set_attr** stores an attribute value on a window for subsequent retrieval by MPI_WIN_GET_ATTR.
+
+This operation is local. If an attribute value is already present for the key, the delete callback function `win_delete_attr_fn` is executed before the new value is stored. The call fails if the delete callback returns an error code other than `MPI_SUCCESS`. It is erroneous to use `MPI_KEYVAL_INVALID` or a nonexistent key value; such errors may return error class `MPI_ERR_KEYVAL`.
+//end::MPI_Win_set_attr[]
+
+//tag::MPI_Win_get_attr[]
+**MPI_Win_get_attr** retrieves an attribute value from a window by key.
+
+This operation is local. If the key exists but no attribute is attached to `win` for that key, the call returns `flag` = false. It is erroneous to use `MPI_KEYVAL_INVALID` or a nonexistent key value; such errors may return error class `MPI_ERR_KEYVAL`.
+//end::MPI_Win_get_attr[]
+
+//tag::MPI_Win_delete_attr[]
+**MPI_Win_delete_attr** deletes an attribute from a window by key.
+
+This operation is local and invokes the attribute delete function `win_delete_attr_fn` specified when the key was created. The call fails if the delete callback returns an error code other than `MPI_SUCCESS`. It is erroneous to use `MPI_KEYVAL_INVALID` or a nonexistent key value; such errors may return error class `MPI_ERR_KEYVAL`.
+//end::MPI_Win_delete_attr[]
+
+//tag::MPI_Type_free_keyval[]
+**MPI_Type_free_keyval** frees an extant datatype attribute key.
+
+This operation is local and sets `type_keyval` to `MPI_KEYVAL_INVALID`. It is not erroneous to free an attribute key that is in use, because the actual free does not occur until all references to the key have been freed. References are freed explicitly via calls to MPI_TYPE_DELETE_ATTR or by calls to MPI_TYPE_FREE that free all attribute instances associated with the freed datatype. Erroneous key values may return error class `MPI_ERR_KEYVAL`.
+//end::MPI_Type_free_keyval[]
+
+//tag::MPI_Type_set_attr[]
+**MPI_Type_set_attr** stores an attribute value on a datatype for subsequent retrieval by MPI_TYPE_GET_ATTR.
+
+This operation is local. If an attribute value is already present for the key, the delete callback function `type_delete_attr_fn` is executed before the new value is stored. The call fails if the delete callback returns an error code other than `MPI_SUCCESS`. It is erroneous to use `MPI_KEYVAL_INVALID` or a nonexistent key value; such errors may return error class `MPI_ERR_KEYVAL`.
+//end::MPI_Type_set_attr[]
+
+//tag::MPI_Type_get_attr[]
+**MPI_Type_get_attr** retrieves an attribute value from a datatype by key.
+
+This operation is local. If the key exists but no attribute is attached to `datatype` for that key, the call returns `flag` = false. It is erroneous to use `MPI_KEYVAL_INVALID` or a nonexistent key value; such errors may return error class `MPI_ERR_KEYVAL`.
+//end::MPI_Type_get_attr[]
+
+//tag::MPI_Type_delete_attr[]
+**MPI_Type_delete_attr** deletes an attribute from a datatype by key.
+
+This operation is local and invokes the attribute delete function `type_delete_attr_fn` specified when the `type_keyval` was created. The call fails if the delete callback returns an error code other than `MPI_SUCCESS`. It is erroneous to use `MPI_KEYVAL_INVALID` or a nonexistent key value; such errors may return error class `MPI_ERR_KEYVAL`.
+//end::MPI_Type_delete_attr[]
+
+//tag::MPI_Comm_set_name[]
+**MPI_Comm_set_name** associates a user-defined name string with a communicator.
+
+This operation is local and noncollective, affecting only the name as seen by the calling MPI process. The character string passed to MPI_COMM_SET_NAME is saved inside the MPI library and may be freed or stack-allocated by the caller immediately after the call. Leading spaces in `comm_name` are significant but trailing ones are not. The maximum name length is limited to `MPI_MAX_OBJECT_NAME`. Assigning the same name to a communicator in all MPI processes where it exists is recommended to avoid confusion when debugging.
+//end::MPI_Comm_set_name[]
+
+//tag::MPI_Type_set_name[]
+**MPI_Type_set_name** associates a user-defined name string with a datatype.
+
+This operation is local. The character string passed to MPI_TYPE_SET_NAME is saved inside the MPI library and may be freed or stack-allocated by the caller immediately after the call. Leading spaces in `type_name` are significant but trailing ones are not. The maximum name length is limited to `MPI_MAX_OBJECT_NAME`. Names do not propagate when the datatype is duplicated or copied by MPI routines.
+//end::MPI_Type_set_name[]
+
+//tag::MPI_Win_set_name[]
+**MPI_Win_set_name** associates a user-defined name string with a window.
+
+This operation is local. The character string is saved inside the MPI library and may be freed or stack-allocated by the caller immediately after the call. Leading spaces in `win_name` are significant but trailing ones are not. The maximum name length is limited to `MPI_MAX_OBJECT_NAME`. Names do not propagate when the window is duplicated or copied by MPI routines.
+//end::MPI_Win_set_name[]
+
+//tag::MPI_Win_get_name[]
+**MPI_Win_get_name** returns the name previously associated with a window.
+
+This operation is local. If no name has been associated with the window, an empty string is returned. Passing `MPI_WIN_NULL` as `win` returns the string "MPI_WIN_NULL".
+//end::MPI_Win_get_name[]
+
+//tag::MPI_Dims_create[]
+**MPI_Dims_create** computes a balanced distribution of MPI processes across a specified number of Cartesian dimensions.
+
+This operation is local. The `dims` array entries are set to describe a Cartesian grid with dimension sizes chosen to be as close to each other as possible using a divisibility algorithm. Entries where `dims[i]` equals zero are modified by the call, while positive entries constrain the routine to preserve those dimensions; for dimensions set by the call, values are ordered in nonincreasing order. The resulting `dims` array is suitable for use as input to MPI_CART_CREATE. Negative values of `dims[i]` are erroneous, and an error occurs if `nnodes` is not a multiple of the product of all non-zero `dims[i]` entries.
+//end::MPI_Dims_create[]
+
+//tag::MPI_Dist_graph_create_adjacent[]
+**MPI_Dist_graph_create_adjacent** creates a new communicator with distributed graph topology information attached.
+
+This collective operation returns a handle to a new communicator to which the distributed graph topology information is attached. Each MPI process specifies its incoming and outgoing edges in the virtual distributed graph topology, allowing a fully distributed specification. The calling processes must ensure that each edge is described by both the source and destination processes with the same weights. The number of MPI processes in `comm_dist_graph` is identical to the number in `comm_old`. Isolated processes with no incoming or outgoing edges are allowed. All processes must provide the same value for `reorder` and `info`. If the graph is weighted but `indegree` or `outdegree` is zero, `MPI_WEIGHTS_EMPTY` or any arbitrary array may be passed to `sourceweights` or `destweights`; `MPI_UNWEIGHTED` may be supplied for the weight array to indicate that all edges have effectively no weight, but it is erroneous to supply `MPI_UNWEIGHTED` for some but not all processes of `comm_old`.
+//end::MPI_Dist_graph_create_adjacent[]
+
+//tag::MPI_Graphdims_get[]
+**MPI_Graphdims_get** retrieves the graph topology dimensions associated with a communicator.
+
+This operation is local. The function returns the number of nodes in the graph in `nnodes`, which is the same as the number of MPI processes in the group of `comm`, and the number of edges in the graph in `nedges`. The information provided by MPI_Graphdims_get can be used to correctly dimension the `index` and `edges` arrays for a subsequent call to MPI_GRAPH_GET.
+//end::MPI_Graphdims_get[]
+
+//tag::MPI_Cartdim_get[]
+**MPI_Cartdim_get** returns the number of dimensions of the Cartesian topology associated with a communicator.
+
+This operation is local. The function returns the Cartesian structure information and can be used together with MPI_CART_GET to retrieve the complete Cartesian topology information. If `comm` is associated with a zero-dimensional Cartesian topology, `ndims` = 0 is returned.
+//end::MPI_Cartdim_get[]
+
+//tag::MPI_Cart_coords[]
+**MPI_Cart_coords** translates a process rank to the corresponding Cartesian coordinates in the topology associated with a communicator.
+
+This operation is local. If `comm` is associated with a zero-dimensional Cartesian topology, `coords` will be unchanged. If `maxdims` is less than the number of dimensions of the Cartesian topology associated with `comm`, the outcome is unspecified.
+//end::MPI_Cart_coords[]
+
+//tag::MPI_Graph_neighbors_count[]
+**MPI_Graph_neighbors_count** returns the number of neighbors for a specified process in a graph topology.
+
+This operation is local. The returned `nneighbors` value and the neighbor ordering reflect the original `index` and `edges` arrays passed to MPI_GRAPH_CREATE. The number of neighbors is computed as (`index[rank]` - `index[rank-1]`), assuming `index[-1]` is zero. The function may be used together with MPI_GRAPH_NEIGHBORS to retrieve adjacency information for a graph topology.
+//end::MPI_Graph_neighbors_count[]
+
+//tag::MPI_Graph_neighbors[]
+**MPI_Graph_neighbors** returns the ranks of processes that are neighbors to a specified process in a graph topology.
+
+This operation is local. The returned `neighbors` array includes all neighbors and reflects the same edge ordering as was specified by the original call to MPI_GRAPH_CREATE. The neighbors returned correspond to entries `edges[index[rank-1]]` through `edges[index[rank]-1]` from the original graph specification, assuming `index[-1]` is zero. MPI_GRAPH_NEIGHBORS_COUNT may be used to determine the number of neighbors before calling this function.
+//end::MPI_Graph_neighbors[]
+
+//tag::MPI_Dist_graph_neighbors_count[]
+**MPI_Dist_graph_neighbors_count** returns the number of incoming and outgoing edges in the distributed graph topology associated with a communicator.
+
+This operation is local. The returned `indegree` and `outdegree` values reflect the total number of edges into and out of the calling MPI process as specified during graph creation via MPI_DIST_GRAPH_CREATE_ADJACENT or MPI_DIST_GRAPH_CREATE. Multiply-defined edges are counted. The `weighted` output returns false if `MPI_UNWEIGHTED` was supplied during graph creation, and true otherwise.
+//end::MPI_Dist_graph_neighbors_count[]
+
+//tag::MPI_Cart_map[]
+**MPI_Cart_map** computes an optimal placement for the calling MPI process on the physical machine based on a specified Cartesian topology.
+
+This operation is local. The function returns `MPI_UNDEFINED` in `newrank` if the calling MPI process does not belong to the specified Cartesian grid. An implementation may always return the rank of the calling MPI process without performing any reordering.
+//end::MPI_Cart_map[]
+
+//tag::MPI_Graph_map[]
+**MPI_Graph_map** computes an optimal placement for the calling MPI process on the physical machine based on a specified graph topology.
+
+This operation is local. The function is not typically called by the user directly but together with communicator manipulation functions is sufficient to implement all other topology functions. An implementation may always return the rank of the calling MPI process without performing any reordering. The function returns `MPI_UNDEFINED` in `newrank` if the calling MPI process does not belong to the specified graph.
+//end::MPI_Graph_map[]
+
+//tag::MPI_Ineighbor_alltoallv[]
+**MPI_Ineighbor_alltoallv** starts a nonblocking neighborhood alltoallv operation on a communicator with an associated virtual topology. This collective operation supports Cartesian, graph, and distributed graph communicators. Each process sends data to each outgoing neighbor starting at offset `sdispls[k]` elements and receives data from each incoming neighbor into offset `rdispls[l]` elements. The nonblocking variant allows relaxed synchronization and overlapping of computation and communication. For distributed graph topologies, the sequence of neighbors is defined by MPI_DIST_GRAPH_NEIGHBORS. The type signature at the sender must equal the type signature at the receiver for each communicating pair. All arguments are significant on all processes and `comm` must have identical values on all processes.
+
+If a neighbor is `MPI_PROC_NULL`, the buffer position is neither communicated nor updated. The in-place option is not meaningful for this operation.
+//end::MPI_Ineighbor_alltoallv[]
+
+//tag::MPI_Ineighbor_alltoallw[]
+**MPI_Ineighbor_alltoallw** starts a nonblocking neighborhood alltoallw operation on a communicator with an associated virtual topology. This collective operation allows sending and receiving with different datatypes to and from each neighbor. The procedure supports Cartesian, graph, and distributed graph communicators. Each process sends data to outgoing neighbors and receives data from incoming neighbors as defined by the topology. The nonblocking variant allows relaxed synchronization and overlapping of computation and communication. The type signature of data sent must match the type signature of data received pairwise between every pair of communicating processes. All arguments are significant on all processes and `comm` must have identical values on all processes.
+
+If a neighbor is `MPI_PROC_NULL`, the buffer is still part of the sequence of neighbors but is neither communicated nor updated. The in-place option is not meaningful for this operation.
+//end::MPI_Ineighbor_alltoallw[]
+
+//tag::MPI_Neighbor_allgather_init[]
+**MPI_Neighbor_allgather_init** creates a persistent collective communication request for the neighborhood allgather operation on a communicator with an associated virtual topology. This collective operation supports Cartesian, graph, and distributed graph communicators. Persistent variants may offer significant performance benefits for programs with repetitive communication patterns. Each process sends its send buffer to all outgoing neighbors and receives data from all incoming neighbors into the receive buffer. For Cartesian topologies, the sequence of neighbors follows dimension order with negative direction first, then positive direction with displacement 1. For distributed graph topologies, the sequence of neighbors is defined by MPI_DIST_GRAPH_NEIGHBORS. The type signature associated with `sendcount` and `sendtype` at a process must equal the type signature associated with `recvcount` and `recvtype` at all neighboring processes.
+
+If a neighbor is `MPI_PROC_NULL`, the buffer position is neither communicated nor updated.
+//end::MPI_Neighbor_allgather_init[]
+
+//tag::MPI_Neighbor_allgatherv_init[]
+**MPI_Neighbor_allgatherv_init** creates a persistent collective communication request for the neighborhood allgatherv operation on a communicator with an associated virtual topology.
+
+This collective operation supports Cartesian, graph, and distributed graph communicators. Persistent variants may offer significant performance benefits for programs with repetitive communication patterns. Each process sends its `sendbuf` to all outgoing neighbors and receives varying amounts of data from incoming neighbors into the receive buffer at displacements specified by `displs`. For Cartesian topologies, the sequence of neighbors follows dimension order with negative direction first then positive direction with displacement 1; for distributed graph topologies, the sequence is defined by MPI_DIST_GRAPH_NEIGHBORS. The type signature associated with `sendcount` and `sendtype` at process j must equal the type signature associated with `recvcounts[l]` and `recvtype` at any other process where `srcs[l]` = j. If a neighbor is `MPI_PROC_NULL`, the buffer position is neither communicated nor updated. The in-place option is not meaningful for this operation.
+//end::MPI_Neighbor_allgatherv_init[]
+
+//tag::MPI_Neighbor_alltoall_init[]
+**MPI_Neighbor_alltoall_init** creates a persistent collective communication request for the neighborhood alltoall operation on a communicator with an associated virtual topology.
+
+This collective operation supports Cartesian, graph, and distributed graph communicators. Persistent variants may offer significant performance benefits for programs with repetitive communication patterns. Each process sends distinct data blocks to its outgoing neighbors and receives data blocks from its incoming neighbors. The k-th block in the send buffer is sent to the k-th outgoing neighbor and the l-th block in the receive buffer is received from the l-th incoming neighbor. For Cartesian topologies, the sequence of neighbors follows dimension order with negative direction first, then positive direction with displacement 1; for distributed graph topologies, the sequence is defined by MPI_DIST_GRAPH_NEIGHBORS. The type signature at a process must equal the type signature at any other process for each communicating pair. If a neighbor is `MPI_PROC_NULL`, the buffer position is neither communicated nor updated.
+//end::MPI_Neighbor_alltoall_init[]
+
+//tag::MPI_Neighbor_alltoallv_init[]
+**MPI_Neighbor_alltoallv_init** creates a persistent collective communication request for the neighborhood alltoallv operation on a communicator with an associated virtual topology.
+
+This collective operation supports Cartesian, graph, and distributed graph communicators. Persistent variants may offer significant performance benefits for programs with repetitive communication patterns. Each process sends varying amounts of data to its outgoing neighbors starting at offset `sdispls[k]` elements and receives data from incoming neighbors into offset `rdispls[l]` elements. For Cartesian topologies, the sequence of neighbors follows dimension order with negative direction first, then positive direction with displacement 1; for distributed graph topologies, the sequence is defined by MPI_DIST_GRAPH_NEIGHBORS. The type signature associated with `sendcounts[k]` and `sendtype` at process i must equal the type signature associated with `recvcounts[l]` and `recvtype` at process j where the k-th destination of i is j and the l-th source of j is i. If a neighbor is `MPI_PROC_NULL`, the buffer position is neither communicated nor updated. The in-place option is not meaningful for this operation.
+//end::MPI_Neighbor_alltoallv_init[]
+
+//tag::MPI_Neighbor_alltoallw_init[]
+**MPI_Neighbor_alltoallw_init** creates a persistent collective communication request for the neighborhood alltoallw operation on a communicator with an associated virtual topology.
+
+This collective operation supports Cartesian, graph, and distributed graph communicators. Persistent variants may offer significant performance benefits for programs with repetitive communication patterns. Each process sends data to outgoing neighbors and receives data from incoming neighbors, with different datatypes permitted to and from each neighbor. For Cartesian topologies, the sequence of neighbors follows dimension order with negative direction first, then positive direction with displacement 1; for distributed graph topologies, the sequence is defined by MPI_DIST_GRAPH_NEIGHBORS. The type signature of data sent must match the type signature of data received pairwise between every pair of communicating processes. If a neighbor is `MPI_PROC_NULL`, the buffer is still part of the sequence of neighbors but is neither communicated nor updated. The in-place option is not meaningful for this operation.
+//end::MPI_Neighbor_alltoallw_init[]
+
+//tag::MPI_Type_create_indexed_block[]
+**MPI_Type_create_indexed_block** is a datatype constructor that creates a derived datatype representing a sequence of blocks with constant block length and arbitrary displacements.
+
+This operation is local and does not require communication with other processes. The constructor is the same as MPI_TYPE_INDEXED except that the block length is uniform for all blocks. Block displacements are specified as multiples of the `oldtype` extent. This function is useful for gather and scatter operations arising from unstructured grids where the block size is always one.
+//end::MPI_Type_create_indexed_block[]
+
+//tag::MPI_Type_create_struct[]
+**MPI_Type_create_struct** is the most general datatype constructor, allowing each block to consist of replications of different datatypes. This operation is local and generalizes MPI_TYPE_CREATE_HINDEXED by permitting distinct datatypes for each block. The newly created datatype has a type map with entries defined by the arrays of block lengths, byte displacements, and types.
+
+Structures combining different basic datatypes are recommended to be defined so that there are no gaps based on alignment rules. If such a datatype is used to create an array of structures, alignment gaps at the end of the structure are recommended to be avoided. Gaps may be added explicitly to both the structure and the MPI derived datatype handle because communication of a contiguous derived datatype may be significantly faster than one that is noncontiguous due to alignment gaps.
+//end::MPI_Type_create_struct[]
+
+//tag::MPI_Type_create_darray[]
+**MPI_Type_create_darray** creates a datatype representing the local portion of an array distributed across a process grid in an HPF-like fashion. The distribution supports `MPI_DISTRIBUTE_BLOCK`, `MPI_DISTRIBUTE_CYCLIC`, and `MPI_DISTRIBUTE_NONE` for each dimension. The product of all entries in `array_of_psizes` must equal `size`. The `order` parameter specifies row-major (`MPI_ORDER_C`) or column-major (`MPI_ORDER_FORTRAN`) storage order. Unused dimensions of `array_of_psizes` may be set to 1. Process ordering in the grid is assumed to be row-major, consistent with virtual Cartesian process topologies.
+//end::MPI_Type_create_darray[]
+
+//tag::MPI_Type_size[]
+**MPI_Type_size** returns the total size in bytes of the entries in the type signature associated with a datatype.
+
+This is the total size of data in a message that would be created with this datatype. Entries that occur multiple times in the datatype are counted with their multiplicity. If the `size` output parameter cannot express the value to be returned, it is set to `MPI_UNDEFINED`.
+//end::MPI_Type_size[]
+
+//tag::MPI_Type_get_extent[]
+**MPI_Type_get_extent** returns the lower bound and extent of a datatype.
+
+The extent is defined as the span from the first byte to the last byte occupied by entries in the datatype, rounded up to satisfy alignment requirements. If either output parameter cannot express the value to be returned, it is set to `MPI_UNDEFINED`. Structures combining different basic datatypes are recommended to be defined so that there are no gaps based on alignment rules, and alignment gaps at the end of a structure are recommended to be avoided when the datatype is used in an array of structures.
+//end::MPI_Type_get_extent[]
+
+//tag::MPI_Type_commit[]
+**MPI_Type_commit** commits a datatype, making it usable in communication operations.
+
+A datatype object must be committed before it can be used in a communication. Basic datatypes are pre-committed and do not require a call to this function. The commit operation commits the formal description of a communication buffer, not the content of that buffer. After a datatype has been committed, it can be repeatedly reused to communicate the changing content of a buffer or different buffers with different starting addresses. Calling MPI_TYPE_COMMIT on an already committed `datatype` is equivalent to a no-op.
+//end::MPI_Type_commit[]
+
+//tag::MPI_Type_dup[]
+**MPI_Type_dup** is a type constructor that duplicates an existing datatype with associated key values.
+
+For each key value, the respective copy callback function determines the attribute value associated with the key in the new datatype; one action a copy callback may take is to delete the attribute from the new datatype. The `newtype` has exactly the same properties as `oldtype`, including identical upper bound, lower bound, and committed state. Any copied cached information is also associated with `newtype`.
+//end::MPI_Type_dup[]
+
+//tag::MPI_Unpack[]
+**MPI_Unpack** unpacks a message from a contiguous buffer into a receive buffer specified by `outbuf`, `outcount`, and `datatype`. The input buffer is a contiguous storage area containing `insize` bytes starting at address `inbuf`. The input value of `position` is the first location in the input buffer occupied by the packed message, and `position` is incremented by the size of the packed message upon return. The `outcount` argument specifies the actual number of items to be unpacked. A packing unit may be unpacked into several successive messages via related calls where each call inputs the `position` value output by the previous call. Each packing unit must be unpacked as a unit by a sequence of related unpack calls.
+//end::MPI_Unpack[]
+
+//tag::MPI_Pack_external[]
+**MPI_Pack_external** packs data into a buffer using the `external32` data representation for portable interchange between MPI implementations.
+
+This operation is local and writes data to the buffer in the `external32` format without headers. The input value of `position` is the first location in the output buffer to be used for packing, and `position` is incremented by the size of the packed message. `MPI_BYTE` may be used to send and receive data packed using this function.
+//end::MPI_Pack_external[]
+
+//tag::MPI_Unpack_external[]
+**MPI_Unpack_external** unpacks data from a contiguous buffer using the `external32` data representation into a receive buffer specified by `outbuf`, `outcount`, and `datatype`.
+
+This operation is local and reads data from the buffer in the `external32` format without headers. The input value of `position` is the first location in the input buffer occupied by the packed message, and `position` is incremented by the size of the unpacked message upon return. The only valid value for `datarep` is "external32". `MPI_BYTE` may be used to send and receive data that is unpacked using this function.
+//end::MPI_Unpack_external[]
+
+//tag::MPI_Pack_external_size[]
+**MPI_Pack_external_size** returns the number of bytes needed to pack data using the `external32` data representation.
+
+This operation is local and calculates the space required to pack a message with the specified `incount` and `datatype` in the `external32` format. The only valid value for `datarep` is "external32". The returned `size` value enables users to allocate appropriate buffer space for MPI_PACK_EXTERNAL operations.
+//end::MPI_Pack_external_size[]
+
+//tag::MPI_Info_get_nkeys[]
+**MPI_Info_get_nkeys** returns the number of currently defined keys in an info object.
+
+This function must retain all key/value pairs so that layered functionality can also use the `info` object.
+//end::MPI_Info_get_nkeys[]
+
+//tag::MPI_Info_free[]
+**MPI_Info_free** frees an info object and sets `info` to `MPI_INFO_NULL`.
+//end::MPI_Info_free[]
+
+//tag::MPI_Info_create_env[]
+**MPI_Info_create_env** creates an `info` object with the same construction as `MPI_INFO_ENV`. This procedure is local, always thread-safe, and may be called before MPI is initialized or after MPI is finalized. The created object is not a direct copy or alias of `MPI_INFO_ENV` and may contain different values based on the input arguments. Multiple calls with the same input arguments produce `info` objects consistent with the definition of `MPI_INFO_ENV`. The user is responsible for freeing the `info` object via MPI_INFO_FREE.
+
+In some circumstances the `info` object may not be populated or may be populated incompletely because the implementation may not be able to determine the correct values, which may result in different values at different MPI processes.
+//end::MPI_Info_create_env[]
+
+//tag::MPI_Init[]
+**MPI_Init** initializes the MPI execution environment using the World Process Model.
+
+This call creates an initial set of MPI processes related by their membership in the `MPI_COMM_WORLD` communicator. An MPI program using the World Process Model must contain exactly one call to MPI_INIT or MPI_INIT_THREAD, and subsequent calls to either initialization routine are erroneous. A call to MPI_Init has the same effect as a call to MPI_INIT_THREAD with `MPI_THREAD_SINGLE`. `MPI_COMM_WORLD` and `MPI_COMM_SELF` are not valid for use as communicators prior to invocation of MPI_INIT or MPI_INIT_THREAD. After MPI is initialized, the application can access information about the execution environment by querying the predefined info object `MPI_INFO_ENV`.
+
+The C procedures accept either the `argc` and `argv` provided by the arguments to main or NULL. Failures in MPI operations prior to or during MPI initialization are reported by invoking the initial error handler; users may use the `mpi_initial_errhandler` info key during the launch of MPI processes to set a nonfatal initial error handler before MPI initialization.
+//end::MPI_Init[]
+
+//tag::MPI_Query_thread[]
+**MPI_Query_thread** returns the current level of thread support provided by MPI.
+
+The call returns in `provided` the thread support level, which is the value returned by MPI_INIT_THREAD if MPI was initialized by a call to MPI_INIT_THREAD. This function is only applicable when using the World Process Model to initialize MPI. In the case of applications using both the World Process Model and the Sessions Process Model, this function only returns the thread support level returned by MPI_INIT_THREAD. Third-party libraries that can run only with specific levels of thread support may use MPI_Query_thread to verify whether the user initialized MPI to the required level.
+//end::MPI_Query_thread[]
+
+//tag::MPI_Is_thread_main[]
+**MPI_Is_thread_main** determines if the calling thread is the main thread. The main thread is the thread that called MPI_INIT or MPI_INIT_THREAD. This function is only applicable when using the World Process Model to initialize MPI. In applications using both the World Process Model and the Sessions Process Model, the behavior is the same as if the application were only using the World Process Model.
+
+Portable third-party libraries may use MPI_QUERY_THREAD to verify the thread support level initialized by the user.
+//end::MPI_Is_thread_main[]
+
+//tag::MPI_Finalize[]
+**MPI_Finalize** cleans up all MPI state associated with the World Process Model.
+
+If an MPI program that initializes the World Process Model terminates normally, each process must call MPI_Finalize before it exits. Before calling MPI_Finalize, a process must locally complete all MPI operations it initiated and execute matching calls needed to complete MPI communications initiated by other processes. All request handles associated with the World Process Model must be freed for nonblocking operations and must be inactive or freed for persistent or partitioned operations. MPI_Finalize does not free objects created by MPI calls; these objects are freed using MPI_xxx_FREE, MPI_COMM_DISCONNECT, or MPI_FILE_CLOSE calls. MPI_Finalize is collective over all connected processes. Once MPI_Finalize returns, no MPI procedure may be called in the World Process Model except for those listed as callable before initialization and after finalization. In multithreaded applications, the call to MPI_Finalize may occur on the main thread that initialized MPI after all process threads have completed their MPI calls with no pending communication or I/O operations.
+
+MPI_Finalize first executes the equivalent of MPI_COMM_FREE on `MPI_COMM_SELF`, invoking delete callback functions on all keys associated with `MPI_COMM_SELF` in reverse order of association. It is not required that all processes return from MPI_Finalize, but when a process has not failed or aborted, at least the process assigned rank 0 in `MPI_COMM_WORLD` must return.
+//end::MPI_Finalize[]
+
+//tag::MPI_Finalized[]
+**MPI_Finalized** determines whether MPI_FINALIZE has completed in the World Process Model.
+
+This routine returns `flag` = true if MPI_FINALIZE has completed and `flag` = false otherwise. It is valid to call MPI_Finalized before MPI_INIT or MPI_INIT_THREAD and after MPI_FINALIZE. This function must always be thread-safe.
+//end::MPI_Finalized[]
+
+//tag::MPI_Session_init[]
+**MPI_Session_init** creates an MPI Session handle for use in the Sessions Process Model.
+
+This is a local procedure intended to be a lightweight operation. An MPI process may instantiate multiple sessions. The `info` argument is used to request the `thread_level` for MPI objects derived from the session, with allowed values `MPI_THREAD_SINGLE`, `MPI_THREAD_FUNNELED`, `MPI_THREAD_SERIALIZED`, and `MPI_THREAD_MULTIPLE`. The `errhandler` argument specifies an error handler to invoke if the session instantiation encounters an error. MPI_Session_init is always thread-safe; multiple threads within an application may invoke it concurrently.
+//end::MPI_Session_init[]
+
+//tag::MPI_Session_get_num_psets[]
+**MPI_Session_get_num_psets** queries the runtime for the number of available process sets in which the calling MPI process is a member.
+
+An MPI implementation may increase the number of available process sets during execution when new process sets become available. MPI implementations are not allowed to change the index of a particular process set name, change the name of the process set at a particular index, or delete a process set name once it has been added. When a process set becomes invalid, for example due to process failures, subsequent usage of the process set name raises an error.
+//end::MPI_Session_get_num_psets[]
+
+//tag::MPI_Session_get_info[]
+**MPI_Session_get_info** returns a new info object containing the hints of the MPI Session associated with `session`. The current setting of all hints related to the MPI Session is returned in `info_used`. An MPI implementation is required to return all hints that are supported by the implementation and have default values specified, any user-supplied hints that were not ignored by the implementation, and any additional hints that were set by the implementation. If no such hints exist, a handle to a newly created info object is returned that contains no key/value pair. The user is responsible for freeing `info_used` via MPI_INFO_FREE.
+//end::MPI_Session_get_info[]
+
+//tag::MPI_Abort[]
+**MPI_Abort** makes a best attempt to abort all MPI processes in the group of `comm`. It may not be possible for an MPI implementation to abort only a subset of processes; in this case, the implementation attempts to abort all connected processes but not unconnected processes. When using the World Process Model with no spawned, accepted, or connected processes, this aborts all processes associated with `MPI_COMM_WORLD`. In the Sessions Process Model, if an MPI process has instantiated multiple sessions, the union of the process sets in those sessions are considered connected processes. Invoking MPI_Abort on a communicator derived from one session aborts all MPI processes in this union.
+
+Whether `errorcode` is returned from the executable or from the MPI process startup mechanism is an aspect of quality of the MPI library and is not mandatory.
+//end::MPI_Abort[]
+
+//tag::MPI_Comm_spawn[]
+**MPI_Comm_spawn** starts MPI processes and establishes communication with them, returning an inter-communicator.
+
+This function is collective over `comm` and may not return until MPI_INIT has been called in the children. MPI_INIT in the children may not return until all parents have called MPI_Comm_spawn, forming a collective operation over the union of parent and child processes. The spawned children have their own `MPI_COMM_WORLD`, which is separate from that of the parents. The returned inter-communicator contains parent processes in the local group and child processes in the remote group. If MPI is unable to spawn `maxprocs` processes, it raises an error of class `MPI_ERR_SPAWN`. An implementation may allow the `info` argument with the `soft` key to spawn a smaller number of processes instead of raising an error; the number of spawned processes is given by the size of the remote group of `intercomm`. Processes spawned at the same time using MPI_COMM_SPAWN_MULTIPLE are placed in the same `MPI_COMM_WORLD`. The constant `MPI_ERRCODES_IGNORE` may be passed in `array_of_errcodes` if error codes are not needed. Starting an application by spawning processes via MPI_Comm_spawn after initialization is discouraged for performance reasons; starting all processes at once as a single MPI application is recommended when possible.
+//end::MPI_Comm_spawn[]
+
+//tag::MPI_Comm_get_parent[]
+**MPI_Comm_get_parent** returns the parent inter-communicator of the current process if it was started with MPI_COMM_SPAWN or MPI_COMM_SPAWN_MULTIPLE. This parent inter-communicator is created implicitly inside of MPI_INIT and is the same inter-communicator returned by the spawn call in the parents. If the process was not spawned, `MPI_COMM_NULL` is returned. After the parent communicator is freed or disconnected, `MPI_COMM_NULL` is returned. Calling MPI_Comm_get_parent a second time returns a handle to the same inter-communicator; freeing the handle with MPI_COMM_DISCONNECT or MPI_COMM_FREE causes other references to the inter-communicator to become invalid.
+//end::MPI_Comm_get_parent[]
+
+//tag::MPI_Comm_spawn_multiple[]
+**MPI_Comm_spawn_multiple** starts multiple MPI executables or the same executable with multiple argument sets and establishes communication with them, returning an inter-communicator.
+
+This function is collective over `comm` and may not return until MPI_INIT has been called in the children. MPI_INIT in the children may not return until all parents have called MPI_Comm_spawn_multiple, forming a collective operation over the union of parent and child processes. All spawned processes share the same `MPI_COMM_WORLD`, with ranks assigned consecutively according to the order of commands in `array_of_commands`. The returned inter-communicator contains parent processes in the local group and child processes in the remote group. If MPI is unable to spawn the requested processes, it raises an error of class `MPI_ERR_SPAWN`. An implementation may allow the `info` argument with the `soft` key to spawn a smaller number of processes instead of raising an error.
+
+Using MPI_Comm_spawn_multiple instead of calling MPI_COMM_SPAWN multiple times is recommended because it creates children with a single `MPI_COMM_WORLD`, may be faster than spawning sequentially, and may enable faster communication between processes spawned together. The constant `MPI_ERRCODES_IGNORE` may be passed in `array_of_errcodes` if error codes are not needed, and `MPI_ARGVS_NULL` may be used to specify no arguments for any commands.
+//end::MPI_Comm_spawn_multiple[]
+
+//tag::MPI_Open_port[]
+**MPI_Open_port** establishes a network address at which a server can accept connections from clients.
+
+This function creates a system-supplied `port_name` that is globally unique within the communication universe and can be used by any client to contact the server via MPI_COMM_CONNECT. The `info` argument may provide implementation-specific instructions on how to establish the address, or `MPI_INFO_NULL` may be used to obtain implementation defaults. A `port_name` may be reused after it is released by MPI_CLOSE_PORT. The maximum size of the `port_name` string is `MPI_MAX_PORT_NAME`, and applications must pass a buffer of sufficient size to hold this value.
+//end::MPI_Open_port[]
+
+//tag::MPI_Close_port[]
+**MPI_Close_port** releases the network address represented by `port_name`. A port name may be reused after it is released by this call and freed by the system.
+//end::MPI_Close_port[]
+
+//tag::MPI_Comm_accept[]
+**MPI_Comm_accept** establishes communication with a client and returns an inter-communicator.
+
+This function is collective over the calling communicator. The `port_name` must have been established through a call to MPI_OPEN_PORT. The returned `newcomm` is an inter-communicator with the client processes as the remote group. Arguments before the `root` argument are examined only on the process whose rank in `comm` equals `root`. The `info` argument may provide implementation-dependent directives that influence the behavior of the call.
+//end::MPI_Comm_accept[]
+
+//tag::MPI_Comm_connect[]
+**MPI_Comm_connect** establishes communication with a server and returns an inter-communicator.
+
+This function is collective over the calling communicator and returns an inter-communicator in which the remote group participated in an MPI_COMM_ACCEPT. The `port_name` must be the same as that returned by MPI_OPEN_PORT on the server. Arguments before the `root` argument are examined only on the process whose rank in `comm` equals `root`. If the named port does not exist or has been closed, an error of class `MPI_ERR_PORT` is raised. If the port exists but does not have a pending MPI_COMM_ACCEPT, the connection attempt will either time out after an implementation-defined time or succeed when the server calls MPI_COMM_ACCEPT; a time out raises an error of class `MPI_ERR_PORT`. MPI provides no guarantee of fairness in servicing connection attempts, meaning attempts are not necessarily satisfied in the order they were initiated.
+//end::MPI_Comm_connect[]
+
+//tag::MPI_Publish_name[]
+**MPI_Publish_name** publishes a (`port_name`, `service_name`) pair so that a client may retrieve a system-supplied port name using a well-known service name.
+
+The implementation defines the scope of a published service name, which determines the domain over which the name is unique and retrievable. The scope may depend on the `info` argument. MPI permits publishing more than one `service_name` for a single `port_name`. If `service_name` has already been published within the scope determined by `info`, the behavior is undefined. The `port_name` argument is expected to be from MPI_OPEN_PORT and not yet released by MPI_CLOSE_PORT.
+//end::MPI_Publish_name[]
+
+//tag::MPI_Unpublish_name[]
+**MPI_Unpublish_name** unpublishes a service name that was previously published with MPI_PUBLISH_NAME.
+
+Attempting to unpublish a name that has not been published or has already been unpublished is erroneous and raises an error of class `MPI_ERR_SERVICE`. All published names must be unpublished before the corresponding port is closed and before the publishing process exits. The behavior is implementation-dependent when a process attempts to unpublish a name that it did not publish. If the `info` argument was used with MPI_PUBLISH_NAME to specify how to publish names, the implementation may require that `info` passed to MPI_UNPUBLISH_NAME contain information to specify how to unpublish the name.
+//end::MPI_Unpublish_name[]
+
+
+
+//tag::MPI_Comm_disconnect[]
+**MPI_Comm_disconnect** waits for all decoupled MPI activities on a communicator to complete internally, deallocates the communicator object, and sets the handle to `MPI_COMM_NULL`.
+
+This function is collective and may not be called with `MPI_COMM_WORLD` or `MPI_COMM_SELF`. All communication must be complete and matched before calling this function, which is the same requirement as for MPI_FINALIZE. Before calling this function, all request handles associated with `comm` must be freed for nonblocking operations, and must be inactive or freed for persistent or partitioned operations. After calling this function, freeing or starting an inactive persistent request handle for a communication operation on `comm` is erroneous. To fully disconnect two processes, MPI_COMM_DISCONNECT, MPI_WIN_FREE, and MPI_FILE_CLOSE may need to be called to remove all communication paths between them.
+//end::MPI_Comm_disconnect[]
+
+//tag::MPI_Comm_join[]
+**MPI_Comm_join** creates an inter-communicator from the union of two MPI processes that are connected by a socket.
+
+This function is intended for MPI implementations in environments supporting the Berkeley Socket interface; implementations in other environments provide the entry point but return `MPI_COMM_NULL`. The `fd` argument must be a file descriptor representing a connected socket of type `SOCK_STREAM` with nonblocking I/O and asynchronous notification via `SIGIO` disabled. The socket must be quiescent when this function is called and remains open and quiescent upon return. This function does not return until both processes have called it. In a multithreaded application, the application must ensure that one thread does not access the socket while another is calling this function, and must not call this function concurrently from multiple threads. Calling this function on two connected MPI processes is undefined because it uses non-MPI communication. An MPI implementation may require a specific communication medium for MPI communication, in which case two processes may not successfully join even with a socket connecting them and using the same MPI implementation.
+//end::MPI_Comm_join[]
+
+//tag::MPI_Get_version[]
+**MPI_Get_version** returns the version and subversion of the MPI standard to which the implementation conforms.
+
+This function may be called at any time in an MPI program. This function is thread-safe.
+//end::MPI_Get_version[]
+
+//tag::MPI_Get_processor_name[]
+**MPI_Get_processor_name** returns the name of the processor on which it was called at the moment of the call. The name is a character string that identifies a specific piece of hardware. The `name` argument must represent storage that is at least `MPI_MAX_PROCESSOR_NAME` characters long. The number of characters written is returned in `resultlen`. MPI implementations that support process migration may return the current processor at the time of the call.
+
+Users must provide at least `MPI_MAX_PROCESSOR_NAME` space for the `name` argument and may examine `resultlen` to determine the actual length.
+//end::MPI_Get_processor_name[]
+
+//tag::MPI_Comm_set_errhandler[]
+**MPI_Comm_set_errhandler** attaches a new error handler to a communicator. This operation is local. The `errhandler` must be either a predefined error handler or an error handler created by a call to MPI_COMM_CREATE_ERRHANDLER.
+
+A newly created communicator inherits the error handler associated with the parent communicator. In the World Process Model, users may specify an error handler for all communicators by associating this handler with the predefined communicators `MPI_COMM_WORLD` and `MPI_COMM_SELF` before creating other communicators.
+//end::MPI_Comm_set_errhandler[]
+
+//tag::MPI_Win_create_errhandler[]
+**MPI_Win_create_errhandler** creates an error handler that can be attached to window objects. The user routine `win_errhandler_fn` defines the error handling procedure to be invoked when errors occur on the associated window. The created error handler is returned in `errhandler`. The attachment of error handlers to objects is local.
+//end::MPI_Win_create_errhandler[]
+
+//tag::MPI_Win_set_errhandler[]
+**MPI_Win_set_errhandler** attaches a new error handler to a window. This operation is local. The `errhandler` must be either a predefined error handler or an error handler created by a call to MPI_WIN_CREATE_ERRHANDLER. The error handler `MPI_ERRORS_ARE_FATAL` is always associated with a window when it is created.
+//end::MPI_Win_set_errhandler[]
+
+//tag::MPI_Win_get_errhandler[]
+**MPI_Win_get_errhandler** retrieves the error handler currently associated with a window.
+
+This operation is local and behaves as if a new error handler object is created. Once the error handler is no longer needed, MPI_ERRHANDLER_FREE is recommended to be called with the returned `errhandler` to mark it for deallocation.
+//end::MPI_Win_get_errhandler[]
+
+//tag::MPI_File_create_errhandler[]
+**MPI_File_create_errhandler** creates an error handler that can be attached to file objects. This operation is local. The user routine `file_errhandler_fn` defines the error handling procedure to be invoked when errors occur on the associated file. The created error handler is returned in `errhandler`. The error handler must be attached to a file using MPI_FILE_SET_ERRHANDLER before it will be invoked. The default error handler for files is `MPI_ERRORS_RETURN`.
+//end::MPI_File_create_errhandler[]
+
+//tag::MPI_File_set_errhandler[]
+**MPI_File_set_errhandler** attaches a new error handler to a file. This operation is local. The `errhandler` must be either a predefined error handler or an error handler created by a call to MPI_FILE_CREATE_ERRHANDLER. Files do not inherit from the initial error handler. The default error handler for files is `MPI_ERRORS_RETURN`.
+//end::MPI_File_set_errhandler[]
+
+//tag::MPI_File_get_errhandler[]
+**MPI_File_get_errhandler** retrieves the error handler currently associated with a file.
+
+This operation is local and behaves as if a new error handler object is created. Once the error handler is no longer needed, MPI_ERRHANDLER_FREE is recommended to be called with the returned `errhandler` to mark it for deallocation.
+//end::MPI_File_get_errhandler[]
+
+//tag::MPI_Session_create_errhandler[]
+**MPI_Session_create_errhandler** creates an error handler that can be attached to a session object.
+
+This operation is local. The user routine `session_errhandler_fn` defines the error handling procedure to be invoked when errors occur on the associated session. The created error handler is returned in `errhandler`. The error handler must be attached to a session using MPI_SESSION_SET_ERRHANDLER or provided via the `errorhandler` argument to MPI_SESSION_INIT before it will be invoked.
+//end::MPI_Session_create_errhandler[]
+
+//tag::MPI_Session_set_errhandler[]
+**MPI_Session_set_errhandler** attaches a new error handler to a session. The error handler must be either a predefined error handler or an error handler created by a call to MPI_SESSION_CREATE_ERRHANDLER. This operation is local and different processes may attach different error handlers to corresponding objects.
+//end::MPI_Session_set_errhandler[]
+
+//tag::MPI_Session_get_errhandler[]
+**MPI_Session_get_errhandler** retrieves the error handler currently associated with a session.
+
+This operation is local and behaves as if a new error handler object is created. Once the error handler is no longer needed, MPI_ERRHANDLER_FREE is recommended to be called with the returned `errhandler` to mark it for deallocation.
+//end::MPI_Session_get_errhandler[]
+
+//tag::MPI_Errhandler_free[]
+**MPI_Errhandler_free** marks the error handler associated with `errhandler` for deallocation. The error handler will be deallocated after all objects associated with it (communicator, window, or file) have been deallocated.
+
+Upon return, `errhandler` is set to `MPI_ERRHANDLER_NULL`.
+//end::MPI_Errhandler_free[]
+
+//tag::MPI_Error_class[]
+**MPI_Error_class** converts an error code into one of a small set of standard error codes called error classes. The function maps each standard error code onto itself.
+
+This function must always be thread-safe. It may be called before MPI is initialized or after MPI is finalized.
+//end::MPI_Error_class[]
+
+//tag::MPI_Error_string[]
+**MPI_Error_string** returns the error string associated with an error code or class. This function must always be thread-safe. It may be called before MPI is initialized or after MPI is finalized.
+//end::MPI_Error_string[]
+
+//tag::MPI_Remove_error_string[]
+**MPI_Remove_error_string** removes a user-defined association of an error string with an error code or class.
+
+This operation is local and thread-safe. This function may be called before MPI is initialized or after MPI is finalized. It is erroneous to call this function with a value for `errorcode` that does not have an error string added by a call to MPI_ADD_ERROR_STRING. Despite being thread-safe, concurrent calls that add and remove the same error string may result in undefined behavior; calls adding an error string are required to precede calls removing that error string even across different threads.
+//end::MPI_Remove_error_string[]
+
+//tag::MPI_Win_call_errhandler[]
+**MPI_Win_call_errhandler** invokes the error handler assigned to a window with a user-supplied error code.
+
+This function allows users to explicitly call an error handler associated with a window. The error handler `MPI_ERRORS_ARE_FATAL` is always associated with a window when it is created. Error handlers are not recommended to be called recursively as this may create an infinite recursion situation.
+//end::MPI_Win_call_errhandler[]
+
+//tag::MPI_Wtime[]
+**MPI_Wtime** returns a floating-point number of seconds representing elapsed wall-clock time since some time in the past. The reference time is guaranteed not to change during the life of the process. This function is portable and allows high-resolution timing. The times returned are local to the node that called them. There is no requirement that different nodes return the same time; the `MPI_WTIME_IS_GLOBAL` attribute indicates whether clocks are synchronized.
+//end::MPI_Wtime[]
+
+//tag::MPI_Wtick[]
+**MPI_Wtick** returns the resolution of MPI_WTIME in seconds. The function returns a double-precision value representing the number of seconds between successive clock ticks.
+//end::MPI_Wtick[]
+
+//tag::MPIX_Async_start[]
+*MPIX_Async_start* registers a user-defined poll function with the MPI progress engine for asynchronous progression.
+The registered `poll_fn` is invoked during MPI progress calls.
+If `stream` is provided, the poll function is associated with that stream's VCI; otherwise it uses a default progress context.
+This function is local and does not involve communication with other processes.
+
+The `poll_fn` callback must return `MPIX_ASYNC_DONE` to signal completion and be removed, or `MPIX_ASYNC_NOPROGRESS` to continue being polled.
+The function uses internal mutex locking to ensure thread-safe registration across concurrent callers.
+//end::MPIX_Async_start[]
+
+//tag::MPIX_Async_get_state[]
+*MPIX_Async_get_state* retrieves the user-defined state pointer associated with an asynchronous progress entry.
+This function is intended to be called from within a poll function callback to access the `extra_state` that was registered via `MPIX_Async_start` or `MPIX_Async_spawn`.
+The function is local and does not involve communication with other processes.
+//end::MPIX_Async_get_state[]
+
+//tag::MPIX_Async_spawn[]
+*MPIX_Async_spawn* creates a new asynchronous progress entry from within an existing poll function callback.
+The spawned entry is queued for future polling rather than being immediately added to the active progress list.
+This function is local and does not involve communication with other processes.
+
+The spawned `poll_fn` must return `MPIX_ASYNC_DONE` when complete or `MPIX_ASYNC_NOPROGRESS` to continue being polled.
+Spawned entries inherit thread-safe handling through the parent entry's progress context.
+//end::MPIX_Async_spawn[]
+
+//tag::MPIX_Op_create_x[]
+*MPIX_Op_create_x* creates a user-defined reduction operation with extended callback support.
+The user function receives `len` and `datatype` as scalar values and an `extra_state` pointer passed through from creation.
+An optional `destructor_fn` is invoked when the operation is freed to release the `extra_state`.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Op_create_x[]
+
+//tag::MPIX_Comm_create_errhandler_x[]
+*MPIX_Comm_create_errhandler_x* creates a user-defined communicator error handler with extended callback support.
+The user-supplied error handler function receives an `extra_state` pointer passed through from creation.
+An optional `destructor_fn` is invoked when the error handler is freed to release the `extra_state`.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Comm_create_errhandler_x[]
+
+//tag::MPIX_Win_create_errhandler_x[]
+*MPIX_Win_create_errhandler_x* creates a user-defined window error handler with extended callback support.
+The user-supplied error handler function receives an `extra_state` pointer passed through from creation.
+An optional `destructor_fn` is invoked when the error handler is freed to release the `extra_state`.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Win_create_errhandler_x[]
+
+//tag::MPIX_File_create_errhandler_x[]
+*MPIX_File_create_errhandler_x* creates a user-defined file error handler with extended callback support.
+The user-supplied error handler function receives an `extra_state` pointer passed through from creation.
+An optional `destructor_fn` is invoked when the error handler is freed to release the `extra_state`.
+This function is local and does not involve communication with other processes.
+//end::MPIX_File_create_errhandler_x[]
+
+//tag::MPIX_Session_create_errhandler_x[]
+*MPIX_Session_create_errhandler_x* creates a user-defined session error handler with extended callback support.
+The user-supplied error handler function receives an `extra_state` pointer passed through from creation.
+An optional `destructor_fn` is invoked when the error handler is freed to release the `extra_state`.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Session_create_errhandler_x[]
+
+//tag::MPIX_Comm_create_keyval_x[]
+*MPIX_Comm_create_keyval_x* creates an attribute key for communicators with extended callback support.
+The `comm_copy_attr_fn` callback is invoked when an attribute is copied via communicator duplication.
+The `comm_delete_attr_fn` callback is invoked when an attribute is deleted from a communicator.
+An optional `destructor_fn` is invoked with `extra_state` when the keyval is freed and its reference count reaches zero.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Comm_create_keyval_x[]
+
+//tag::MPIX_Type_create_keyval_x[]
+*MPIX_Type_create_keyval_x* creates an attribute key for MPI datatypes with extended callback support.
+The `type_copy_attr_fn` callback is invoked when an attribute is copied via datatype duplication.
+The `type_delete_attr_fn` callback is invoked when an attribute is deleted from a datatype.
+An optional `destructor_fn` is invoked with `extra_state` when the keyval is freed and its reference count reaches zero.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Type_create_keyval_x[]
+
+//tag::MPIX_Win_create_keyval_x[]
+*MPIX_Win_create_keyval_x* creates an attribute key for MPI windows with extended callback support.
+The `win_copy_attr_fn` callback is invoked when an attribute is copied via window duplication.
+The `win_delete_attr_fn` callback is invoked when an attribute is deleted from a window.
+An optional `destructor_fn` is invoked with `extra_state` when the keyval is freed and its reference count reaches zero.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Win_create_keyval_x[]
+
+//tag::MPIX_Comm_get_attr_as_fortran[]
+*MPIX_Comm_get_attr_as_fortran* retrieves a communicator attribute value using Fortran-style semantics.
+For built-in attributes, the value is returned as a scalar integer cast to a pointer rather than a pointer to the value.
+For user-defined attributes, if the attribute was set via a Fortran binding, the stored integer value is returned directly.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Comm_get_attr_as_fortran[]
+
+//tag::MPIX_Comm_set_attr_as_fortran[]
+*MPIX_Comm_set_attr_as_fortran* attaches an attribute to a communicator using Fortran-style semantics.
+The attribute value is stored as a scalar integer cast to a pointer, enabling interoperability with Fortran bindings.
+If an attribute with the same key exists, the associated delete callback is invoked before replacement.
+A new attribute is allocated and added to the front of the communicator's attribute list when no matching key is found.
+This function is local and does not involve communication with other processes.
+
+When threadcomm is enabled, attributes are stored in thread-local storage associated with the communicator.
+//end::MPIX_Comm_set_attr_as_fortran[]
+
+//tag::MPIX_Type_get_attr_as_fortran[]
+*MPIX_Type_get_attr_as_fortran* retrieves a datatype attribute value using Fortran-style semantics.
+For user-defined attributes, if the attribute was set via a Fortran binding, the stored integer value is returned directly.
+If the attribute was set via a C binding, a pointer to the internal storage is returned instead.
+The `flag` output indicates whether an attribute is associated with the specified key.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Type_get_attr_as_fortran[]
+
+//tag::MPIX_Type_set_attr_as_fortran[]
+*MPIX_Type_set_attr_as_fortran* attaches an attribute to a datatype using Fortran-style semantics.
+The attribute value is stored as a scalar integer cast to a pointer, enabling interoperability with Fortran bindings.
+If an attribute with the same key exists, the associated delete callback is invoked before replacement.
+A new attribute is allocated and inserted into the datatype's attribute list when no matching key is found.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Type_set_attr_as_fortran[]
+
+//tag::MPIX_Win_get_attr_as_fortran[]
+*MPIX_Win_get_attr_as_fortran* retrieves a window attribute value using Fortran-style semantics.
+For built-in attributes such as `MPI_WIN_SIZE`, `MPI_WIN_DISP_UNIT`, `MPI_WIN_CREATE_FLAVOR`, and `MPI_WIN_MODEL`, the value is returned as a scalar integer cast to a pointer rather than a pointer to the value.
+For user-defined attributes, if the attribute was set via a Fortran binding, the stored integer value is returned directly.
+The `flag` output indicates whether an attribute is associated with the specified key.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Win_get_attr_as_fortran[]
+
+//tag::MPIX_Win_set_attr_as_fortran[]
+*MPIX_Win_set_attr_as_fortran* attaches an attribute to a window using Fortran-style semantics.
+The attribute value is stored as a scalar integer cast to a pointer, enabling interoperability with Fortran bindings.
+If an attribute with the same key exists, the associated delete callback is invoked before replacement.
+A new attribute is allocated and inserted into the window's attribute list when no matching key is found.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Win_set_attr_as_fortran[]
+
+//tag::MPIX_Comm_test_threadcomm[]
+*MPIX_Comm_test_threadcomm* tests whether a communicator is a threadcomm.
+The `flag` output is set to true if `comm` was created via `MPIX_Threadcomm_init` and has an associated threadcomm structure.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Comm_test_threadcomm[]
+
+//tag::MPIX_Comm_revoke[]
+*MPIX_Comm_revoke* prevents a communicator from being used for future non-local MPI operations.
+This function notifies all MPI processes in the local and remote groups associated with `comm` that the communicator is revoked.
+The revocation completes non-local MPI operations on `comm` at all processes by raising an error of class `MPI_ERR_REVOKED`, with the exception of `MPIX_Comm_shrink` and `MPIX_Comm_agree`.
+This function is not collective and does not require a matching call on remote processes.
+All non-failed processes belonging to `comm` will be notified of the revocation despite failures.
+
+Once revoked at a process, all subsequent non-local operations on `comm` complete locally by raising `MPI_ERR_REVOKED`.
+//end::MPIX_Comm_revoke[]
+
+//tag::MPIX_Comm_shrink[]
+*MPIX_Comm_shrink* creates a new communicator by excluding failed MPI processes from an existing communicator.
+This collective operation agrees upon the set of failed processes during execution and creates either an intra- or intercommunicator accordingly.
+The resulting communicator includes every process that returns from the operation and excludes every process whose failure caused `MPI_ERR_PROC_FAILED` or `MPI_ERR_PROC_FAILED_PENDING` errors before initiation.
+The operation is semantically equivalent to `MPI_Comm_split` where participating processes use the same color and their rank in `comm` as the key.
+The implementation uses internal allreduce operations to achieve consensus on failures and may retry multiple times if new failures occur.
+
+This function never raises `MPI_ERR_PROC_FAILED` or `MPI_ERR_REVOKED` errors and maintains defined semantics when `comm` is revoked or contains failed processes.
+This operation is collective and nonlocal; all non-failed processes must participate for successful completion.
+//end::MPIX_Comm_shrink[]
+
+//tag::MPIX_Comm_failure_ack[]
+*MPIX_Comm_failure_ack* acknowledges all locally notified process failures on a communicator.
+This local operation enables `MPI_ANY_SOURCE` receive operations to proceed without raising `MPI_ERR_PROC_FAILED_PENDING` for acknowledged failures.
+After acknowledgment, subsequent calls to `MPIX_Comm_agree` will not raise `MPI_ERR_PROC_FAILED` for the acknowledged processes.
+The function updates the internal marker tracking the last known failed process and re-enables any-source matching on `comm`.
+//end::MPIX_Comm_failure_ack[]
+
+//tag::MPIX_Comm_failure_get_acked[]
+*MPIX_Comm_failure_get_acked* retrieves the group of failed processes that have been locally acknowledged on a communicator.
+This local operation returns in `failedgrp` the processes from `comm` that were acknowledged by preceding calls to `MPIX_Comm_failure_ack`.
+The returned group may be `MPI_GROUP_EMPTY` if no failures have been acknowledged.
+This function is used in conjunction with `MPIX_Comm_agree` to determine which failures are already known before performing agreement operations.
+//end::MPIX_Comm_failure_get_acked[]
+
+//tag::MPIX_Comm_agree[]
+*MPIX_Comm_agree* performs a fault-tolerant collective agreement operation over all non-failed processes in a communicator.
+On completion, all participating processes set `flag` to the bitwise AND of all contributed input values.
+For intercommunicators, the result is computed over values from the remote group.
+When a process fails before contributing, its value is excluded from the computation.
+The operation internally gathers the globally known failed processes and performs consensus using allreduce.
+This operation continues to function on revoked communicators where most other collective operations would fail.
+
+The function raises `MPI_ERR_PROC_FAILED` consistently at all processes when unacknowledged failures are detected; prior acknowledgment via `MPIX_Comm_failure_ack` suppresses this error.
+This operation is collective and nonlocal; all non-failed processes must participate for successful completion.
+//end::MPIX_Comm_agree[]
+
+//tag::MPIX_Comm_get_failed[]
+*MPIX_Comm_get_failed* returns the group of processes locally known to have failed on a communicator.
+This local operation queries PMI for dead processes and returns their intersection with `comm` in `failedgrp`.
+The returned group may be `MPI_GROUP_EMPTY` if no failures are locally known.
+Failed processes maintain consistent ordering across calls; for any two groups obtained from this function at the same process with the same `comm`, the smaller group is a prefix of the larger group.
+//end::MPIX_Comm_get_failed[]
+
+//tag::MPIX_Type_iov_len[]
+*MPIX_Type_iov_len* computes the number of contiguous memory segments needed to represent an MPI datatype within a specified byte limit.
+This function queries the datatype's internal representation to determine how many I/O vector entries fit within `max_iov_bytes`.
+The actual byte coverage is returned separately to indicate the precise portion of the datatype covered.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Type_iov_len[]
+
+//tag::MPIX_Type_iov[]
+*MPIX_Type_iov* returns contiguous memory segments representing the layout of an MPI datatype as an array of I/O vectors.
+The function populates the `iov` array with base addresses and lengths for each contiguous region in the datatype.
+Callers can skip an initial number of segments using `iov_offset` to retrieve segments incrementally.
+The actual number of segments written is returned in `actual_iov_len`.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Type_iov[]
+
+//tag::MPIX_Info_set_hex[]
+*MPIX_Info_set_hex* stores arbitrary binary data in an MPI info object by encoding the value as a hexadecimal string.
+The binary data referenced by `value` is converted to a hex representation and associated with the specified `key`.
+If the key already exists, its value is replaced with the new encoded data.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Info_set_hex[]
+
+//tag::MPIX_GPU_query_support[]
+*MPIX_GPU_query_support* queries whether the MPI implementation supports a specific GPU type.
+The function checks the runtime GPU configuration and sets `is_supported` to indicate availability.
+Supported GPU types include CUDA, Intel Level Zero (ZE), and AMD HIP.
+This function is local and does not involve communication with other processes.
+
+An invalid `gpu_type` argument causes an error.
+//end::MPIX_GPU_query_support[]
+
+//tag::MPIX_Query_cuda_support[]
+*MPIX_Query_cuda_support* queries whether the MPI implementation supports CUDA GPU operations.
+The function returns a non-zero value if CUDA support is available and zero otherwise.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Query_cuda_support[]
+
+//tag::MPIX_Query_ze_support[]
+*MPIX_Query_ze_support* queries whether the MPI implementation supports Intel Level Zero (ZE) GPU operations.
+The function returns a non-zero value if ZE support is available and zero otherwise.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Query_ze_support[]
+
+//tag::MPIX_Query_hip_support[]
+*MPIX_Query_hip_support* queries whether the MPI implementation supports AMD HIP GPU operations.
+The function returns a non-zero value if HIP support is available and zero otherwise.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Query_hip_support[]
+
+//tag::MPIX_Grequest_start[]
+*MPIX_Grequest_start* creates a user-defined extended generalized request with additional callback support for polling and waiting.
+This function extends the standard `MPI_Grequest_start` by accepting `poll_fn` and `wait_fn` callbacks that are invoked during test and wait operations respectively.
+The `poll_fn` callback is called when request completion is tested, allowing user-defined progress.
+The `wait_fn` callback is called when the request is waited on, enabling custom blocking behavior.
+This function is local and does not involve communication with other processes.
+
+This routine is not thread-safe when using fine-grained threading.
+//end::MPIX_Grequest_start[]
+
+//tag::MPIX_Grequest_class_create[]
+*MPIX_Grequest_class_create* creates a reusable generalized request class by registering callback functions for query, free, cancel, poll, and wait operations.
+The class handle returned in `greq_class` can be passed to `MPIX_Grequest_class_allocate` to create multiple request instances that share the same callbacks.
+Internally, the function allocates a class object and maintains a linked list of all created classes for cleanup at MPI finalization.
+This function is local and does not involve communication with other processes.
+
+This routine is not thread-safe when using fine-grained threading.
+//end::MPIX_Grequest_class_create[]
+
+//tag::MPIX_Grequest_class_allocate[]
+*MPIX_Grequest_class_allocate* creates a generalized request instance from a previously created generalized request class.
+The returned request inherits the query, free, cancel, poll, and wait callbacks registered with `greq_class`.
+The `extra_state` pointer is passed to these callbacks when they are invoked.
+This function is local and does not involve communication with other processes.
+
+This routine is not thread-safe when using fine-grained threading.
+//end::MPIX_Grequest_class_allocate[]
+
+//tag::MPIX_Request_is_complete[]
+*MPIX_Request_is_complete* tests whether the communication associated with `request` has completed.
+This function returns true if the request has finished or if `request` is `MPI_REQUEST_NULL`.
+This function is local and does not involve communication with other processes.
+
+The completion check uses atomic operations for thread-safe access to the request's internal completion counter.
+//end::MPIX_Request_is_complete[]
+
+//tag::MPIX_Stream_create[]
+*MPIX_Stream_create* creates a stream object for associating communication with a dedicated virtual communication interface (VCI).
+The `info` argument specifies the stream type; for GPU streams, the `type` and `value` keys must be set with the GPU stream handle.
+This function is local and does not involve communication with other processes.
+The created stream can be attached to a communicator via `MPIX_Stream_comm_create` or `MPIX_Stream_comm_create_multiplex`.
+
+Each general stream receives a unique VCI, while GPU streams share a single VCI for thread-safe progress.
+//end::MPIX_Stream_create[]
+
+//tag::MPIX_Stream_free[]
+*MPIX_Stream_free* releases a stream object and deallocates its associated resources.
+The function decrements the stream's reference count and frees the object only when no references remain.
+If the stream is still in use by a communicator, general streams raise an error while GPU streams allow deferred cleanup.
+This function is local and does not involve communication with other processes.
+
+The function sets `stream` to `MPIX_STREAM_NULL` upon successful completion.
+//end::MPIX_Stream_free[]
+
+//tag::MPIX_Stream_comm_create[]
+*MPIX_Stream_comm_create* creates a new communicator with a stream attached for concurrent communication progress.
+The function duplicates `comm` and associates the local `stream` with the resulting `newcomm`.
+A VCI table is constructed via an internal allgather to track each process's stream VCI.
+If `stream` is `MPIX_STREAM_NULL`, the default VCI of zero is used for that process.
+The new communicator inherits attributes from `comm` and holds a reference to `stream`.
+Subsequent point-to-point operations on `newcomm` use stream-indexed VCIs for thread-safe message matching.
+
+This operation is collective and nonlocal; all processes in `comm` must participate.
+//end::MPIX_Stream_comm_create[]
+
+//tag::MPIX_Stream_comm_create_multiplex[]
+*MPIX_Stream_comm_create_multiplex* creates a new communicator with multiple streams attached for concurrent communication progress.
+The function duplicates `comm` and associates the local `array_of_streams` with the resulting `newcomm`.
+If `count` is zero, the function uses `MPIX_STREAM_NULL` as a single default stream.
+A displacement table is constructed via internal allgather operations to track each process's stream count and VCIs.
+The new communicator is marked as a multiplex stream communicator, enabling stream-indexed point-to-point operations.
+Each attached stream receives an incremented reference count.
+Subsequent operations on `newcomm` use stream indices to select VCIs for thread-safe message matching.
+
+This operation is collective and nonlocal; all processes in `comm` must participate.
+//end::MPIX_Stream_comm_create_multiplex[]
+
+//tag::MPIX_Stream_progress[]
+*MPIX_Stream_progress* invokes progress on the specified stream to advance pending communication operations.
+When `stream` is `MPIX_STREAM_NULL`, general progress is made across all VCIs.
+For GPU streams, the function progresses enqueued work queue operations and completes pending wait list items.
+The function tests progress on the VCI associated with the stream.
+This function is local and does not involve communication with other processes.
+
+In lockless threading mode, network progress proceeds without VCI locking.
+//end::MPIX_Stream_progress[]
+
+//tag::MPIX_Comm_get_stream[]
+*MPIX_Comm_get_stream* retrieves the stream object attached to a communicator at a specified index.
+For single-stream communicators, only `idx` zero returns a valid stream.
+For multiplex-stream communicators, `idx` selects among the local streams attached during communicator creation.
+If `idx` is out of range or the communicator has no attached streams, `stream` is set to `MPIX_STREAM_NULL`.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Comm_get_stream[]
+
+//tag::MPIX_Start_progress_thread[]
+*MPIX_Start_progress_thread* starts a dedicated progress thread that polls for communication progress on the specified stream.
+The progress thread runs asynchronously and invokes stream progress until stopped via `MPIX_Stop_progress_thread`.
+If `stream` is `MPIX_STREAM_NULL`, general progress is made across all VCIs.
+This function is local and does not involve communication with other processes.
+
+The progress thread uses internal mutex locking to coordinate with concurrent MPI operations.
+Thread affinity can be configured via the `MPIR_CVAR_PROGRESS_THREAD_AFFINITY` environment variable.
+//end::MPIX_Start_progress_thread[]
+
+//tag::MPIX_Stop_progress_thread[]
+*MPIX_Stop_progress_thread* stops a dedicated progress thread that was started via `MPIX_Start_progress_thread` on the specified stream.
+The function signals the progress thread to exit and blocks until the thread terminates.
+If no progress thread is running on the specified `stream`, the function returns immediately.
+This function is local and does not involve communication with other processes.
+
+The function uses atomic operations to coordinate thread termination.
+//end::MPIX_Stop_progress_thread[]
+
+//tag::MPIX_Stream_isend[]
+*MPIX_Stream_isend* initiates a nonblocking send from a specific local stream to a specific destination stream.
+The function requires a multiplex stream communicator created via `MPIX_Stream_comm_create_multiplex`.
+Stream indices select the source and destination VCIs for thread-safe message matching.
+The function returns immediately after initiating the send and provides a `request` handle to track completion.
+This operation is nonlocal and requires a matching receive at the destination process.
+
+An error is raised if `comm` is not a multiplex stream communicator or if `source_stream_index` or `dest_stream_index` are out of range.
+Messages sent using the same streams and communicator are non-overtaking with respect to each other.
+//end::MPIX_Stream_isend[]
+
+//tag::MPIX_Stream_send[]
+*MPIX_Stream_send* performs a blocking point-to-point send from a specific local stream to a specific destination stream.
+The function requires a multiplex stream communicator created via `MPIX_Stream_comm_create_multiplex`.
+Stream indices select the source and destination VCIs for thread-safe message matching.
+The send completes locally only after the message has been buffered or received by the destination.
+This operation is nonlocal and requires a matching receive at the destination process.
+
+An error is raised if `comm` is not a multiplex stream communicator or if stream indices are out of range.
+//end::MPIX_Stream_send[]
+
+//tag::MPIX_Stream_recv[]
+*MPIX_Stream_recv* performs a blocking point-to-point receive from a specific source stream to a specific local stream.
+The function requires a multiplex stream communicator created via `MPIX_Stream_comm_create_multiplex`.
+Stream indices select the source and destination VCIs for thread-safe message matching.
+The receive blocks until a matching message arrives from the source process.
+This operation is nonlocal and requires a matching send from the source process.
+
+The `source` may be `MPI_ANY_SOURCE` and `tag` may be `MPI_ANY_TAG` to receive from any sender or with any tag.
+An error is raised if `comm` is not a multiplex stream communicator or if `source_stream_index` or `dest_stream_index` are out of range.
+Messages received using the same streams and communicator are non-overtaking with respect to each other.
+//end::MPIX_Stream_recv[]
+
+//tag::MPIX_Stream_irecv[]
+*MPIX_Stream_irecv* initiates a nonblocking receive from a specific source stream to a specific local stream.
+The function requires a multiplex stream communicator created via `MPIX_Stream_comm_create_multiplex`.
+Stream indices select the source and destination VCIs for thread-safe message matching.
+The function returns immediately after initiating the receive and provides a `request` handle to track completion.
+This operation is nonlocal and requires a matching send from the source process.
+
+The `source` may be `MPI_ANY_SOURCE` and `tag` may be `MPI_ANY_TAG` to receive from any sender or with any tag.
+An error is raised if `comm` is not a multiplex stream communicator or if `source_stream_index` or `dest_stream_index` are out of range.
+Messages received using the same streams and communicator are non-overtaking with respect to each other.
+//end::MPIX_Stream_irecv[]
+
+//tag::MPIX_Send_enqueue[]
+*MPIX_Send_enqueue* enqueues a blocking send operation to the GPU stream associated with `comm`.
+The operation is deferred until GPU execution reaches the enqueued work item, at which point the MPI send is initiated via a host callback.
+If the buffer resides in GPU memory, data is packed into a host buffer before sending.
+The communicator must have an attached GPU stream created via `MPIX_Stream_create`.
+This operation is nonlocal and requires a matching receive at the destination process.
+
+Progress on enqueued operations occurs via `MPIX_Stream_progress` or a dedicated progress thread started with `MPIX_Start_progress_thread`.
+Messages sent via the same stream and communicator are non-overtaking with respect to each other.
+//end::MPIX_Send_enqueue[]
+
+//tag::MPIX_Recv_enqueue[]
+*MPIX_Recv_enqueue* enqueues a blocking receive operation to the GPU stream associated with `comm`.
+The operation is deferred until GPU execution reaches the enqueued work item, at which point the MPI receive is initiated via a host callback.
+If the buffer resides in GPU memory, data is received into a host staging buffer and then unpacked to the device.
+The communicator must have an attached GPU stream created via `MPIX_Stream_create`.
+This operation is nonlocal and requires a matching send from the source process.
+Progress on enqueued operations occurs via `MPIX_Stream_progress` or a dedicated progress thread started with `MPIX_Start_progress_thread`.
+
+The `source` may be `MPI_ANY_SOURCE` and `tag` may be `MPI_ANY_TAG` to receive from any sender or with any tag.
+Messages received via the same stream and communicator are non-overtaking with respect to each other.
+//end::MPIX_Recv_enqueue[]
+
+//tag::MPIX_Isend_enqueue[]
+*MPIX_Isend_enqueue* enqueues a nonblocking send operation to the GPU stream associated with `comm`.
+The operation is deferred until GPU execution reaches the enqueued work item, at which point the MPI send is initiated via a host callback.
+If the buffer resides in GPU memory, data is packed into a host buffer before sending.
+The communicator must have an attached GPU stream created via `MPIX_Stream_create`.
+The function returns immediately after enqueuing and provides a `request` handle to track completion.
+This operation is nonlocal and requires a matching receive at the destination process.
+
+Progress on enqueued operations occurs via `MPIX_Stream_progress` or a dedicated progress thread started with `MPIX_Start_progress_thread`.
+Messages sent via the same stream and communicator are non-overtaking with respect to each other.
+//end::MPIX_Isend_enqueue[]
+
+//tag::MPIX_Irecv_enqueue[]
+*MPIX_Irecv_enqueue* enqueues a nonblocking receive operation to the GPU stream associated with `comm`.
+The operation is deferred until GPU execution reaches the enqueued work item, at which point the MPI receive is initiated via a host callback.
+If the buffer resides in GPU memory, data is received into a host staging buffer and then unpacked to the device.
+The communicator must have an attached GPU stream created via `MPIX_Stream_create`.
+The function returns immediately after enqueuing and provides a `request` handle to track completion.
+This operation is nonlocal and requires a matching send from the source process.
+
+The `source` may be `MPI_ANY_SOURCE` and `tag` may be `MPI_ANY_TAG` to receive from any sender or with any tag.
+Messages received via the same stream and communicator are non-overtaking with respect to each other.
+//end::MPIX_Irecv_enqueue[]
+
+//tag::MPIX_Wait_enqueue[]
+*MPIX_Wait_enqueue* enqueues a wait operation to the GPU stream associated with `request`.
+The operation is deferred until GPU execution reaches the enqueued work item, at which point the underlying MPI wait is performed via a host callback.
+For receive requests, data is unpacked from any host staging buffer to GPU memory after the wait completes.
+This function is local and does not involve communication with other processes.
+
+Progress on enqueued operations occurs via `MPIX_Stream_progress` or a dedicated progress thread.
+Operations enqueued to the same GPU stream complete in order.
+//end::MPIX_Wait_enqueue[]
+
+//tag::MPIX_Waitall_enqueue[]
+*MPIX_Waitall_enqueue* enqueues a wait-all operation to the GPU stream associated with the requests.
+All requests in `array_of_requests` must be enqueue requests created via enqueue operations on the same GPU stream.
+The operation is deferred until GPU execution reaches the enqueued work item, at which point the underlying MPI wait-all is performed via a host callback.
+For receive requests, data is unpacked from any host staging buffer to GPU memory after completion.
+The input requests are set to `MPI_REQUEST_NULL` as ownership transfers to the enqueued operation.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Waitall_enqueue[]
+
+//tag::MPIX_Allreduce_enqueue[]
+*MPIX_Allreduce_enqueue* enqueues an allreduce operation to the GPU stream associated with `comm`.
+The operation is deferred until GPU execution reaches the enqueued work item, at which point the MPI allreduce is initiated via a host callback.
+If `sendbuf` or `recvbuf` reside in GPU memory, data is staged through host buffers before and after the collective operation.
+The communicator must have an attached GPU stream created via `MPIX_Stream_create`.
+Non-contiguous datatypes require thread-local storage support; otherwise an error is raised.
+Progress on enqueued operations occurs via `MPIX_Stream_progress` or a dedicated progress thread started with `MPIX_Start_progress_thread`.
+
+This operation is collective and nonlocal; all processes in `comm` must participate.
+Operations enqueued to the same GPU stream complete in order.
+//end::MPIX_Allreduce_enqueue[]
+
+//tag::MPIX_Threadcomm_init[]
+*MPIX_Threadcomm_init* creates a persistent thread communicator from an existing communicator for use in multithreaded parallel regions.
+The function duplicates `comm` and attaches a threadcomm structure that maps multiple threads per process to unique ranks within the new communicator.
+Thread counts from all processes are gathered via an internal collective operation to construct a global rank offset table.
+The function allocates thread-local storage structures, atomic barrier counters, and transport-specific message queues or mailboxes for inter-thread communication.
+If initialized without `MPI_THREAD_MULTIPLE`, the function records this state and adjusts threading settings during subsequent `MPIX_Threadcomm_start` calls.
+The resulting communicator must be activated inside a thread parallel region via `MPIX_Threadcomm_start` before use.
+
+This operation is collective and nonlocal; all processes in `comm` must participate.
+Threads within the same process communicate via lock-free queues; threads across processes use standard MPI point-to-point with encoded thread identifiers.
+//end::MPIX_Threadcomm_init[]
+
+//tag::MPIX_Threadcomm_free[]
+*MPIX_Threadcomm_free* deallocates a persistent thread communicator and releases all associated resources.
+This function must be called outside of thread parallel regions after all threads have finished using the communicator via `MPIX_Threadcomm_finish`.
+For derived threadcomms created via duplication, the function internally finishes the threadcomm and synchronizes via atomic counters to ensure all threads have exited before cleanup.
+The function frees transport-specific resources including message queues, mailboxes, cell pools, and rank offset tables.
+This function is local and does not involve communication with other processes.
+//end::MPIX_Threadcomm_free[]
+
+//tag::MPIX_Threadcomm_start[]
+*MPIX_Threadcomm_start* activates a thread communicator for use within a thread parallel region.
+Each thread within the process must call this function to synchronize activation via an internal thread barrier.
+The function enables thread-safe MPI operations by setting global threading state if MPI was initialized without `MPI_THREAD_MULTIPLE`.
+Thread-local storage is allocated after the barrier to associate each calling thread with a unique thread identifier.
+This function is local and does not involve communication with other processes.
+
+All participating threads must call this function; the last arriving thread triggers global state changes before any thread exits the barrier.
+//end::MPIX_Threadcomm_start[]
+
+//tag::MPIX_Threadcomm_finish[]
+*MPIX_Threadcomm_finish* deactivates a thread communicator at the end of a thread parallel region.
+Each thread within the process must call this function to synchronize deactivation via an internal thread barrier.
+The function frees thread-local attributes by invoking registered delete callbacks and removes thread-local storage.
+If MPI was initialized without `MPI_THREAD_MULTIPLE`, the function restores the original single-threaded state after all threads arrive.
+This function is local and does not involve communication with other processes.
+
+All participating threads must call this function; the last arriving thread triggers global state restoration before any thread exits the barrier.
+//end::MPIX_Threadcomm_finish[]
+


### PR DESCRIPTION
## Pull Request Description
 Currently documentation is very minimal or boilerplate and aimed at developers and those familiar with MPI. It leaves a gap for those learning MPI through MPICH and users looking to orient themselves in the large standard. As MPIX functions are not in the standard yet users have no easy way of looking up their usage beyond the one sentence description manpages have currently. The generated descriptions provide a way of getting more information for users who do not wish to scour the codebase or search for papers where the function was proposed. 

Pull request provides semantic descriptions based off of the latest MPI Standard and source code.
Directions and script for making new descriptions in Box. 

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
