### PR TITLE
maint/local_python: Added links in "See also" and MPIX warning

### DIFF
--- a/doc/mansrc/docnotes.adoc
+++ b/doc/mansrc/docnotes.adoc
@@ -163,6 +163,15 @@ failed nor completed.
 
 
 -----------------------------------------------------------------------------
+MPIX Explination
+//tag::MPIX[]
+== MPIX Function
+This routine is part of the MPIX extention to the MPI standard. It may become
+part of the standard in the future, in which its signature will change to the 
+MPI prefix.
+//end::MPIX[]
+
+-----------------------------------------------------------------------------
 Deprecated routines (see 2.6.1)
 // tag::Deprecated[]
 == Deprecated Function

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -1425,7 +1425,10 @@ def dump_manpage(func, out):
         out.append("")
     if 'seealso' in func:
         out.append("== See also")
-        out.append(re.sub(r'(MPI\w+)', r'*\1*(3)', func['seealso']))
+        outString = ""
+        adjList = re.compile(r'(MPI\w+)').findall(func['seealso'])
+        for adj in adjList: outString += "link:"+adj.lower()+".html[*"+adj+"*(3)]"
+        out.append(outString)
 
 def dump_manpage_list(list, header, out):
     count = len(list)

--- a/src/binding/c/async_api.txt
+++ b/src/binding/c/async_api.txt
@@ -4,6 +4,7 @@ MPIX_Async_start:
     poll_fn: FUNCTION, func_type=MPIX_Async_poll_function, [user defined poll function for progressing async things]
     extra_state: EXTRA_STATE, [extra state for callback function]
     stream: STREAM, [stream object]
+    .docnotes: MPIX
 {
     mpi_errno = MPIR_Async_things_add(poll_fn, extra_state, stream_ptr);
     if (mpi_errno) goto fn_fail;
@@ -14,6 +15,7 @@ MPIX_Async_get_state:
     async_thing: ASYNC_THING, [opaque pointer for async thing]
     .impl: direct
     .skip: validate-ASYNC_THING
+    .docnotes: MPIX
 {
     return MPIR_Async_thing_get_state(async_thing);
 }
@@ -24,6 +26,7 @@ MPIX_Async_spawn:
     extra_state: EXTRA_STATE, [extra state for callback function]
     stream: STREAM, [stream object]
     .skip: validate-ASYNC_THING
+    .docnotes: MPIX
 {
     mpi_errno = MPIR_Async_thing_spawn(async_thing, poll_fn, extra_state, stream_ptr);
     if (mpi_errno) goto fn_fail;

--- a/src/binding/c/binding_api.txt
+++ b/src/binding/c/binding_api.txt
@@ -5,6 +5,7 @@ MPIX_Op_create_x:
     extra_state: EXTRA_STATE, [extra state]
     op: OPERATION, direction=out, [operation]
     .desc: Creates a user-defined reduction op with an extra_state
+    .docnotes: MPIX
 /*
     Notes on MPIX_User_function_x:
     The calling list for the user function type is
@@ -25,6 +26,7 @@ MPIX_Comm_create_errhandler_x:
     extra_state: EXTRA_STATE, [extra state]
     errhandler: ERRHANDLER, direction=out
     .desc: Creates an MPI-style communicator errorhandler with an extra_state
+    .docnotes: MPIX
 
 MPIX_Win_create_errhandler_x:
     comm_errhandler_fn_x: FUNCTION, func_type=MPIX_Win_errhandler_function_x, [user defined error handling procedure with extra_state]
@@ -32,6 +34,7 @@ MPIX_Win_create_errhandler_x:
     extra_state: EXTRA_STATE, [extra state]
     errhandler: ERRHANDLER, direction=out
     .desc: Creates an MPI-style window errorhandler with an extra_state
+    .docnotes: MPIX
 
 MPIX_File_create_errhandler_x:
     comm_errhandler_fn_x: FUNCTION, func_type=MPIX_File_errhandler_function_x, [user defined error handling procedure with extra_state]
@@ -39,6 +42,7 @@ MPIX_File_create_errhandler_x:
     extra_state: EXTRA_STATE, [extra state]
     errhandler: ERRHANDLER, direction=out
     .desc: Creates an MPI-style file errorhandler with an extra_state
+    .docnotes: MPIX
 
 MPIX_Session_create_errhandler_x:
     comm_errhandler_fn_x: FUNCTION, func_type=MPIX_Session_errhandler_function_x, [user defined error handling procedure with extra_state]
@@ -46,6 +50,7 @@ MPIX_Session_create_errhandler_x:
     extra_state: EXTRA_STATE, [extra state]
     errhandler: ERRHANDLER, direction=out
     .desc: Creates an MPI-style session errorhandler with an extra_state
+    .docnotes: MPIX
 
 MPIX_Comm_create_keyval_x:
     comm_copy_attr_fn: FUNCTION_SMALL, func_type=MPI_Comm_copy_attr_function, [copy callback function for comm_keyval]
@@ -53,6 +58,7 @@ MPIX_Comm_create_keyval_x:
     destructor_fn: FUNCTION, func_type=MPIX_Destructor_function, [callback when keyval is freed]
     comm_keyval: KEYVAL, direction=out, [key value for future access]
     extra_state: EXTRA_STATE, [extra state for callback function]
+    .docnotes: MPIX
 
 MPIX_Type_create_keyval_x:
     type_copy_attr_fn: FUNCTION_SMALL, func_type=MPI_Type_copy_attr_function, [copy callback function for type_keyval]
@@ -60,6 +66,7 @@ MPIX_Type_create_keyval_x:
     destructor_fn: FUNCTION, func_type=MPIX_Destructor_function, [callback when keyval is freed]
     type_keyval: KEYVAL, direction=out, [key value for future access]
     extra_state: EXTRA_STATE, [extra state for callback function]
+    .docnotes: MPIX
 
 MPIX_Win_create_keyval_x:
     win_copy_attr_fn: FUNCTION_SMALL, func_type=MPI_Win_copy_attr_function, [copy callback function for win_keyval]
@@ -67,36 +74,43 @@ MPIX_Win_create_keyval_x:
     destructor_fn: FUNCTION, func_type=MPIX_Destructor_function, [callback when keyval is freed]
     win_keyval: KEYVAL, direction=out, [key value for future access]
     extra_state: EXTRA_STATE, [extra state for callback function]
+    .docnotes: MPIX
 
 MPIX_Comm_get_attr_as_fortran:
     comm: COMMUNICATOR, [communicator to which the attribute is attached]
     comm_keyval: KEYVAL, [key value]
     attribute_val: ATTRIBUTE_VAL, direction=out, [attribute value, unless flag = false]
     flag: LOGICAL, direction=out, [false if no attribute is associated with the key]
+    .docnotes: MPIX
 
 MPIX_Comm_set_attr_as_fortran:
     comm: COMMUNICATOR, direction=in, [communicator to which attribute will be attached]
     comm_keyval: KEYVAL, [key value]
     attribute_val: ATTRIBUTE_VAL, [attribute value]
+    .docnotes: MPIX
 
 MPIX_Type_get_attr_as_fortran:
     datatype: DATATYPE, [datatype to which the attribute is attached]
     type_keyval: KEYVAL, [key value]
     attribute_val: ATTRIBUTE_VAL, direction=out, [attribute value, unless flag = false]
     flag: LOGICAL, direction=out, [false if no attribute is associated with the key]
+    .docnotes: MPIX
 
 MPIX_Type_set_attr_as_fortran:
     datatype: DATATYPE, direction=in, [datatype to which attribute will be attached]
     type_keyval: KEYVAL, [key value]
     attribute_val: ATTRIBUTE_VAL, [attribute value]
+    .docnotes: MPIX
 
 MPIX_Win_get_attr_as_fortran:
     win: WINDOW, [window to which the attribute is attached]
     win_keyval: KEYVAL, [key value]
     attribute_val: ATTRIBUTE_VAL, direction=out, [attribute value, unless flag = false]
     flag: LOGICAL, direction=out, [false if no attribute is associated with the key]
+    .docnotes: MPIX
 
 MPIX_Win_set_attr_as_fortran:
     win: WINDOW, direction=in, [window to which attribute will be attached]
     win_keyval: KEYVAL, [key value]
     attribute_val: ATTRIBUTE_VAL, [attribute value]
+    .docnotes: MPIX

--- a/src/binding/c/comm_api.txt
+++ b/src/binding/c/comm_api.txt
@@ -189,6 +189,7 @@ MPIX_Comm_test_threadcomm:
     flag: LOGICAL, direction=out, [true if comm is an inter-communicator]
     .desc: Tests to see if a comm is a threadcomm
     .skip: global_cs
+    .docnotes: MPIX
 
 MPI_Intercomm_create_from_groups:
     .desc: Create an intercommuncator from local and remote groups
@@ -317,6 +318,7 @@ MPIX_Comm_revoke:
     comm: COMMUNICATOR, [communicator to revoke]
     .desc: Prevent a communicator from being used in the future
     .extra: ignore_revoked_comm
+    .docnotes: MPIX
 /*
     Notes:
     This function notifies all MPI processes in the groups (local and remote) associated with the communicator comm that this communicator is revoked. The revocation of a communicator by any MPIprocess completes non-local MPI operations on comm at all MPI processes by raising an error of class MPI_ERR_REVOKED (with the exception of MPIX_Comm_shrink, MPIX_Comm_agree). This function is not collective and therefore does not have a matching call on remote MPI processes. All non-failed MPIprocesses belonging to comm will be notified of the revocation despite failures.
@@ -335,6 +337,7 @@ MPIX_Comm_shrink:
     newcomm: COMMUNICATOR, direction=out, [new communicator]
     .desc: Creates a new communitor from an existing communicator while excluding failed processes
     .extra: ignore_revoked_comm
+    .docnotes: MPIX
 /*
     Notes:
     This collective operation creates a new intra- or intercommunicator newcomm from the intra- or intercommunicator comm, respectively, by excluding the group of failed MPI processes as agreed upon during the operation. The groups of newcomm must include everyMPIprocess that returns from MPIX_Comm_shrink, and it must exclude every MPI process whose failure caused an operation on comm to raise an MPI error of class MPI_ERR_PROC_FAILED or MPI_ERR_PROC_FAILED_PENDING at a member of the groups of newcomm, before that member initiated MPIX_Comm_shrink. This call is semantically equivalent to an MPI_Comm_split operation that would succeed despite failures, where members of the groups of newcomm participate with the same color and a key equal to their rank incomm.
@@ -348,6 +351,7 @@ MPIX_Comm_failure_ack:
     .desc: Acknowledge the current group of failed processes
     .extra: ignore_revoked_comm
     .impl: mpid
+    .docnotes: MPIX
 /*
     Notes:
     This local operation gives the users a way to acknowledge all locally notified failures on comm. After the call, unmatched MPI_ANY_SOURCE receive operations that would haveraised an error of class MPI_ERR_PROC_FAILED_PENDING due to MPI process failure proceed without further raising errors due to those acknowledged failures. Also after this call, MPIX_Comm_agree will not raise an error of class MPI_ERR_PROC_FAILED due to those acknowledged failures.
@@ -359,6 +363,7 @@ MPIX_Comm_failure_get_acked:
     .desc: Get the group of acknowledged failures.
     .extra: ignore_revoked_comm
     .impl: mpid
+    .docnotes: MPIX
 /*
     Notes:
     This local operation returns the group failedgrp of processes, from the communicatorcomm, that have been locally acknowledged as failed by preceding calls to MPIX_Comm_failure_ack. The failedgrp can be empty, that is, equal to MPI_GROUP_EMPTY.
@@ -369,6 +374,7 @@ MPIX_Comm_agree:
     flag: LOGICAL, direction=out, [new communicator]
     .desc: Performs agreement operation on comm
     .extra: ignore_revoked_comm
+    .docnotes: MPIX
 /*
     Notes:
     The purpose of this collective communication is to agree on the integer value flag and on the group of failed processes in comm.
@@ -384,6 +390,7 @@ MPIX_Comm_get_failed:
     comm: COMMUNICATOR, [communicator]
     failedgrp: GROUP, direction=out, [group of failed processes]
     .desc: This local operation returns the group of processes that are locally known to have failed.
+    .docnotes: MPIX
 /*
     Notes:
     The returned failedgrp can be empty, that is, equal to MPI_GROUP_EMPTY.

--- a/src/binding/c/datatype_api.txt
+++ b/src/binding/c/datatype_api.txt
@@ -546,6 +546,7 @@ MPIX_Type_iov_len:
     iov_len: DISPLACEMENT_COUNT, direction=out, [number of iovs within max_iov_bytes]
     actual_iov_bytes: DISPLACEMENT_COUNT, direction=out, [actual number of bytes in the iovs]
     .desc: Return the number of contiguous segments within max_iov_bytes
+    .docnotes: MPIX
 {
     MPI_Aint max_iov_bytes_i, iov_len_i, actual_iov_bytes_i;
 
@@ -570,6 +571,7 @@ MPIX_Type_iov:
     max_iov_len: DISPLACEMENT_COUNT, [capacity for the segments array]
     actual_iov_len: DISPLACEMENT_COUNT, direction=out, [actual number of segments in output]
     .desc: Return contiguous segments starting from an iov offset
+    .docnotes: MPIX
 {
     MPI_Aint iov_offset_i, max_iov_len_i, actual_iov_len_i;
 

--- a/src/binding/c/info_api.txt
+++ b/src/binding/c/info_api.txt
@@ -100,3 +100,4 @@ MPIX_Info_set_hex:
     key: STRING, constant=True, [key]
     value: BUFFER, constant=True, [value]
     value_size: INFO_VALUE_LENGTH, [size of value]
+    .docnotes: MPIX

--- a/src/binding/c/misc_api.txt
+++ b/src/binding/c/misc_api.txt
@@ -139,11 +139,13 @@ MPIX_GPU_query_support:
     is_supported: LOGICAL, direction=out, [true if gpu of given type is supported, false otherwise.]
     .desc: Returns whether the specific type of GPU is supported
     .skip: global_cs, validate-GPU_TYPE
+    .docnotes: MPIX
 
 MPIX_Query_cuda_support:
     .desc: Returns whether CUDA is supported
     .impl: direct
     .skip: global_cs, Errors
+    .docnotes: MPIX
 {
     int is_supported = 0;
     int mpi_errno ATTRIBUTE((unused));
@@ -158,6 +160,7 @@ MPIX_Query_ze_support:
     .desc: Returns whether ZE (Intel GPU) is supported
     .impl: direct
     .skip: global_cs, Errors
+    .docnotes: MPIX
 {
     int is_supported = 0;
     int mpi_errno ATTRIBUTE((unused));
@@ -172,6 +175,7 @@ MPIX_Query_hip_support:
     .desc: Returns whether HIP (AMD GPU) is supported
     .impl: direct
     .skip: global_cs, Errors
+    .docnotes: MPIX
 {
     int is_supported = 0;
     int mpi_errno ATTRIBUTE((unused));

--- a/src/binding/c/request_api.txt
+++ b/src/binding/c/request_api.txt
@@ -43,6 +43,7 @@ MPIX_Grequest_start:
     request: REQUEST, direction=out, [generalized request]
     .file: grequest_start_x
     .desc: Create and return a user-defined extended request
+    .docnotes: MPIX
 {
     MPIR_Request *request_ptr = NULL;
     mpi_errno = MPIR_Grequest_start_impl(query_fn, free_fn, cancel_fn, extra_state, &request_ptr);
@@ -61,12 +62,14 @@ MPIX_Grequest_class_create:
     poll_fn: FUNCTION_SMALL, func_type=MPIX_Grequest_poll_function, [callback function invoked when request completion is tested]
     wait_fn: FUNCTION_SMALL, func_type=MPIX_Grequest_wait_function, [callback function invoked when request is waited on]
     greq_class: GREQUEST_CLASS, direction=out, [generalized request class]
+    .docnotes: MPIX
 
 MPIX_Grequest_class_allocate:
     greq_class: GREQUEST_CLASS, [generalized request class]
     extra_state: EXTRA_STATE, [extra state]
     request: REQUEST, direction=out, [generalized request]
     .desc: Create and return a user-defined extended request based on a generalized request class
+    .docnotes: MPIX
 
 MPI_Request_free:
     .desc: Frees a communication request object
@@ -541,6 +544,7 @@ MPIX_Request_is_complete:
     .return: LOGICAL
     request: REQUEST, direction=in, pointer=False
     .impl: direct
+    .docnotes: MPIX
 {
     MPIR_Request *request_ptr;
     MPIR_Request_get_ptr(request, request_ptr);

--- a/src/binding/c/stream_api.txt
+++ b/src/binding/c/stream_api.txt
@@ -4,16 +4,19 @@ MPIX_Stream_create:
     .desc: Create a new stream object
     info: INFO, [info argument]
     stream: STREAM, direction=out, [stream object created]
+    .docnotes: MPIX
 
 MPIX_Stream_free:
     .desc: Free a stream object
     stream: STREAM, direction=inout, [stream object]
+    .docnotes: MPIX
 
 MPIX_Stream_comm_create:
     .desc: Create a new communicator with local stream attached
     comm: COMMUNICATOR, [communicator]
     stream: STREAM, [stream object]
     newcomm: COMMUNICATOR, direction=out, [new stream-associated communicator]
+    .docnotes: MPIX
 
 MPIX_Stream_comm_create_multiplex:
     .desc: Create a new communicator with multiple local streams attached
@@ -21,25 +24,30 @@ MPIX_Stream_comm_create_multiplex:
     count: ARRAY_LENGTH_NNI, [list length]
     array_of_streams: STREAM, length=count, [stream object array]
     newcomm: COMMUNICATOR, direction=out, [new stream-associated communicator]
+    .docnotes: MPIX
 
 MPIX_Comm_get_stream:
     .desc: Get the stream object that is attached to the communicator
     comm: COMMUNICATOR, [communicator]
     idx: INDEX
     stream: STREAM, direction=out, [stream object]
+    .docnotes: MPIX
 
 MPIX_Stream_progress:
     stream: STREAM, [stream object]
     .desc: Invoke progress on the given stream
     .impl: mpid
+    .docnotes: MPIX
 
 MPIX_Start_progress_thread:
     .desc: Start a progress thread that will poll progress on the given stream
     stream: STREAM, [stream object]
+    .docnotes: MPIX
 
 MPIX_Stop_progress_thread:
     .desc: Stop the progress thread that polls progress on the given stream
     stream: STREAM, [stream object]
+    .docnotes: MPIX
 
 MPIX_Stream_send:
     .desc: Send message from a specific local stream to a specific destination stream
@@ -51,6 +59,7 @@ MPIX_Stream_send:
     comm: COMMUNICATOR
     source_stream_index: INDEX
     dest_stream_index: INDEX
+    .docnotes: MPIX
 {
     MPIR_Request *request_ptr = NULL;
 
@@ -82,6 +91,7 @@ MPIX_Stream_isend:
     source_stream_index: INDEX
     dest_stream_index: INDEX
     request: REQUEST, direction=out
+    .docnotes: MPIX
 {
     MPIR_Request *request_ptr = NULL;
 
@@ -114,6 +124,7 @@ MPIX_Stream_recv:
     source_stream_index: INDEX
     dest_stream_index: INDEX
     status: STATUS, direction=out
+    .docnotes: MPIX
 {
     MPIR_Request *request_ptr = NULL;
 
@@ -146,6 +157,7 @@ MPIX_Stream_irecv:
     source_stream_index: INDEX
     dest_stream_index: INDEX
     request: REQUEST, direction=out
+    .docnotes: MPIX
 {
     MPIR_Request *request_ptr = NULL;
 
@@ -171,6 +183,7 @@ MPIX_Send_enqueue:
     comm: COMMUNICATOR
     .impl: mpid
     .decl: MPIR_Send_enqueue_impl
+    .docnotes: MPIX
 
 MPIX_Recv_enqueue:
     .desc: Enqueue a receive operation to a GPU stream that is associated with the local stream
@@ -183,6 +196,7 @@ MPIX_Recv_enqueue:
     status: STATUS, direction=out
     .impl: mpid
     .decl: MPIR_Recv_enqueue_impl
+    .docnotes: MPIX
 
 MPIX_Isend_enqueue:
     .desc: Enqueue a nonblocking send operation to a GPU stream that is associated with the local stream
@@ -195,6 +209,7 @@ MPIX_Isend_enqueue:
     request: REQUEST, direction=out
     .impl: mpid
     .decl: MPIR_Isend_enqueue_impl
+    .docnotes: MPIX
 
 MPIX_Irecv_enqueue:
     .desc: Enqueue a nonblocking receive operation to a GPU stream that is associated with the local stream
@@ -207,6 +222,7 @@ MPIX_Irecv_enqueue:
     request: REQUEST, direction=out
     .impl: mpid
     .decl: MPIR_Irecv_enqueue_impl
+    .docnotes: MPIX
 
 MPIX_Wait_enqueue:
     .desc: Enqueue a wait operation to a GPU stream that is associated with the local stream
@@ -214,6 +230,7 @@ MPIX_Wait_enqueue:
     status: STATUS, direction=out
     .impl: mpid
     .decl: MPIR_Wait_enqueue_impl
+    .docnotes: MPIX
 
 MPIX_Waitall_enqueue:
     .desc: Enqueue a waitall operation to a GPU stream that is associated with the local stream
@@ -222,6 +239,7 @@ MPIX_Waitall_enqueue:
     array_of_statuses: STATUS, direction=out, length=*, pointer=False, [array of status objects]
     .impl: mpid
     .decl: MPIR_Waitall_enqueue_impl
+    .docnotes: MPIX
 { -- error_check -- array_of_statuses
     if (count > 0) {
         MPIR_ERRTEST_ARGNULL(array_of_statuses, "array_of_statuses", mpi_errno);
@@ -236,3 +254,4 @@ MPIX_Allreduce_enqueue:
     datatype: DATATYPE, [data type of elements of send buffer]
     op: OPERATION, [operation]
     comm: COMMUNICATOR, [communicator]
+    .docnotes: MPIX

--- a/src/binding/c/threadcomm_api.txt
+++ b/src/binding/c/threadcomm_api.txt
@@ -6,18 +6,22 @@ MPIX_Threadcomm_init:
     newthreadcomm: COMMUNICATOR, direction=out, [new thread communicator]
     .desc: initialize a thread communicator (outside thread parallel regions)
     .seealso: MPIX_Threadcomm_start, MPIX_Threadcomm_finish, MPIX_Threadcomm_free
+    .docnotes: MPIX
 
 MPIX_Threadcomm_free:
     threadcomm: COMMUNICATOR, direction=inout, [thread communicator]
     .desc: free a thread communicator (outside thread parallel regions)
     .seealso: MPIX_Threadcomm_init, MPIX_Threadcomm_start, MPIX_Threadcomm_finish
+    .docnotes: MPIX
 
 MPIX_Threadcomm_start:
     threadcomm: COMMUNICATOR, [thread communicator]
     .desc: start/activiate a thread communicator (inside thread parallel regions)
     .seealso: MPIX_Threadcomm_init, MPIX_Threadcomm_finish, MPIX_Threadcomm_free
+    .docnotes: MPIX
 
 MPIX_Threadcomm_finish:
     threadcomm: COMMUNICATOR, [thread communicator]
     .desc: finish/deactiviate a thread communicator (inside thread parallel regions)
     .seealso: MPIX_Threadcomm_init, MPIX_Threadcomm_start, MPIX_Threadcomm_free
+    .docnotes: MPIX


### PR DESCRIPTION
## Pull Request Description
Added links in the 'See Also' section of the manpages for a smoother browsing experience. 
Added MPIX warning to make it clear what is an extension on the standard MPI.

## Author Checklist
* [ ] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [ ] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
