### PR TITLE
doc: separate function notes

### DIFF
--- a/doc/mansrc/docnotes.adoc
+++ b/doc/mansrc/docnotes.adoc
@@ -163,6 +163,15 @@ failed nor completed.
 
 
 -----------------------------------------------------------------------------
+MPIX Explanation
+//tag::MPIX[]
+== MPIX Function
+This routine is part of the MPIX extension to the MPI standard. It may become
+part of the standard in the future, in which its signature will change to the 
+MPI prefix.
+//end::MPIX[]
+
+-----------------------------------------------------------------------------
 Deprecated routines (see 2.6.1)
 // tag::Deprecated[]
 == Deprecated Function
@@ -394,17 +403,17 @@ indicates that an attempt was made to call 'MPI_INIT' a second time.
 
 
 // tag::MPI_ERR_INFO_VALUE[]
-* MPI_ERR_INFO_VALUE - Invalid or null value string for info
+* MPI_ERR_INFO_VALUE - Invalid or null value string for info.
 // end::MPI_ERR_INFO_VALUE[]
 
 
 // tag::MPI_ERR_INFO_NOKEY[] 
-* MPI_ERR_INFO_NOKEY - 
+* MPI_ERR_INFO_NOKEY - Invalid key passed to MPI_INFO_DELETE.
 // end::MPI_ERR_INFO_NOKEY []
 
 
 // tag::MPI_ERR_NAME[]
-* MPI_ERR_NAME - 
+* MPI_ERR_NAME -  Invalid service name passed to MPI_LOOKUP_NAME.
 // end::MPI_ERR_NAME[]
 
 
@@ -465,22 +474,22 @@ indicates that an attempt was made to call 'MPI_INIT' a second time.
 
 
 // tag::MPI_ERR_RMA_SYNC[]
-* MPI_ERR_RMA_SYNC -
+* MPI_ERR_RMA_SYNC - Wrong synchronization of RMA calls
 // end::MPI_ERR_RMA_SYNC[]
 
 
 // tag::MPI_ERR_SIZE[]
-* MPI_ERR_SIZE - 
+* MPI_ERR_SIZE -  Invalid size argument
 // end::MPI_ERR_SIZE[]
 
 
 // tag::MPI_ERR_DISP[]
-* MPI_ERR_DISP - 
+* MPI_ERR_DISP - Invalid displacement argument
 // end::MPI_ERR_DISP[]
 
 
 // tag::MPI_ERR_ASSERT[]
-* MPI_ERR_ASSERT - 
+* MPI_ERR_ASSERT -  Invalid assertion argument
 // end::MPI_ERR_ASSERT[]
 
 
@@ -491,62 +500,65 @@ indicates that an attempt was made to call 'MPI_INIT' a second time.
 
 
 // tag::MPI_ERR_ACCESS[]
-* MPI_ERR_ACCESS -
+* MPI_ERR_ACCESS -Permission denied
 // end::MPI_ERR_ACCESS[]
 
 
 // tag::MPI_ERR_AMODE[]
-* MPI_ERR_AMODE - 
+* MPI_ERR_AMODE - Error related to the amode passed to MPI_FILE_OPEN
 // end::MPI_ERR_AMODE[]
 
 
 // tag::MPI_ERR_BAD_FILE[]
-* MPI_ERR_BAD_FILE - 
+* MPI_ERR_BAD_FILE - Invalid file name(e.g., path name too long)
 // end::MPI_ERR_BAD_FILE[]
 
 
 // tag::MPI_ERR_FILE_EXISTS[]
-* MPI_ERR_FILE_EXISTS - 
+* MPI_ERR_FILE_EXISTS - File exists
 // end::MPI_ERR_FILE_EXISTS[]
 
 
 // tag::MPI_ERR_FILE_IN_USE[]
-* MPI_ERR_FILE_IN_USE - 
+* MPI_ERR_FILE_IN_USE - File operation could not be completed, as the
+file is currently open by some process
 // end::MPI_ERR_FILE_IN_USE[]
 
 
 // tag::MPI_ERR_NO_SPACE[]
-* MPI_ERR_NO_SPACE - 
+* MPI_ERR_NO_SPACE - Not enough space
 // end::MPI_ERR_NO_SPACE[]
 
 
 // tag::MPI_ERR_NO_SUCH_FILE[]
-* MPI_ERR_NO_SUCH_FILE - 
+* MPI_ERR_NO_SUCH_FILE - File does not exist
 // end::MPI_ERR_NO_SUCH_FILE[]
 
 
 // tag::MPI_ERR_IO[]
-* MPI_ERR_IO - 
+* MPI_ERR_IO - Other I/O error
 // end::MPI_ERR_IO[]
 
 
 // tag::MPI_ERR_READ_ONLY[]
-* MPI_ERR_READ_ONLY - 
+* MPI_ERR_READ_ONLY - Read-only file or file system
 // end::MPI_ERR_READ_ONLY[]
 
 
 // tag::MPI_ERR_CONVERSION[]
-* MPI_ERR_CONVERSION - 
+* MPI_ERR_CONVERSION -  An error occurred in a user supplied data conversion function.
 // end::MPI_ERR_CONVERSION[]
 
 
 // tag::MPI_ERR_DUP_DATAREP[]
-* MPI_ERR_DUP_DATAREP - 
+* MPI_ERR_DUP_DATAREP - Conversion functions could not be registered 
+because a data representation identifier that was already defined was 
+passed to MPI_REGISTER_DATAREP.
 // end::MPI_ERR_DUP_DATAREP[]
 
 
 // tag::MPI_ERR_UNSUPPORTED_DATAREP[]
-* MPI_ERR_UNSUPPORTED_DATAREP - 
+* MPI_ERR_UNSUPPORTED_DATAREP - Unsupported datarep passed to MPI_FILE_SET_VIEW.
 // end::MPI_ERR_UNSUPPORTED_DATAREP[]
 
 
@@ -628,6 +640,23 @@ indicates that an attempt was made to call 'MPI_INIT' a second time.
 // tag::MPI_T_ERR_INVALID[]
 * MPI_T_ERR_INVALID - Invalid use of the interface or bad parameter values(s).
 // end::MPI_T_ERR_INVALID[]
+
+// tag::MPI_T_ERR_INVALID_ITEM[]
+MPI_T_ERR_INVALID_ITEM  - The source index is invalid.
+// end::MPI_T_ERR_INVALID_ITEM[]
+
+// tag::MPI_T_ERR_NOT_SUPPORTED[]
+* MPI_T_ERR_NOT_SUPPORTED - Requested functionality not supported.
+// end::MPI_T_ERR_NOT_SUPPORTED[]
+
+// tag::MPI_ERR_ERRHANDLER[]
+* MPI_ERR_ERRHANDLER - Invalid error handler argument.
+// end::MPI_ERR_ERRHANDLER[]
+
+// tag::MPIX_ERR_STREAM[]
+* MPIX_ERR_STREAM - MPIX stream object has failed.
+// end::MPIX_ERR_STREAM[]
+
 
 
 // tag::NULL[]

--- a/doc/mansrc/funcnotes.txt
+++ b/doc/mansrc/funcnotes.txt
@@ -1,0 +1,1573 @@
+MPI_Comm_create_keyval:
+    == Notes
+    Key values are global (available for any and all communicators).
+
+    Default copy and delete functions are available.  These are
+
+    * `MPI_COMM_NULL_COPY_FN`   - empty copy function
+    * `MPI_COMM_NULL_DELETE_FN` - empty delete function
+    * `MPI_COMM_DUP_FN`         - simple dup function
+
+    There are subtle differences between C and Fortran that require that the
+    `copy_fn` be written in the same language from which `MPI_Comm_create_keyval`
+    is called.
+    This should not be a problem for most users; only programmers using both
+    Fortran and C in the same program need to be sure that they follow this rule.
+
+MPI_Comm_get_attr:
+    == Notes
+    Attributes must be extracted from the same language as they were inserted
+    in with `MPI_ATTR_PUT`.  The notes for C and Fortran below explain why.
+
+    == Notes for C
+    Even though the `attribute_val` argument is declared as `+void *+`, it is
+    really the address of a void pointer (i.e., a `+void **+`).  Using
+    a `+void *+`, however, is more in keeping with C idiom and allows the
+    pointer to be passed without additional casts.
+
+    // tag:Fortran
+    The `attribute_val` in Fortran is a pointer to a Fortran integer, not
+    a pointer to a `+void *+`.
+
+MPI_Comm_set_attr:
+    == Notes
+    Values of the permanent attributes `MPI_TAG_UB`, `MPI_HOST`, `MPI_IO`,
+    `MPI_WTIME_IS_GLOBAL`, `MPI_UNIVERSE_SIZE`, `MPI_LASTUSEDCODE`, and
+    `MPI_APPNUM` may not be changed.
+
+    The type of the attribute value depends on whether C, C++, or Fortran
+    is being used.
+    In C and C++, an attribute value is a pointer (`+void *+`); in Fortran, it is an
+    address-sized integer.
+
+    If an attribute is already present, the delete function (specified when the
+    corresponding keyval was created) will be called.
+
+MPI_Type_create_keyval:
+    == Notes
+    Key values are global (available for any and all derived datatypes).
+
+    Default copy and delete functions are available.  These are
+
+    * `MPI_TYPE_NULL_COPY_FN`   - empty copy function
+    * `MPI_TYPE_NULL_DELETE_FN` - empty delete function
+    * `MPI_TYPE_DUP_FN`         - simple dup function
+
+    There are subtle differences between C and Fortran that require that the
+    `copy_fn` be written in the same language from which `MPI_Type_create_keyval`
+    is called.
+    This should not be a problem for most users; only programmers using both
+    Fortran and C in the same program need to be sure that they follow this rule.
+
+MPI_Type_get_attr:
+    == Notes
+    Attributes must be extracted from the same language as they were inserted
+    in with `MPI_ATTR_PUT`.  The notes for C and Fortran below explain why.
+
+    == Notes for C
+    Even though the `attribute_val` argument is declared as `+void *+`, it is
+    really the address of a void pointer (i.e., a `+void **+`).  Using
+    a `+void *+`, however, is more in keeping with C idiom and allows the
+    pointer to be passed without additional casts.
+
+    // tag:Fortran
+    The `attribute_val` in Fortran is a pointer to a Fortran integer, not
+    a pointer to a `+void *+`.
+
+MPI_Type_set_attr:
+    == Notes
+    The type of the attribute value depends on whether C or Fortran is being used.
+    In C, an attribute value is a pointer (`+void *+`); in Fortran, it is an
+    address-sized integer.
+
+    If an attribute is already present, the delete function (specified when the
+    corresponding keyval was created) will be called.
+
+MPI_Win_create_keyval:
+    == Notes
+    Key values are global (available for any and all communicators).
+
+    Default copy and delete functions are available.  These are
+
+    * `MPI_WIN_NULL_COPY_FN`   - empty copy function
+    * `MPI_WIN_NULL_DELETE_FN` - empty delete function
+    * `MPI_WIN_DUP_FN`         - simple dup function
+
+    There are subtle differences between C and Fortran that require that the
+    `copy_fn` be written in the same language from which `MPI_Win_create_keyval`
+    is called.
+    This should not be a problem for most users; only programmers using both
+    Fortran and C in the same program need to be sure that they follow this rule.
+
+MPI_Win_get_attr:
+    == Notes
+    The following attributes are predefined for all MPI Window objects:
+
+    * `MPI_WIN_BASE` - window base address.
+    * `MPI_WIN_SIZE` - window size, in bytes.
+    * `MPI_WIN_DISP_UNIT` - displacement unit associated with the window.
+
+    Attributes must be extracted from the same language as they were inserted
+    in with `MPI_ATTR_PUT`.  The notes for C and Fortran below explain why.
+
+    == Notes for C
+    Even though the `attribute_val` argument is declared as `+void **+`, it is
+    really the address of a void pointer (i.e., a `+void ***+`).  Using
+    a `+void *+`, however, is more in keeping with C idiom and allows the
+    pointer to be passed without additional casts.
+
+    // tag:Fortran
+    The `attribute_val` in Fortran is a pointer to a Fortran integer, not
+    a pointer to a `+void *+`.
+
+MPI_Win_set_attr:
+    == Notes
+    The type of the attribute value depends on whether C or Fortran is being used.
+    In C, an attribute value is a pointer (`+void *+`); in Fortran, it is an
+    address-sized integer.
+
+    If an attribute is already present, the delete function (specified when the
+    corresponding keyval was created) will be called.
+
+MPIX_Op_create_x:
+    == Notes on MPIX_User_function_x
+    The calling list for the user function type is
+
+    [source, c]
+    ----
+    typedef void (MPIX_User_function_x) (void * a, void * b,
+        MPI_Count len, MPI_Datatype datatype,
+        void *extra_state);
+    ----
+
+    There are a few differences from `MPI_User_function` used in `MPI_Op_create`.
+
+    * It passes len and datatype as scalar input, rather than as addresses.
+    * The len is of MPI_Count, rather than int.
+    * It accepts a void * `extra_state` which is passed from users during `MPIX_Op_create_x`.
+
+MPI_Allgather:
+    == Notes
+    The MPI standard (1.0 and 1.1) says that
+
+    The jth block of data sent from  each process is received by every process
+    and placed in the jth block of the buffer `recvbuf`.
+
+    This is misleading; a better description is
+
+    The block of data sent from the jth process is received by every
+    process and placed in the jth block of the buffer `recvbuf`.
+
+    This text was suggested by Rajeev Thakur and has been adopted as a
+    clarification by the MPI Forum.
+
+MPI_Allgatherv:
+    == Notes
+    The MPI standard (1.0 and 1.1) says that
+
+    The jth block of data sent from
+    each process is received by every process and placed in the jth block of the
+    buffer `recvbuf`.
+
+    This is misleading; a better description is
+
+    The block of data sent from the jth process is received by every
+    process and placed in the jth block of the buffer `recvbuf`.
+
+    This text was suggested by Rajeev Thakur, and has been adopted as a
+    clarification to the MPI standard by the MPI-Forum.
+
+MPI_Barrier:
+    == Notes
+    Blocks the caller until all processes in the communicator have called it;
+    that is, the call returns at any process only after all members of the
+    communicator have entered the call.
+
+MPI_Exscan:
+    == Notes
+    `MPI_Exscan` is like `MPI_Scan`, except that the contribution from the
+    calling process is not included in the result at the calling process
+    (it is contributed to the subsequent processes, of course).
+
+MPI_Ibarrier:
+    == Notes
+    `MPI_Ibarrier` is a nonblocking version of MPI_barrier. By calling `MPI_Ibarrier`,
+    a process notifies that it has reached the barrier. The call returns
+    immediately, independent of whether other processes have called `MPI_Ibarrier`.
+    The usual barrier semantics are enforced at the corresponding completion
+    operation (test or wait), which in the intra-communicator case will complete
+    only after all other processes in the communicator have called `MPI_Ibarrier`. In
+    the intercommunicator case, it will complete when all processes in the remote
+    group have called `MPI_Ibarrier`.
+
+MPI_Neighbor_allgather:
+    == Notes
+    In this function, each process i gathers data items from each process j if an edge (j,i) exists in the topology graph, and each process i sends the same data items to all processes j where an edge (i,j) exists. The send buffer is sent to each neighboring process and the l-th block in the receive buffer is received from the l-th neighbor.
+
+MPI_Neighbor_alltoall:
+    == Notes
+    In this function, each process i receives data items from each process j if an edge (j,i) exists in the topology graph or Cartesian topology.  Similarly, each process i sends data items to all processes j where an edge (i,j) exists. This call is more general than `MPI_NEIGHBOR_ALLGATHER` in that different data items can be sent to each neighbor. The k-th block in send buffer is sent to the k-th neighboring process and the l-th block in the receive buffer is received from the l-th neighbor.
+
+MPI_Comm_compare:
+    // tag:ThreadSafe
+    (To perform the communicator comparisons, this routine may need to
+    allocate some memory.  Memory allocation is not interrupt-safe, and hence
+    this routine is only thread-safe.)
+
+MPI_Comm_dup:
+    == Notes
+    This routine is used to create a new communicator that has a new
+    communication context but contains the same group of processes as
+    the input communicator.  Since all MPI communication is performed
+    within a communicator (specifies as the group of processes _plus_
+    the context), this routine provides an effective way to create a
+    private communicator for use by a software module or library.  In
+    particular, no library routine should use `MPI_COMM_WORLD` as the
+    communicator; instead, a duplicate of a user-specified communicator
+    should always be used.  For more information, see Using MPI, 2nd
+    edition.
+
+    Because this routine essentially produces a copy of a communicator,
+    it also copies any attributes that have been defined on the input
+    communicator, using the attribute copy function specified by the
+    `copy_function` argument to `MPI_Keyval_create`.  This is
+    particularly useful for (a) attributes that describe some property
+    of the group associated with the communicator, such as its
+    interconnection topology and (b) communicators that are given back
+    to the user; the attributes in this case can track subsequent
+    `MPI_Comm_dup` operations on this communicator.
+
+MPI_Comm_dup_with_info:
+    == Notes
+    `MPI_Comm_dup_with_info` behaves exactly as `MPI_Comm_dup` except that
+    the info hints associated with the communicator comm are not
+    duplicated in newcomm.  The hints provided by the argument info are
+    associated with the output communicator newcomm instead.
+
+MPI_Comm_free:
+    == Notes
+    This routine _frees_ a communicator.  Because the communicator may still
+    be in use by other MPI routines, the actual communicator storage will not
+    be freed until all references to this communicator are removed.  For most
+    users, the effect of this routine is the same as if it was in fact freed
+    at this time of this call.
+
+    == Null Handles
+    The MPI 1.1 specification, in the section on opaque objects, explicitly
+    disallows freeing a null communicator.  The text from the standard is:
+
+    ____
+    A null handle argument is an erroneous IN argument in MPI calls, unless an
+    exception is explicitly stated in the text that defines the function. Such
+    exception is allowed for handles to request objects in Wait and Test calls
+    (sections Communication Completion and Multiple Completions). Otherwise, a
+    null handle can only be passed to a function that allocates a new object and
+    returns a reference to it in the handle.
+    ____
+
+MPI_Comm_remote_group:
+    == Notes
+    The user is responsible for freeing the group when it is no longer needed.
+
+MPI_Comm_set_info:
+    == Notes
+    The call is collective on the group of `comm`. The info object may be different
+    on each process, but any info entries that an implementation requires to be
+    the same on all processes must appear with the same value in each process'
+    info object. 
+
+MPI_Comm_split:
+    == Notes
+    The `color` must be non-negative or `MPI_UNDEFINED`.
+
+    == Algorithm
+
+    ----
+    1. Use `MPI_Allgather` to get the color and key from each process
+    2. Count the number of processes with the same color; create a
+        communicator with that many processes.  If this process has
+        'MPI_UNDEFINED' as the color, create a process with a single member.
+    3. Use key to order the ranks
+    ----
+
+MPI_Comm_split_type:
+    == Notes
+    The `split_type` must be non-negative or `MPI_UNDEFINED`.
+
+MPI_Intercomm_create:
+    == Notes
+    `peer_comm` is significant only for the process designated the
+    `local_leader` in the `local_comm`.
+
+    The MPI 1.1 Standard contains two mutually exclusive comments on the
+    input intercommunicators.  One says that their respective groups must be
+    disjoint; the other that the leaders can be the same process.  After
+    some discussion by the MPI Forum, it has been decided that the groups must
+    be disjoint.  Note that the _reason_ given for this in the standard is
+    _not_ the reason for this choice; rather, the _other_ operations on
+    intercommunicators (like `MPI_Intercomm_merge`) do not make sense if the
+    groups are not disjoint.
+
+MPI_Intercomm_merge:
+    == Notes
+    While all processes may provide the same value for the `high` parameter,
+    this requires the MPI implementation to determine which group of
+    processes should be ranked first.
+
+    == Algorithm
+
+    ----
+    1. Allocate contexts
+    2. Local and remote group leaders swap high values
+    3. Determine the high value.
+    4. Merge the two groups and make the intra-communicator
+    ----
+
+
+MPIX_Comm_revoke:
+    == Notes
+    This function notifies all MPI processes in the groups (local and remote) associated with the communicator `comm` that this communicator is revoked. The revocation of a communicator by any MPI process completes non-local MPI operations on `comm` at all MPI processes by raising an error of class `MPI_ERR_REVOKED` (with the exception of `MPIX_Comm_shrink`, `MPIX_Comm_agree`). This function is not collective and therefore does not have a matching call on remote MPI processes. All non-failed MPI processes belonging to `comm` will be notified of the revocation despite failures.
+
+    A communicator is revoked at a given MPI process either when `MPIX_Comm_revoke` is locally called on it, or when any MPI operation on `comm` raises an error of class `MPI_ERR_REVOKED` at that process. Once a communicator has been revoked at an MPI process, all subsequent non-local operations on that communicator (with thesame exceptions as above), are considered local and must complete by raising an error of class `MPI_ERR_REVOKED` at that MPI process.
+
+MPIX_Comm_shrink:
+    == Notes
+    This collective operation creates a new intra- or intercommunicator `newcomm` from the intra- or intercommunicator comm, respectively, by excluding the group of failed MPI processes as agreed upon during the operation. The groups of `newcomm` must include every MPI process that returns from `MPIX_Comm_shrink`, and it must exclude every MPI process whose failure caused an operation on `comm` to raise an MPI error of class `MPI_ERR_PROC_FAILED` or `MPI_ERR_PROC_FAILED_PENDING` at a member of the groups of `newcomm`, before that member initiated `MPIX_Comm_shrink`. This call is semantically equivalent to an `MPI_Comm_split` operation that would succeed despite failures, where members of the groups of `newcomm` participate with the same color and a key equal to their rank incomm.
+
+    This function never raises an error of class `MPI_ERR_PROC_FAILED` or `MPI_ERR_REVOKED`. The defined semantics of `MPIX_Comm_shrink` are maintained when `comm` is revoked, or when the group of `comm` contains failed MPI processes
+
+MPIX_Comm_failure_ack:
+    == Notes
+    This local operation gives the users a way to acknowledge all locally notified failures on `comm`. After the call, unmatched `MPI_ANY_SOURCE` receive operations that would have raised an error of class `MPI_ERR_PROC_FAILED_PENDING` due to MPI process failure proceed without further raising errors due to those acknowledged failures. Also after this call, `MPIX_Comm_agree` will not raise an error of class `MPI_ERR_PROC_FAILED` due to those acknowledged failures.
+
+MPIX_Comm_failure_get_acked:
+    == Notes
+    This local operation returns the group `failedgrp` of processes, from the communicator `comm`, that have been locally acknowledged as failed by preceding calls to `MPIX_Comm_failure_ack`. The `failedgrp` can be empty, that is, equal to `MPI_GROUP_EMPTY`.
+
+MPIX_Comm_agree:
+    == Notes
+    The purpose of this collective communication is to agree on the integer value flag and on the group of failed processes in `comm`.
+
+    On completion, all non-failed MPI processes have agreed to set the output integer value of `flag` to the result of a bitwise AND operation over the contributed input values of `flag`. If `comm` is an intercommunicator, the value of `flag` is a bitwise AND operation over the values contributed by the remote group.
+
+    When an MPI process fails before contributing to the operation, the `flag` is computed ignoring its contribution, and `MPIX_Comm_agree` raises an error of class `MPI_ERR_PROC_FAILED`. However, if all MPI processes have acknowledged this failure priorto the call to `MPIX_Comm_agree`, using `MPIX_Comm_failure_ack`, the error related to this failure is not raised. When an error of class `MPI_ERR_PROC_FAILED` is raised, it is consistently raised at all MPI processes, in both the local and remote groups (if applicable).
+
+    After `MPIX_Comm_agree` raised an error of class `MPI_ERR_PROC_FAILED`, a subsequent call to `MPIX_Comm_failure_ack` on `comm` acknowledges the failure of every MPI process that didn't contribute to the computation offlag.
+
+MPIX_Comm_get_failed:
+    == Notes
+    The returned `failedgrp` can be empty, that is, equal to `MPI_GROUP_EMPTY`.
+
+    For any two groups obtained from calls to this routine at the same MPI process with the same `comm`, the smaller group is a prefix of the larger group, that is, the same failed process will have the same rank in the returned `failedgrp`.
+
+MPI_Type_create_f90_integer:
+    == Notes
+    If there is no corresponding type for the specified range, the call is
+    erroneous.  This implementation sets `newtype` to `MPI_DATATYPE_NULL` and
+    returns an error of class `MPI_ERR_ARG`.
+
+MPI_Type_create_f90_real:
+    == Notes
+    If there is no corresponding type for the specified range, the call is
+    erroneous.  This implementation sets `newtype` to `MPI_DATATYPE_NULL` and
+    returns an error of class `MPI_ERR_ARG`.
+
+MPI_Type_create_f90_complex:
+    == Notes
+    If there is no corresponding type for the specified range, the call is
+    erroneous.  This implementation sets `newtype` to `MPI_DATATYPE_NULL` and
+    returns an error of class `MPI_ERR_ARG`.
+
+MPI_Get_address:
+    == Notes
+    This routine is provided for both the Fortran and C programmers.
+    On many systems, the address returned by this routine will be the same
+    as produced by the C `&` operator, but this is not required in C and
+    may not be true of systems with word- rather than byte-oriented
+    instructions or systems with segmented address spaces.
+
+    // tag:Fortran
+    In Fortran, the integer type is always signed.  This can cause problems
+    on systems where the address fits into a four byte unsigned integer but
+    the value is larger than the largest signed integer.  For example, a system
+    with more than 2 GBytes of memory may have addresses that do not fit within
+    a four byte signed integer.  Unfortunately, there is no easy solution to
+    this problem, as there is no Fortran datatype that can be used here (using
+    a longer integer type will cause other problems, as well as surprising
+    users when the size of the integer type is larger that the size of a pointer
+    in C).  In this case, it is recommended that you use C to manipulate
+    addresses.
+
+MPI_Get_count:
+    == Notes
+    If the size of the `datatype` is zero, this routine will return a count of
+    zero.  If the amount of data in `status` is not an exact multiple of the
+    size of `datatype` (so that `count` would not be integral), a `count` of
+    `MPI_UNDEFINED` is returned instead.
+
+MPI_Get_elements:
+    == Notes
+    If the size of the `datatype` is zero and the amount of data returned as
+    determined by `status` is also zero, this routine will return a count of
+    zero.  This is consistent with a clarification made by the MPI Forum.
+
+MPI_Pack:
+    == Notes (from the specifications)
+    The input value of `position` is the first location in the output buffer to be
+    used for packing.  `position` is incremented by the size of the packed message,
+    and the output value of `position` is the first location in the output buffer
+    following the locations occupied by the packed message.  The `comm` argument is
+    the communicator that will be subsequently used for sending the packed
+    message.
+
+MPI_Pack_size:
+    == Notes
+    The MPI standard document describes this in terms of `MPI_Pack`, but it
+    applies to both `MPI_Pack` and `MPI_Unpack`.  That is, the value `size` is
+    the maximum that is needed by either `MPI_Pack` or `MPI_Unpack`.
+
+MPI_Type_free:
+    == Predefined types
+    The MPI standard states that (in Opaque Objects):
+
+    ____
+    MPI provides certain predefined opaque objects and predefined, static handles
+    to these objects. Such objects may not be destroyed.
+    ____
+
+    Thus, it is an error to free a predefined datatype.  The same section makes
+    it clear that it is an error to free a null datatype.
+
+MPI_Type_create_indexed_block:
+    // tag:Fortran
+    The indices are displacements, and are based on a zero origin.  A common error
+    is to do something like the following
+
+    [source, fortran]
+    ----
+    integer a(100)
+    integer blens(10), indices(10)
+    do i=1,10
+        indices(i) = 1 + (i-1)*10
+    call MPI_TYPE_CREATE_INDEXED_BLOCK(10,1,indices,MPI_INTEGER,newtype,ierr)
+    call MPI_TYPE_COMMIT(newtype,ierr)
+    call MPI_SEND(a,1,newtype,...)
+    ----
+
+    expecting this to send "a(1),a(11),..." because the indices have values
+    "1,11,...".   Because these are _displacements_ from the beginning of "a",
+    it actually sends "a(1+1),a(1+11),...".
+    
+    If you wish to consider the displacements as indices into a Fortran array,
+    consider declaring the Fortran array with a zero origin
+
+    [source, fortran]
+    ----
+    integer a(0:99)
+    ----
+
+MPI_Type_hindexed:
+    // tag:Fortran
+    The array_of_displacements are displacements, and are based on a zero origin.  A common error
+    is to do something like to following
+
+    [source, fortran]
+    ----
+    integer a(100)
+    integer array_of_blocklengths(10), array_of_displacements(10)
+    do i=1,10
+        array_of_blocklengths(i) = 1
+        array_of_displacements(i) = (1 + (i-1)*10) * sizeofint
+    call MPI_TYPE_HINDEXED(10,array_of_blocklengths,array_of_displacements,MPI_INTEGER,newtype,ierr)
+    call MPI_TYPE_COMMIT(newtype,ierr)
+    call MPI_SEND(a,1,newtype,...)
+    ----
+
+    expecting this to send "a(1),a(11),..." because the array_of_displacements have values
+    "1,11,...".   Because these are _displacements_ from the beginning of "a",
+    it actually sends "a(1+1),a(1+11),...".
+    
+    If you wish to consider the displacements as array_of_displacements into a Fortran array,
+    consider declaring the Fortran array with a zero origin
+
+    [source, fortran]
+    ----
+    integer a(0:99)
+    ----
+
+MPI_Type_indexed:
+    // tag:Fortran
+    The array_of_displacements are displacements, and are based on a zero origin.  A common error
+    is to do something like to following
+
+    [source, fortran]
+    ----
+    integer a(100)
+    integer array_of_blocklengths(10), array_of_displacements(10)
+    do i=1,10
+        array_of_blocklengths(i)   = 1
+        array_of_displacements(i) = 1 + (i-1)*10
+    call MPI_TYPE_INDEXED(10,array_of_blocklengths,array_of_displacements,MPI_INTEGER,newtype,ierr)
+    call MPI_TYPE_COMMIT(newtype,ierr)
+    call MPI_SEND(a,1,newtype,...)
+    ----
+
+    expecting this to send "a(1),a(11),..." because the array_of_displacements have values
+    "1,11,...".   Because these are _displacements_ from the beginning of "a",
+    it actually sends "a(1+1),a(1+11),...".
+    
+    If you wish to consider the displacements as array_of_displacements into a Fortran array,
+    consider declaring the Fortran array with a zero origin
+
+    [source, fortran]
+    ----
+    integer a(0:99)
+    ----
+
+MPI_Type_struct:
+    == Notes
+    If an upperbound is set explicitly by using the MPI datatype `MPI_UB`, the
+    corresponding index must be positive.
+    
+    The MPI standard originally made vague statements about padding and alignment;
+    this was intended to allow the simple definition of structures that could
+    be sent with a `count` greater than one.  For example,
+
+    [source, c]
+    ----
+    struct { int a; char b; } foo;
+    ----
+
+    may have `sizeof(foo) > sizeof(int) + sizeof(char)`; for example,
+    `sizeof(foo) == 2*sizeof(int)`.  The initial version of the MPI standard
+    defined the extent of a datatype as including an _epsilon_ that would have
+    allowed an implementation to make the extent an MPI datatype
+    for this structure equal to `2*sizeof(int)`.
+    However, since different systems might define different paddings, there was
+    much discussion by the MPI Forum about what was the correct value of
+    epsilon, and one suggestion was to define epsilon as zero.
+    This would have been the best thing to do in MPI 1.0, particularly since
+    the `MPI_UB` type allows the user to easily set the end of the structure.
+    Unfortunately, this change did not make it into the final document.
+    Currently, this routine does not add any padding, since the amount of
+    padding needed is determined by the compiler that the user is using to
+    build their code, not the compiler used to construct the MPI library.
+    A later version of MPICH may provide for some natural choices of padding
+    (e.g., multiple of the size of the largest basic member), but users are
+    advised to never depend on this, even with vendor MPI implementations.
+    Instead, if you define a structure datatype and wish to send or receive
+    multiple items, you should explicitly include an `MPI_UB` entry as the
+    last member of the structure.  For example, the following code can be used
+    for the structure foo
+
+    [source, c]
+    ----
+    blen[0] = 1; array_of_displacements[0] = 0; oldtypes[0] = MPI_INT;
+    blen[1] = 1; array_of_displacements[1] = &foo.b - &foo; oldtypes[1] = MPI_CHAR;
+    blen[2] = 1; array_of_displacements[2] = sizeof(foo); oldtypes[2] = MPI_UB;
+    MPI_Type_struct(3, blen, array_of_displacements, oldtypes, &newtype);
+    ----
+
+MPI_Type_match_size:
+    == Notes
+    `typeclass` is one of `MPI_TYPECLASS_REAL`, `MPI_TYPECLASS_INTEGER` and
+    `MPI_TYPECLASS_COMPLEX`, corresponding to the desired typeclass.
+    The function returns an MPI datatype matching a local variable of type
+    `(typeclass, size)`.
+
+MPI_Add_error_string:
+    == Notes
+    The string must be no more than `MPI_MAX_ERROR_STRING` characters long.
+    The length of the string is as defined in the calling language.
+    The length of the string does not include the null terminator in C or C++.
+    Note that the string is `const` even though the MPI standard does not
+    specify it that way.
+
+    According to the MPI-2 standard, it is erroneous to call `MPI_Add_error_string`
+    for an error code or class with a value less than or equal
+    to `MPI_ERR_LASTCODE`.  Thus, you cannot replace the predefined error messages
+    with this routine.
+
+MPI_Error_string:
+    == Notes
+    Error codes are the values return by MPI routines (in C) or in the
+    `ierr` argument (in Fortran).  These can be converted into error classes
+    with the routine `MPI_Error_class`.
+
+MPI_Comm_create_errhandler:
+    == Notes
+    The MPI Standard states that an implementation may make the output value
+    `errhandler` simply the address of the function.  However, the action of
+    `MPI_Errhandler_free` makes this impossible, since it is required to set the
+    value of the argument to `MPI_ERRHANDLER_NULL`.  In addition, the actual
+    error handler must remain until all communicators that use it are
+    freed.
+
+MPI_Comm_get_errhandler:
+    == Note on Implementation
+
+    The MPI Standard was unclear on whether this routine required the user to call
+    `MPI_Errhandler_free` once for each call made to this routine in order to
+    free the error handler.  After some debate, the MPI Forum added an explicit
+    statement that users are required to call `MPI_Errhandler_free` when the
+    return value from this routine is no longer needed.  This behavior is similar
+    to the other MPI routines for getting objects; for example, `MPI_Comm_group`
+    requires that the user call `MPI_Group_free` when the group returned
+    by `MPI_Comm_group` is no longer needed.
+
+MPI_Remove_error_string:
+    == Notes
+    According to the MPI 4.1 standard, it is erroneous to call `MPI_Remove_error_string`
+    for an error code or class with a value less than or equal
+    to `MPI_ERR_LASTCODE`.  Thus, you cannot replace the predefined error messages
+    with this routine.
+
+MPI_Group_difference:
+    == Notes
+    The generated group contains the members of `group1` that are not in `group2`.
+
+MPI_Group_excl:
+    == Note
+    The MPI standard requires that each of the ranks to excluded must be
+    a valid rank in the group and all elements must be distinct or the
+    function is erroneous.
+
+MPI_Group_intersection:
+    == Notes
+    The output group contains those processes that are in both `group1` and
+    `group2`.
+
+MPI_Group_translate_ranks:
+    == Notes
+    As a special case (see the MPI-2 errata), if the input rank is
+    `MPI_PROC_NULL`, `MPI_PROC_NULL` is given as the output rank.
+
+MPI_Info_get:
+    == Deprecated
+   `MPI_Info_get_string` should be used instead of this routine.
+
+MPI_Info_get_valuelen:
+    == Deprecated
+    `MPI_Info_get_string` should be used instead of this routine.
+
+MPI_Info_create_env:
+    == Notes for C
+    `MPI_Info_create_env` accepts NULL as input parameters. Doing so impacts
+    the returned value.
+
+    == Notes for Fortran
+    The Fortran binding for `MPI_Info_create_env` does not take `argc` and `argv`.
+
+    [source, fortran]
+    ----
+    subroutine MPI_INFO_CREATE_ENV(info, ierr)
+    integer info, ierr
+    ----
+
+MPI_Abort:
+    == Notes
+    Terminates all MPI processes associated with the communicator `comm`; in
+    most systems (all to date), terminates _all_ processes.
+
+    == NotThreadSafe
+    Because the `MPI_Abort` routine is intended to ensure that an MPI
+    process (and possibly an entire job), it cannot wait for a thread to
+    release a lock or other mechanism for atomic access.
+
+MPI_Finalize:
+    == Notes
+    All processes must call this routine before exiting.  The number of
+    processes running _after_ this routine is called is undefined;
+    it is best not to perform much more than a `return rc` after calling
+    `MPI_Finalize`.
+
+    == Thread and Signal Safety
+    The MPI standard requires that `MPI_Finalize` be called _only_ by the same
+    thread that initialized MPI with either `MPI_Init` or `MPI_Init_thread`.
+
+MPI_Init:
+    == Notes
+    The MPI standard does not say what a program can do before an `MPI_INIT` or
+    after an `MPI_FINALIZE`.  In the MPICH implementation, you should do
+    as little as possible.  In particular, avoid anything that changes the
+    external state of the program, such as opening files, reading standard
+    input or writing to standard output.
+
+    == Thread Level
+    MPICH by default set thread level to `MPI_THREAD_SINGLE`. This can be changed
+    by setting `MPIR_CVAR_DEFAULT_THREAD_LEVEL`.
+
+    == Thread and Signal Safety
+    This routine must be called by one thread only.  That thread is called
+    the _main thread_ and must be the thread that calls `MPI_Finalize`.
+
+    == Notes for C
+    As of MPI-2, `MPI_Init` will accept NULL as input parameters. Doing so
+    will impact the values stored in `MPI_INFO_ENV`.
+
+    == Notes for Fortran
+    The Fortran binding for `MPI_Init` has only the error return
+
+    [source, fortran]
+    ----
+    subroutine MPI_INIT(ierr)
+    integer ierr
+    ----
+
+MPI_Init_thread:
+    == Command line arguments
+    MPI specifies no command-line arguments but does allow an MPI
+    implementation to make use of them.  See `MPI_INIT` for a description of
+    the command line arguments supported by `MPI_INIT` and `MPI_INIT_THREAD`.
+
+    == Notes
+    The valid values for the level of thread support are:
+
+    * `MPI_THREAD_SINGLE` - Only one thread will execute.
+    * `MPI_THREAD_FUNNELED` - The process may be multi-threaded, but only the main
+    thread will make MPI calls (all MPI calls are funneled to the
+    main thread).
+    * `MPI_THREAD_SERIALIZED` - The process may be multi-threaded, and multiple
+    threads may make MPI calls, but only one at a time: MPI calls are not
+    made concurrently from two distinct threads (all MPI calls are serialized).
+    * `MPI_THREAD_MULTIPLE` - Multiple threads may call MPI, with no restrictions.
+
+    == Notes for Fortran
+    Note that the Fortran binding for this routine does not have the `argc` and
+    `argv` arguments. (`MPI_INIT_THREAD(required, provided, ierror)`)
+
+MPI_Query_thread:
+    == Notes
+    The valid values for the level of thread support are:
+
+    * `MPI_THREAD_SINGLE` - Only one thread will execute.
+    * `MPI_THREAD_FUNNELED` - The process may be multi-threaded, but only the main
+    thread will make MPI calls (all MPI calls are funneled to the
+    main thread).
+    * `MPI_THREAD_SERIALIZED` - The process may be multi-threaded, and multiple
+    threads may make MPI calls, but only one at a time: MPI calls are not
+    made concurrently from two distinct threads (all MPI calls are serialized).
+    * `MPI_THREAD_MULTIPLE` - Multiple threads may call MPI, with no restrictions.
+
+    If `MPI_Init` was called instead of `MPI_Init_thread`, the level of
+    thread support is defined by the implementation.  This routine allows
+    you to find out the provided level.  It is also useful for library
+    routines that discover that MPI has already been initialized and
+    wish to determine what level of thread support is available.
+
+MPI_Session_init:
+    == Info Hints
+    Following keys are supported:
+    
+    * "thread_level" - Set MPI thread level. The default is `MPI_THREAD_MULTIPLE`.
+        Note this is different from the default in `MPI_Init`. MPICH does not support different thread levels in different
+        sessions. The provided thread level will be the one set by the first `MPI_Session_init`, `MPI_Init`, or `MPI_Init_thread`.
+    * "mpi_memory_alloc_kinds" - Set the memory allocation kinds to be used by
+        by the calling MPI process on MPI objects derived from the Session.
+
+MPI_Aint_add:
+    == Notes
+    `MPI_Aint_Add` produces a new MPI_Aint value that is equivalent to the sum of the
+    `base` and `disp` arguments, where `base` represents a base address returned by a call
+    to `MPI_GET_ADDRESS` and `disp` represents a signed integer displacement. The resulting
+    address is valid only at the process that generated `base`, and it must correspond
+    to a location in the same object referenced by `base`. The addition is performed in
+    a manner that results in the correct MPI_Aint representation of the output address,
+    as if the process that originally produced `base` had called
+
+    [source, c]
+    ----
+    MPI_Get_address((char *) base + disp, &result)
+    ----
+
+MPI_Aint_diff:
+    == Notes
+    `MPI_Aint_diff` produces a new MPI_Aint value that is equivalent to the difference
+    between `addr1` and `addr2` arguments, where `addr1` and `addr2` represent addresses
+    returned by calls to `MPI_GET_ADDRESS`. The resulting address is valid only at the
+    process that generated `addr1` and `addr2`, and `addr1` and `addr2` must correspond to
+    locations in the same object in the same process. The difference is calculated
+    in a manner that results the signed difference from `addr1` to `addr2`, as if the
+    process that originally produced the addresses had called
+
+    [source, c]
+    ----
+    (char *) addr1 - (char *) addr2
+    ----
+
+    on the addresses initially passed to `MPI_GET_ADDRESS`.
+
+MPI_Get_processor_name:
+    == Notes
+    The `name` returned should identify a particular piece of hardware;
+    the exact format is implementation defined.  This `name` may or may not
+    be the same as might be returned by `gethostname`, `uname`, or `sysinfo`.
+
+    // tag:Fortran
+    In Fortran, the character argument should be declared as a character string
+    of 'MPI_MAX_PROCESSOR_NAME' rather than an array of dimension
+    'MPI_MAX_PROCESSOR_NAME'.  That is,
+
+    [source, fortran]
+    ----
+    character*(MPI_MAX_PROCESSOR_NAME) name
+    ----
+
+    rather than
+
+    [source, fortran]
+    ----
+    character name(MPI_MAX_PROCESSOR_NAME)
+    ----
+
+    The sizes of MPI strings in Fortran are one less than the sizes of that string in C/C++ because the C/C++ versions provide room for the trailing null character required by C/C++. For example, `MPI_MAX_ERROR_STRING` is mpif.h is one smaller than the same value in mpi.h. See the MPI standard, sections 2.6.2 and 4.12.9. 
+
+MPI_Pcontrol:
+    == Notes
+	This routine provides a common interface for profiling control.  The
+	interpretation of `level` and any other arguments is left to the
+	profiling library.  The intention is that a profiling library will
+	provide a replacement for this routine and define the interpretation
+	of the parameters.
+
+MPI_T_category_changed:
+    == Notes
+    If two subsequent calls to this routine return the same timestamp, it is guaranteed that
+    the category information has not changed between the two calls. If the timestamp retrieved
+    from the second call is higher, then some categories have been added or expanded.
+
+MPI_T_finalize:
+    == Notes
+    This routine may be called as often as the corresponding `MPI_T_init_thread` routine
+    up to the current point of execution. Calling it more times returns a corresponding
+    error code. As long as the number of calls to `MPI_T_finalize` is smaller than the
+    number of calls to `MPI_T_init_thread` up to the current point of execution, the MPI
+    tool information interface remains initialized and calls to its routines are permissible.
+    Further, additional calls to `MPI_T_init_thread` after one or more calls to `MPI_T_finalize`
+    are permissible. Once `MPI_T_finalize` is called the same number of times as the routine
+    `MPI_T_init_thread` up to the current point of execution, the MPI tool information
+    interface is no longer initialized. The interface can be reinitialized by subsequent calls
+    to `MPI_T_init_thread`.
+    
+    At the end of the program execution, unless `MPI_Abort` is called, an application must
+    have called `MPI_T_init_thread` and `MPI_T_finalize` an equal number of times.
+
+MPI_T_init_thread:
+    == Notes
+    The valid values for the level of thread support are:
+
+    * `MPI_THREAD_SINGLE` - Only one thread will execute.
+    * `MPI_THREAD_FUNNELED` - The process may be multi-threaded, but only the main
+      thread will make MPI_T calls (all MPI_T calls are funneled to the
+      main thread).
+    * `MPI_THREAD_SERIALIZED` - The process may be multi-threaded, and multiple
+      threads may make MPI_T calls, but only one at a time: MPI_T calls are not
+      made concurrently from two distinct threads (all MPI_T calls are serialized).
+    * `MPI_THREAD_MULTIPLE` - Multiple threads may call MPI_T, with no restrictions.
+
+MPI_T_pvar_read:
+    == Notes
+    The `MPI_T_pvar_read` call queries the value of the performance variable with the
+    handle `handle` in the session identified by the parameter `session` and stores the result
+    in the buffer identified by the parameter `buf`. The user is responsible to ensure that the
+    buffer is of the appropriate size to hold the entire value of the performance variable
+    (based on the datatype and count returned by the corresponding previous calls to
+    `MPI_T_pvar_get_info` and `MPI_T_pvar_handle_alloc`, respectively).
+    
+    The constant `MPI_T_PVAR_ALL_HANDLES` cannot be used as an argument for the function
+    `MPI_T_pvar_read`.
+
+MPI_T_pvar_reset:
+    == Notes
+    The `MPI_T_pvar_reset` call sets the performance variable with the handle identified
+    by the parameter `handle` to its starting value. If it is not possible
+    to change the variable, the function returns `MPI_T_ERR_PVAR_NO_WRITE`.
+    If the constant `MPI_T_PVAR_ALL_HANDLES` is passed in `handle`, the MPI implementation
+    attempts to reset all variables within the session identified by the parameter `session` for
+    which handles have been allocated. In this case, the routine returns `MPI_SUCCESS` if all
+    variables are reset successfully, otherwise `MPI_T_ERR_PVAR_NO_WRITE` is returned. Readonly
+    variables are ignored when `MPI_T_PVAR_ALL_HANDLES` is specified.
+
+MPI_T_pvar_session_free:
+    == Notes
+    Calls to the MPI tool information interface can no longer be made
+    within the context of a session after it is freed. On a successful
+    return, MPI sets the session identifier to `MPI_T_PVAR_SESSION_NULL`.
+
+MPI_T_pvar_start:
+    == Notes
+    If the constant `MPI_T_PVAR_ALL_HANDLES` is passed in `handle`, the MPI implementation
+    attempts to start all variables within the session identified by the parameter `session` for
+    which handles have been allocated. In this case, the routine returns `MPI_SUCCESS` if all
+    variables are started successfully, otherwise `MPI_T_ERR_PVAR_NO_STARTSTOP` is returned.
+    Continuous variables and variables that are already started are ignored when
+    `MPI_T_PVAR_ALL_HANDLES` is specified.
+
+MPI_T_pvar_stop:
+    == Notes
+    This functions stops the performance variable with the handle identified by the parameter
+    `handle` in the session identified by the parameter `session`.
+    
+    If the constant `MPI_T_PVAR_ALL_HANDLES` is passed in `handle`, the MPI implementation
+    attempts to stop all variables within the session identified by the parameter `session` for
+    which handles have been allocated. In this case, the routine returns `MPI_SUCCESS` if all
+    variables are stopped successfully, otherwise `MPI_T_ERR_PVAR_NO_STARTSTOP` is returned.
+    Continuous variables and variables that are already stopped are ignored when
+    `MPI_T_PVAR_ALL_HANDLES` is specified.
+
+MPI_T_pvar_write:
+    == Notes
+    The `MPI_T_pvar_write` call attempts to write the value of the performance variable
+    with the handle identified by the parameter `handle` in the session identified by the parameter
+    `session`. The value to be written is passed in the buffer identified by the parameter `buf`. The
+    user must ensure that the buffer is of the appropriate size to hold the entire value of the
+    performance variable (based on the datatype and count returned by the corresponding previous
+    calls to `MPI_T_pvar_get_info` and `MPI_T_pvar_handle_alloc`, respectively).
+    
+    The constant `MPI_T_PVAR_ALL_HANDLES` cannot be used as an argument for the function
+    `MPI_T_pvar_write`.
+
+MPI_Op_create:
+    == Notes on the user function
+    For `MPI_Op_create`, the calling list for the user function type is
+
+    [source, c]
+    ----
+    typedef void (MPI_User_function) (void * a, void * b, int * len, MPI_Datatype *);
+    ----
+
+    For `MPI_Op_create_c`, the calling list for the user function type is
+
+    [source, c]
+    ----
+    typedef void (MPI_User_function_c) (void * a, void * b, MPI_Count * len, MPI_Datatype *);
+    ----
+
+    where the operation is `b[i] = a[i] op b[i]`, for `i=0,...,len-1`.  A pointer
+    to the datatype given to the MPI collective computation routine (i.e.,
+    `MPI_Reduce`, `MPI_Allreduce`, `MPI_Scan`, or `MPI_Reduce_scatter`) is also
+    passed to the user-specified routine.
+
+MPI_Bsend:
+    == Notes
+    This send is provided as a convenience function; it allows the user to
+    send messages without worring about where they are buffered (because the
+    user _must_ have provided buffer space with `MPI_Buffer_attach`).
+
+    In deciding how much buffer space to allocate, remember that the buffer space
+    is not available for reuse by subsequent `MPI_Bsend`s unless you are certain
+    that the message
+    has been received (not just that it should have been received).  For example,
+    this code does not allocate enough buffer space
+
+    [source, c]
+    ----
+    MPI_Buffer_attach(b, n*sizeof(double) + MPI_BSEND_OVERHEAD);
+    for (i=0; i<m; i++) {
+        MPI_Bsend(buf, n, MPI_DOUBLE, ...);
+    }
+    ----
+
+    because only enough buffer space is provided for a single send, and the
+    loop may start a second `MPI_Bsend` before the first is done making use of the
+    buffer.
+
+    In C, you can
+    force the messages to be delivered by
+
+    [source, c]
+    ----
+    MPI_Buffer_detach(&b, &n);
+    MPI_Buffer_attach(b, n);
+    ----
+
+    (The `MPI_Buffer_detach` will not complete until all buffered messages are
+    delivered.)
+
+MPI_Buffer_attach:
+    == Notes
+    The size given should be the sum of the sizes of all outstanding Bsends that
+    you intend to have, plus `MPI_BSEND_OVERHEAD` for each Bsend that you do.
+    For the purposes of calculating size, you should use `MPI_Pack_size`.
+    In other words, in the code
+
+    [source, c]
+    ----
+    MPI_Buffer_attach(buffer, size);
+    MPI_Bsend(..., count=20, datatype=type1,  ...);
+    ...
+    MPI_Bsend(..., count=40, datatype=type2, ...);
+    ----
+
+    the value of `size` in the `MPI_Buffer_attach` call should be greater than
+    the value computed by
+
+    [source, c]
+    ----
+    MPI_Pack_size(20, type1, comm, &s1);
+    MPI_Pack_size(40, type2, comm, &s2);
+    size = s1 + s2 + 2 * MPI_BSEND_OVERHEAD;
+    ----
+
+    The `MPI_BSEND_OVERHEAD` gives the maximum amount of space that may be used in
+    the buffer for use by the BSEND routines in using the buffer.  This value
+    is in `mpi.h` (for C) and `mpif.h` (for Fortran).
+
+    == NotThreadSafe
+    Because the buffer for buffered sends (e.g., `MPI_Bsend`) is shared by all
+    threads in a process, the user is responsible for ensuring that only
+    one thread at a time calls this routine or `MPI_Buffer_detach`.
+
+MPI_Buffer_detach:
+    == Notes
+    The reason that `MPI_Buffer_detach` returns the address and size of the
+    buffer being detached is to allow nested libraries to replace and restore
+    the buffer.  For example, consider
+
+    [source, c]
+    ----
+    int size, mysize, idummy;
+    void *ptr, *myptr, *dummy;
+    MPI_Buffer_detach(&ptr, &size);
+    MPI_Buffer_attach(myptr, mysize);
+    ...
+    ... library code ...
+    ...
+    MPI_Buffer_detach(&dummy, &idummy);
+    MPI_Buffer_attach(ptr, size);
+    ----
+
+    This is much like the action of the Unix signal routine and has the same
+    strengths (it is simple) and weaknesses (it only works for nested usages).
+
+    Note that for this approach to work, `MPI_Buffer_detach` must return `MPI_SUCCESS`
+    even when there is no buffer to detach.  In that case, it returns a size of
+    zero.  The MPI 1.1 standard for `MPI_BUFFER_DETACH` contains the text
+
+    ____
+    The statements made in this section describe the behavior of MPI for
+    buffered-mode sends. When no buffer is currently associated, MPI behaves
+    as if a zero-sized buffer is associated with the process.
+    ____
+
+    This could be read as applying only to the various Bsend routines.  This
+    implementation takes the position that this applies to `MPI_BUFFER_DETACH`
+    as well.
+
+    == NotThreadSafe
+    Because the buffer for buffered sends (e.g., `MPI_Bsend`) is shared by all
+    threads in a process, the user is responsible for ensuring that only
+    one thread at a time calls this routine or `MPI_Buffer_attach`.
+
+    == Notes for C
+    Even though the `bufferptr` argument is declared as `+void *+`, it is
+    really the address of a void pointer.  See the rationale in the
+    standard for more details.
+
+    // tag:Fortran
+    The Fortran binding for this routine is different.  Because Fortran
+    does not have pointers, it is impossible to provide a way to use the
+    output of this routine to exchange buffers.  In this case, only the
+    size field is set.
+
+MPI_Recv:
+    == Notes
+    The `count` argument indicates the maximum length of a message; the actual
+    length of the message can be determined with `MPI_Get_count`.
+
+MPI_Send:
+    == Notes
+    This routine may block until the message is received by the destination
+    process.
+
+MPI_Cancel:
+    == Notes
+    The primary expected use of `MPI_Cancel` is in multi-buffering
+    schemes, where speculative `MPI_Irecvs` are made.  When the computation
+    completes, some of these receive requests may remain; using `MPI_Cancel` allows
+    the user to cancel these unsatisfied requests.
+
+    Cancelling a send operation is much more difficult, in large part because the
+    send will usually be at least partially complete (the information on the tag,
+    size, and source are usually sent immediately to the destination).
+    Users are
+    advised that cancelling a send, while a local operation (as defined by the MPI
+    standard), is likely to be expensive (usually generating one or more internal
+    messages).
+
+MPI_Request_free:
+    == Notes
+
+    This routine is normally used to free inactive persistent requests created with
+    either `MPI_Recv_init` or `MPI_Send_init` and friends.  It _is_ also
+    permissible to free an active request.  However, once freed, the request can no
+    longer be used in a wait or test routine (e.g., `MPI_Wait`) to determine
+    completion.
+
+    This routine may also be used to free a non-persistent requests such as those
+    created with `MPI_Irecv` or `MPI_Isend` and friends.  Like active persistent
+    requests, once freed, the request can no longer be used with test/wait routines
+    to determine completion.
+
+MPI_Request_get_status:
+    == Notes
+    Unlike `MPI_Test`, `MPI_Request_get_status` does not deallocate or
+    deactivate the `request`.  A call to one of the test/wait routines or
+    `MPI_Request_free` should be made to release the `request` object.
+
+MPI_Startall:
+    == Notes
+    Unlike `MPI_Waitall`, `MPI_Startall` does not provide a mechanism for
+    returning multiple errors nor pinpointing the request(s) involved.
+    Furthermore, the behavior of `MPI_Startall` after an error occurs is not
+    defined by the MPI standard.  If well-defined error reporting and behavior
+    are required, multiple calls to `MPI_Start` should be used instead.
+
+MPI_Testall:
+    == Notes
+    `flag` is true only if all requests have completed.  Otherwise, `flag` is
+    false and neither the `array_of_requests` nor the `array_of_statuses` is
+    modified.
+
+    If one or more of the requests completes with an error, `MPI_ERR_IN_STATUS` is
+    returned.  An error value will be present is elements of `array_of_statuses`
+    associated with the requests.  Likewise, the `MPI_ERROR` field in the status
+    elements associated with requests that have successfully completed will be
+    `MPI_SUCCESS`.  Finally, those requests that have not completed will have a
+    value of `MPI_ERR_PENDING`.
+
+    While it is possible to list a request handle more than once in the
+    `array_of_requests`, such an action is considered erroneous and may cause the
+    program to unexecpectedly terminate or produce incorrect results.
+
+MPI_Testany:
+    == Notes
+    While it is possible to list a request handle more than once in the
+    `array_of_requests`, such an action is considered erroneous and may cause the
+    program to unexecpectedly terminate or produce incorrect results.
+
+MPI_Testsome:
+    == Notes
+    While it is possible to list a request handle more than once in the
+    `array_of_requests`, such an action is considered erroneous and may cause the
+    program to unexecpectedly terminate or produce incorrect results.
+
+MPI_Waitall:
+    == Notes
+    If one or more of the requests completes with an error, `MPI_ERR_IN_STATUS` is
+    returned.  An error value will be present is elements of `array_of_statuses`
+    associated with the requests.  Likewise, the `MPI_ERROR` field in the status
+    elements associated with requests that have successfully completed will be
+    `MPI_SUCCESS`.  Finally, those requests that have not completed will have a
+    value of `MPI_ERR_PENDING`.
+
+    While it is possible to list a request handle more than once in the
+    `array_of_requests`, such an action is considered erroneous and may cause the
+    program to unexecpectedly terminate or produce incorrect results.
+
+MPI_Waitany:
+    == Notes
+    If all of the requests are `MPI_REQUEST_NULL`, then `indx` is returned as
+    `MPI_UNDEFINED`, and `status` is returned as an empty status.
+
+    While it is possible to list a request handle more than once in the
+    `array_of_requests`, such an action is considered erroneous and may cause the
+    program to unexecpectedly terminate or produce incorrect results.
+
+MPI_Waitsome:
+    == Notes
+    The array of indices are in the range `0` to `incount - 1` for C and
+    in the range `1` to `incount` for Fortran.
+
+    Null requests are ignored; if all requests are null, then the routine
+    returns with `outcount` set to `MPI_UNDEFINED`.
+
+    While it is possible to list a request handle more than once in the
+    `array_of_requests`, such an action is considered erroneous and may cause the
+    program to unexecpectedly terminate or produce incorrect results.
+
+    `MPI_Waitsome` provides an interface much like the Unix select or poll
+    calls and, in a high qualilty implementation, indicates all of the requests
+    that have completed when `MPI_Waitsome` is called.
+    However, `MPI_Waitsome` only guarantees that at least one
+    request has completed; there is no guarantee that _all_ completed requests
+    will be returned, or that the entries in `array_of_indices` will be in
+    increasing order. Also, requests that are completed while `MPI_Waitsome` is
+    executing may or may not be returned, depending on the timing of the
+    completion of the message.
+
+MPI_Alloc_mem:
+    == Notes
+    Using this routine from Fortran requires that the Fortran compiler accept
+    a common pointer extension.  See Section 4.11 (Memory Allocation) in the
+    MPI-2 standard for more information and examples.
+
+    Also note that while `baseptr` is a `+void *+` type, this is
+    simply to allow easy use of any pointer object for this parameter.
+    In fact, this argument is really a `+void **+` type, that is, a
+    pointer to a pointer.
+
+MPI_Compare_and_swap:
+    == Notes
+    This operation is atomic with respect to other "accumulate" operations.
+
+    The parameter datatype must belong to one of the following categories of
+    predefined datatypes: C integer, Fortran integer, Logical, Multi-language
+    types, or Byte as specified in Section 5.9.2 on page 176. The origin and result
+    buffers (`origin_addr` and `result_addr`) must be disjoint.
+
+MPI_Fetch_and_op:
+    == Notes
+    This operations is atomic with respect to other "accumulate" operations.
+
+    The generic functionality of `MPI_Get_accumulate` might limit the performance of
+    fetch-and-increment or fetch-and-add calls that might be supported by special
+    hardware operations. `MPI_Fetch_and_op` thus allows for a fast implementation
+    of a commonly used subset of the functionality of `MPI_Get_accumulate`.
+
+    The origin and result buffers (`origin_addr` and `result_addr`) must be disjoint.
+    Any of the predefined operations for `MPI_Reduce`, as well as `MPI_NO_OP` or
+    `MPI_REPLACE`, can be specified as op; user-defined functions cannot be used. The
+    `datatype` argument must be a predefined datatype.
+
+MPI_Get_accumulate:
+    == Notes
+    This operations is atomic with respect to other "accumulate" operations.
+
+    The get and accumulate steps are executed atomically for each basic element in
+    the datatype (see MPI 3.0 Section 11.7 for details). The predefined operation
+    `MPI_REPLACE` provides fetch-and-set behavior.
+
+    The origin and result buffers (`origin_addr` and `result_addr`) must be disjoint.
+    Each datatype argument must be a predefined datatype or a derived datatype
+    where all basic components are of the same predefined datatype. All datatype
+    arguments must be constructed from the same predefined datatype. The
+    operation op applies to elements of that predefined type. `target_datatype` must
+    not specify overlapping entries, and the target buffer must fit in the target
+    window or in attached memory in a dynamic window.
+
+    Any of the predefined operations for `MPI_Reduce`, as well as `MPI_NO_OP` or
+    `MPI_REPLACE` can be specified as op. User-defined functions cannot be used. A
+    new predefined operation, `MPI_NO_OP`, is defined. It corresponds to the
+    associative function f (a, b) = a; i.e., the current value in the target memory
+    is returned in the result buffer at the origin and no operation is performed on
+    the target buffer. `MPI_NO_OP` can be used only in `MPI_Get_accumulate`,
+    `MPI_Rget_accumulate`, and `MPI_Fetch_and_op`. `MPI_NO_OP` cannot be used in
+    `MPI_Accumulate`, `MPI_Raccumulate`, or collective reduction operations, such as
+    `MPI_Reduce` and others.
+
+MPI_Raccumulate:
+    == Notes
+    The basic components of both the origin and target datatype must be the same
+    predefined datatype (e.g., all `MPI_INT` or all `MPI_DOUBLE_PRECISION`).
+
+MPI_Rget_accumulate:
+    == Notes
+    This operations is atomic with respect to other "accumulate" operations.
+
+    The get and accumulate steps are executed atomically for each basic element in
+    the datatype (see MPI 3.0 Section 11.7 for details). The predefined operation
+    `MPI_REPLACE` provides fetch-and-set behavior.
+
+    The basic components of both the origin and target datatype must be the same
+    predefined datatype (e.g., all `MPI_INT` or all `MPI_DOUBLE_PRECISION`).
+
+MPI_Win_allocate_shared:
+    == Notes
+    This is a collective call executed by all processes in the group of `comm`. On
+    each process i, it allocates memory of at least `size` bytes that is shared among
+    all processes in `comm`, and returns a pointer to the locally allocated segment
+    in `baseptr` that can be used for load/store accesses on the calling process. The
+    locally allocated memory can be the target of load/store accesses by remote
+    processes; the base pointers for other processes can be queried using the
+    function `MPI_Win_shared_query`.
+
+    The call also returns a window object that can be used by all processes in comm
+    to perform RMA operations. The `size` argument may be different at each process
+    and size = 0 is valid. It is the user's responsibility to ensure that the
+    communicator `comm` represents a group of processes that can create a shared
+    memory segment that can be accessed by all processes in the group. The
+    allocated memory is contiguous across process ranks unless the info key
+    `alloc_shared_noncontig` is specified. Contiguous across process ranks means that
+    the first address in the memory segment of process i is consecutive with the
+    last address in the memory segment of process i - 1. This may enable the user
+    to calculate remote address offsets with local information only.
+
+MPI_Win_create:
+    == Notes
+    The displacement unit argument is provided to facilitate address arithmetic in
+    RMA operations: the target displacement argument of an RMA operation is scaled
+    by the factor `disp_unit` specified by the target process, at window creation.
+
+    The `info` argument provides optimization hints to the runtime about the expected
+    usage pattern of the window. The following info keys are predefined.
+
+    * `no_locks`- If set to true, then the implementation may assume that passive
+        target synchronization (i.e., `MPI_Win_lock`, `MPI_Win_lock_all`) will not be used on
+        the given window. This implies that this window is not used for 3-party
+        communication, and RMA can be implemented with no (less) asynchronous agent
+        activity at this process.
+
+    * `accumulate_ordering` - Controls the ordering of accumulate operations at the
+        target.  The argument string should contain a comma-separated list of the
+        following read/write ordering rules, where e.g. "raw" means read-after-write:
+        "rar,raw,war,waw".
+
+    * `accumulate_ops` - If set to same_op, the implementation will assume that all
+        concurrent accumulate calls to the same target address will use the same
+        operation. If set to `same_op_no_op`, then the implementation will assume that
+        all concurrent accumulate calls to the same target address will use the same
+        operation or `MPI_NO_OP`. This can eliminate the need to protect access for
+        certain operation types where the hardware can guarantee atomicity. The default
+        is `same_op_no_op`.
+
+    * `mpi_accumulate_granularity` - Controls the desired synchronization granularity
+        for accumulate ops. It sets the size of memory range in bytes for which the
+        MPI library should acquire a synchronization primitive to ensure the atomicity
+        of updates. The default is 0 which let the MPI library decides the granularity.
+        When the info hint is set to a positive value, the actual range of synchroniation
+        is round-up to the next size that fits the Datatype used in the accumulate
+        operation (see MPI standard 4.1). All processes in the group of a windows must
+        set to the same value.
+
+MPI_Win_create_dynamic:
+    == Notes
+    Users are cautioned that displacement arithmetic can overflow in variables of
+    type MPI_Aint and result in unexpected values on some platforms. This issue may
+    be addressed in a future version of MPI.
+
+    Memory in this window may not be used as the target of one-sided accesses in
+    this window until it is attached using the function `MPI_Win_attach`. That is, in
+    addition to using `MPI_Win_create_dynamic` to create an MPI window, the user must
+    use `MPI_Win_attach` before any local memory may be the target of an MPI RMA
+    operation. Only memory that is currently accessible may be attached.
+
+MPI_Win_detach:
+    == Notes
+    Memory also becomes detached when the associated dynamic memory window is freed.
+
+MPI_Win_fence:
+    == Notes
+    The `assert` argument is used to indicate special conditions for the
+    fence that an implementation may use to optimize the `MPI_Win_fence`
+    operation.  The value zero is always correct.  Other assertion values
+    may be or'ed together.  Assertions that are valid for `MPI_Win_fence` are:
+
+    * `MPI_MODE_NOSTORE` - the local window was not updated by local stores
+      (or local get or receive calls) since last synchronization.
+    * `MPI_MODE_NOPUT` - the local window will not be updated by put or accumulate
+      calls after the fence call, until the ensuing (fence) synchronization.
+    * `MPI_MODE_NOPRECEDE` - the fence does not complete any sequence of locally
+      issued RMA calls. If this assertion is given by any process in the window
+      group, then it must be given by all processes in the group.
+    * `MPI_MODE_NOSUCCEED` - the fence does not start any sequence of locally
+      issued RMA calls. If the assertion is given by any process in the window
+      group, then it must be given by all processes in the group.
+
+MPI_Win_free:
+    == Notes
+    If successfully freed, `win` is set to `MPI_WIN_NULL`.
+    If the user attribute free function returns an error, then do not free the window
+
+
+MPI_Win_get_group:
+    == Notes
+    The `group` is a duplicate of the group from the communicator used to
+    create the MPI window, and should be freed with `MPI_Group_free` when
+    it is no longer needed.  This `group` can be used to form the group of
+    neighbors for the routines `MPI_Win_post` and `MPI_Win_start`.
+
+MPI_Win_get_info:
+    == Notes
+    The info object returned in `info_used` will contain all hints currently active
+    for this window. This set of hints may be greater or smaller than the set of
+    hints specified when the window was created, as the system may not recognize
+    some hints set by the user, and may recognize other hints that the user has not
+    set.
+
+MPI_Win_lock:
+    == Notes
+    The name of this routine is misleading.  In particular, this
+    routine need not block, except when the target process is the calling
+    process.
+
+    Implementations may restrict the use of RMA communication that is
+    synchronized
+    by lock calls to windows in memory allocated by `MPI_Alloc_mem`. Locks can
+    be used portably only in such memory.
+
+    The `assert` argument is used to indicate special conditions for the
+    fence that an implementation may use to optimize the `MPI_Win_lock`
+    operation.  The value zero is always correct.  Other assertion values
+    may be or'ed together.  Assertions that are valid for `MPI_Win_lock` are:
+
+    * `MPI_MODE_NOCHECK` - no other process holds, or will attempt to acquire a
+      conflicting lock, while the caller holds the window lock. This is useful
+      when mutual exclusion is achieved by other means, but the coherence
+      operations that may be attached to the lock and unlock calls are still
+      required.
+
+MPI_Win_lock_all:
+    == Notes
+    This call is not collective.
+
+    The `assert` argument is used to indicate special conditions for the fence that
+    an implementation may use to optimize the `MPI_Win_lock_all` operation.  The
+    value zero is always correct.  Other assertion values may be or'ed together.
+    Assertions that are valid for `MPI_Win_lock_all` are:
+
+    * `MPI_MODE_NOCHECK` - No other process holds, or will attempt to acquire a
+      conflicting lock, while the caller holds the window lock. This is useful
+      when mutual exclusion is achieved by other means, but the coherence
+      operations that may be attached to the lock and unlock calls are still
+      required.
+
+    There may be additional overheads associated with using `MPI_Win_lock` and
+    `MPI_Win_lock_all` concurrently on the same window. These overheads could be
+    avoided by specifying the assertion `MPI_MODE_NOCHECK` when possible
+
+MPI_Win_post:
+    == Notes
+    The `assert` argument is used to indicate special conditions for the
+    fence that an implementation may use to optimize the `MPI_Win_post`
+    operation.  The value zero is always correct.  Other assertion values
+    may be or'ed together.  Assertions that are valid for `MPI_Win_post` are:
+
+    * `MPI_MODE_NOCHECK` - the matching calls to `MPI_WIN_START` have not yet
+      occurred on any origin processes when the call to `MPI_WIN_POST` is made.
+      The nocheck option can be specified by a post call if and only if it is
+      specified by each matching start call.
+    * `MPI_MODE_NOSTORE` - the local window was not updated by local stores (or
+      local get or receive calls) since last synchronization. This may avoid
+      the need for cache synchronization at the post call.
+    * `MPI_MODE_NOPUT` - the local window will not be updated by put or accumulate
+      calls after the post call, until the ensuing (wait) synchronization. This
+      may avoid the need for cache synchronization at the wait call.
+
+MPI_Win_set_info:
+    == Notes
+    Some info items that an implementation can use when it creates a window cannot
+    easily be changed once the window has been created. Thus, an implementation may
+    ignore hints issued in this call that it would have accepted in a creation
+    call.
+
+MPI_Win_shared_query:
+    == Notes
+    The returned `baseptr` points to the calling process' address space of the
+    shared segment belonging to the target `rank`.
+
+MPI_Win_start:
+    == Notes
+    The `assert` argument is used to indicate special conditions for the
+    fence that an implementation may use to optimize the `MPI_Win_start`
+    operation.  The value zero is always correct.  Other assertion values
+    may be or'ed together.  Assertions that are valid for `MPI_Win_start` are:
+
+    * `MPI_MODE_NOCHECK` - the matching calls to `MPI_WIN_POST` have already
+      completed on all target processes when the call to `MPI_WIN_START` is made.
+      The nocheck option can be specified in a start call if and only if it is
+      specified in each matching post call. This is similar to the optimization
+      of ready-send that may save a handshake when the handshake is implicit in
+      the code. (However, ready-send is matched by a regular receive, whereas
+      both start and post must specify the nocheck option.)
+
+MPI_Win_unlock_all:
+    == Notes
+    This call is not collective.
+
+MPI_Comm_get_parent:
+    == Notes
+    If a process was started with `MPI_Comm_spawn` or `MPI_Comm_spawn_multiple`,
+    `MPI_Comm_get_parent` returns the parent intercommunicator of the current
+    process. This parent intercommunicator is created implicitly inside of
+    `MPI_Init` and is the same intercommunicator returned by `MPI_Comm_spawn`
+    in the parents.
+
+    If the process was not spawned, `MPI_Comm_get_parent` returns
+    `MPI_COMM_NULL`.
+
+    After the parent communicator is freed or disconnected, `MPI_Comm_get_parent`
+    returns `MPI_COMM_NULL`.
+
+MPI_Comm_join:
+    == Notes
+    The socket must be quiescent before `MPI_COMM_JOIN` is called and after
+    `MPI_COMM_JOIN` returns. More specifically, on entry to `MPI_COMM_JOIN`, a
+    read on the socket will not read any data that was written to the socket
+    before the remote process called `MPI_COMM_JOIN`.
+
+MPI_Open_port:
+    == Notes
+    MPI copies a system-supplied port name into `port_name`. `port_name` identifies
+    the newly opened port and can be used by a client to contact the server.
+    The maximum size string that may be supplied by the system is
+    `MPI_MAX_PORT_NAME`.
+
+    == Reserved Info Key Values
+
+    * `ip_port` - Value contains IP port number at which to establish a port.
+    * `ip_address` - Value contains IP address at which to establish a port.
+    If the address is not a valid IP address of the host on which the
+    `MPI_OPEN_PORT` call is made, the results are undefined.
+
+MPI_Comm_disconnect:
+    == Notes
+    This routine waits for all pending communication to complete, then frees the
+    communicator and sets `comm` to `MPI_COMM_NULL`.  It may not be called
+    with `MPI_COMM_WORLD` or `MPI_COMM_SELF`.
+
+MPI_Lookup_name:
+    == Notes
+    If the `service_name` is found, MPI copies the associated value into
+    `port_name`.  The maximum size string that may be supplied by the system is
+    `MPI_MAX_PORT_NAME`.
+
+MPI_Publish_name:
+    == Notes
+    The maximum size string that may be supplied for `port_name` is
+    `MPI_MAX_PORT_NAME`.
+
+MPI_Wtick:
+    == Return value
+    Time in seconds since an arbitrary time in the past.
+
+    == Notes
+    This is intended to be a high-resolution, elapsed (or wall) clock.
+    See `MPI_WTICK` to determine the resolution of `MPI_WTIME`.
+    If the attribute `MPI_WTIME_IS_GLOBAL` is defined and true, then the
+    value is synchronized across all processes in `MPI_COMM_WORLD`.
+
+    == Notes for Fortran
+    This is a function, declared as `DOUBLE PRECISION MPI_WTIME` in Fortran.
+
+MPI_Wtime:
+    == Return value
+    Time in seconds of resolution of `MPI_Wtime`
+
+    == Notes for Fortran
+    This is a function, declared as `DOUBLE PRECISION MPI_WTICK` in Fortran.
+
+
+MPI_Cart_create:
+    == Algorithm
+    We ignore `reorder` info currently.
+
+MPI_Cart_rank:
+    == Notes
+    Out-of-range coordinates are erroneous for non-periodic dimensions.
+    Versions of MPICH before 1.2.2 returned `MPI_PROC_NULL` for the rank in this
+    case.
+
+MPI_Cart_shift:
+    == Notes
+    The `direction` argument is in the range `[0,n-1]` for an n-dimensional
+    Cartesian mesh.
+
+MPI_Graph_create:
+    == Notes
+    Each process must provide a description of the entire graph, not just the
+    neighbors of the calling process.
+    
+    == Algorithm
+    We ignore the `reorder` info currently.
+

--- a/maint/createhtmlindex
+++ b/maint/createhtmlindex
@@ -127,7 +127,6 @@ sub AddDirectoryConstants {
     open In, "$rootdir/$file" or die "Can't open $rootdir/$file\n";
     while (<In>) {
         if (/<dt class="hdlist1">(\w+)\s*<\/dt>/) {
-            print "dt: $1\n";
             # TODO: add id reference
             $links{$1} = "$file";
         }

--- a/maint/gen_binding_c.py
+++ b/maint/gen_binding_c.py
@@ -38,6 +38,7 @@ def main():
         G.check_write_path(mansrc_dir + '/')
         G.hints = collect_info_hint_blocks("src")
         G.semantics = collect_mansrc_semantics("doc/mansrc/semantics.adoc")
+        collect_function_notes("doc/mansrc/funcnotes.txt")
     else:
         G.hints = None
         G.semantics = {}
@@ -213,6 +214,25 @@ def collect_mansrc_semantics(filepath):
             if RE.match(r'\/\/ *tag::(\w+)\[\]', line):
                 semantics[RE.m.group(1)] = 1
     return semantics
+
+def collect_function_notes(filepath):
+    func = None
+    notes = None
+    with open(filepath, 'r') as f:
+        for line in f:
+            if RE.match(r'(MPIX*_\w+):', line):
+                func = G.FUNCS[RE.m.group(1).lower()]
+                if not func:
+                    raise Exception("Unknown function %s in %s" % (RE.m.group(1), filepath))
+                if 'notes' in func:
+                    raise Exception("Duplicated notes in %s" % func['name'])
+                notes = []
+                func['notes'] = notes
+            elif RE.match(r'\s+\/\/ *tag:(\w+)\s*$', line):
+                notes = []
+                func['notes-' + RE.m.group(1)] = notes
+            else:
+                notes.append(line[4:])
 
 # ---------------------------------------------------------
 if __name__ == "__main__":

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -505,6 +505,8 @@ def check_func_directives(func):
         if RE.search(r'(NotThreadSafe)', func['docnotes']):
             func['_skip_global_cs'] = 1
 
+    if func['name'].startswith("MPIX_"):
+        func['_docnotes'].append('MPIX')
     if not '_skip_ThreadSafe' in func:
         func['_docnotes'].append('ThreadSafe')
     if not '_skip_Fortran' in func:
@@ -1424,7 +1426,10 @@ def dump_manpage(func, out):
         out.append("")
     if 'seealso' in func:
         out.append("== See also")
-        out.append(re.sub(r'(MPI\w+)', r'*\1*(3)', func['seealso']))
+        outString = ""
+        adjList = re.compile(r'(MPI\w+)').findall(func['seealso'])
+        for adj in adjList: outString += "link:"+adj+".html[*"+adj+"*(3)] "
+        out.append(outString)
 
 def dump_manpage_list(list, header, out):
     count = len(list)

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -130,7 +130,7 @@ def get_mansrc_file_path(func, root_dir):
         file_path = dir_path + '/' + func['file'] + ".adoc"
     elif RE.match(r'(MPI(X|_T)?_\w+)', func['name'], re.IGNORECASE):
         name = RE.m.group(1)
-        file_path = dir_path + '/' + name.lower() + ".adoc"
+        file_path = dir_path + '/' + name + ".adoc"
     else:
         raise Exception("Error in function name pattern: %s\n" % func['name'])
 

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -1374,8 +1374,7 @@ def dump_manpage(func, out):
 
     # Add the custom notes (specified in e.g. pt2pt_api.txt) as is.
     if 'notes' in func:
-        for l in func['notes']:
-            out.append(l)
+        out.extend(func['notes'])
         out.append("")
 
     if 'replace' in func:
@@ -1409,11 +1408,11 @@ def dump_manpage(func, out):
                         has['FortranStatus'] = 1
             for k in has:
                 out.append("include::../docnotes.adoc[tag=%s]" % k)
-        out.append("")
 
-    if 'notes2' in func:
-        for l in func['notes2']:
-            out.append(l)
+        # add custom notes from doc/mansrc/funcnotes.txt
+        if 'notes-' + note in func:
+            out.extend(func['notes-' + note])
+
         out.append("")
 
     if '_skip_err_codes' not in func:

--- a/maint/local_python/mpi_api.py
+++ b/maint/local_python/mpi_api.py
@@ -166,16 +166,6 @@ def load_mpi_api(api_txt, gen_in_dir=""):
                     stage = "FUNC-body"
                     if 'body' not in cur_func:
                         cur_func['body'] = []
-                elif RE.match(r'\/\*', line):
-                    # man page notes
-                    stage = "FUNC-notes"
-                    # 'notes' and 'notes2' goes before and after auto-generated notes
-                    if RE.match(r'\/\*\s*-+\s*notes-2\s*-+', line):
-                        cur_func['notes2'] = []
-                    elif 'notes' not in cur_func:
-                        cur_func['notes'] = []
-                    else:
-                        cur_func['notes2'] = []
             elif stage == "FUNC-body":
                 if RE.match(r'}', line):
                     stage = "FUNC"
@@ -188,15 +178,6 @@ def load_mpi_api(api_txt, gen_in_dir=""):
                 else:
                     line = re.sub(r'^    ', '', line)
                     cur_func[stage].append(line)
-            elif stage == "FUNC-notes":
-                if RE.match(r'\*\/', line):
-                    stage = "FUNC"
-                else:
-                    line = re.sub(r'^    ', '', line)
-                    if 'notes2' in cur_func:
-                        cur_func['notes2'].append(line)
-                    else:
-                        cur_func['notes'].append(line)
 
 def parse_param_attributes(p):
     """Parse the parameter attribute string and populate common fields"""

--- a/src/binding/c/attr_api.txt
+++ b/src/binding/c/attr_api.txt
@@ -6,7 +6,6 @@ MPI_Attr_delete:
 
 MPI_Attr_get:
     .desc: Retrieves attribute value by key
-    .skip: Fortran
     .replace: deprecated with MPI_Comm_get_attr
     .seealso: MPI_Attr_put, MPI_Keyval_create, MPI_Attr_delete, MPI_Comm_get_attr
 
@@ -29,21 +28,6 @@ MPI_Comm_create_keyval:
     .desc: Create a new attribute key
     .docnotes: AttrErrReturn
     .seealso: MPI_Comm_free_keyval
-/*
-    Notes:
-    Key values are global (available for any and all communicators).
-
-    Default copy and delete functions are available.  These are
-    + MPI_COMM_NULL_COPY_FN   - empty copy function
-    . MPI_COMM_NULL_DELETE_FN - empty delete function
-    - MPI_COMM_DUP_FN         - simple dup function
-
-    There are subtle differences between C and Fortran that require that the
-    copy_fn be written in the same language from which 'MPI_Comm_create_keyval'
-    is called.
-    This should not be a problem for most users; only programmers using both
-    Fortran and C in the same program need to be sure that they follow this rule.
-*/
 
 MPI_Comm_delete_attr:
     .desc: Deletes an attribute value associated with a key on a communicator
@@ -55,62 +39,16 @@ MPI_Comm_free_keyval:
 
 MPI_Comm_get_attr:
     .desc: Retrieves attribute value by key
-    .skip: Fortran
     .extra: ignore_revoked_comm
-/*
-    Notes:
-        Attributes must be extracted from the same language as they were inserted
-        in with 'MPI_ATTR_PUT'.  The notes for C and Fortran below explain why.
-*/
-/*
-    Notes for C:
-        Even though the 'attribute_val' argument is declared as 'void *', it is
-        really the address of a void pointer (i.e., a 'void **').  Using
-        a 'void *', however, is more in keeping with C idiom and allows the
-        pointer to be passed without additional casts.
-
-    .N Fortran
-        The 'attribute_val' in Fortran is a pointer to a Fortran integer, not
-        a pointer to a 'void *'.
-*/
 
 MPI_Comm_set_attr:
     .desc: Stores attribute value associated with a key
     .seealso: MPI_Comm_create_keyval, MPI_Comm_delete_attr
     .extra: ignore_revoked_comm
-/*
-    Notes:
-    Values of the permanent attributes 'MPI_TAG_UB', 'MPI_HOST', 'MPI_IO',
-    'MPI_WTIME_IS_GLOBAL', 'MPI_UNIVERSE_SIZE', 'MPI_LASTUSEDCODE', and
-    'MPI_APPNUM' may not be changed.
-
-    The type of the attribute value depends on whether C, C++, or Fortran
-    is being used.
-    In C and C++, an attribute value is a pointer ('void *'); in Fortran, it is an
-    address-sized integer.
-
-    If an attribute is already present, the delete function (specified when the
-    corresponding keyval was created) will be called.
-*/
 
 MPI_Type_create_keyval:
     .desc: Create an attribute keyval for MPI datatypes
     .docnotes: AttrErrReturn
-/*
-    Notes:
-    Key values are global (available for any and all derived datatypes).
-
-    Default copy and delete functions are available.  These are
-    + MPI_TYPE_NULL_COPY_FN   - empty copy function
-    . MPI_TYPE_NULL_DELETE_FN - empty delete function
-    - MPI_TYPE_DUP_FN         - simple dup function
-
-    There are subtle differences between C and Fortran that require that the
-    copy_fn be written in the same language from which 'MPI_Type_create_keyval'
-    is called.
-    This should not be a problem for most users; only programmers using both
-    Fortran and C in the same program need to be sure that they follow this rule.
-*/
 
 MPI_Type_delete_attr:
     .desc: Deletes an attribute value associated with a key on a datatype
@@ -120,55 +58,13 @@ MPI_Type_free_keyval:
 
 MPI_Type_get_attr:
     .desc: Retrieves attribute value by key
-    .skip: Fortran
-/*
-    Notes:
-        Attributes must be extracted from the same language as they were inserted
-        in with 'MPI_ATTR_PUT'.  The notes for C and Fortran below explain why.
-*/
-/*
-    Notes for C:
-        Even though the 'attribute_val' argument is declared as 'void *', it is
-        really the address of a void pointer (i.e., a 'void **').  Using
-        a 'void *', however, is more in keeping with C idiom and allows the
-        pointer to be passed without additional casts.
-
-    .N Fortran
-        The 'attribute_val' in Fortran is a pointer to a Fortran integer, not
-        a pointer to a 'void *'.
-*/
 
 MPI_Type_set_attr:
     .desc: Stores attribute value associated with a key
-/*
-    Notes:
-
-    The type of the attribute value depends on whether C or Fortran is being used.
-    In C, an attribute value is a pointer ('void *'); in Fortran, it is an
-    address-sized integer.
-
-    If an attribute is already present, the delete function (specified when the
-    corresponding keyval was created) will be called.
-*/
 
 MPI_Win_create_keyval:
     .desc: Create an attribute keyval for MPI window objects
     .docnotes: AttrErrReturn
-/*
-    Notes:
-    Key values are global (available for any and all communicators).
-
-    Default copy and delete functions are available.  These are
-    + MPI_WIN_NULL_COPY_FN   - empty copy function
-    . MPI_WIN_NULL_DELETE_FN - empty delete function
-    - MPI_WIN_DUP_FN         - simple dup function
-
-    There are subtle differences between C and Fortran that require that the
-    copy_fn be written in the same language from which 'MPI_Win_create_keyval'
-    is called.
-    This should not be a problem for most users; only programmers using both
-    Fortran and C in the same program need to be sure that they follow this rule.
-*/
 
 MPI_Win_delete_attr:
     .desc: Deletes an attribute value associated with a key on a window
@@ -178,39 +74,6 @@ MPI_Win_free_keyval:
 
 MPI_Win_get_attr:
     .desc: Get attribute cached on an MPI window object
-    .skip: Fortran
-/*
-    Notes:
-    The following attributes are predefined for all MPI Window objects\:
-
-    + MPI_WIN_BASE - window base address.
-    . MPI_WIN_SIZE - window size, in bytes.
-    - MPI_WIN_DISP_UNIT - displacement unit associated with the window.
-
-    Attributes must be extracted from the same language as they were inserted
-    in with 'MPI_ATTR_PUT'.  The notes for C and Fortran below explain why.
-*/
-/*
-    Notes for C:
-        Even though the 'attribute_val' argument is declared as 'void *', it is
-        really the address of a void pointer (i.e., a 'void **').  Using
-        a 'void *', however, is more in keeping with C idiom and allows the
-        pointer to be passed without additional casts.
-
-    .N Fortran
-        The 'attribute_val' in Fortran is a pointer to a Fortran integer, not
-        a pointer to a 'void *'.
-*/
 
 MPI_Win_set_attr:
     .desc: Stores attribute value associated with a key
-/*
-    Notes:
-
-    The type of the attribute value depends on whether C or Fortran is being used.
-    In C, an attribute value is a pointer ('void *'); in Fortran, it is an
-    address-sized integer.
-
-    If an attribute is already present, the delete function (specified when the
-    corresponding keyval was created) will be called.
-*/

--- a/src/binding/c/binding_api.txt
+++ b/src/binding/c/binding_api.txt
@@ -5,19 +5,6 @@ MPIX_Op_create_x:
     extra_state: EXTRA_STATE, [extra state]
     op: OPERATION, direction=out, [operation]
     .desc: Creates a user-defined reduction op with an extra_state
-/*
-    Notes on MPIX_User_function_x:
-    The calling list for the user function type is
-    .vb
-        typedef void (MPIX_User_function_x) (void * a, void * b,
-                                             MPI_Count len, MPI_Datatype datatype,
-                                             void *extra_state);
-    .ve
-    There are a few differences from MPI_User_function used in MPI_Op_create.
-    1. It passes len and datatype as scalar input, rather than as addresses.
-    2. The len is of MPI_Count, rather than int.
-    3. It accepts a void *extra_state which is passed from users during MPIX_Op_create_x.
-*/
 
 MPIX_Comm_create_errhandler_x:
     comm_errhandler_fn_x: FUNCTION, func_type=MPIX_Comm_errhandler_function_x, [user defined error handling procedure with extra_state]

--- a/src/binding/c/coll_api.txt
+++ b/src/binding/c/coll_api.txt
@@ -3,25 +3,6 @@
 MPI_Allgather:
     .desc: Gathers data from all tasks and distribute the combined data to all tasks
     .extra: threadcomm
-/*
-    Notes:
-     The MPI standard (1.0 and 1.1) says that
-    .n
-    .n
-     The jth block of data sent from  each process is received by every process
-     and placed in the jth block of the buffer 'recvbuf'.
-    .n
-    .n
-     This is misleading; a better description is
-    .n
-    .n
-     The block of data sent from the jth process is received by every
-     process and placed in the jth block of the buffer 'recvbuf'.
-    .n
-    .n
-     This text was suggested by Rajeev Thakur and has been adopted as a
-     clarification by the MPI Forum.
-*/
 { -- early_return --
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM) {
         if ((sendcount == 0 && sendbuf != MPI_IN_PLACE) || recvcount == 0) {
@@ -36,26 +17,6 @@ MPI_Allgather_init:
 MPI_Allgatherv:
     .desc: Gathers data from all tasks and deliver the combined data to all tasks
     .extra: threadcomm
-/*
-    Notes:
-     The MPI standard (1.0 and 1.1) says that
-    .n
-    .n
-     The jth block of data sent from
-     each process is received by every process and placed in the jth block of the
-     buffer 'recvbuf'.
-    .n
-    .n
-     This is misleading; a better description is
-    .n
-    .n
-     The block of data sent from the jth process is received by every
-     process and placed in the jth block of the buffer 'recvbuf'.
-    .n
-    .n
-     This text was suggested by Rajeev Thakur, and has been adopted as a
-     clarification to the MPI standard by the MPI-Forum.
-*/
 { -- early_return --
     if (MPIR_is_self_comm(comm_ptr)) {
         if (sendbuf != MPI_IN_PLACE) {
@@ -117,12 +78,6 @@ MPI_Alltoallw_init:
 MPI_Barrier:
     .desc: Blocks until all processes in the communicator have reached this routine.
     .extra: threadcomm
-/*
-    Notes:
-    Blocks the caller until all processes in the communicator have called it;
-    that is, the call returns at any process only after all members of the
-    communicator have entered the call.
-*/
 { -- early_return --
     if (MPIR_is_self_comm(comm_ptr)) {
         goto fn_exit;
@@ -148,12 +103,6 @@ MPI_Exscan:
     .desc: Computes the exclusive scan (partial reductions) of data on a collection of processes
     .docnotes: collops
     .extra: errtest_comm_intra, threadcomm
-/*
-    Notes:
-      'MPI_Exscan' is like 'MPI_Scan', except that the contribution from the
-       calling process is not included in the result at the calling process
-       (it is contributed to the subsequent processes, of course).
-*/
 { -- early_return --
     if (comm_ptr->comm_kind == MPIR_COMM_KIND__INTRACOMM && count == 0) {
         goto fn_exit;
@@ -243,17 +192,6 @@ MPI_Ialltoallw:
 
 MPI_Ibarrier:
     .desc: Notifies the process that it has reached the barrier and returns immediately
-/*
-    Notes:
-    MPI_Ibarrier is a nonblocking version of MPI_barrier. By calling MPI_Ibarrier,
-    a process notifies that it has reached the barrier. The call returns
-    immediately, independent of whether other processes have called MPI_Ibarrier.
-    The usual barrier semantics are enforced at the corresponding completion
-    operation (test or wait), which in the intra-communicator case will complete
-    only after all other processes in the communicator have called MPI_Ibarrier. In
-    the intercommunicator case, it will complete when all processes in the remote
-    group have called MPI_Ibarrier.
-*/
 { -- early_return --
     if (MPIR_is_self_comm(comm_ptr)) {
         MPIR_Request *request_ptr = MPIR_Request_create_complete(MPIR_REQUEST_KIND__COLL);
@@ -382,10 +320,6 @@ MPI_Iscatterv:
 
 MPI_Neighbor_allgather:
     .desc: Gathers data from all neighboring processes and distribute the combined data to all neighboring processes
-/*
-    Notes:
-    In this function, each process i gathers data items from each process j if an edge (j,i) exists in the topology graph, and each process i sends the same data items to all processes j where an edge (i,j) exists. The send buffer is sent to each neighboring process and the l-th block in the receive buffer is received from the l-th neighbor.
-*/
 
 MPI_Neighbor_allgather_init:
     .desc: Create a persistent request for neighbor_allgather.
@@ -399,10 +333,6 @@ MPI_Neighbor_allgatherv_init:
 
 MPI_Neighbor_alltoall:
     .desc: Sends and Receivs data from all neighboring processes
-/*
-    Notes:
-    In this function, each process i receives data items from each process j if an edge (j,i) exists in the topology graph or Cartesian topology.  Similarly, each process i sends data items to all processes j where an edge (i,j) exists. This call is more general than MPI_NEIGHBOR_ALLGATHER in that different data items can be sent to each neighbor. The k-th block in send buffer is sent to the k-th neighboring process and the l-th block in the receive buffer is received from the l-th neighbor.
-*/
 
 MPI_Neighbor_alltoall_init:
     .desc: Create a persistent request for neighbor_alltoall.

--- a/src/binding/c/comm_api.txt
+++ b/src/binding/c/comm_api.txt
@@ -2,14 +2,7 @@
 
 MPI_Comm_compare:
     .desc: Compares two communicators
-    .skip: ThreadSafe
     .extra: ignore_revoked_comm
-/*
-    .N ThreadSafe
-    (To perform the communicator comparisons, this routine may need to
-    allocate some memory.  Memory allocation is not interrupt-safe, and hence
-    this routine is only thread-safe.)
-*/
 
 MPI_Comm_create:
     .desc: Creates a new communicator
@@ -24,64 +17,14 @@ MPI_Comm_dup:
     .desc: Duplicates an existing communicator
     .seealso: MPI_Comm_free, MPI_Keyval_create, MPI_Attr_put, MPI_Attr_delete, MPI_Comm_create_keyval, MPI_Comm_set_attr, MPI_Comm_delete_attr
     .extra: threadcomm
-/*
-    Notes:
-      This routine is used to create a new communicator that has a new
-      communication context but contains the same group of processes as
-      the input communicator.  Since all MPI communication is performed
-      within a communicator (specifies as the group of processes `plus`
-      the context), this routine provides an effective way to create a
-      private communicator for use by a software module or library.  In
-      particular, no library routine should use 'MPI_COMM_WORLD' as the
-      communicator; instead, a duplicate of a user-specified communicator
-      should always be used.  For more information, see Using MPI, 2nd
-      edition.
-
-      Because this routine essentially produces a copy of a communicator,
-      it also copies any attributes that have been defined on the input
-      communicator, using the attribute copy function specified by the
-      'copy_function' argument to 'MPI_Keyval_create'.  This is
-      particularly useful for (a) attributes that describe some property
-      of the group associated with the communicator, such as its
-      interconnection topology and (b) communicators that are given back
-      to the user; the attributes in this case can track subsequent
-      'MPI_Comm_dup' operations on this communicator.
-*/
 
 MPI_Comm_dup_with_info:
     .desc: Duplicates an existing communicator using the supplied info hints
     .seealso: MPI_Comm_dup, MPI_Comm_free, MPI_Keyval_create, MPI_Attr_put, MPI_Attr_delete, MPI_Comm_create_keyval, MPI_Comm_set_attr, MPI_Comm_delete_attr
-/*
-    Notes:
-      MPI_Comm_dup_with_info behaves exactly as MPI_Comm_dup except that
-      the info hints associated with the communicator comm are not
-      duplicated in newcomm.  The hints provided by the argument info are
-      associated with the output communicator newcomm instead.
-*/
 
 MPI_Comm_free:
     .desc: Marks the communicator object for deallocation
     .extra: ignore_revoked_comm, threadcomm
-/*
-    Notes:
-    This routine `frees` a communicator.  Because the communicator may still
-    be in use by other MPI routines, the actual communicator storage will not
-    be freed until all references to this communicator are removed.  For most
-    users, the effect of this routine is the same as if it was in fact freed
-    at this time of this call.
-
-    Null Handles:
-    The MPI 1.1 specification, in the section on opaque objects, explicitly
-    disallows freeing a null communicator.  The text from the standard is:
-    .vb
-     A null handle argument is an erroneous IN argument in MPI calls, unless an
-     exception is explicitly stated in the text that defines the function. Such
-     exception is allowed for handles to request objects in Wait and Test calls
-     (sections Communication Completion and Multiple Completions). Otherwise, a
-     null handle can only be passed to a function that allocates a new object and
-     returns a reference to it in the handle.
-    .ve
-*/
 { -- error_check --
     if (HANDLE_IS_BUILTIN(*comm)) {
         mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE, __func__, __LINE__,
@@ -120,10 +63,6 @@ MPI_Comm_remote_group:
     .desc: Accesses the remote group associated with
     .seealso: MPI_Group_free
     .extra: ignore_revoked_comm
-/*
-    Notes:
-    The user is responsible for freeing the group when it is no longer needed.
-*/
 
 MPI_Comm_remote_size:
     .desc: Determines the size of the remote group
@@ -132,13 +71,6 @@ MPI_Comm_remote_size:
 
 MPI_Comm_set_info:
     .desc: Set new values for the hints of the communicator associated with comm
-/*
-    Notes:
-    The call is collective on the group of comm. The info object may be different
-    on each process, but any info entries that an implementation requires to be
-    the same on all processes must appear with the same value in each process'
-    info object. 
-*/
 
 MPI_Comm_set_name:
     .desc: Sets the print name for a communicator
@@ -153,29 +85,11 @@ MPI_Comm_split:
     .desc: Creates new communicators based on colors and keys
     .skip: validate-COLOR, validate-KEY
     .seealso: MPI_Comm_free
-/*
-    Notes:
-      The 'color' must be non-negative or 'MPI_UNDEFINED'.
-*/
-/*
-    Algorithm:
-    .vb
-      1. Use MPI_Allgather to get the color and key from each process
-      2. Count the number of processes with the same color; create a
-         communicator with that many processes.  If this process has
-         'MPI_UNDEFINED' as the color, create a process with a single member.
-      3. Use key to order the ranks
-    .ve
-*/
 
 MPI_Comm_split_type:
     .desc: Creates new communicators based on split types and keys
     .skip: validate-SPLIT_TYPE, validate-KEY
     .seealso: MPI_Comm_free
-/*
-    Notes:
-      The 'split_type' must be non-negative or 'MPI_UNDEFINED'.
-*/
 { -- error_check --
     CHECKENUM: split_type, splittype, MPI_UNDEFINED MPI_COMM_TYPE_SHARED MPI_COMM_TYPE_HW_GUIDED MPI_COMM_TYPE_HW_UNGUIDED MPI_COMM_TYPE_RESOURCE_GUIDED MPIX_COMM_TYPE_NEIGHBORHOOD
 }
@@ -204,20 +118,6 @@ MPI_Intercomm_create:
     .skip: validate-RANK
     .extra: errtest_comm_intra
     .seealso: MPI_Intercomm_merge, MPI_Comm_free, MPI_Comm_remote_group, MPI_Comm_remote_size
-/*
-    Notes:
-       'peer_comm' is significant only for the process designated the
-       'local_leader' in the 'local_comm'.
-
-      The MPI 1.1 Standard contains two mutually exclusive comments on the
-      input intercommunicators.  One says that their respective groups must be
-      disjoint; the other that the leaders can be the same process.  After
-      some discussion by the MPI Forum, it has been decided that the groups must
-      be disjoint.  Note that the `reason` given for this in the standard is
-      `not` the reason for this choice; rather, the `other` operations on
-      intercommunicators (like 'MPI_Intercomm_merge') do not make sense if the
-      groups are not disjoint.
-*/
 { -- error_check --
     /* Validate local_comm_ptr */
     MPIR_Comm_valid_ptr(local_comm_ptr, mpi_errno, FALSE);
@@ -272,21 +172,6 @@ MPI_Intercomm_merge:
     .skip: validate-LOGICAL
     .extra: setup_intercomm_localcomm
     .seealso: MPI_Intercomm_create, MPI_Comm_free
-/*
-    Notes:
-     While all processes may provide the same value for the 'high' parameter,
-     this requires the MPI implementation to determine which group of
-     processes should be ranked first.
-*/
-/*
-    Algorithm:
-    .Eb
-    .i Allocate contexts
-    .i Local and remote group leaders swap high values
-    .i Determine the high value.
-    .i Merge the two groups and make the intra-communicator
-    .Ee
-*/
 { -- handle_ptr --
     /* Make sure that we have a local intercommunicator */
     if (!intercomm_ptr->local_comm) {
@@ -317,12 +202,6 @@ MPIX_Comm_revoke:
     comm: COMMUNICATOR, [communicator to revoke]
     .desc: Prevent a communicator from being used in the future
     .extra: ignore_revoked_comm
-/*
-    Notes:
-    This function notifies all MPI processes in the groups (local and remote) associated with the communicator comm that this communicator is revoked. The revocation of a communicator by any MPIprocess completes non-local MPI operations on comm at all MPI processes by raising an error of class MPI_ERR_REVOKED (with the exception of MPIX_Comm_shrink, MPIX_Comm_agree). This function is not collective and therefore does not have a matching call on remote MPI processes. All non-failed MPIprocesses belonging to comm will be notified of the revocation despite failures.
-
-    A communicator is revoked at a given MPI process either when MPIX_Comm_revoke is locally called on it, or when any MPI operation on comm raises an error of class MPI_ERR_REVOKED at that process. Once a communicator has been revoked at an MPI process, all subsequent non-local operations on that communicator (with thesame exceptions as above), are considered local and must complete by raising an error of class MPI_ERR_REVOKED at that MPI process.
-*/
 {
     mpi_errno = MPID_Comm_revoke(comm_ptr, 0);
     if (mpi_errno) {
@@ -335,23 +214,12 @@ MPIX_Comm_shrink:
     newcomm: COMMUNICATOR, direction=out, [new communicator]
     .desc: Creates a new communitor from an existing communicator while excluding failed processes
     .extra: ignore_revoked_comm
-/*
-    Notes:
-    This collective operation creates a new intra- or intercommunicator newcomm from the intra- or intercommunicator comm, respectively, by excluding the group of failed MPI processes as agreed upon during the operation. The groups of newcomm must include everyMPIprocess that returns from MPIX_Comm_shrink, and it must exclude every MPI process whose failure caused an operation on comm to raise an MPI error of class MPI_ERR_PROC_FAILED or MPI_ERR_PROC_FAILED_PENDING at a member of the groups of newcomm, before that member initiated MPIX_Comm_shrink. This call is semantically equivalent to an MPI_Comm_split operation that would succeed despite failures, where members of the groups of newcomm participate with the same color and a key equal to their rank incomm.
-
-    This function never raises an error of class MPI_ERR_PROC_FAILED or MPI_ERR_REVOKED. The defined semantics of MPIX_Comm_shrink are maintained when comm is revoked, or when the group of comm contains failed MPI processes
-*/
-
 
 MPIX_Comm_failure_ack:
     comm: COMMUNICATOR, [communicator]
     .desc: Acknowledge the current group of failed processes
     .extra: ignore_revoked_comm
     .impl: mpid
-/*
-    Notes:
-    This local operation gives the users a way to acknowledge all locally notified failures on comm. After the call, unmatched MPI_ANY_SOURCE receive operations that would haveraised an error of class MPI_ERR_PROC_FAILED_PENDING due to MPI process failure proceed without further raising errors due to those acknowledged failures. Also after this call, MPIX_Comm_agree will not raise an error of class MPI_ERR_PROC_FAILED due to those acknowledged failures.
-*/
 
 MPIX_Comm_failure_get_acked:
     comm: COMMUNICATOR, [communicator]
@@ -359,34 +227,14 @@ MPIX_Comm_failure_get_acked:
     .desc: Get the group of acknowledged failures.
     .extra: ignore_revoked_comm
     .impl: mpid
-/*
-    Notes:
-    This local operation returns the group failedgrp of processes, from the communicatorcomm, that have been locally acknowledged as failed by preceding calls to MPIX_Comm_failure_ack. The failedgrp can be empty, that is, equal to MPI_GROUP_EMPTY.
-*/
 
 MPIX_Comm_agree:
     comm: COMMUNICATOR, [communicator]
     flag: LOGICAL, direction=out, [new communicator]
     .desc: Performs agreement operation on comm
     .extra: ignore_revoked_comm
-/*
-    Notes:
-    The purpose of this collective communication is to agree on the integer value flag and on the group of failed processes in comm.
-
-    On completion, all non-failed MPI processes have agreed to set the output integer value of flag to the result of a bitwise AND operation over the contributed input values of flag. If comm is an intercommunicator, the value of flagis a bitwise AND operation over the values contributed by the remote group.
-
-    When an MPI process fails before contributing to the operation, the flag is computed ignoring its contribution, and MPIX_Comm_agree raises an error of class MPI_ERR_PROC_FAILED. However, if all MPI processes have acknowledged this failure priorto the call to MPIX_Comm_agree, using MPIX_Comm_failure_ack, the error related to this failure is not raised. When an error of class MPI_ERR_PROC_FAILED is raised, it is consistently raised at allMPI processes, in both the local and remote groups (if applicable).
-
-    After MPIX_Comm_agree raised an error of class MPI_ERR_PROC_FAILED, a subse-quent call to MPIX_Comm_failure_ack on comm acknowledges the failure of every MPI process that didn't contribute to the computation offlag.
-*/
 
 MPIX_Comm_get_failed:
     comm: COMMUNICATOR, [communicator]
     failedgrp: GROUP, direction=out, [group of failed processes]
     .desc: This local operation returns the group of processes that are locally known to have failed.
-/*
-    Notes:
-    The returned failedgrp can be empty, that is, equal to MPI_GROUP_EMPTY.
-
-    For any two groups obtained from calls to this routine at the same MPI process with the same comm, the smaller group is a prefix of the larger group, that is, the same failed process will have the same rank in the returned failedgrp.
-*/

--- a/src/binding/c/datatype_api.txt
+++ b/src/binding/c/datatype_api.txt
@@ -9,56 +9,16 @@ MPI_Address:
 
 MPI_Type_create_f90_integer:
     .desc: Return a predefined type that matches the specified range
-/*
-    Notes:
-    If there is no corresponding type for the specified range, the call is
-    erroneous.  This implementation sets 'newtype' to 'MPI_DATATYPE_NULL' and
-    returns an error of class 'MPI_ERR_ARG'.
-*/
 
 MPI_Type_create_f90_real:
     .desc: Return a predefined type that matches the specified range
-/*
-    Notes:
-    If there is no corresponding type for the specified range, the call is
-    erroneous.  This implementation sets 'newtype' to 'MPI_DATATYPE_NULL' and
-    returns an error of class 'MPI_ERR_ARG'.
-*/
 
 MPI_Type_create_f90_complex:
     .desc: Return a predefined type that matches the specified range
-/*
-    Notes:
-    If there is no corresponding type for the specified range, the call is
-    erroneous.  This implementation sets 'newtype' to 'MPI_DATATYPE_NULL' and
-    returns an error of class 'MPI_ERR_ARG'.
-*/
 
 MPI_Get_address:
     .desc: Get the address of a location in memory
-    .skip: Fortran, global_cs
-/*
-    Notes:
-    This routine is provided for both the Fortran and C programmers.
-    On many systems, the address returned by this routine will be the same
-    as produced by the C '&' operator, but this is not required in C and
-    may not be true of systems with word- rather than byte-oriented
-    instructions or systems with segmented address spaces.
-*/
-/*
-    .N Fortran
-
-     In Fortran, the integer type is always signed.  This can cause problems
-     on systems where the address fits into a four byte unsigned integer but
-     the value is larger than the largest signed integer.  For example, a system
-     with more than 2 GBytes of memory may have addresses that do not fit within
-     a four byte signed integer.  Unfortunately, there is no easy solution to
-     this problem, as there is no Fortran datatype that can be used here (using
-     a longer integer type will cause other problems, as well as surprising
-     users when the size of the integer type is larger that the size of a pointer
-     in C).  In this case, it is recommended that you use C to manipulate
-     addresses.
-*/
+    .skip: global_cs
 { -- error_check -- location
     /* location can be NULL (MPI_BOTTOM) */
 }
@@ -67,23 +27,10 @@ MPI_Get_count:
     .desc: Gets the number of "top level" elements
     .skip: global_cs
     .poly_impl: use_aint
-/*
-    Notes:
-    If the size of the datatype is zero, this routine will return a count of
-    zero.  If the amount of data in 'status' is not an exact multiple of the
-    size of 'datatype' (so that 'count' would not be integral), a 'count' of
-    'MPI_UNDEFINED' is returned instead.
-*/
 
 MPI_Get_elements:
     .desc: Returns the number of basic elements
     .skip: global_cs
-/*
-    Notes:
-    If the size of the datatype is zero and the amount of data returned as
-    determined by 'status' is also zero, this routine will return a count of
-    zero.  This is consistent with a clarification made by the MPI Forum.
-*/
 {
     MPI_Count count_x;
     MPI_Count byte_count = MPIR_STATUS_GET_COUNT(*status);
@@ -128,15 +75,6 @@ MPI_Pack:
     .desc: Packs a datatype into contiguous memory
     .skip: global_cs
     .poly_impl: use_aint
-/*
-    Notes (from the specifications):
-    The input value of position is the first location in the output buffer to be
-    used for packing.  position is incremented by the size of the packed message,
-    and the output value of position is the first location in the output buffer
-    following the locations occupied by the packed message.  The comm argument is
-    the communicator that will be subsequently used for sending the packed
-    message.
-*/
 { -- error_check -- inbuf, outbuf
     /* MPI_BOTTOM cannot be used when count > 1 */
     if (incount > 1) {
@@ -167,12 +105,6 @@ MPI_Pack_external_size:
 MPI_Pack_size:
     .desc: Returns the upper bound on the amount of space needed to pack a message
     .poly_impl: use_aint
-/*
-    Notes:
-    The MPI standard document describes this in terms of 'MPI_Pack', but it
-    applies to both 'MPI_Pack' and 'MPI_Unpack'.  That is, the value 'size' is
-    the maximum that is needed by either 'MPI_Pack' or 'MPI_Unpack'.
-*/
 
 MPI_Unpack:
     .desc: Unpack a buffer according to a datatype into contiguous memory
@@ -229,16 +161,6 @@ MPI_Type_commit:
 
 MPI_Type_free:
     .desc: Frees the datatype
-/*
-    Predefined types:
-    The MPI standard states that (in Opaque Objects)
-    .Bqs
-    MPI provides certain predefined opaque objects and predefined, static handles
-    to these objects. Such objects may not be destroyed.
-    .Bqe
-    Thus, it is an error to free a predefined datatype.  The same section makes
-    it clear that it is an error to free a null datatype.
-*/
 { -- error_check --
     if (MPIR_DATATYPE_IS_PREDEFINED(*datatype)) {
         mpi_errno = MPIR_Err_create_code(MPI_SUCCESS, MPIR_ERR_RECOVERABLE,
@@ -373,29 +295,6 @@ MPI_Type_create_hvector:
 
 MPI_Type_create_indexed_block:
     .desc: Create an indexed datatype with constant-sized blocks
-/* -- notes-2 --
-    Notes:
-    The indices are displacements, and are based on a zero origin.  A common error
-    is to do something like the following
-    .vb
-        integer a(100)
-        integer blens(10), indices(10)
-        do i=1,10
-    10       indices(i) = 1 + (i-1)*10
-        call MPI_TYPE_CREATE_INDEXED_BLOCK(10,1,indices,MPI_INTEGER,newtype,ierr)
-        call MPI_TYPE_COMMIT(newtype,ierr)
-        call MPI_SEND(a,1,newtype,...)
-    .ve
-    expecting this to send "a(1),a(11),..." because the indices have values
-    "1,11,...".   Because these are `displacements` from the beginning of "a",
-    it actually sends "a(1+1),a(1+11),...".
-    
-    If you wish to consider the displacements as indices into a Fortran array,
-    consider declaring the Fortran array with a zero origin
-    .vb
-        integer a(0:99)
-    .ve
-*/
 
 MPI_Type_create_resized:
     .desc: Create a datatype with a new lower bound and extent from an existing datatype
@@ -413,32 +312,7 @@ MPI_Type_hindexed:
     oldtype: DATATYPE, [old datatype]
     newtype: DATATYPE, direction=out, [new datatype]
     .desc: Creates an indexed datatype with offsets in bytes
-    .skip: Fortran
     .replace: removed with MPI_Type_create_hindexed
-/* -- notes-2 --
-    .N Fortran
-    The array_of_displacements are displacements, and are based on a zero origin.  A common error
-    is to do something like to following
-    .vb
-        integer a(100)
-        integer array_of_blocklengths(10), array_of_displacements(10)
-        do i=1,10
-             array_of_blocklengths(i)   = 1
-    10       array_of_displacements(i) = (1 + (i-1)*10) * sizeofint
-        call MPI_TYPE_HINDEXED(10,array_of_blocklengths,array_of_displacements,MPI_INTEGER,newtype,ierr)
-        call MPI_TYPE_COMMIT(newtype,ierr)
-        call MPI_SEND(a,1,newtype,...)
-    .ve
-    expecting this to send "a(1),a(11),..." because the array_of_displacements have values
-    "1,11,...".   Because these are `displacements` from the beginning of "a",
-    it actually sends "a(1+1),a(1+11),...".
-    
-    If you wish to consider the displacements as array_of_displacements into a Fortran array,
-    consider declaring the Fortran array with a zero origin
-    .vb
-        integer a(0:99)
-    .ve
-*/
 
 MPI_Type_hvector:
     count: DTYPE_NUM_ELEM_NNI_SMALL, [number of blocks]
@@ -452,31 +326,6 @@ MPI_Type_hvector:
 
 MPI_Type_indexed:
     .desc: Creates an indexed datatype
-    .skip: Fortran
-/* -- notes-2 --
-    .N Fortran
-    The array_of_displacements are displacements, and are based on a zero origin.  A common error
-    is to do something like to following
-    .vb
-        integer a(100)
-        integer array_of_blocklengths(10), array_of_displacements(10)
-        do i=1,10
-             array_of_blocklengths(i)   = 1
-    10       array_of_displacements(i) = 1 + (i-1)*10
-        call MPI_TYPE_INDEXED(10,array_of_blocklengths,array_of_displacements,MPI_INTEGER,newtype,ierr)
-        call MPI_TYPE_COMMIT(newtype,ierr)
-        call MPI_SEND(a,1,newtype,...)
-    .ve
-    expecting this to send "a(1),a(11),..." because the array_of_displacements have values
-    "1,11,...".   Because these are `displacements` from the beginning of "a",
-    it actually sends "a(1+1),a(1+11),...".
-    
-    If you wish to consider the displacements as array_of_displacements into a Fortran array,
-    consider declaring the Fortran array with a zero origin
-    .vb
-        integer a(0:99)
-    .ve
-*/
 
 MPI_Type_struct:
     count: DTYPE_NUM_ELEM_NNI_SMALL, [number of blocks also number of entries in arrays array_of_types, array_of_displacements, and array_of_blocklengths]
@@ -486,45 +335,6 @@ MPI_Type_struct:
     newtype: DATATYPE, direction=out, [new datatype]
     .desc: Creates a struct datatype
     .replace: removed with MPI_Type_create_struct
-/*
-    Notes:
-    If an upperbound is set explicitly by using the MPI datatype 'MPI_UB', the
-    corresponding index must be positive.
-    
-    The MPI standard originally made vague statements about padding and alignment;
-    this was intended to allow the simple definition of structures that could
-    be sent with a count greater than one.  For example,
-    .vb
-        struct { int a; char b; } foo;
-    .ve
-    may have 'sizeof(foo) > sizeof(int) + sizeof(char)'; for example,
-    'sizeof(foo) == 2*sizeof(int)'.  The initial version of the MPI standard
-    defined the extent of a datatype as including an `epsilon` that would have
-    allowed an implementation to make the extent an MPI datatype
-    for this structure equal to '2*sizeof(int)'.
-    However, since different systems might define different paddings, there was
-    much discussion by the MPI Forum about what was the correct value of
-    epsilon, and one suggestion was to define epsilon as zero.
-    This would have been the best thing to do in MPI 1.0, particularly since
-    the 'MPI_UB' type allows the user to easily set the end of the structure.
-    Unfortunately, this change did not make it into the final document.
-    Currently, this routine does not add any padding, since the amount of
-    padding needed is determined by the compiler that the user is using to
-    build their code, not the compiler used to construct the MPI library.
-    A later version of MPICH may provide for some natural choices of padding
-    (e.g., multiple of the size of the largest basic member), but users are
-    advised to never depend on this, even with vendor MPI implementations.
-    Instead, if you define a structure datatype and wish to send or receive
-    multiple items, you should explicitly include an 'MPI_UB' entry as the
-    last member of the structure.  For example, the following code can be used
-    for the structure foo
-    .vb
-        blen[0] = 1; array_of_displacements[0] = 0; oldtypes[0] = MPI_INT;
-        blen[1] = 1; array_of_displacements[1] = &foo.b - &foo; oldtypes[1] = MPI_CHAR;
-        blen[2] = 1; array_of_displacements[2] = sizeof(foo); oldtypes[2] = MPI_UB;
-        MPI_Type_struct(3, blen, array_of_displacements, oldtypes, &newtype);
-    .ve
-*/
 
 MPI_Type_vector:
     .desc: Creates a vector (strided) datatype
@@ -532,13 +342,6 @@ MPI_Type_vector:
 MPI_Type_match_size:
     .desc: Find an MPI datatype matching a specified size
     .skip: validate-TYPECLASS, validate-TYPECLASS_SIZE
-/*
-    Notes:
-    'typeclass' is one of 'MPI_TYPECLASS_REAL', 'MPI_TYPECLASS_INTEGER' and
-    'MPI_TYPECLASS_COMPLEX', corresponding to the desired typeclass.
-    The function returns an MPI datatype matching a local variable of type
-    '(typeclass, size)'.
-*/
 
 MPIX_Type_iov_len:
     datatype: DATATYPE

--- a/src/binding/c/errhan_api.txt
+++ b/src/binding/c/errhan_api.txt
@@ -8,19 +8,6 @@ MPI_Add_error_code:
 
 MPI_Add_error_string:
     .desc: Associates an error string with an MPI error code or class
-/*
-    Notes:
-    The string must be no more than 'MPI_MAX_ERROR_STRING' characters long.
-    The length of the string is as defined in the calling language.
-    The length of the string does not include the null terminator in C or C++.
-    Note that the string is 'const' even though the MPI standard does not
-    specify it that way.
-
-    According to the MPI-2 standard, it is erroneous to call 'MPI_Add_error_string'
-    for an error code or class with a value less than or equal
-    to 'MPI_ERR_LASTCODE'.  Thus, you cannot replace the predefined error messages
-    with this routine.
-*/
 
 MPI_Error_class:
     .desc: Converts an error code into an error class
@@ -29,12 +16,6 @@ MPI_Error_class:
 MPI_Error_string:
     .desc: Return a string for a given error code
     .skip: initcheck
-/*
-    Notes:
-    Error codes are the values return by MPI routines (in C) or in the
-    'ierr' argument (in Fortran).  These can be converted into error classes
-    with the routine 'MPI_Error_class'.
-*/
 
 MPI_Errhandler_create:
     comm_errhandler_fn: FUNCTION_SMALL, func_type=MPI_Comm_errhandler_function, [user defined error handling procedure]
@@ -67,32 +48,11 @@ MPI_Comm_call_errhandler:
 
 MPI_Comm_create_errhandler:
     .desc: Create a communicator error handler
-/*
-    Notes:
-    The MPI Standard states that an implementation may make the output value
-    (errhandler) simply the address of the function.  However, the action of
-    'MPI_Errhandler_free' makes this impossible, since it is required to set the
-    value of the argument to 'MPI_ERRHANDLER_NULL'.  In addition, the actual
-    error handler must remain until all communicators that use it are
-    freed.
-*/
 
 MPI_Comm_get_errhandler:
     .desc: Get the error handler attached to a communicator
     .extra: ignore_revoked_comm
     .docnotes: ThreadSafeNoUpdate
-/*
-    Note on Implementation:
-
-    The MPI Standard was unclear on whether this routine required the user to call
-    'MPI_Errhandler_free' once for each call made to this routine in order to
-    free the error handler.  After some debate, the MPI Forum added an explicit
-    statement that users are required to call 'MPI_Errhandler_free' when the
-    return value from this routine is no longer needed.  This behavior is similar
-    to the other MPI routines for getting objects; for example, 'MPI_Comm_group'
-    requires that the user call 'MPI_Group_free' when the group returned
-    by 'MPI_Comm_group' is no longer needed.
-*/
 
 MPI_Comm_set_errhandler:
     .desc: Set the error handler for a communicator
@@ -132,13 +92,6 @@ MPI_Remove_error_code:
 
 MPI_Remove_error_string:
     .desc: Remove the error string associated with an MPI error code or class
-/*
-    Notes:
-    According to the MPI 4.1 standard, it is erroneous to call 'MPI_Remove_error_string'
-    for an error code or class with a value less than or equal
-    to 'MPI_ERR_LASTCODE'.  Thus, you cannot replace the predefined error messages
-    with this routine.
-*/
 
 MPI_Win_call_errhandler:
     .desc: Call the error handler installed on a window

--- a/src/binding/c/group_api.txt
+++ b/src/binding/c/group_api.txt
@@ -6,20 +6,10 @@ MPI_Group_compare:
 MPI_Group_difference:
     .desc: Makes a group from the difference of two groups
     .seealso: MPI_Group_free
-/*
-    Notes:
-    The generated group contains the members of 'group1' that are not in 'group2'.
-*/
 
 MPI_Group_excl:
     .desc: Produces a group by reordering an existing group and taking only unlisted members
     .seealso: MPI_Group_free
-/*
-    Note:
-    The MPI standard requires that each of the ranks to excluded must be
-    a valid rank in the group and all elements must be distinct or the
-    function is erroneous.
-*/
 { -- error_check --
     if (group_ptr) {
         mpi_errno = MPIR_Group_check_valid_ranks(group_ptr, ranks, n);
@@ -59,11 +49,6 @@ MPI_Group_incl:
 MPI_Group_intersection:
     .desc: Produces a group as the intersection of two existing groups
     .seealso: MPI_Group_free
-/*
-    Notes:
-    The output group contains those processes that are in both 'group1' and
-    'group2'.
-*/
 
 MPI_Group_range_excl:
     .desc: Produces a group by excluding ranges of processes from an existing group
@@ -101,10 +86,6 @@ MPI_Group_size:
 
 MPI_Group_translate_ranks:
     .desc: Translates the ranks of processes in one group to those in another group
-/*
-    As a special case (see the MPI-2 errata), if the input rank is
-    'MPI_PROC_NULL', 'MPI_PROC_NULL' is given as the output rank.
-*/
 { -- error_check --
     if (group1_ptr) {
 	/* Check that the rank entries are valid */

--- a/src/binding/c/init_api.txt
+++ b/src/binding/c/init_api.txt
@@ -4,31 +4,10 @@ MPI_Abort:
     .desc: Terminates MPI execution environment
     .skip: ThreadSafe, validate-ERROR_CODE
     .extra: ignore_revoked_comm
-/*
-    Notes:
-    Terminates all MPI processes associated with the communicator 'comm'; in
-    most systems (all to date), terminates `all` processes.
-
-    .N NotThreadSafe
-    Because the 'MPI_Abort' routine is intended to ensure that an MPI
-    process (and possibly an entire job), it cannot wait for a thread to
-    release a lock or other mechanism for atomic access.
-*/
 
 MPI_Finalize:
     .desc: Terminates MPI execution environment
     .skip: ThreadSafe, global_cs
-/*
-    Notes:
-    All processes must call this routine before exiting.  The number of
-    processes running `after` this routine is called is undefined;
-    it is best not to perform much more than a 'return rc' after calling
-    'MPI_Finalize'.
-
-    Thread and Signal Safety:
-    The MPI standard requires that 'MPI_Finalize' be called `only` by the same
-    thread that initialized MPI with either 'MPI_Init' or 'MPI_Init_thread'.
-*/
 
 MPI_Finalized:
     .desc: Indicates whether 'MPI_Finalize' has been called.
@@ -37,36 +16,9 @@ MPI_Finalized:
 
 MPI_Init:
     .desc: Initialize the MPI execution environment
-    .skip: ThreadSafe, Fortran, initcheck, validate-ARGUMENT_COUNT, validate-ARGUMENT_LIST
+    .skip: ThreadSafe, initcheck, validate-ARGUMENT_COUNT, validate-ARGUMENT_LIST
     .seealso: MPI_Init_thread, MPI_Finalize
     .include: mpi_init.h
-/*
-    Notes:
-       The MPI standard does not say what a program can do before an 'MPI_INIT' or
-       after an 'MPI_FINALIZE'.  In the MPICH implementation, you should do
-       as little as possible.  In particular, avoid anything that changes the
-       external state of the program, such as opening files, reading standard
-       input or writing to standard output.
-
-    Thread Level:
-        MPICH by default set thread level to MPI_THREAD_SINGLE. This can be changed
-        by setting MPIR_CVAR_DEFAULT_THREAD_LEVEL.
-
-    Thread and Signal Safety:
-        This routine must be called by one thread only.  That thread is called
-        the `main thread` and must be the thread that calls 'MPI_Finalize'.
-
-    Notes for C:
-        As of MPI-2, 'MPI_Init' will accept NULL as input parameters. Doing so
-        will impact the values stored in 'MPI_INFO_ENV'.
-
-    Notes for Fortran:
-    The Fortran binding for 'MPI_Init' has only the error return
-    .vb
-        subroutine MPI_INIT(ierr)
-        integer ierr
-    .ve
-*/
 { -- error_check --
     MPIR_ERRTEST_INITTWICE();
 }
@@ -78,31 +30,9 @@ MPI_Initialized:
 
 MPI_Init_thread:
     .desc: Initialize the MPI execution environment
-    .skip: ThreadSafe, Fortran, initcheck, validate-THREAD_LEVEL, validate-ARGUMENT_COUNT, validate-ARGUMENT_LIST
+    .skip: ThreadSafe, initcheck, validate-THREAD_LEVEL, validate-ARGUMENT_COUNT, validate-ARGUMENT_LIST
     .seealso: MPI_Init, MPI_Finalize
     .include: mpi_init.h
-/*
-    Command line arguments:
-    MPI specifies no command-line arguments but does allow an MPI
-    implementation to make use of them.  See 'MPI_INIT' for a description of
-    the command line arguments supported by 'MPI_INIT' and 'MPI_INIT_THREAD'.
-
-    Notes:
-    The valid values for the level of thread support are\:
-    + MPI_THREAD_SINGLE - Only one thread will execute.
-    . MPI_THREAD_FUNNELED - The process may be multi-threaded, but only the main
-    thread will make MPI calls (all MPI calls are funneled to the
-    main thread).
-    . MPI_THREAD_SERIALIZED - The process may be multi-threaded, and multiple
-    threads may make MPI calls, but only one at a time: MPI calls are not
-    made concurrently from two distinct threads (all MPI calls are serialized).
-    - MPI_THREAD_MULTIPLE - Multiple threads may call MPI, with no restrictions.
-*/
-/*
-    Notes for Fortran:
-    Note that the Fortran binding for this routine does not have the 'argc' and
-    'argv' arguments. ('MPI_INIT_THREAD(required, provided, ierror)')
-*/
 { -- error_check --
     MPIR_ERRTEST_INITTWICE();
 }
@@ -114,40 +44,10 @@ MPI_Is_thread_main:
 MPI_Query_thread:
     .desc: Return the level of thread support provided by the MPI library
     .skip: global_cs
-/*
-    Notes:
-    The valid values for the level of thread support are\:
-    + MPI_THREAD_SINGLE - Only one thread will execute.
-    . MPI_THREAD_FUNNELED - The process may be multi-threaded, but only the main
-    thread will make MPI calls (all MPI calls are funneled to the
-    main thread).
-    . MPI_THREAD_SERIALIZED - The process may be multi-threaded, and multiple
-    threads may make MPI calls, but only one at a time: MPI calls are not
-    made concurrently from two distinct threads (all MPI calls are serialized).
-    - MPI_THREAD_MULTIPLE - Multiple threads may call MPI, with no restrictions.
-
-    If 'MPI_Init' was called instead of 'MPI_Init_thread', the level of
-    thread support is defined by the implementation.  This routine allows
-    you to find out the provided level.  It is also useful for library
-    routines that discover that MPI has already been initialized and
-    wish to determine what level of thread support is available.
-*/
 
 MPI_Session_init:
     .desc: Initialize an MPI session
     .skip: initcheck
-/*
-    Info Hints:
-        Following keys are supported:
-        "thread_level" - Set MPI thread level. The default is MPI_THREAD_MULTIPLE.
-                         Note this is different from the default in MPI_Init.
-                         MPICH does not support different thread levels in different
-                         sessions. The provided thread level will be the one set by
-                         the first MPI_Session_init, MPI_Init, or MPI_Init_thread.
-        "mpi_memory_alloc_kinds" - Set the memory allocation kinds to be used by
-                                   by the calling MPI process on MPI objects derived
-                                   from the Session.
-*/
 
 MPI_Session_finalize:
     .desc: Finalize an MPI Session

--- a/src/binding/c/misc_api.txt
+++ b/src/binding/c/misc_api.txt
@@ -5,19 +5,6 @@ MPI_Aint_add:
     .skip: ThreadSafe, Fortran, Errors, validate-ANY
     .seealso: MPI_Aint_diff
     .impl: direct
-/*
-    Notes:
-    MPI_Aint_Add produces a new MPI_Aint value that is equivalent to the sum of the
-    base and disp arguments, where base represents a base address returned by a call
-    to MPI_GET_ADDRESS and disp represents a signed integer displacement. The resulting
-    address is valid only at the process that generated base, and it must correspond
-    to a location in the same object referenced by base. The addition is performed in
-    a manner that results in the correct MPI_Aint representation of the output address,
-    as if the process that originally produced base had called
-    .vb
-        MPI_Get_address((char *) base + disp, &result)
-    .ve
-*/
 {
     MPI_Aint result;
 
@@ -35,20 +22,6 @@ MPI_Aint_diff:
     .skip: ThreadSafe, Fortran, Errors, validate-ANY
     .seealso: MPI_Aint_add
     .impl: direct
-/*
-    Notes:
-    MPI_Aint_diff produces a new MPI_Aint value that is equivalent to the difference
-    between addr1 and addr2 arguments, where addr1 and addr2 represent addresses
-    returned by calls to MPI_GET_ADDRESS. The resulting address is valid only at the
-    process that generated addr1 and addr2, and addr1 and addr2 must correspond to
-    locations in the same object in the same process. The difference is calculated
-    in a manner that results the signed difference from addr1 to addr2, as if the
-    process that originally produced the addresses had called
-    .vb
-        (char *) addr1 - (char *) addr2
-    .ve
-    on the addresses initially passed to MPI_GET_ADDRESS.
-*/
 {
     MPI_Aint result;
 
@@ -63,26 +36,6 @@ MPI_Aint_diff:
 
 MPI_Get_processor_name:
     .desc: Gets the name of the processor
-/*
-    Notes:
-    The name returned should identify a particular piece of hardware;
-    the exact format is implementation defined.  This name may or may not
-    be the same as might be returned by 'gethostname', 'uname', or 'sysinfo'.
-*/
-/* -- notes-2 --
-     In Fortran, the character argument should be declared as a character string
-     of 'MPI_MAX_PROCESSOR_NAME' rather than an array of dimension
-     'MPI_MAX_PROCESSOR_NAME'.  That is,
-    .vb
-       character*(MPI_MAX_PROCESSOR_NAME) name
-    .ve
-     rather than
-    .vb
-       character name(MPI_MAX_PROCESSOR_NAME)
-    .ve
-
-     The sizes of MPI strings in Fortran are one less than the sizes of that string in C/C++ because the C/C++ versions provide room for the trailing null character required by C/C++. For example, MPI_MAX_ERROR_STRING is mpif.h is one smaller than the same value in mpi.h. See the MPI standard, sections 2.6.2 and 4.12.9. 
-*/
 {
     mpi_errno = MPID_Get_processor_name(name, MPI_MAX_PROCESSOR_NAME, resultlen);
     if (mpi_errno != MPI_SUCCESS)
@@ -97,14 +50,6 @@ MPI_Pcontrol:
     .desc: Controls profiling
     .skip: initcheck, ThreadSafe, validate-PROFILE_LEVEL, validate-VARARGS
     .impl: direct
-/*
-    Notes:
-	This routine provides a common interface for profiling control.  The
-	interpretation of 'level' and any other arguments is left to the
-	profiling library.  The intention is that a profiling library will
-	provide a replacement for this routine and define the interpretation
-	of the parameters.
-*/
 {
     int mpi_errno = MPI_SUCCESS;
     va_list list;

--- a/src/binding/c/mpit_api.txt
+++ b/src/binding/c/mpit_api.txt
@@ -2,12 +2,6 @@
 
 MPI_T_category_changed:
     .desc: Get the timestamp indicating the last change to the categories
-/*
-    Notes:
-    If two subsequent calls to this routine return the same timestamp, it is guaranteed that
-    the category information has not changed between the two calls. If the timestamp retrieved
-    from the second call is higher, then some categories have been added or expanded.
-*/
 {
     *update_number = cat_stamp;
 }
@@ -203,22 +197,6 @@ MPI_T_finalize:
     .skip: global_cs
     .seealso: MPI_T_init_thread
     .error: MPI_T_ERR_NOT_INITIALIZED
-/*
-    Notes:
-    This routine may be called as often as the corresponding MPI_T_init_thread() routine
-    up to the current point of execution. Calling it more times returns a corresponding
-    error code. As long as the number of calls to MPI_T_finalize() is smaller than the
-    number of calls to MPI_T_init_thread() up to the current point of execution, the MPI
-    tool information interface remains initialized and calls to its routines are permissible.
-    Further, additional calls to MPI_T_init_thread() after one or more calls to MPI_T_finalize()
-    are permissible. Once MPI_T_finalize() is called the same number of times as the routine
-    MPI_T_init_thread() up to the current point of execution, the MPI tool information
-    interface is no longer initialized. The interface can be reinitialized by subsequent calls
-    to MPI_T_init_thread().
-    
-    At the end of the program execution, unless MPI_Abort() is called, an application must
-    have called MPI_T_init_thread() and MPI_T_finalize() an equal number of times.
-*/
 {
     --MPIR_T_init_balance;
     if (MPIR_T_init_balance < 0) {
@@ -236,18 +214,6 @@ MPI_T_init_thread:
     .desc: Initialize the MPI_T execution environment
     .skip: global_cs, initcheck
     .seealso: MPI_T_finalize
-/*
-    Notes:
-      The valid values for the level of thread support are:
-    + MPI_THREAD_SINGLE - Only one thread will execute.
-    . MPI_THREAD_FUNNELED - The process may be multi-threaded, but only the main
-      thread will make MPI_T calls (all MPI_T calls are funneled to the
-      main thread).
-    . MPI_THREAD_SERIALIZED - The process may be multi-threaded, and multiple
-      threads may make MPI_T calls, but only one at a time: MPI_T calls are not
-      made concurrently from two distinct threads (all MPI_T calls are serialized).
-    - MPI_THREAD_MULTIPLE - Multiple threads may call MPI_T, with no restrictions.
-*/
 { -- error_check -- required
     CHECKENUM: required, thread_level, MPI_THREAD_SINGLE MPI_THREAD_FUNNELED MPI_THREAD_SERIALIZED MPI_THREAD_MULTIPLE
 }
@@ -359,18 +325,6 @@ MPI_T_pvar_handle_free:
 
 MPI_T_pvar_read:
     .desc: Read the value of a performance variable
-/*
-    Notes:
-    The MPI_T_pvar_read() call queries the value of the performance variable with the
-    handle "handle" in the session identified by the parameter session and stores the result
-    in the buffer identified by the parameter buf. The user is responsible to ensure that the
-    buffer is of the appropriate size to hold the entire value of the performance variable
-    (based on the datatype and count returned by the corresponding previous calls to
-    MPI_T_pvar_get_info() and MPI_T_pvar_handle_alloc(), respectively).
-    
-    The constant MPI_T_PVAR_ALL_HANDLES cannot be used as an argument for the function
-    MPI_T_pvar_read().
-*/
 
 MPI_T_pvar_readreset:
     .desc: Read the value of a performance variable and then reset it
@@ -391,17 +345,6 @@ MPI_T_pvar_readreset:
 MPI_T_pvar_reset:
     .desc: Reset a performance variable
     .error: MPI_T_ERR_INVALID_HANDLE, MPI_T_ERR_PVAR_NO_WRITE
-/*
-    Notes:
-    The MPI_T_pvar_reset() call sets the performance variable with the handle identified
-    by the parameter handle to its starting value. If it is not possible
-    to change the variable, the function returns MPI_T_ERR_PVAR_NO_WRITE.
-    If the constant MPI_T_PVAR_ALL_HANDLES is passed in handle, the MPI implementation
-    attempts to reset all variables within the session identified by the parameter session for
-    which handles have been allocated. In this case, the routine returns MPI_SUCCESS if all
-    variables are reset successfully, otherwise MPI_T_ERR_PVAR_NO_WRITE is returned. Readonly
-    variables are ignored when MPI_T_PVAR_ALL_HANDLES is specified.
-*/
 {
     MPIR_T_pvar_handle_t *hnd;
     /* If handle is MPI_T_PVAR_ALL_HANDLES, dispatch the call.
@@ -438,25 +381,10 @@ MPI_T_pvar_session_create:
 
 MPI_T_pvar_session_free:
     .desc: Free an existing performance variable session
-/*
-    Notes:
-    Calls to the MPI tool information interface can no longer be made
-    within the context of a session after it is freed. On a successful
-    return, MPI sets the session identifier to MPI_T_PVAR_SESSION_NULL.
-*/
 
 MPI_T_pvar_start:
     .desc: Start a performance variable
     .error: MPI_T_ERR_INVALID_HANDLE, MPI_T_ERR_PVAR_NO_STARTSTOP
-/*
-    Notes:
-    If the constant MPI_T_PVAR_ALL_HANDLES is passed in handle, the MPI implementation
-    attempts to start all variables within the session identified by the parameter session for
-    which handles have been allocated. In this case, the routine returns MPI_SUCCESS if all
-    variables are started successfully, otherwise MPI_T_ERR_PVAR_NO_STARTSTOP is returned.
-    Continuous variables and variables that are already started are ignored when
-    MPI_T_PVAR_ALL_HANDLES is specified.
-*/
 {
     if (handle == MPI_T_PVAR_ALL_HANDLES) {
         MPIR_T_pvar_handle_t *hnd;
@@ -485,18 +413,6 @@ MPI_T_pvar_start:
 MPI_T_pvar_stop:
     .desc: Stop a performance variable
     .error: MPI_T_ERR_INVALID_HANDLE, MPI_T_ERR_PVAR_NO_STARTSTOP
-/*
-    Notes:
-    This functions stops the performance variable with the handle identified by the parameter
-    handle in the session identified by the parameter session.
-    
-    If the constant MPI_T_PVAR_ALL_HANDLES is passed in handle, the MPI implementation
-    attempts to stop all variables within the session identified by the parameter session for
-    which handles have been allocated. In this case, the routine returns MPI_SUCCESS if all
-    variables are stopped successfully, otherwise MPI_T_ERR_PVAR_NO_STARTSTOP is returned.
-    Continuous variables and variables that are already stopped are ignored when
-    MPI_T_PVAR_ALL_HANDLES is specified.
-*/
 {
     /* If handle is MPI_T_PVAR_ALL_HANDLES, dispatch the call.
      * Otherwise, do correctness check, then go to impl.
@@ -531,18 +447,6 @@ MPI_T_pvar_stop:
 MPI_T_pvar_write:
     .desc: Write a performance variable
     .error: MPI_T_ERR_PVAR_NO_WRITE
-/*
-    Notes:
-    The MPI_T_pvar_write() call attempts to write the value of the performance variable
-    with the handle identified by the parameter handle in the session identified by the parameter
-    session. The value to be written is passed in the buffer identified by the parameter buf. The
-    user must ensure that the buffer is of the appropriate size to hold the entire value of the
-    performance variable (based on the datatype and count returned by the corresponding previous
-    calls to MPI_T_pvar_get_info() and MPI_T_pvar_handle_alloc(), respectively).
-    
-    The constant MPI_T_PVAR_ALL_HANDLES cannot be used as an argument for the function
-    MPI_T_pvar_write().
-*/
 { -- error_check --
     if (MPIR_T_pvar_is_readonly(handle)) {
         mpi_errno = MPI_T_ERR_PVAR_NO_WRITE;

--- a/src/binding/c/pt2pt_api.txt
+++ b/src/binding/c/pt2pt_api.txt
@@ -4,36 +4,6 @@ MPI_Bsend:
     .desc: Basic send with user-provided buffering
     .seealso: MPI_Buffer_attach, MPI_Ibsend, MPI_Bsend_init
     .earlyreturn: pt2pt_proc_null
-/*
-    Notes:
-    This send is provided as a convenience function; it allows the user to
-    send messages without worring about where they are buffered (because the
-    user `must` have provided buffer space with 'MPI_Buffer_attach').
-
-    In deciding how much buffer space to allocate, remember that the buffer space
-    is not available for reuse by subsequent 'MPI_Bsend's unless you are certain
-    that the message
-    has been received (not just that it should have been received).  For example,
-    this code does not allocate enough buffer space
-    .vb
-        MPI_Buffer_attach(b, n*sizeof(double) + MPI_BSEND_OVERHEAD);
-        for (i=0; i<m; i++) {
-            MPI_Bsend(buf, n, MPI_DOUBLE, ...);
-        }
-    .ve
-    because only enough buffer space is provided for a single send, and the
-    loop may start a second 'MPI_Bsend' before the first is done making use of the
-    buffer.
-
-    In C, you can
-    force the messages to be delivered by
-    .vb
-        MPI_Buffer_detach(&b, &n);
-        MPI_Buffer_attach(b, n);
-    .ve
-    (The 'MPI_Buffer_detach' will not complete until all buffered messages are
-    delivered.)
-*/
 {
     mpi_errno = MPIR_Bsend_isend(buf, count, datatype, dest, tag, comm_ptr, NULL);
     if (mpi_errno != MPI_SUCCESS)
@@ -59,91 +29,11 @@ MPI_Buffer_attach:
     .desc: Attaches a user-provided buffer for sending
     .skip: ThreadSafe
     .seealso: MPI_Buffer_detach, MPI_Bsend
-/*
-    Notes:
-    The size given should be the sum of the sizes of all outstanding Bsends that
-    you intend to have, plus 'MPI_BSEND_OVERHEAD' for each Bsend that you do.
-    For the purposes of calculating size, you should use 'MPI_Pack_size'.
-    In other words, in the code
-    .vb
-         MPI_Buffer_attach(buffer, size);
-         MPI_Bsend(..., count=20, datatype=type1,  ...);
-         ...
-         MPI_Bsend(..., count=40, datatype=type2, ...);
-    .ve
-    the value of 'size' in the 'MPI_Buffer_attach' call should be greater than
-    the value computed by
-    .vb
-         MPI_Pack_size(20, type1, comm, &s1);
-         MPI_Pack_size(40, type2, comm, &s2);
-         size = s1 + s2 + 2 * MPI_BSEND_OVERHEAD;
-    .ve
-    The 'MPI_BSEND_OVERHEAD' gives the maximum amount of space that may be used in
-    the buffer for use by the BSEND routines in using the buffer.  This value
-    is in 'mpi.h' (for C) and 'mpif.h' (for Fortran).
-
-    .N NotThreadSafe
-    Because the buffer for buffered sends (e.g., 'MPI_Bsend') is shared by all
-    threads in a process, the user is responsible for ensuring that only
-    one thread at a time calls this routine or 'MPI_Buffer_detach'.
-*/
 
 MPI_Buffer_detach:
     .desc: Removes an existing buffer (for use in MPI_Bsend etc)
     .skip: ThreadSafe, Fortran
     .seealso: MPI_Buffer_attach
-/*
-    Notes:
-        The reason that 'MPI_Buffer_detach' returns the address and size of the
-    buffer being detached is to allow nested libraries to replace and restore
-    the buffer.  For example, consider
-
-    .vb
-        int size, mysize, idummy;
-        void *ptr, *myptr, *dummy;
-        MPI_Buffer_detach(&ptr, &size);
-        MPI_Buffer_attach(myptr, mysize);
-        ...
-        ... library code ...
-        ...
-        MPI_Buffer_detach(&dummy, &idummy);
-        MPI_Buffer_attach(ptr, size);
-    .ve
-
-    This is much like the action of the Unix signal routine and has the same
-    strengths (it is simple) and weaknesses (it only works for nested usages).
-
-    Note that for this approach to work, MPI_Buffer_detach must return MPI_SUCCESS
-    even when there is no buffer to detach.  In that case, it returns a size of
-    zero.  The MPI 1.1 standard for 'MPI_BUFFER_DETACH' contains the text
-
-    .vb
-       The statements made in this section describe the behavior of MPI for
-       buffered-mode sends. When no buffer is currently associated, MPI behaves
-       as if a zero-sized buffer is associated with the process.
-    .ve
-
-    This could be read as applying only to the various Bsend routines.  This
-    implementation takes the position that this applies to 'MPI_BUFFER_DETACH'
-    as well.
-
-    .N NotThreadSafe
-    Because the buffer for buffered sends (e.g., 'MPI_Bsend') is shared by all
-    threads in a process, the user is responsible for ensuring that only
-    one thread at a time calls this routine or 'MPI_Buffer_attach'.
-
-    .N Fortran
-
-        The Fortran binding for this routine is different.  Because Fortran
-        does not have pointers, it is impossible to provide a way to use the
-        output of this routine to exchange buffers.  In this case, only the
-        size field is set.
-
-    Notes for C:
-        Even though the 'bufferptr' argument is declared as 'void *', it is
-        really the address of a void pointer.  See the rationale in the
-        standard for more details.
-*/
 
 MPI_Buffer_flush:
     .desc: block until all messages currently in the globally shared buffer of the calling process have been transmitted
@@ -359,11 +249,6 @@ MPI_Recv:
     .desc: Blocking receive for a message
     .earlyreturn: pt2pt_proc_null
     .extra: threadcomm
-/*
-    Notes:
-    The 'count' argument indicates the maximum length of a message; the actual
-    length of the message can be determined with 'MPI_Get_count'.
-*/
 {
     MPIR_Request *request_ptr = NULL;
 
@@ -438,11 +323,6 @@ MPI_Send:
     .seealso: MPI_Isend, MPI_Bsend
     .earlyreturn: pt2pt_proc_null
     .extra: threadcomm
-/*
-    Notes:
-    This routine may block until the message is received by the destination
-    process.
-*/
 {
     MPIR_Request *request_ptr = NULL;
 

--- a/src/binding/c/request_api.txt
+++ b/src/binding/c/request_api.txt
@@ -3,21 +3,6 @@
 MPI_Cancel:
     .desc: Cancels a communication request
     .docnotes: NULL
-/*
-    Notes:
-    The primary expected use of 'MPI_Cancel' is in multi-buffering
-    schemes, where speculative 'MPI_Irecvs' are made.  When the computation
-    completes, some of these receive requests may remain; using 'MPI_Cancel' allows
-    the user to cancel these unsatisfied requests.
-
-    Cancelling a send operation is much more difficult, in large part because the
-    send will usually be at least partially complete (the information on the tag,
-    size, and source are usually sent immediately to the destination).
-    Users are
-    advised that cancelling a send, while a local operation (as defined by the MPI
-    standard), is likely to be expensive (usually generating one or more internal
-    messages).
-*/
 
 MPI_Grequest_complete:
     .desc: Notify MPI that a user-defined request is complete
@@ -71,29 +56,9 @@ MPIX_Grequest_class_allocate:
 MPI_Request_free:
     .desc: Frees a communication request object
     .seealso: MPI_Isend, MPI_Irecv, MPI_Issend, MPI_Ibsend, MPI_Irsend, MPI_Recv_init, MPI_Send_init, MPI_Ssend_init, MPI_Rsend_init, MPI_Wait, MPI_Test, MPI_Waitall, MPI_Waitany, MPI_Waitsome, MPI_Testall, MPI_Testany, MPI_Testsome
-/*
-    Notes:
-
-    This routine is normally used to free inactive persistent requests created with
-    either 'MPI_Recv_init' or 'MPI_Send_init' and friends.  It `is` also
-    permissible to free an active request.  However, once freed, the request can no
-    longer be used in a wait or test routine (e.g., 'MPI_Wait') to determine
-    completion.
-
-    This routine may also be used to free a non-persistent requests such as those
-    created with 'MPI_Irecv' or 'MPI_Isend' and friends.  Like active persistent
-    requests, once freed, the request can no longer be used with test/wait routines
-    to determine completion.
-*/
 
 MPI_Request_get_status:
     .desc: Nondestructive test for the completion of a Request
-/*
-    Notes:
-    Unlike 'MPI_Test', 'MPI_Request_get_status' does not deallocate or
-    deactivate the request.  A call to one of the test/wait routines or
-    'MPI_Request_free' should be made to release the request object.
-*/
 { -- early_return --
     if (request == MPI_REQUEST_NULL || !MPIR_Request_is_active(request_ptr)) {
         *flag = 1;
@@ -153,14 +118,6 @@ MPI_Start:
 MPI_Startall:
     .desc: Starts a collection of persistent requests
     .impl: mpid
-/*
-    Notes:
-    Unlike 'MPI_Waitall', 'MPI_Startall' does not provide a mechanism for
-    returning multiple errors nor pinpointing the request(s) involved.
-    Furthermore, the behavior of 'MPI_Startall' after an error occurs is not
-    defined by the MPI standard.  If well-defined error reporting and behavior
-    are required, multiple calls to 'MPI_Start' should be used instead.
-*/
 
 MPI_Status_get_error:
     .desc: Get MPI_ERROR field from the status
@@ -254,23 +211,6 @@ MPI_Testall:
     .desc: Tests for the completion of all previously initiated requests
     .docnotes: waitstatus
     .error: MPI_ERR_IN_STATUS
-/*
-    Notes:
-      'flag' is true only if all requests have completed.  Otherwise, flag is
-      false and neither the 'array_of_requests' nor the 'array_of_statuses' is
-      modified.
-
-    If one or more of the requests completes with an error, 'MPI_ERR_IN_STATUS' is
-    returned.  An error value will be present is elements of 'array_of_statuses'
-    associated with the requests.  Likewise, the 'MPI_ERROR' field in the status
-    elements associated with requests that have successfully completed will be
-    'MPI_SUCCESS'.  Finally, those requests that have not completed will have a
-    value of 'MPI_ERR_PENDING'.
-
-    While it is possible to list a request handle more than once in the
-    'array_of_requests', such an action is considered erroneous and may cause the
-    program to unexecpectedly terminate or produce incorrect results.
-*/
 {
     mpi_errno = MPIR_Testall(count, request_ptrs, flag, array_of_statuses);
     if (*flag) {
@@ -307,13 +247,6 @@ MPI_Testall:
 MPI_Testany:
     .desc: Tests for completion of any previdously initiated requests
     .docnotes: waitstatus
-/*
-    Notes:
-
-    While it is possible to list a request handle more than once in the
-    'array_of_requests', such an action is considered erroneous and may cause the
-    program to unexecpectedly terminate or produce incorrect results.
-*/
 {
     /* Pass down request ptr to avoid redundant handle to ptr translation. */
     mpi_errno = MPIR_Testany(count, request_ptrs, indx, flag, status);
@@ -333,13 +266,6 @@ MPI_Testany:
 MPI_Testsome:
     .desc: Tests for some given requests to complete
     .docnotes: waitstatus
-/*
-    Notes:
-
-    While it is possible to list a request handle more than once in the
-    'array_of_requests', such an action is considered erroneous and may cause the
-    program to unexecpectedly terminate or produce incorrect results.
-*/
 { -- error_check -- array_of_indices
     if (incount > 0) {
         MPIR_ERRTEST_ARGNULL(array_of_requests, "array_of_requests", mpi_errno);
@@ -403,20 +329,6 @@ MPI_Waitall:
     .desc: Waits for all given MPI Requests to complete
     .docnotes: waitstatus
     .error: MPI_ERR_IN_STATUS
-/*
-    Notes:
-
-    If one or more of the requests completes with an error, 'MPI_ERR_IN_STATUS' is
-    returned.  An error value will be present is elements of 'array_of_statuses'
-    associated with the requests.  Likewise, the 'MPI_ERROR' field in the status
-    elements associated with requests that have successfully completed will be
-    'MPI_SUCCESS'.  Finally, those requests that have not completed will have a
-    value of 'MPI_ERR_PENDING'.
-
-    While it is possible to list a request handle more than once in the
-    array_of_requests, such an action is considered erroneous and may cause the
-    program to unexecpectedly terminate or produce incorrect results.
-*/
 {
     mpi_errno = MPIR_Waitall(count, request_ptrs, array_of_statuses);
     for (int i = 0; i < count; i++) {
@@ -451,15 +363,6 @@ MPI_Waitall:
 MPI_Waitany:
     .desc: Waits for any specified MPI Request to complete
     .docnotes: waitstatus
-/*
-    Notes:
-    If all of the requests are 'MPI_REQUEST_NULL', then 'indx' is returned as
-    'MPI_UNDEFINED', and 'status' is returned as an empty status.
-
-    While it is possible to list a request handle more than once in the
-    array_of_requests, such an action is considered erroneous and may cause the
-    program to unexecpectedly terminate or produce incorrect results.
-*/
 {
     /* Pass down request ptr to avoid redundant handle to ptr translation. */
     mpi_errno = MPIR_Waitany(count, request_ptrs, indx, status);
@@ -478,30 +381,7 @@ MPI_Waitany:
 
 MPI_Waitsome:
     .desc: Waits for some given MPI Requests to complete
-/*
-    Notes:
-    The array of indices are in the range '0' to 'incount - 1' for C and
-    in the range '1' to 'incount' for Fortran.
-
-    Null requests are ignored; if all requests are null, then the routine
-    returns with 'outcount' set to 'MPI_UNDEFINED'.
-
-    While it is possible to list a request handle more than once in the
-    array_of_requests, such an action is considered erroneous and may cause the
-    program to unexecpectedly terminate or produce incorrect results.
-
-    'MPI_Waitsome' provides an interface much like the Unix 'select' or 'poll'
-    calls and, in a high qualilty implementation, indicates all of the requests
-    that have completed when 'MPI_Waitsome' is called.
-    However, 'MPI_Waitsome' only guarantees that at least one
-    request has completed; there is no guarantee that `all` completed requests
-    will be returned, or that the entries in 'array_of_indices' will be in
-    increasing order. Also, requests that are completed while 'MPI_Waitsome' is
-    executing may or may not be returned, depending on the timing of the
-    completion of the message.
-
-    .N waitstatus
-*/
+    .docnotes: waitstatus
 { -- error_check -- array_of_indices
     if (incount > 0) {
         MPIR_ERRTEST_ARGNULL(array_of_indices, "array_of_indices", mpi_errno);

--- a/src/binding/c/rma_api.txt
+++ b/src/binding/c/rma_api.txt
@@ -3,17 +3,6 @@
 MPI_Alloc_mem:
     .desc: Allocate memory for message passing and RMA
     .error: MPI_ERR_NO_MEM
-/*
-    Notes:
-    Using this routine from Fortran requires that the Fortran compiler accept
-    a common pointer extension.  See Section 4.11 (Memory Allocation) in the
-    MPI-2 standard for more information and examples.
-
-    Also note that while 'baseptr' is a 'void *' type, this is
-    simply to allow easy use of any pointer object for this parameter.
-    In fact, this argument is really a 'void **' type, that is, a
-    pointer to a pointer.
-*/
 {
     void *ap = MPID_Alloc_mem(size, info_ptr);
 
@@ -69,15 +58,6 @@ MPI_Compare_and_swap:
     .skip: ThreadSafe, validate-DATATYPE
     .impl: mpid
     .earlyreturn: pt2pt_proc_null
-/*
-    Notes:
-    This operation is atomic with respect to other "accumulate" operations.
-
-    The parameter datatype must belong to one of the following categories of
-    predefined datatypes: C integer, Fortran integer, Logical, Multi-language
-    types, or Byte as specified in Section 5.9.2 on page 176. The origin and result
-    buffers (origin_addr and result_addr) must be disjoint.
-*/
 { -- error_check --
     MPIR_ERRTEST_DATATYPE(datatype, "datatype", mpi_errno);
     /* Check if datatype is a C integer, Fortran Integer,
@@ -92,20 +72,6 @@ MPI_Fetch_and_op:
     .impl: mpid
     .earlyreturn: pt2pt_proc_null
     .error: MPI_ERR_OP
-/*
-    Notes:
-    This operations is atomic with respect to other "accumulate" operations.
-
-    The generic functionality of 'MPI_Get_accumulate' might limit the performance of
-    fetch-and-increment or fetch-and-add calls that might be supported by special
-    hardware operations. 'MPI_Fetch_and_op' thus allows for a fast implementation
-    of a commonly used subset of the functionality of 'MPI_Get_accumulate'.
-
-    The origin and result buffers (origin_addr and result_addr) must be disjoint.
-    Any of the predefined operations for 'MPI_Reduce', as well as 'MPI_NO_OP' or
-    'MPI_REPLACE', can be specified as op; user-defined functions cannot be used. The
-    datatype argument must be a predefined datatype.
-*/
 { -- error_check --
     if (op != MPI_NO_OP) {
         /* NOTE: when op is MPI_NO_OP, origin_addr is allowed to be NULL.
@@ -133,32 +99,6 @@ MPI_Get_accumulate:
     .seealso: MPI_Rget_accumulate MPI_Fetch_and_op
     .impl: mpid
     .earlyreturn: pt2pt_proc_null
-/*
-    Notes:
-    This operations is atomic with respect to other "accumulate" operations.
-
-    The get and accumulate steps are executed atomically for each basic element in
-    the datatype (see MPI 3.0 Section 11.7 for details). The predefined operation
-    'MPI_REPLACE' provides fetch-and-set behavior.
-
-    The origin and result buffers (origin_addr and result_addr) must be disjoint.
-    Each datatype argument must be a predefined datatype or a derived datatype
-    where all basic components are of the same predefined datatype. All datatype
-    arguments must be constructed from the same predefined datatype. The
-    operation op applies to elements of that predefined type. target_datatype must
-    not specify overlapping entries, and the target buffer must fit in the target
-    window or in attached memory in a dynamic window.
-
-    Any of the predefined operations for 'MPI_Reduce', as well as 'MPI_NO_OP' or
-    'MPI_REPLACE' can be specified as op. User-defined functions cannot be used. A
-    new predefined operation, 'MPI_NO_OP', is defined. It corresponds to the
-    associative function f (a, b) = a; i.e., the current value in the target memory
-    is returned in the result buffer at the origin and no operation is performed on
-    the target buffer. 'MPI_NO_OP' can be used only in 'MPI_Get_accumulate',
-    'MPI_Rget_accumulate', and 'MPI_Fetch_and_op'. 'MPI_NO_OP' cannot be used in
-    'MPI_Accumulate', 'MPI_Raccumulate', or collective reduction operations, such as
-    'MPI_Reduce' and others.
-*/
 
 MPI_Put:
     .desc: Put data into a memory window on a remote process
@@ -172,11 +112,6 @@ MPI_Raccumulate:
     .seealso: MPI_Accumulate
     .impl: mpid
     .earlyreturn: pt2pt_proc_null
-/*
-    Notes:
-    The basic components of both the origin and target datatype must be the same
-    predefined datatype (e.g., all 'MPI_INT' or all 'MPI_DOUBLE_PRECISION').
-*/
 
 MPI_Rget:
     .desc: Get data from a memory window on a remote process
@@ -190,17 +125,6 @@ MPI_Rget_accumulate:
     .seealso: MPI_Get_accumulate MPI_Fetch_and_op
     .impl: mpid
     .earlyreturn: pt2pt_proc_null
-/*
-    Notes:
-    This operations is atomic with respect to other "accumulate" operations.
-
-    The get and accumulate steps are executed atomically for each basic element in
-    the datatype (see MPI 3.0 Section 11.7 for details). The predefined operation
-    'MPI_REPLACE' provides fetch-and-set behavior.
-
-    The basic components of both the origin and target datatype must be the same
-    predefined datatype (e.g., all 'MPI_INT' or all 'MPI_DOUBLE_PRECISION').
-*/
 
 MPI_Rput:
     .desc: Put data into a memory window on a remote process and return a request
@@ -217,26 +141,6 @@ MPI_Win_allocate_shared:
     .desc: Create an MPI Window object for one-sided communication and shared memory access, and allocate memory at each process
     .seealso: MPI_Win_allocate MPI_Win_create MPI_Win_create_dynamic MPI_Win_free MPI_Win_shared_query
     .impl: mpid
-/*
-    This is a collective call executed by all processes in the group of comm. On
-    each process i, it allocates memory of at least size bytes that is shared among
-    all processes in comm, and returns a pointer to the locally allocated segment
-    in baseptr that can be used for load/store accesses on the calling process. The
-    locally allocated memory can be the target of load/store accesses by remote
-    processes; the base pointers for other processes can be queried using the
-    function 'MPI_Win_shared_query'.
-
-    The call also returns a window object that can be used by all processes in comm
-    to perform RMA operations. The size argument may be different at each process
-    and size = 0 is valid. It is the user''s responsibility to ensure that the
-    communicator comm represents a group of processes that can create a shared
-    memory segment that can be accessed by all processes in the group. The
-    allocated memory is contiguous across process ranks unless the info key
-    alloc_shared_noncontig is specified. Contiguous across process ranks means that
-    the first address in the memory segment of process i is consecutive with the
-    last address in the memory segment of process i - 1. This may enable the user
-    to calculate remote address offsets with local information only.
-*/
 
 MPI_Win_attach:
     .desc: Attach memory to a dynamic window
@@ -255,71 +159,16 @@ MPI_Win_create:
     .desc: Create an MPI Window object for one-sided communication
     .seealso: MPI_Win_allocate MPI_Win_allocate_shared MPI_Win_create_dynamic MPI_Win_free
     .impl: mpid
-/*
-    Notes:
-
-    The displacement unit argument is provided to facilitate address arithmetic in
-    RMA operations: the target displacement argument of an RMA operation is scaled
-    by the factor disp_unit specified by the target process, at window creation.
-
-    The info argument provides optimization hints to the runtime about the expected
-    usage pattern of the window. The following info keys are predefined.
-
-    . no_locks - If set to true, then the implementation may assume that passive
-        target synchronization (i.e., 'MPI_Win_lock', 'MPI_Win_lock_all') will not be used on
-        the given window. This implies that this window is not used for 3-party
-        communication, and RMA can be implemented with no (less) asynchronous agent
-        activity at this process.
-
-    . accumulate_ordering - Controls the ordering of accumulate operations at the
-        target.  The argument string should contain a comma-separated list of the
-        following read/write ordering rules, where e.g. "raw" means read-after-write:
-        "rar,raw,war,waw".
-
-    . accumulate_ops - If set to same_op, the implementation will assume that all
-        concurrent accumulate calls to the same target address will use the same
-        operation. If set to same_op_no_op, then the implementation will assume that
-        all concurrent accumulate calls to the same target address will use the same
-        operation or 'MPI_NO_OP'. This can eliminate the need to protect access for
-        certain operation types where the hardware can guarantee atomicity. The default
-        is same_op_no_op.
-
-    . mpi_accumulate_granularity - Controls the desired synchronization granularity
-        for accumulate ops. It sets the size of memory range in bytes for which the
-        MPI library should acquire a synchronization primitive to ensure the atomicity
-        of updates. The default is 0 which let the MPI library decides the granularity.
-        When the info hint is set to a positive value, the actual range of synchroniation
-        is round-up to the next size that fits the Datatype used in the accumulate
-        operation (see MPI standard 4.1). All processes in the group of a windows must
-        set to the same value.
-*/
 
 MPI_Win_create_dynamic:
     .desc: Create an MPI Window object for one-sided communication
     .seealso: MPI_Win_attach MPI_Win_detach MPI_Win_allocate MPI_Win_allocate_shared MPI_Win_create MPI_Win_free
     .impl: mpid
-/*
-    Notes:
-
-    Users are cautioned that displacement arithmetic can overflow in variables of
-    type 'MPI_Aint' and result in unexpected values on some platforms. This issue may
-    be addressed in a future version of MPI.
-
-    Memory in this window may not be used as the target of one-sided accesses in
-    this window until it is attached using the function 'MPI_Win_attach'. That is, in
-    addition to using 'MPI_Win_create_dynamic' to create an MPI window, the user must
-    use 'MPI_Win_attach' before any local memory may be the target of an MPI RMA
-    operation. Only memory that is currently accessible may be attached.
-*/
 
 MPI_Win_detach:
     .desc: Detach memory from a dynamic window
     .seealso: MPI_Win_create_dynamic MPI_Win_attach
     .impl: mpid
-/*
-    Notes:
-    Memory also becomes detached when the associated dynamic memory window is freed.
-*/
 { -- early_return --
     if (base == NULL)
         goto fn_exit;
@@ -330,24 +179,6 @@ MPI_Win_fence:
     .skip: validate-ASSERT
     .impl: mpid
     .error: MPI_ERR_ARG
-/*
-    Notes:
-    The 'assert' argument is used to indicate special conditions for the
-    fence that an implementation may use to optimize the 'MPI_Win_fence'
-    operation.  The value zero is always correct.  Other assertion values
-    may be or''ed together.  Assertions that are valid for 'MPI_Win_fence' are\:
-
-    + MPI_MODE_NOSTORE - the local window was not updated by local stores
-      (or local get or receive calls) since last synchronization.
-    . MPI_MODE_NOPUT - the local window will not be updated by put or accumulate
-      calls after the fence call, until the ensuing (fence) synchronization.
-    . MPI_MODE_NOPRECEDE - the fence does not complete any sequence of locally
-      issued RMA calls. If this assertion is given by any process in the window
-      group, then it must be given by all processes in the group.
-    - MPI_MODE_NOSUCCEED - the fence does not start any sequence of locally
-      issued RMA calls. If the assertion is given by any process in the window
-      group, then it must be given by all processes in the group.
-*/
 { -- error_check --
     CHECKMASK: assert, assert, MPI_MODE_NOSTORE MPI_MODE_NOPUT MPI_MODE_NOPRECEDE MPI_MODE_NOSUCCEED
 }
@@ -376,10 +207,6 @@ MPI_Win_flush_local_all:
 
 MPI_Win_free:
     .desc: Free an MPI RMA window
-/*
-    Notes:
-    If successfully freed, 'win' is set to 'MPI_WIN_NULL'.
-*/
 {
     if (MPIR_Process.attr_free && win_ptr->attributes) {
         mpi_errno = MPIR_Process.attr_free(win_ptr->handle, &win_ptr->attributes);
@@ -405,13 +232,6 @@ MPI_Win_free:
 
 MPI_Win_get_group:
     .desc: Get the MPI Group of the window object
-/*
-    Notes:
-    The group is a duplicate of the group from the communicator used to
-    create the MPI window, and should be freed with 'MPI_Group_free' when
-    it is no longer needed.  This group can be used to form the group of
-    neighbors for the routines 'MPI_Win_post' and 'MPI_Win_start'.
-*/
 {
     MPIR_Group *group_ptr = NULL;
     MPIR_Comm *win_comm_ptr = win_ptr->comm_ptr;
@@ -425,15 +245,6 @@ MPI_Win_get_info:
     .desc: Returns a new info object containing the hints of the window
     .seealso: MPI_Win_set_info
     .impl: mpid
-/*
-    Notes:
-
-    The info object returned in info_used will contain all hints currently active
-    for this window. This set of hints may be greater or smaller than the set of
-    hints specified when the window was created, as the system may not recognize
-    some hints set by the user, and may recognize other hints that the user has not
-    set.
-*/
 
 MPI_Win_get_name:
     .desc: Get the print name associated with the MPI RMA window
@@ -443,28 +254,6 @@ MPI_Win_lock:
     .skip: validate-ASSERT, validate-LOCK_TYPE
     .impl: mpid
     .earlyreturn: pt2pt_proc_null
-/*
-    Notes:
-    The name of this routine is misleading.  In particular, this
-    routine need not block, except when the target process is the calling
-    process.
-
-    Implementations may restrict the use of RMA communication that is
-    synchronized
-    by lock calls to windows in memory allocated by 'MPI_Alloc_mem'. Locks can
-    be used portably only in such memory.
-
-    The 'assert' argument is used to indicate special conditions for the
-    fence that an implementation may use to optimize the 'MPI_Win_lock'
-    operation.  The value zero is always correct.  Other assertion values
-    may be or''ed together.  Assertions that are valid for 'MPI_Win_lock' are\:
-
-    . MPI_MODE_NOCHECK - no other process holds, or will attempt to acquire a
-      conflicting lock, while the caller holds the window lock. This is useful
-      when mutual exclusion is achieved by other means, but the coherence
-      operations that may be attached to the lock and unlock calls are still
-      required.
-*/
 { -- error_check --
     CHECKMASK: assert, assert, MPI_MODE_NOCHECK
     CHECKENUM: lock_type, locktype, MPI_LOCK_SHARED MPI_LOCK_EXCLUSIVE
@@ -475,26 +264,6 @@ MPI_Win_lock_all:
     .seealso: MPI_Win_unlock_all
     .skip: validate-ASSERT
     .impl: mpid
-/*
-    Notes:
-
-    This call is not collective.
-
-    The 'assert' argument is used to indicate special conditions for the fence that
-    an implementation may use to optimize the 'MPI_Win_lock_all' operation.  The
-    value zero is always correct.  Other assertion values may be or''ed together.
-    Assertions that are valid for 'MPI_Win_lock_all' are\:
-
-    . 'MPI_MODE_NOCHECK' - No other process holds, or will attempt to acquire a
-      conflicting lock, while the caller holds the window lock. This is useful
-      when mutual exclusion is achieved by other means, but the coherence
-      operations that may be attached to the lock and unlock calls are still
-      required.
-
-    There may be additional overheads associated with using 'MPI_Win_lock' and
-    'MPI_Win_lock_all' concurrently on the same window. These overheads could be
-    avoided by specifying the assertion 'MPI_MODE_NOCHECK' when possible
-*/
 { -- error_check --
     CHECKMASK: assert, assert, MPI_MODE_NOCHECK
 }
@@ -503,40 +272,11 @@ MPI_Win_post:
     .desc: Start an RMA exposure epoch
     .skip: ThreadSafe, validate-ASSERT
     .impl: mpid
-/*
-    Notes:
-    The 'assert' argument is used to indicate special conditions for the
-    fence that an implementation may use to optimize the 'MPI_Win_post'
-    operation.  The value zero is always correct.  Other assertion values
-    may be or''ed together.  Assertions that are valid for 'MPI_Win_post' are\:
-
-    + MPI_MODE_NOCHECK - the matching calls to 'MPI_WIN_START' have not yet
-      occurred on any origin processes when the call to 'MPI_WIN_POST' is made.
-      The nocheck option can be specified by a post call if and only if it is
-      specified by each matching start call.
-    . MPI_MODE_NOSTORE - the local window was not updated by local stores (or
-      local get or receive calls) since last synchronization. This may avoid
-      the need for cache synchronization at the post call.
-    - MPI_MODE_NOPUT - the local window will not be updated by put or accumulate
-      calls after the post call, until the ensuing (wait) synchronization. This
-      may avoid the need for cache synchronization at the wait call.
-*/
-{ -- error_check --
-    CHECKMASK: assert, assert, MPI_MODE_NOCHECK MPI_MODE_NOSTORE MPI_MODE_NOPUT
-}
 
 MPI_Win_set_info:
     .desc: Set new values for the hints of the window associated with win
     .seealso: MPI_Win_get_info
     .impl: mpid
-/*
-    Notes:
-
-    Some info items that an implementation can use when it creates a window cannot
-    easily be changed once the window has been created. Thus, an implementation may
-    ignore hints issued in this call that it would have accepted in a creation
-    call.
-*/
 
 MPI_Win_set_name:
     .desc: Set the print name for an MPI RMA window
@@ -545,31 +285,11 @@ MPI_Win_shared_query:
     .desc: Query the size and base pointer for a patch of a shared memory window
     .seealso: MPI_Win_allocate_shared
     .poly_impl: use_aint
-/*
-    Notes:
-    The returned baseptr points to the calling process' address space of the
-    shared segment belonging to the target rank.
-*/
 
 MPI_Win_start:
     .desc: Start an RMA access epoch for MPI
     .impl: mpid
     .skip: validate-ASSERT
-/*
-    Notes:
-    The 'assert' argument is used to indicate special conditions for the
-    fence that an implementation may use to optimize the 'MPI_Win_start'
-    operation.  The value zero is always correct.  Other assertion values
-    may be or''ed together.  Assertions that are valid for 'MPI_Win_start' are\:
-
-    . MPI_MODE_NOCHECK - the matching calls to 'MPI_WIN_POST' have already
-      completed on all target processes when the call to 'MPI_WIN_START' is made.
-      The nocheck option can be specified in a start call if and only if it is
-      specified in each matching post call. This is similar to the optimization
-      of ready-send that may save a handshake when the handshake is implicit in
-      the code. (However, ready-send is matched by a regular receive, whereas
-      both start and post must specify the nocheck option.)
-*/
 { -- error_check --
     CHECKMASK: assert, assert, MPI_MODE_NOCHECK
 }
@@ -594,10 +314,6 @@ MPI_Win_unlock_all:
     .desc: Completes an RMA access epoch at all processes on the given window
     .seealso: MPI_Win_lock_all
     .impl: mpid
-/*
-    Notes:
-    This call is not collective.
-*/
 
 MPI_Win_wait:
     .desc: Completes an RMA exposure epoch begun with MPI_Win_post

--- a/src/binding/c/spawn_api.txt
+++ b/src/binding/c/spawn_api.txt
@@ -3,30 +3,9 @@
 MPI_Comm_get_parent:
     .desc: Return the parent communicator for this process
     .skip: global_cs
-/*
-    Notes:
-    If a process was started with 'MPI_Comm_spawn' or 'MPI_Comm_spawn_multiple',
-    'MPI_Comm_get_parent' returns the parent intercommunicator of the current
-    process. This parent intercommunicator is created implicitly inside of
-    'MPI_Init' and is the same intercommunicator returned by 'MPI_Comm_spawn'
-    in the parents.
-
-    If the process was not spawned, 'MPI_Comm_get_parent' returns
-    'MPI_COMM_NULL'.
-
-    After the parent communicator is freed or disconnected, 'MPI_Comm_get_parent'
-    returns 'MPI_COMM_NULL'.
-*/
 
 MPI_Comm_join:
     .desc: Create a communicator by joining two processes connected by a socket
-/*
-    Notes:
-    The socket must be quiescent before 'MPI_COMM_JOIN' is called and after
-    'MPI_COMM_JOIN' returns. More specifically, on entry to 'MPI_COMM_JOIN', a
-    read on the socket will not read any data that was written to the socket
-    before the remote process called 'MPI_COMM_JOIN'.
-*/
 
 MPI_Comm_spawn:
     .desc: Spawn up to maxprocs instances of a single MPI application
@@ -84,19 +63,6 @@ MPI_Comm_spawn_multiple:
 
 MPI_Open_port:
     .desc: Establish an address that can be used to establish connections between groups of MPI processes
-/*
-    Notes:
-    MPI copies a system-supplied port name into 'port_name'. 'port_name' identifies
-    the newly opened port and can be used by a client to contact the server.
-    The maximum size string that may be supplied by the system is
-    'MPI_MAX_PORT_NAME'.
-
-     Reserved Info Key Values:
-    + ip_port - Value contains IP port number at which to establish a port.
-    - ip_address - Value contains IP address at which to establish a port.
-     If the address is not a valid IP address of the host on which the
-     'MPI_OPEN_PORT' call is made, the results are undefined.
-*/
 
 MPI_Close_port:
     .desc: close port
@@ -121,29 +87,12 @@ MPI_Comm_disconnect:
     .desc: Disconnect from a communicator
     .seealso: MPI_Comm_connect, MPI_Comm_join
     .extra: ignore_revoked_comm
-/*
-    Notes:
-    This routine waits for all pending communication to complete, then frees the
-    communicator and sets 'comm' to 'MPI_COMM_NULL'.  It may not be called
-    with 'MPI_COMM_WORLD' or 'MPI_COMM_SELF'.
-*/
 
 MPI_Lookup_name:
     .desc: Lookup a port given a service name
-/*
-    Notes:
-    If the 'service_name' is found, MPI copies the associated value into
-    'port_name'.  The maximum size string that may be supplied by the system is
-    'MPI_MAX_PORT_NAME'.
-*/
 
 MPI_Publish_name:
     .desc: Publish a service name for use with MPI_Comm_connect
-/*
-    Notes:
-    The maximum size string that may be supplied for 'port_name' is
-    'MPI_MAX_PORT_NAME'.
-*/
 
 MPI_Unpublish_name:
     .desc: Unpublish a service name published with MPI_Publish_name

--- a/src/binding/c/topo_api.txt
+++ b/src/binding/c/topo_api.txt
@@ -19,10 +19,6 @@ MPI_Cart_create:
     .desc: Makes a new communicator to which topology information has been attached
     .extra: errtest_comm_intra
     .impl: topo_fns->cartCreate
-/*
-    Algorithm:
-    We ignore 'reorder' info currently.
-*/
 { -- error_check -- dims, periods
     if (ndims > 0) {
         MPIR_ERRTEST_ARGNULL(dims, "dims", mpi_errno);
@@ -58,12 +54,6 @@ MPI_Cart_rank:
     .desc: Determines process rank in communicator given Cartesian location
     .skip: global_cs
     .extra: ignore_revoked_comm
-/*
-    Notes:
-     Out-of-range coordinates are erroneous for non-periodic dimensions.
-     Versions of MPICH before 1.2.2 returned 'MPI_PROC_NULL' for the rank in this
-     case.
-*/
 { -- error_check -- coords
     MPIR_Topology *cart_ptr = MPIR_Topology_get(comm_ptr);
     MPIR_ERR_CHKANDJUMP((!cart_ptr || cart_ptr->kind != MPI_CART),
@@ -87,11 +77,6 @@ MPI_Cart_shift:
     .desc: Returns the shifted source and destination ranks, given a shift direction and amount
     .skip: global_cs
     .extra: ignore_revoked_comm
-/*
-    Notes:
-    The 'direction' argument is in the range '[0,n-1]' for an n-dimensional
-    Cartesian mesh.
-*/
 { -- error_check -- disp
 }
 
@@ -215,14 +200,6 @@ MPI_Graph_create:
     .desc: Makes a new communicator to which topology information
     .extra: errtest_comm_intra
     .impl: topo_fns->graphCreate
-/*
-    Notes:
-    Each process must provide a description of the entire graph, not just the
-    neighbors of the calling process.
-    
-    Algorithm:
-    We ignore the 'reorder' info currently.
-*/
 { -- error_check -- nnodes, indx, edges
     int comm_size = comm_old_ptr->remote_size;
 


### PR DESCRIPTION
## Pull Request Description
Separate the inline notes from binding specification to mansrc/.

This affords easier effort to maintain and improve.

Convert the following Doctext syntax to AsciiDoc syntax:
```
    ┌────────────────────────────┬───────────────────────┐
    │          Doctext           │       AsciiDoc        │
    ├────────────────────────────┼───────────────────────┤
    │ Notes: (headings)          │ == Notes              │
    ├────────────────────────────┼───────────────────────┤
    │ .N Fortran (named blocks)  │ == Fortran            │
    ├────────────────────────────┼───────────────────────┤
    │ .vb / .ve (verbatim)       │ ---- / ----           │
    ├────────────────────────────┼───────────────────────┤
    │ .Bqs / .Bqe (block quote)  │ ____ / ____           │
    ├────────────────────────────┼───────────────────────┤
    │ .Eb / .Ee / .i (enum list) │ . item (ordered list) │
    ├────────────────────────────┼───────────────────────┤
    │ + / . / - (list items)     │ * item                │
    ├────────────────────────────┼───────────────────────┤
    │ .n (line break)            │ blank line            │
    ├────────────────────────────┼───────────────────────┤
    │ 'code' (inline code)       │ `code`                │
    ├────────────────────────────┼───────────────────────┤
    │ `emphasis`                 │ _emphasis_            │
    ├────────────────────────────┼───────────────────────┤
    │ \: (escaped colon)         │ :                     │
    ├────────────────────────────┼───────────────────────┤
    │ '' (escaped quote)         │ '                     │
    └────────────────────────────┴───────────────────────┘
```
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
