### PR TITLE
Improve multi-NIC performance in OFI netmod

### DIFF
--- a/src/include/mpir_hwtopo.h
+++ b/src/include/mpir_hwtopo.h
@@ -170,4 +170,13 @@ MPIR_hwtopo_gid_t MPIR_hwtopo_get_parent_socket(MPIR_hwtopo_gid_t gid);
  * Return the local index of my nic in my first non io ancestor.
  */
 int MPIR_hwtopo_get_pci_network_lid(int domain, int bus, int dev, int func);
+
+/*
+ * Return the global id of the host bridge above the PCI device.
+ * This provides a finer-grained grouping than get_dev_parent_by_pci (which
+ * returns the socket). Used to distinguish NICs on different PCIe root
+ * complexes within the same socket.
+ */
+MPIR_hwtopo_gid_t MPIR_hwtopo_get_dev_bridge_by_pci(int domain, int bus, int dev, int func);
+
 #endif /* MPIR_HWTOPO_H_INCLUDED */

--- a/src/include/mpir_process.h
+++ b/src/include/mpir_process.h
@@ -28,6 +28,7 @@ typedef struct MPIR_Process_t {
     int size;
     int local_rank;
     int local_size;
+    int package_rank;           /* rank's index among local procs on same NUMA node/package */
     int num_nodes;
     int *node_map;              /* int[size], maps rank to node_id */
     int *node_local_map;        /* int[local_size], maps local_id to rank of local proc */

--- a/src/mpid/ch4/netmod/ofi/ofi_nic.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.c
@@ -45,6 +45,17 @@ static MPIR_hwtopo_gid_t get_nic_parent(struct fi_info *info)
     return MPIR_hwtopo_get_obj_by_name(info->domain_attr->name);
 }
 
+/* Return the HostBridge ancestor of the NIC (finer-grained than socket) */
+static MPIR_hwtopo_gid_t get_nic_bridge(struct fi_info *info)
+{
+    if (info->nic->bus_attr->bus_type == FI_BUS_PCI) {
+        struct fi_pci_attr pci = info->nic->bus_attr->attr.pci;
+        return MPIR_hwtopo_get_dev_bridge_by_pci(pci.domain_id, pci.bus_id, pci.device_id,
+                                                 pci.function_id);
+    }
+    return MPIR_hwtopo_get_obj_by_name(info->domain_attr->name);
+}
+
 /* Return true if the NIC is bound to the same socket as calling process */
 static bool is_nic_close(struct fi_info *info)
 {
@@ -248,6 +259,90 @@ static int compare_nics_snc4(const void *nic1, const void *nic2)
     return compare_nic_names(&(i1->nic), &(i2->nic));
 }
 
+/* Interleave close NICs across HostBridges so that consecutive indices
+ * alternate between bridges rather than being grouped by bridge.
+ * This spreads PCIe bandwidth when ranks are assigned sequentially via
+ * package_rank % num_close_nics.
+ *
+ * For example, if close NICs are [A0, A1, A2, A3, B0, B1, B2, B3] grouped
+ * by bridge after sort, this reorders them to [A0, B0, A1, B1, A2, B2, A3, B3].
+ *
+ * Conceptually treats close NICs as a tree:
+ *   root -> bridge_0 -> [nic_0, nic_1, ...]
+ *        -> bridge_1 -> [nic_4, nic_5, ...]
+ * and reads breadth-first across bridges at each depth level.
+ */
+static void interleave_nics_by_bridge(MPIDI_OFI_nic_info_t * nics, int num_close_nics)
+{
+    /* Discover distinct bridges, and map NIC-to-distinct bridge index */
+    MPIR_hwtopo_gid_t bridges[MPIDI_OFI_MAX_NICS];
+    int nic_bridge_idx[MPIDI_OFI_MAX_NICS];
+    int num_bridges = 0;
+
+    for (int i = 0; i < num_close_nics; i++) {
+        MPIR_hwtopo_gid_t bridge = get_nic_bridge(nics[i].nic);
+        int idx = -1;
+        for (int b = 0; b < num_bridges; b++) {
+            if (bridges[b] == bridge) {
+                idx = b;
+                break;
+            }
+        }
+        if (idx < 0) {
+            idx = num_bridges;
+            bridges[num_bridges++] = bridge;
+        }
+        nic_bridge_idx[i] = idx;
+    }
+
+    if (num_bridges <= 1 || num_close_nics <= num_bridges) {
+        return;
+    }
+
+    /* Group close NICs by bridge into a flat array using group offsets */
+    int group_size[MPIDI_OFI_MAX_NICS] = { 0 };
+    int group_start[MPIDI_OFI_MAX_NICS];
+
+    for (int i = 0; i < num_close_nics; i++) {
+        group_size[nic_bridge_idx[i]]++;
+    }
+
+    group_start[0] = 0;
+    for (int b = 1; b < num_bridges; b++) {
+        group_start[b] = group_start[b - 1] + group_size[b - 1];
+    }
+
+    MPIDI_OFI_nic_info_t *grouped =
+        MPL_malloc(num_close_nics * sizeof(MPIDI_OFI_nic_info_t), MPL_MEM_OTHER);
+    if (!grouped) {
+        return;
+    }
+
+    int pos[MPIDI_OFI_MAX_NICS] = { 0 };
+    for (int i = 0; i < num_close_nics; i++) {
+        int b = nic_bridge_idx[i];
+        grouped[group_start[b] + pos[b]++] = nics[i];
+    }
+
+    /* Read out breadth-first: one NIC from each bridge per round */
+    int max_depth = 0;
+    for (int b = 0; b < num_bridges; b++) {
+        if (group_size[b] > max_depth)
+            max_depth = group_size[b];
+    }
+
+    int dest = 0;
+    for (int depth = 0; depth < max_depth; depth++) {
+        for (int b = 0; b < num_bridges; b++) {
+            if (depth < group_size[b]) {
+                nics[dest++] = grouped[group_start[b] + depth];
+            }
+        }
+    }
+
+    MPL_free(grouped);
+}
+
 /* TODO: Now that multiple NICs are detected, sort them based on preferred-ness,
  * closeness and count of other processes using the NIC. */
 static int setup_multi_nic(int nic_count)
@@ -255,7 +350,6 @@ static int setup_multi_nic(int nic_count)
     int mpi_errno = MPI_SUCCESS;
     MPIR_hwtopo_gid_t parents[MPIDI_OFI_MAX_NICS] = { 0 };
     int num_parents = 0;
-    int local_rank = MPIR_Process.local_rank;
     MPIDI_OFI_nic_info_t *nics = MPIDI_OFI_global.nic_info;
     MPIR_CHKLMEM_DECL();
 
@@ -399,10 +493,11 @@ static int setup_multi_nic(int nic_count)
             qsort(nics, nic_count, sizeof(nics[0]), compare_nics);
         }
 
-        /* Because we cannot communicate with the other local processes to avoid collisions with the
-         * same NICs, just shift NICs that have multiple close NICs around according to their local
-         * rank. This will likely give the same result as long as processes have been bound properly. */
-        int old_idx = (num_close_nics == 0) ? 0 : local_rank % num_close_nics;
+        /* Distribute ranks across close NICs using package_rank (rank's index among
+         * local procs on the same NUMA/package). This ensures even distribution regardless
+         * of whether ranks are placed sequentially or interleaved across NUMA nodes. */
+        interleave_nics_by_bridge(nics, num_close_nics);
+        int old_idx = (num_close_nics == 0) ? 0 : MPIR_Process.package_rank % num_close_nics;
 
         if (old_idx != 0) {
             MPIDI_OFI_nic_info_t *old_nics;

--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -398,7 +398,7 @@ typedef struct {
 } MPIDI_OFI_win_t;
 
 /* Maximum number of network interfaces CH4 can support. */
-#define MPIDI_OFI_MAX_NICS 8
+#define MPIDI_OFI_MAX_NICS 128
 
 /* Imagine a dimension of [local_vci][local_nic][rank][vci][nic] -
  * all local endpoints will share the same remote address due to the same insertion order

--- a/src/mpid/ch4/shm/posix/posix_init.c
+++ b/src/mpid/ch4/shm/posix/posix_init.c
@@ -73,6 +73,7 @@ static int choose_posix_eager(void);
 static void *host_alloc(uintptr_t size);
 static void host_free(void *ptr);
 static void init_topo_info(void);
+static void compute_package_rank(void);
 static int posix_coll_init(void);
 static int posix_coll_finalize(void);
 
@@ -86,6 +87,44 @@ static void host_free(void *ptr)
     MPL_free(ptr);
 }
 
+/* Compute rank's index among local procs on same NUMA node.
+ * This is needed for distributing NUMA-local resources (e.g., NICs) evenly
+ * across ranks sharing a NUMA node. Falls back to local_rank if NUMA topology
+ * is unavailable or shared memory allocation fails. */
+static void compute_package_rank(void)
+{
+    MPIR_Process.package_rank = MPIR_Process.local_rank;
+
+    if (MPIR_Process.local_size <= 1 || MPIDI_POSIX_global.topo.numa_id < 0) {
+        return;
+    }
+
+    int local_size = MPIR_Process.local_size;
+    size_t shm_size = local_size * sizeof(int);
+    char shm_name[128];
+    snprintf(shm_name, sizeof(shm_name), "/mpich_numa_%x_%d",
+             MPIR_Process.world_id, MPIR_Process.node_map[MPIR_Process.rank]);
+
+    bool is_root;
+    int *numa_ids = (int *) MPL_initshm_open(shm_name, shm_size, &is_root);
+    if (!numa_ids) {
+        return;
+    }
+
+    numa_ids[MPIR_Process.local_rank] = MPIDI_POSIX_global.topo.numa_id;
+    MPIR_pmi_barrier_local();
+
+    int package_rank = 0;
+    for (int i = 0; i < MPIR_Process.local_rank; i++) {
+        if (numa_ids[i] == MPIDI_POSIX_global.topo.numa_id) {
+            package_rank++;
+        }
+    }
+    MPIR_Process.package_rank = package_rank;
+
+    MPIR_pmi_barrier_local();
+    MPL_initshm_free(shm_name, numa_ids, shm_size, true);
+}
 
 static int choose_posix_eager(void)
 {
@@ -214,6 +253,8 @@ int MPIDI_POSIX_init_local(int *tag_bits /* unused */)
     if (MPIR_CVAR_CH4_SHM_POSIX_TOPO_ENABLE) {
         init_topo_info();
     }
+
+    compute_package_rank();
 
     choose_posix_eager();
 

--- a/src/util/mpir_hwtopo.c
+++ b/src/util/mpir_hwtopo.c
@@ -756,3 +756,35 @@ int MPIR_hwtopo_get_pci_network_lid(int domain, int bus, int dev, int func)
 #endif
     return myIndex;
 }
+
+MPIR_hwtopo_gid_t MPIR_hwtopo_get_dev_bridge_by_pci(int domain, int bus, int dev, int func)
+{
+    MPIR_hwtopo_gid_t gid = MPIR_HWTOPO_GID_ROOT;
+    if (!bindset_is_valid)
+        return gid;
+#ifdef HAVE_HWLOC
+    hwloc_obj_t obj = hwloc_get_pcidev_by_busid(hwloc_topology, domain, bus, dev, func);
+    if (!obj) {
+        return gid;
+    }
+    /* Walk up through IO objects to find the host bridge */
+    while (obj->parent) {
+        obj = obj->parent;
+        if (obj->type == HWLOC_OBJ_BRIDGE &&
+            obj->attr->bridge.upstream_type == HWLOC_OBJ_BRIDGE_HOST) {
+            gid = HWTOPO_GET_GID(get_type_class(obj->type), obj->depth, obj->logical_index);
+            return gid;
+        }
+        /* Stop if we've left the IO tree */
+        if (!hwloc_obj_type_is_io(obj->type)) {
+            break;
+        }
+    }
+    /* Fallback: return the first non-IO ancestor (socket) */
+    obj = hwloc_get_pcidev_by_busid(hwloc_topology, domain, bus, dev, func);
+    hwloc_obj_t first_non_io = hwloc_get_non_io_ancestor_obj(hwloc_topology, obj);
+    gid = HWTOPO_GET_GID(get_type_class(first_non_io->type), first_non_io->depth,
+                         first_non_io->logical_index);
+#endif
+    return gid;
+}

--- a/src/util/mpir_nodemap.c
+++ b/src/util/mpir_nodemap.c
@@ -114,6 +114,7 @@ int MPIR_build_locality(void)
     MPIR_Process.node_local_map = node_local_map;
     MPIR_Process.local_size = local_size;
     MPIR_Process.local_rank = local_rank;
+    MPIR_Process.package_rank = local_rank;     /* default; refined later by POSIX init */
 
     return MPI_SUCCESS;
 }


### PR DESCRIPTION
## Pull Request Description
This increases the maximum supported number of OFI NICs, and adds NUMA and bus topology awareness to NIC mapping across local ranks. The goal of the new NIC assignment logic is to ensure that only NICs attached to the rank's bound NUMA node is assigned, and to distribute load across connected busses by striping NICs by host bridge. This avoids cross-NUMA bottlenecks, and spreads load across PCIe busses attached to a given node. 

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
