### PR TITLE
romio: use MPI_ERR_UNSUPPORTED_DATAREP

### DIFF
--- a/src/mpi/romio/mpi-io/io_impl.c
+++ b/src/mpi/romio/mpi-io/io_impl.c
@@ -3040,7 +3040,7 @@ static int MPIOI_Register_datarep(const char *datarep,
     if ((read_conversion_fn != NULL) || (write_conversion_fn != NULL)) {
         error_code = MPIO_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
                                           myname, __LINE__,
-                                          MPI_ERR_CONVERSION, "**drconvnotsupported", 0);
+                                          MPI_ERR_UNSUPPORTED_DATAREP, "**drconvnotsupported", 0);
 
         error_code = MPIO_Err_return_file(MPI_FILE_NULL, error_code);
         goto fn_exit;


### PR DESCRIPTION
## Pull Request Description
Use MPI_ERR_UNSUPPORTED_DATAREP instead of MPI_ERR_CONVERSION for error code on user-defined datarep.

Fixes #7873 



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
