### PR TITLE
ch4/ofi: refactor MPIDI_OFI_init_local

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_comm.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_comm.c
@@ -118,9 +118,13 @@ int MPIDI_OFI_mpi_comm_commit_pre_hook(MPIR_Comm * comm)
     int mpi_errno = MPI_SUCCESS;
     MPIR_FUNC_ENTER;
 
-    if ((comm->attr & MPIR_COMM_ATTR__BOOTSTRAP) && !MPIDI_OFI_global.got_named_av) {
-        mpi_errno = MPIDI_OFI_comm_addr_exchange(comm);
+    if (comm->attr & MPIR_COMM_ATTR__BOOTSTRAP) {
+        mpi_errno = MPIDI_OFI_init_fabric(comm);
         MPIR_ERR_CHECK(mpi_errno);
+        if (!MPIDI_OFI_global.got_named_av) {
+            mpi_errno = MPIDI_OFI_comm_addr_exchange(comm);
+            MPIR_ERR_CHECK(mpi_errno);
+        }
     }
 
     /* no connection for non-dynamic or non-root-rank of intercomm */

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -653,9 +653,19 @@ int MPIDI_OFI_init_local(int *tag_bits)
     /* A way to tell which av is empty */
     MPIDI_OFI_global.lpid0 = MPIR_LPID_INVALID;
 
-    /* -------------------------------- */
-    /* Set up the libfabric provider(s) */
-    /* -------------------------------- */
+  fn_exit:
+    *tag_bits = MPIDI_OFI_TAG_BITS;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
+}
+
+static bool fabric_initialized = false;
+
+/* we delay init fabric until the first comm creation (in MPIDI_OFI_mpi_comm_commit_pre_hook) */
+int MPIDI_OFI_init_fabric(MPIR_Comm * comm)
+{
+    int mpi_errno = MPI_SUCCESS;
 
     /* WB TODO - I assume that after this function is done, there will be an array of providers in
      * MPIDI_OFI_global.prov_use that will map to the VNI contexts below. We can also use it to
@@ -667,6 +677,8 @@ int MPIDI_OFI_init_local(int *tag_bits)
     /* init multi-nic and populates MPIDI_OFI_global.prov_use[] */
     mpi_errno = MPIDI_OFI_init_multi_nic(prov);
     MPIR_ERR_CHECK(mpi_errno);
+
+    MPIDI_OFI_find_provider_cleanup();
 
     if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
@@ -740,9 +752,9 @@ int MPIDI_OFI_init_local(int *tag_bits)
     MPIDI_OFI_global.num_vcis = 1;
     MPIDI_OFI_init_per_vci(0);
 
+    fabric_initialized = true;
+
   fn_exit:
-    *tag_bits = MPIDI_OFI_TAG_BITS;
-    MPIDI_OFI_find_provider_cleanup();
     return mpi_errno;
   fn_fail:
     goto fn_exit;

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -860,106 +860,109 @@ int MPIDI_OFI_mpi_finalize_hook(void)
 
     MPIR_FUNC_ENTER;
 
-    /* Progress until we drain all inflight RMA send long buffers */
-    /* NOTE: am currently only use vci 0. Need update once that changes */
-    for (int vci = 0; vci < MPIDI_OFI_global.num_vcis; vci++) {
-        while (MPIDI_OFI_global.per_vci[vci].am_inflight_rma_send_mrs > 0) {
-            MPIDI_OFI_PROGRESS(vci);
-        }
-    }
-
-    /* Destroy RMA key allocator */
-    MPIDI_OFI_mr_key_allocator_destroy();
-
-    if (strcmp("sockets", MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name) == 0) {
-        /* sockets provider need flush any last lightweight send. */
-        mpi_errno = flush_send_queue();
-        MPIR_ERR_CHECK(mpi_errno);
-    } else if (MPIR_CVAR_NO_COLLECTIVE_FINALIZE) {
-        /* skip collective work arounds */
-    } else if (strcmp("verbs;ofi_rxm", MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name) == 0
-               || strcmp("psm2", MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name) == 0
-               || strcmp("psm3", MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name) == 0) {
-        /* verbs;ofi_rxm provider need barrier to prevent message loss */
-        mpi_errno = MPIR_pmi_barrier();
-        MPIR_ERR_CHECK(mpi_errno);
-    }
-
-    /* Progress until we drain all inflight injection emulation requests */
-    /* NOTE: am currently only use vci 0. Need update once that changes */
-    for (int vci = 0; vci < MPIDI_OFI_global.num_vcis; vci++) {
-        while (MPIDI_OFI_global.per_vci[vci].am_inflight_inject_emus > 0) {
-            MPIDI_OFI_PROGRESS(vci);
-        }
-        MPIR_Assert(MPIDI_OFI_global.per_vci[vci].am_inflight_inject_emus == 0);
-    }
-
-    if (MPIDI_OFI_ENABLE_HMEM && MPIDI_OFI_ENABLE_MR_HMEM) {
-        MPIDI_GPU_RDMA_queue_t *queue_mr, *tmp;
-        DL_FOREACH_SAFE(MPIDI_OFI_global.gdr_mrs, queue_mr, tmp) {
-            if (queue_mr->mr) {
-                struct fid_mr *mr = (struct fid_mr *) queue_mr->mr;
-                if (mr != NULL) {
-                    MPIDI_OFI_CALL(fi_close(&mr->fid), mr_unreg);
-                }
-
-                DL_DELETE(MPIDI_OFI_global.gdr_mrs, queue_mr);
-                MPL_free(queue_mr);
-            }
-        }
-    }
-
-    /* Tearing down endpoints in reverse order they were created */
-    for (int nic = MPIDI_OFI_global.num_nics - 1; nic >= 0; nic--) {
-        for (int vci = MPIDI_OFI_global.num_vcis - 1; vci >= 0; vci--) {
-            /* If the user has not freed all MPI objects, ofi might not shut down cleanly.
-             * We intentionally ignore errors to avoid crashing in finalize. Debug builds
-             * will warn about unfreed objects/memory. */
-            (void) destroy_vci_context(vci, nic);
-        }
-    }
-
-    MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.fabric->fid), fabricclose);
-
-    for (i = 0; i < MPIDI_OFI_global.num_nics; i++) {
-        fi_freeinfo(MPIDI_OFI_global.prov_use[i]);
-    }
-
-    /* free av entries for multiple vcis and nics */
-    for (i = 0; i < MPIR_Process.size; i++) {
-        MPIDI_av_entry_t *av = MPIDIU_lpid_to_av(i);
-        MPL_free(MPIDI_OFI_AV(av).all_dest);
-        MPIDI_OFI_AV(av).all_dest = NULL;
-    }
-
-    MPIDIU_map_destroy(MPIDI_OFI_global.win_map);
-
-    for (int vci = 0; vci < MPIDI_OFI_global.num_vcis; vci++) {
-        MPIDU_genq_private_pool_destroy(MPIDI_OFI_global.per_vci[vci].pipeline_pool);
-    }
-
-    if (MPIDI_OFI_ENABLE_AM) {
+    if (fabric_initialized) {
+        /* Progress until we drain all inflight RMA send long buffers */
+        /* NOTE: am currently only use vci 0. Need update once that changes */
         for (int vci = 0; vci < MPIDI_OFI_global.num_vcis; vci++) {
-            while (MPIDI_OFI_global.per_vci[vci].am_unordered_msgs) {
-                MPIDI_OFI_am_unordered_msg_t *uo_msg =
-                    MPIDI_OFI_global.per_vci[vci].am_unordered_msgs;
-                DL_DELETE(MPIDI_OFI_global.per_vci[vci].am_unordered_msgs, uo_msg);
+            while (MPIDI_OFI_global.per_vci[vci].am_inflight_rma_send_mrs > 0) {
+                MPIDI_OFI_PROGRESS(vci);
             }
-            MPIDIU_map_destroy(MPIDI_OFI_global.per_vci[vci].am_send_seq_tracker);
-            MPIDIU_map_destroy(MPIDI_OFI_global.per_vci[vci].am_recv_seq_tracker);
-
-            MPIDIU_map_destroy(MPIDI_OFI_global.per_vci[vci].req_map);
-
-            MPIDI_OFI_unregister_am_bufs();
-            MPL_free(MPIDI_OFI_global.per_vci[vci].am_bufs);
-
-            MPIDU_genq_private_pool_destroy(MPIDI_OFI_global.per_vci[vci].am_hdr_buf_pool);
-
-            MPIR_Assert(MPIDI_OFI_global.per_vci[vci].cq_buffered_static_head ==
-                        MPIDI_OFI_global.per_vci[vci].cq_buffered_static_tail);
-            MPIR_Assert(NULL == MPIDI_OFI_global.per_vci[vci].cq_buffered_dynamic_head);
         }
+
+        const char *prov_name = MPIDI_OFI_global.prov_use[0]->fabric_attr->prov_name;
+        if (strcmp("sockets", prov_name) == 0) {
+            /* sockets provider need flush any last lightweight send. */
+            mpi_errno = flush_send_queue();
+            MPIR_ERR_CHECK(mpi_errno);
+        } else if (MPIR_CVAR_NO_COLLECTIVE_FINALIZE) {
+            /* skip collective work arounds */
+        } else if (strcmp("verbs;ofi_rxm", prov_name) == 0 ||
+                   strcmp("psm2", prov_name) == 0 || strcmp("psm3", prov_name) == 0) {
+            /* verbs;ofi_rxm provider need barrier to prevent message loss */
+            mpi_errno = MPIR_pmi_barrier();
+            MPIR_ERR_CHECK(mpi_errno);
+        }
+
+        /* Progress until we drain all inflight injection emulation requests */
+        /* NOTE: am currently only use vci 0. Need update once that changes */
+        for (int vci = 0; vci < MPIDI_OFI_global.num_vcis; vci++) {
+            while (MPIDI_OFI_global.per_vci[vci].am_inflight_inject_emus > 0) {
+                MPIDI_OFI_PROGRESS(vci);
+            }
+            MPIR_Assert(MPIDI_OFI_global.per_vci[vci].am_inflight_inject_emus == 0);
+        }
+
+        if (MPIDI_OFI_ENABLE_HMEM && MPIDI_OFI_ENABLE_MR_HMEM) {
+            MPIDI_GPU_RDMA_queue_t *queue_mr, *tmp;
+            DL_FOREACH_SAFE(MPIDI_OFI_global.gdr_mrs, queue_mr, tmp) {
+                if (queue_mr->mr) {
+                    struct fid_mr *mr = (struct fid_mr *) queue_mr->mr;
+                    if (mr != NULL) {
+                        MPIDI_OFI_CALL(fi_close(&mr->fid), mr_unreg);
+                    }
+
+                    DL_DELETE(MPIDI_OFI_global.gdr_mrs, queue_mr);
+                    MPL_free(queue_mr);
+                }
+            }
+        }
+
+        /* Tearing down endpoints in reverse order they were created */
+        for (int nic = MPIDI_OFI_global.num_nics - 1; nic >= 0; nic--) {
+            for (int vci = MPIDI_OFI_global.num_vcis - 1; vci >= 0; vci--) {
+                /* If the user has not freed all MPI objects, ofi might not shut down cleanly.
+                 * We intentionally ignore errors to avoid crashing in finalize. Debug builds
+                 * will warn about unfreed objects/memory. */
+                (void) destroy_vci_context(vci, nic);
+            }
+        }
+
+        MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.fabric->fid), fabricclose);
+
+        for (i = 0; i < MPIDI_OFI_global.num_nics; i++) {
+            fi_freeinfo(MPIDI_OFI_global.prov_use[i]);
+        }
+
+        /* free av entries for multiple vcis and nics */
+        for (i = 0; i < MPIR_Process.size; i++) {
+            MPIDI_av_entry_t *av = MPIDIU_lpid_to_av(i);
+            MPL_free(MPIDI_OFI_AV(av).all_dest);
+            MPIDI_OFI_AV(av).all_dest = NULL;
+        }
+
+        for (int vci = 0; vci < MPIDI_OFI_global.num_vcis; vci++) {
+            MPIDU_genq_private_pool_destroy(MPIDI_OFI_global.per_vci[vci].pipeline_pool);
+        }
+
+        if (MPIDI_OFI_ENABLE_AM) {
+            for (int vci = 0; vci < MPIDI_OFI_global.num_vcis; vci++) {
+                while (MPIDI_OFI_global.per_vci[vci].am_unordered_msgs) {
+                    MPIDI_OFI_am_unordered_msg_t *uo_msg =
+                        MPIDI_OFI_global.per_vci[vci].am_unordered_msgs;
+                    DL_DELETE(MPIDI_OFI_global.per_vci[vci].am_unordered_msgs, uo_msg);
+                }
+                MPIDIU_map_destroy(MPIDI_OFI_global.per_vci[vci].am_send_seq_tracker);
+                MPIDIU_map_destroy(MPIDI_OFI_global.per_vci[vci].am_recv_seq_tracker);
+
+                MPIDIU_map_destroy(MPIDI_OFI_global.per_vci[vci].req_map);
+
+                MPIDI_OFI_unregister_am_bufs();
+                MPL_free(MPIDI_OFI_global.per_vci[vci].am_bufs);
+
+                MPIDU_genq_private_pool_destroy(MPIDI_OFI_global.per_vci[vci].am_hdr_buf_pool);
+
+                MPIR_Assert(MPIDI_OFI_global.per_vci[vci].cq_buffered_static_head ==
+                            MPIDI_OFI_global.per_vci[vci].cq_buffered_static_tail);
+                MPIR_Assert(NULL == MPIDI_OFI_global.per_vci[vci].cq_buffered_dynamic_head);
+            }
+        }
+
+        fabric_initialized = false;
     }
+
+    /* Destroy resources initialized in init_local */
+    MPIDI_OFI_mr_key_allocator_destroy();
+    MPIDIU_map_destroy(MPIDI_OFI_global.win_map);
 
     int err;
     MPID_Thread_mutex_destroy(&MPIDI_OFI_THREAD_UTIL_MUTEX, &err);

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -650,6 +650,8 @@ int MPIDI_OFI_init_local(int *tag_bits)
     mpi_errno = MPIDI_OFI_vci_init();
     MPIR_ERR_CHECK(mpi_errno);
 
+    MPIDI_OFI_global.num_vcis = 1;
+
     /* A way to tell which av is empty */
     MPIDI_OFI_global.lpid0 = MPIR_LPID_INVALID;
 
@@ -667,90 +669,116 @@ int MPIDI_OFI_init_fabric(MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    /* WB TODO - I assume that after this function is done, there will be an array of providers in
-     * MPIDI_OFI_global.prov_use that will map to the VNI contexts below. We can also use it to
-     * generate the addresses in the business card exchange. */
-    struct fi_info *prov = NULL;
-    mpi_errno = MPIDI_OFI_find_provider(&prov);
-    MPIR_ERR_CHECK(mpi_errno);
+    bool is_comm_world = (comm == MPIR_Process.comm_world);
 
-    /* init multi-nic and populates MPIDI_OFI_global.prov_use[] */
-    mpi_errno = MPIDI_OFI_init_multi_nic(prov);
-    MPIR_ERR_CHECK(mpi_errno);
+    if (!fabric_initialized) {
+        /* -------------------------------- */
+        /* Set up the libfabric provider(s) */
+        /* -------------------------------- */
+        struct fi_info *prov = NULL;
+        mpi_errno = MPIDI_OFI_find_provider(&prov);
+        MPIR_ERR_CHECK(mpi_errno);
 
-    MPIDI_OFI_find_provider_cleanup();
+        mpi_errno = MPIDI_OFI_fill_prov_use(prov);
+        MPIR_ERR_CHECK(mpi_errno);
 
-    if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
+        MPIDI_OFI_find_provider_cleanup();
+
+        /* find close nics and prepare {num_nics, close_nic_map} */
+    }
+
+    /* collectively order nics if we are in the world model */
+    bool all_need_init = false;
+    if (is_comm_world) {
+        /* NOTE: we can't skip the collective based on `fabric_initialized` */
+        /* TODO: run collective and decide all_need_init (as well as num_nics, close_nic_map) */
+    }
+
+    if (!fabric_initialized) {
+        if (all_need_init) {
+            /* order nics based on allgathered global info */
+            mpi_errno = MPIDI_OFI_order_multi_nic_global();
+            MPIR_ERR_CHECK(mpi_errno);
+        } else {
+            /* order nics based on local rank */
+            mpi_errno = MPIDI_OFI_order_multi_nic_local();
+            MPIR_ERR_CHECK(mpi_errno);
+        }
+    }
+
+    if (!fabric_initialized) {
+        if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
-        /* Note: currently we request a single tx and rx ctx under MPIDI_OFI_VNI_USE_DOMAIN */
-        int num_ctx_per_nic = 1;
+            /* Note: currently we request a single tx and rx ctx under MPIDI_OFI_VNI_USE_DOMAIN */
+            int num_ctx_per_nic = 1;
 #else
-        /* the actual needed number of vcis is not known yet. Use the CVAR. */
-        int num_ctx_per_nic = MPIR_CVAR_CH4_NUM_VCIS + MPIR_CVAR_CH4_RESERVE_VCIS;
+            /* the actual needed number of vcis is not known yet. Use the CVAR. */
+            int num_ctx_per_nic = MPIR_CVAR_CH4_NUM_VCIS + MPIR_CVAR_CH4_RESERVE_VCIS;
 #endif
-        int max_by_prov = MPL_MIN(MPIDI_OFI_global.prov_use[0]->domain_attr->tx_ctx_cnt,
-                                  MPIDI_OFI_global.prov_use[0]->domain_attr->rx_ctx_cnt);
-        num_ctx_per_nic = MPL_MIN(num_ctx_per_nic, max_by_prov);
-        for (int i = 0; i < MPIDI_OFI_global.num_nics; i++) {
-            /* set rx_ctx_cnt and tx_ctx_cnt in ep_attr */
-            MPIDI_OFI_global.prov_use[i]->ep_attr->tx_ctx_cnt = num_ctx_per_nic;
-            MPIDI_OFI_global.prov_use[i]->ep_attr->rx_ctx_cnt = num_ctx_per_nic;
+            int max_by_prov = MPL_MIN(MPIDI_OFI_global.prov_use[0]->domain_attr->tx_ctx_cnt,
+                                      MPIDI_OFI_global.prov_use[0]->domain_attr->rx_ctx_cnt);
+            num_ctx_per_nic = MPL_MIN(num_ctx_per_nic, max_by_prov);
+            for (int i = 0; i < MPIDI_OFI_global.num_nics; i++) {
+                /* set rx_ctx_cnt and tx_ctx_cnt in ep_attr */
+                MPIDI_OFI_global.prov_use[i]->ep_attr->tx_ctx_cnt = num_ctx_per_nic;
+                MPIDI_OFI_global.prov_use[i]->ep_attr->rx_ctx_cnt = num_ctx_per_nic;
+            }
         }
-    }
 
-    mpi_errno = update_global_limits(MPIDI_OFI_global.prov_use[0]);
-    MPIR_ERR_CHECK(mpi_errno);
+        mpi_errno = update_global_limits(MPIDI_OFI_global.prov_use[0]);
+        MPIR_ERR_CHECK(mpi_errno);
 
-    if (MPIR_CVAR_DEBUG_SUMMARY && MPIR_Process.rank == 0) {
-        dump_global_settings();
-    }
-
-    if (MPIR_CVAR_DEBUG_SUMMARY >= 2) {
-        if (MPIR_Process.rank == 0) {
-            fprintf(stdout, "====== Rank to NIC assignment ========\n");
+        if (MPIR_CVAR_DEBUG_SUMMARY && MPIR_Process.rank == 0) {
+            dump_global_settings();
         }
-        /* prevent messages from different ranks get interleaved. */
-        fflush(stdout);
-        MPIR_pmi_barrier();
-        fprintf(stdout, "Rank: %d, Local_rank: %d, NIC: %s\n", MPIR_Process.rank,
-                MPIR_Process.local_rank, MPIDI_OFI_global.prov_use[0]->domain_attr->name);
-        fflush(stdout);
-        MPIR_pmi_barrier();
+
+        if (MPIR_CVAR_DEBUG_SUMMARY >= 2 && is_comm_world) {
+            if (MPIR_Process.rank == 0) {
+                fprintf(stdout, "====== Rank to NIC assignment ========\n");
+            }
+            /* prevent messages from different ranks get interleaved. */
+            fflush(stdout);
+            MPIR_pmi_barrier();
+            fprintf(stdout, "Rank: %d, Local_rank: %d, NIC: %s\n", MPIR_Process.rank,
+                    MPIR_Process.local_rank, MPIDI_OFI_global.prov_use[0]->domain_attr->name);
+            fflush(stdout);
+            MPIR_pmi_barrier();
+        }
+
+        /* Finally open the fabric */
+        MPIDI_OFI_CALL(fi_fabric(MPIDI_OFI_global.prov_use[0]->fabric_attr,
+                                 &MPIDI_OFI_global.fabric, NULL), fabric);
+
+        /* ------------------------------------------------------------------------ */
+        /* Create transport level communication contexts.                           */
+        /* ------------------------------------------------------------------------ */
+
+        /* Creating the context for vci 0 and nic 0.
+         * This code maybe moved to a later stage */
+        mpi_errno = MPIDI_OFI_create_vci_context(0, 0);
+        MPIR_ERR_CHECK(mpi_errno);
+
+        char *addrname[FI_NAME_MAX];
+        size_t addrnamelen = FI_NAME_MAX;
+        MPIDI_OFI_CALL(fi_getname((fid_t) MPIDI_OFI_global.ctx[0].ep, addrname, &addrnamelen),
+                       getname);
+
+        MPIR_Lpid lpid = MPIR_Process.rank;
+        MPIDI_av_entry_t *av = MPIDIU_lpid_to_av(lpid);
+        MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[0].av, addrname, 1,
+                                    &MPIDI_OFI_AV_ADDR_ROOT(av), 0ULL, NULL), avmap);
+        MPIR_Assert(MPIDI_OFI_AV_ADDR_ROOT(av) != FI_ADDR_NOTAVAIL);
+        MPIDI_OFI_global.lpid0 = lpid;
+        MPIDI_OFI_global.addrnamelen = addrnamelen;
+
+        /* index datatypes for RMA atomics. */
+        MPIDI_OFI_index_datatypes(MPIDI_OFI_global.ctx[0].tx);
+
+        /* make sure ch4 pack buffer pool has sufficient cell size */
+        MPIR_Assert(MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE <= MPIR_CVAR_CH4_PACK_BUFFER_SIZE);
+
+        MPIDI_OFI_init_per_vci(0);
     }
-
-    /* Finally open the fabric */
-    MPIDI_OFI_CALL(fi_fabric(MPIDI_OFI_global.prov_use[0]->fabric_attr,
-                             &MPIDI_OFI_global.fabric, NULL), fabric);
-
-    /* ------------------------------------------------------------------------ */
-    /* Create transport level communication contexts.                           */
-    /* ------------------------------------------------------------------------ */
-
-    /* Creating the context for vci 0 and nic 0.
-     * This code maybe moved to a later stage */
-    mpi_errno = MPIDI_OFI_create_vci_context(0, 0);
-    MPIR_ERR_CHECK(mpi_errno);
-
-    char *addrname[FI_NAME_MAX];
-    size_t addrnamelen = FI_NAME_MAX;
-    MPIDI_OFI_CALL(fi_getname((fid_t) MPIDI_OFI_global.ctx[0].ep, addrname, &addrnamelen), getname);
-
-    MPIR_Lpid lpid = MPIR_Process.rank;
-    MPIDI_av_entry_t *av = MPIDIU_lpid_to_av(lpid);
-    MPIDI_OFI_CALL(fi_av_insert(MPIDI_OFI_global.ctx[0].av, addrname, 1,
-                                &MPIDI_OFI_AV_ADDR_ROOT(av), 0ULL, NULL), avmap);
-    MPIR_Assert(MPIDI_OFI_AV_ADDR_ROOT(av) != FI_ADDR_NOTAVAIL);
-    MPIDI_OFI_global.lpid0 = lpid;
-    MPIDI_OFI_global.addrnamelen = addrnamelen;
-
-    /* index datatypes for RMA atomics. */
-    MPIDI_OFI_index_datatypes(MPIDI_OFI_global.ctx[0].tx);
-
-    /* make sure ch4 pack buffer pool has sufficient cell size */
-    MPIR_Assert(MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE <= MPIR_CVAR_CH4_PACK_BUFFER_SIZE);
-
-    MPIDI_OFI_global.num_vcis = 1;
-    MPIDI_OFI_init_per_vci(0);
 
     fabric_initialized = true;
 

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -655,6 +655,25 @@ int MPIDI_OFI_init_local(int *tag_bits)
     /* A way to tell which av is empty */
     MPIDI_OFI_global.lpid0 = MPIR_LPID_INVALID;
 
+    /* -------------------------------- */
+    /* Set up the libfabric provider(s) */
+    /* -------------------------------- */
+    struct fi_info *prov = NULL;
+    mpi_errno = MPIDI_OFI_find_provider(&prov);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    mpi_errno = MPIDI_OFI_fill_prov_use(prov);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    MPIDI_OFI_find_provider_cleanup();
+
+    mpi_errno = update_global_limits(MPIDI_OFI_global.prov_use[0]);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    if (MPIR_CVAR_DEBUG_SUMMARY && MPIR_Process.rank == 0) {
+        dump_global_settings();
+    }
+
   fn_exit:
     *tag_bits = MPIDI_OFI_TAG_BITS;
     return mpi_errno;
@@ -670,22 +689,6 @@ int MPIDI_OFI_init_fabric(MPIR_Comm * comm)
     int mpi_errno = MPI_SUCCESS;
 
     bool is_comm_world = (comm == MPIR_Process.comm_world);
-
-    if (!fabric_initialized) {
-        /* -------------------------------- */
-        /* Set up the libfabric provider(s) */
-        /* -------------------------------- */
-        struct fi_info *prov = NULL;
-        mpi_errno = MPIDI_OFI_find_provider(&prov);
-        MPIR_ERR_CHECK(mpi_errno);
-
-        mpi_errno = MPIDI_OFI_fill_prov_use(prov);
-        MPIR_ERR_CHECK(mpi_errno);
-
-        MPIDI_OFI_find_provider_cleanup();
-
-        /* find close nics and prepare {num_nics, close_nic_map} */
-    }
 
     /* collectively order nics if we are in the world model */
     bool all_need_init = false;
@@ -723,13 +726,6 @@ int MPIDI_OFI_init_fabric(MPIR_Comm * comm)
                 MPIDI_OFI_global.prov_use[i]->ep_attr->tx_ctx_cnt = num_ctx_per_nic;
                 MPIDI_OFI_global.prov_use[i]->ep_attr->rx_ctx_cnt = num_ctx_per_nic;
             }
-        }
-
-        mpi_errno = update_global_limits(MPIDI_OFI_global.prov_use[0]);
-        MPIR_ERR_CHECK(mpi_errno);
-
-        if (MPIR_CVAR_DEBUG_SUMMARY && MPIR_Process.rank == 0) {
-            dump_global_settings();
         }
 
         if (MPIR_CVAR_DEBUG_SUMMARY >= 2 && is_comm_world) {
@@ -947,10 +943,6 @@ int MPIDI_OFI_mpi_finalize_hook(void)
 
         MPIDI_OFI_CALL(fi_close(&MPIDI_OFI_global.fabric->fid), fabricclose);
 
-        for (i = 0; i < MPIDI_OFI_global.num_nics; i++) {
-            fi_freeinfo(MPIDI_OFI_global.prov_use[i]);
-        }
-
         /* free av entries for multiple vcis and nics */
         for (i = 0; i < MPIR_Process.size; i++) {
             MPIDI_av_entry_t *av = MPIDIU_lpid_to_av(i);
@@ -986,6 +978,10 @@ int MPIDI_OFI_mpi_finalize_hook(void)
         }
 
         fabric_initialized = false;
+    }
+
+    for (i = 0; i < MPIDI_OFI_global.num_nics; i++) {
+        fi_freeinfo(MPIDI_OFI_global.prov_use[i]);
     }
 
     /* Destroy resources initialized in init_local */

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -40,6 +40,10 @@ int MPIDI_OFI_init_per_vci(int vci);
 
 bool MPIDI_OFI_nic_is_up(struct fi_info *prov);
 
+int MPIDI_OFI_fill_prov_use(struct fi_info *prov);
+int MPIDI_OFI_order_multi_nic_local(void);
+int MPIDI_OFI_order_multi_nic_global(void);
+
 int MPIDI_OFI_comm_addr_exchange(MPIR_Comm * comm);
 
 #endif /* OFI_INIT_H_INCLUDED */

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -10,6 +10,7 @@ int MPIDI_OFI_get_required_version(void);
 
 int MPIDI_OFI_find_provider(struct fi_info **prov_out);
 void MPIDI_OFI_find_provider_cleanup(void);
+int MPIDI_OFI_init_fabric(MPIR_Comm * comm);
 int MPIDI_OFI_init_multi_nic(struct fi_info *prov);
 int MPIDI_OFI_vci_init(void);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_nic.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.c
@@ -23,103 +23,39 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
+/* ---------------------------------- */
+/* Forward declarations for static    */
+/* functions called from public APIs  */
+/* ---------------------------------- */
+
+static bool match_prov_addr(struct fi_info *prov, const char *hostname);
+static int compare_nic_names(const void *info1, const void *info2);
+static int order_multi_nic_by_pref(int pref);
 #ifdef HAVE_LIBFABRIC_NIC
-/* Sometime the provider may report "null" pci info (looking at you: opx) */
-static bool is_nic_pci_valid(struct fi_info *info)
+static bool is_nic_pci_valid(struct fi_info *info);
+static int set_nic_info(void);
+#endif
+
+/* ================================== */
+/* Public MPIDI_OFI functions         */
+/* ================================== */
+
+/* -- NIC status ------------------------------------------------ */
+
+bool MPIDI_OFI_nic_is_up(struct fi_info *prov)
 {
-    if (info->nic->bus_attr->bus_type == FI_BUS_PCI) {
-        struct fi_pci_attr pci = info->nic->bus_attr->attr.pci;
-        return (pci.domain_id > 0 || pci.bus_id > 0 || pci.device_id > 0 || pci.function_id > 0);
+#ifdef HAVE_LIBFABRIC_NIC
+    /* Make sure the NIC returned by OFI is not down. Some providers don't include NIC
+     * information so we need to skip those. */
+    if (prov->nic != NULL && prov->nic->link_attr->state == FI_LINK_DOWN) {
+        return false;
     }
-    return false;
+#endif
+
+    return true;
 }
 
-/* Return the parent object (typically socket) of the NIC */
-static MPIR_hwtopo_gid_t get_nic_parent(struct fi_info *info)
-{
-    if (info->nic->bus_attr->bus_type == FI_BUS_PCI) {
-        struct fi_pci_attr pci = info->nic->bus_attr->attr.pci;
-        return MPIR_hwtopo_get_dev_parent_by_pci(pci.domain_id, pci.bus_id, pci.device_id,
-                                                 pci.function_id);
-    }
-    return MPIR_hwtopo_get_obj_by_name(info->domain_attr->name);
-}
-
-/* Return true if the NIC is bound to the same socket as calling process */
-static bool is_nic_close(struct fi_info *info)
-{
-    if (info->nic->bus_attr->bus_type == FI_BUS_PCI) {
-        struct fi_pci_attr pci = info->nic->bus_attr->attr.pci;
-        return MPIR_hwtopo_is_dev_close_by_pci(pci.domain_id, pci.bus_id, pci.device_id,
-                                               pci.function_id);
-    }
-    return MPIR_hwtopo_is_dev_close_by_name(info->domain_attr->name);
-}
-
-/* Return true if the NIC is close to the group of the calling process */
-static bool is_nic_close_snc4(const MPIDI_OFI_nic_info_t * nic_info, int num_parents)
-{
-    int nic_socket_gid = MPIR_hwtopo_get_parent_socket(nic_info->parent);
-    int rank_socket_gid = MPIR_hwtopo_get_parent_socket(MPIR_hwtopo_get_first_pu_group());
-
-    /* In SNC4 mode, when there are 4 groups that have nics, it means that there are 4
-     * other adjacent groups with no nics. This leads to each set of 2 groups having 2 nics
-     * such that, the first group has no nics and the second group has 2 nics.
-     * The correct assignment strategy is such the 2 nics of the second group is considered
-     * close to the ranks on both the groups.*/
-    if (num_parents == 4) {
-        /* Check that the parent socket of the rank and the nic is the same */
-        if (nic_socket_gid == rank_socket_gid) {
-            int nic_group_lid = MPIR_hwtopo_get_lid(nic_info->parent);
-            int rank_group_lid = MPIR_hwtopo_get_lid(MPIR_hwtopo_get_first_pu_group());
-            if (nic_group_lid == rank_group_lid || nic_group_lid - rank_group_lid == 1) {
-                struct fi_info *info = (struct fi_info *) (nic_info->nic);
-                if (info->nic->bus_attr->bus_type == FI_BUS_PCI) {
-                    struct fi_pci_attr pci = info->nic->bus_attr->attr.pci;
-
-                    int nic_lid = MPIR_hwtopo_get_pci_network_lid(pci.domain_id,
-                                                                  pci.bus_id,
-                                                                  pci.device_id,
-                                                                  pci.function_id);
-
-                    /* Map 1st nic of the group to the previous group */
-                    if (nic_lid == 0 && nic_group_lid - rank_group_lid == 1)
-                        return 1;
-                    /* Map 2nd nic of the group to the current group */
-                    else if (nic_lid == 1 && nic_group_lid == rank_group_lid)
-                        return 1;
-                }
-            }
-        }
-    } else {
-        /* On using a different configuration than having 4 num_parents, simply
-         * compare parent socket of the nic and the rank */
-        if (nic_socket_gid == rank_socket_gid)
-            return 1;
-    }
-    return 0;
-}
-
-/* Comparison function for NIC names. Used in qsort() */
-static int compare_nic_names(const void *info1, const void *info2)
-{
-    const struct fi_info **n1 = (const struct fi_info **) info1;
-    const struct fi_info **n2 = (const struct fi_info **) info2;
-    return strcmp((*n1)->domain_attr->name, (*n2)->domain_attr->name);
-}
-
-/* Comparison function for NICs. This function is used in qsort(). */
-static int compare_nics(const void *nic1, const void *nic2)
-{
-    const MPIDI_OFI_nic_info_t *i1 = (const MPIDI_OFI_nic_info_t *) nic1;
-    const MPIDI_OFI_nic_info_t *i2 = (const MPIDI_OFI_nic_info_t *) nic2;
-    if (i1->close && !i2->close)
-        return -1;
-    else if (i2->close && !i1->close)
-        return 1;
-    return compare_nic_names(&(i1->nic), &(i2->nic));
-}
-
+#ifdef HAVE_LIBFABRIC_NIC
 /* Determine if NIC has already been included in others */
 bool MPIDI_OFI_nic_already_used(const struct fi_info * prov, struct fi_info ** others,
                                 int nic_count)
@@ -141,10 +77,7 @@ bool MPIDI_OFI_nic_already_used(const struct fi_info * prov, struct fi_info ** o
 }
 #endif
 
-static bool match_prov_addr(struct fi_info *prov, const char *hostname);
-#ifdef HAVE_LIBFABRIC_NIC
-static int set_nic_info(void);
-#endif
+/* -- NIC initialization ---------------------------------------- */
 
 int MPIDI_OFI_fill_prov_use(struct fi_info *prov)
 {
@@ -278,6 +211,87 @@ int MPIDI_OFI_fill_prov_use(struct fi_info *prov)
     goto fn_exit;
 }
 
+/* -- NIC ordering ---------------------------------------------- */
+
+int MPIDI_OFI_order_multi_nic_local(void)
+{
+    /* TODO: pass comm and use comm->local_rank */
+    int pref = MPIR_Process.local_rank % MPIDI_OFI_global.num_close_nics;
+
+    return order_multi_nic_by_pref(pref);
+}
+
+int MPIDI_OFI_order_multi_nic_global(void)
+{
+    /* TODO: pass comm, use comm->local_rank, and globally determine pref */
+    int pref = MPIR_Process.local_rank % MPIDI_OFI_global.num_close_nics;
+
+    return order_multi_nic_by_pref(pref);
+}
+
+/* ================================== */
+/* Static internal functions          */
+/* ================================== */
+
+/* -- Provider matching ----------------------------------------- */
+
+static bool match_prov_addr(struct fi_info *prov, const char *hostname)
+{
+    bool match = false;
+
+    if (!hostname) {
+        goto fn_exit;
+    }
+
+    char addr_buf[500];
+    switch (prov->addr_format) {
+        case FI_SOCKADDR_IN:
+            inet_ntop(AF_INET, &((struct sockaddr_in *) prov->src_addr)->sin_addr, addr_buf, 500);
+            match = (strcmp(hostname, addr_buf) == 0);
+            break;
+        case FI_SOCKADDR_IN6:
+            inet_ntop(AF_INET6, &((struct sockaddr_in6 *) prov->src_addr)->sin6_addr,
+                      addr_buf, 500);
+            match = (strcmp(hostname, addr_buf) == 0);
+            break;
+        case FI_SOCKADDR_IB:
+            break;
+        case FI_ADDR_PSMX:
+            break;
+        case FI_ADDR_GNI:
+            break;
+        case FI_ADDR_STR:
+            match = (strcmp(hostname, (char *) prov->src_addr) == 0);
+            break;
+        default:
+            break;
+    }
+  fn_exit:
+    return match;
+}
+
+/* -- NIC comparison and ordering ------------------------------- */
+
+/* Comparison function for NIC names. Used in qsort() */
+static int compare_nic_names(const void *info1, const void *info2)
+{
+    const struct fi_info **n1 = (const struct fi_info **) info1;
+    const struct fi_info **n2 = (const struct fi_info **) info2;
+    return strcmp((*n1)->domain_attr->name, (*n2)->domain_attr->name);
+}
+
+/* Comparison function for NICs. This function is used in qsort(). */
+static int compare_nics(const void *nic1, const void *nic2)
+{
+    const MPIDI_OFI_nic_info_t *i1 = (const MPIDI_OFI_nic_info_t *) nic1;
+    const MPIDI_OFI_nic_info_t *i2 = (const MPIDI_OFI_nic_info_t *) nic2;
+    if (i1->close && !i2->close)
+        return -1;
+    else if (i2->close && !i1->close)
+        return 1;
+    return compare_nic_names(&(i1->nic), &(i2->nic));
+}
+
 static int order_multi_nic_by_pref(int pref)
 {
     MPIDI_OFI_nic_info_t *nics = MPIDI_OFI_global.nic_info;
@@ -309,24 +323,85 @@ static int order_multi_nic_by_pref(int pref)
     return MPI_SUCCESS;
 }
 
-int MPIDI_OFI_order_multi_nic_local(void)
-{
-    /* TODO: pass comm and use comm->local_rank */
-    int pref = MPIR_Process.local_rank % MPIDI_OFI_global.num_close_nics;
-
-    return order_multi_nic_by_pref(pref);
-}
-
-int MPIDI_OFI_order_multi_nic_global(void)
-{
-    /* TODO: pass comm, use comm->local_rank, and globally determine pref */
-    int pref = MPIR_Process.local_rank % MPIDI_OFI_global.num_close_nics;
-
-    return order_multi_nic_by_pref(pref);
-}
-
+/* -- NIC closeness detection ----------------------------------- */
 
 #ifdef HAVE_LIBFABRIC_NIC
+/* Sometime the provider may report "null" pci info (looking at you: opx) */
+static bool is_nic_pci_valid(struct fi_info *info)
+{
+    if (info->nic->bus_attr->bus_type == FI_BUS_PCI) {
+        struct fi_pci_attr pci = info->nic->bus_attr->attr.pci;
+        return (pci.domain_id > 0 || pci.bus_id > 0 || pci.device_id > 0 || pci.function_id > 0);
+    }
+    return false;
+}
+
+/* Return the parent object (typically socket) of the NIC */
+static MPIR_hwtopo_gid_t get_nic_parent(struct fi_info *info)
+{
+    if (info->nic->bus_attr->bus_type == FI_BUS_PCI) {
+        struct fi_pci_attr pci = info->nic->bus_attr->attr.pci;
+        return MPIR_hwtopo_get_dev_parent_by_pci(pci.domain_id, pci.bus_id, pci.device_id,
+                                                 pci.function_id);
+    }
+    return MPIR_hwtopo_get_obj_by_name(info->domain_attr->name);
+}
+
+/* Return true if the NIC is bound to the same socket as calling process */
+static bool is_nic_close(struct fi_info *info)
+{
+    if (info->nic->bus_attr->bus_type == FI_BUS_PCI) {
+        struct fi_pci_attr pci = info->nic->bus_attr->attr.pci;
+        return MPIR_hwtopo_is_dev_close_by_pci(pci.domain_id, pci.bus_id, pci.device_id,
+                                               pci.function_id);
+    }
+    return MPIR_hwtopo_is_dev_close_by_name(info->domain_attr->name);
+}
+
+/* Return true if the NIC is close to the group of the calling process */
+static bool is_nic_close_snc4(const MPIDI_OFI_nic_info_t * nic_info, int num_parents)
+{
+    int nic_socket_gid = MPIR_hwtopo_get_parent_socket(nic_info->parent);
+    int rank_socket_gid = MPIR_hwtopo_get_parent_socket(MPIR_hwtopo_get_first_pu_group());
+
+    /* In SNC4 mode, when there are 4 groups that have nics, it means that there are 4
+     * other adjacent groups with no nics. This leads to each set of 2 groups having 2 nics
+     * such that, the first group has no nics and the second group has 2 nics.
+     * The correct assignment strategy is such the 2 nics of the second group is considered
+     * close to the ranks on both the groups.*/
+    if (num_parents == 4) {
+        /* Check that the parent socket of the rank and the nic is the same */
+        if (nic_socket_gid == rank_socket_gid) {
+            int nic_group_lid = MPIR_hwtopo_get_lid(nic_info->parent);
+            int rank_group_lid = MPIR_hwtopo_get_lid(MPIR_hwtopo_get_first_pu_group());
+            if (nic_group_lid == rank_group_lid || nic_group_lid - rank_group_lid == 1) {
+                struct fi_info *info = (struct fi_info *) (nic_info->nic);
+                if (info->nic->bus_attr->bus_type == FI_BUS_PCI) {
+                    struct fi_pci_attr pci = info->nic->bus_attr->attr.pci;
+
+                    int nic_lid = MPIR_hwtopo_get_pci_network_lid(pci.domain_id,
+                                                                  pci.bus_id,
+                                                                  pci.device_id,
+                                                                  pci.function_id);
+
+                    /* Map 1st nic of the group to the previous group */
+                    if (nic_lid == 0 && nic_group_lid - rank_group_lid == 1)
+                        return 1;
+                    /* Map 2nd nic of the group to the current group */
+                    else if (nic_lid == 1 && nic_group_lid == rank_group_lid)
+                        return 1;
+                }
+            }
+        }
+    } else {
+        /* On using a different configuration than having 4 num_parents, simply
+         * compare parent socket of the nic and the rank */
+        if (nic_socket_gid == rank_socket_gid)
+            return 1;
+    }
+    return 0;
+}
+
 static bool get_is_snc4_with_cxi_nics(void)
 {
     int num_numa_nodes = MPIR_hwtopo_get_num_numa_nodes();
@@ -382,51 +457,3 @@ static int set_nic_info(void)
 }
 
 #endif
-
-bool MPIDI_OFI_nic_is_up(struct fi_info * prov)
-{
-#ifdef HAVE_LIBFABRIC_NIC
-    /* Make sure the NIC returned by OFI is not down. Some providers don't include NIC
-     * information so we need to skip those. */
-    if (prov->nic != NULL && prov->nic->link_attr->state == FI_LINK_DOWN) {
-        return false;
-    }
-#endif
-
-    return true;
-}
-
-static bool match_prov_addr(struct fi_info *prov, const char *hostname)
-{
-    bool match = false;
-
-    if (!hostname) {
-        goto fn_exit;
-    }
-
-    char addr_buf[500];
-    switch (prov->addr_format) {
-        case FI_SOCKADDR_IN:
-            inet_ntop(AF_INET, &((struct sockaddr_in *) prov->src_addr)->sin_addr, addr_buf, 500);
-            match = (strcmp(hostname, addr_buf) == 0);
-            break;
-        case FI_SOCKADDR_IN6:
-            inet_ntop(AF_INET6, &((struct sockaddr_in6 *) prov->src_addr)->sin6_addr,
-                      addr_buf, 500);
-            match = (strcmp(hostname, addr_buf) == 0);
-            break;
-        case FI_SOCKADDR_IB:
-            break;
-        case FI_ADDR_PSMX:
-            break;
-        case FI_ADDR_GNI:
-            break;
-        case FI_ADDR_STR:
-            match = (strcmp(hostname, (char *) prov->src_addr) == 0);
-            break;
-        default:
-            break;
-    }
-  fn_exit:
-    return match;
-}

--- a/src/mpid/ch4/netmod/ofi/ofi_nic.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.c
@@ -119,10 +119,13 @@ int MPIDI_OFI_fill_prov_use(struct fi_info *prov)
         MPIR_Assert(MPIDI_OFI_global.prov_use[0]);
 
         MPIDI_OFI_global.num_nics_available = 1;
+        MPIDI_OFI_global.num_nics = 1;
         MPIDI_OFI_global.nic_info[0].nic = MPIDI_OFI_global.prov_use[0];
         MPIDI_OFI_global.nic_info[0].id = 0;
         MPIDI_OFI_global.nic_info[0].close = 1;
     } else {
+        MPIDI_OFI_global.num_nics_available = nic_count;
+
         /* nic_count >= 1 */
         /* Initially sort the NICs by name. This way all intranode ranks have a consistent view. */
         qsort(MPIDI_OFI_global.prov_use, nic_count, sizeof(struct fi_info *), compare_nic_names);
@@ -138,7 +141,7 @@ int MPIDI_OFI_fill_prov_use(struct fi_info *prov)
             /* default single nic (will selelct closest nic if nic_count > 1) */
             num_nics = 1;
         }
-        MPIDI_OFI_global.num_nics_available = num_nics;
+        MPIDI_OFI_global.num_nics = num_nics;
 
         for (int i = 0; i < MPIDI_OFI_global.num_nics_available; i++) {
             MPIDI_OFI_global.nic_info[i].nic = MPIDI_OFI_global.prov_use[i];

--- a/src/mpid/ch4/netmod/ofi/ofi_nic.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.c
@@ -117,12 +117,6 @@ static int compare_nics(const void *nic1, const void *nic2)
         return -1;
     else if (i2->close && !i1->close)
         return 1;
-    else if (i1->prefer - i2->prefer)
-        return i1->prefer - i2->prefer;
-    else if (i1->count - i2->count)
-        return i1->count - i2->count;
-    else if (i1->id - i2->id)
-        return i1->id - i2->id;
     return compare_nic_names(&(i1->nic), &(i2->nic));
 }
 
@@ -147,14 +141,12 @@ bool MPIDI_OFI_nic_already_used(const struct fi_info * prov, struct fi_info ** o
 }
 #endif
 
-/* Setup the multi-NIC data structures to use the fi_info structure given in prov */
-static int setup_single_nic(void);
-#ifdef HAVE_LIBFABRIC_NIC
-static int setup_multi_nic(int nic_count);
-#endif
 static bool match_prov_addr(struct fi_info *prov, const char *hostname);
+#ifdef HAVE_LIBFABRIC_NIC
+static int set_nic_info(void);
+#endif
 
-int MPIDI_OFI_init_multi_nic(struct fi_info *prov)
+int MPIDI_OFI_fill_prov_use(struct fi_info *prov)
 {
     int mpi_errno = MPI_SUCCESS;
     int nic_count = 0;
@@ -192,20 +184,93 @@ int MPIDI_OFI_init_multi_nic(struct fi_info *prov)
         /* If no NICs are detected, then force using first provider */
         MPIDI_OFI_global.prov_use[0] = fi_dupinfo(pref_prov);
         MPIR_Assert(MPIDI_OFI_global.prov_use[0]);
-        mpi_errno = setup_single_nic();
-        MPIR_ERR_CHECK(mpi_errno);
-    }
+
+        MPIDI_OFI_global.num_nics_available = 1;
+        MPIDI_OFI_global.nic_info[0].nic = MPIDI_OFI_global.prov_use[0];
+        MPIDI_OFI_global.nic_info[0].id = 0;
+        MPIDI_OFI_global.nic_info[0].close = 1;
+    } else {
+        /* nic_count >= 1 */
+        /* Initially sort the NICs by name. This way all intranode ranks have a consistent view. */
+        qsort(MPIDI_OFI_global.prov_use, nic_count, sizeof(struct fi_info *), compare_nic_names);
+
+        int num_nics = 1;
+        if (MPIR_CVAR_CH4_OFI_MAX_NICS == -1) {
+            /* use all nics */
+            num_nics = nic_count;
+        } else if (MPIR_CVAR_CH4_OFI_MAX_NICS > 1) {
+            /* use multiple nics */
+            num_nics = MPL_MIN(MPIR_CVAR_CH4_OFI_MAX_NICS, nic_count);
+        } else {
+            /* default single nic (will selelct closest nic if nic_count > 1) */
+            num_nics = 1;
+        }
+        MPIDI_OFI_global.num_nics_available = num_nics;
+
+        for (int i = 0; i < MPIDI_OFI_global.num_nics_available; i++) {
+            MPIDI_OFI_global.nic_info[i].nic = MPIDI_OFI_global.prov_use[i];
+            MPIDI_OFI_global.nic_info[i].id = i;
+            MPIDI_OFI_global.nic_info[i].close = 0;
+        }
+
+        if (MPIR_CVAR_CH4_OFI_PREF_NIC > -1 &&
+            MPIR_CVAR_CH4_OFI_PREF_NIC < MPIDI_OFI_global.num_nics_available) {
+            /* set the pref_nic's close to 1, all other nics' close to 0 */
+            MPIDI_OFI_global.nic_info[MPIR_CVAR_CH4_OFI_PREF_NIC].close = 1;
+        } else {
 #ifdef HAVE_LIBFABRIC_NIC
-    else if (nic_count >= 1) {
-        mpi_errno = setup_multi_nic(nic_count);
-        MPIR_ERR_CHECK(mpi_errno);
-    }
+            /* check all nics have valid pci info */
+            bool all_valid = true;
+            for (int i = 0; i < nic_count; ++i) {
+                if (!is_nic_pci_valid(MPIDI_OFI_global.prov_use[i])) {
+                    all_valid = false;
+                    break;
+                }
+            }
+            if (all_valid) {
+                /* determine close via nic_pci */
+                mpi_errno = set_nic_info();
+                MPIR_ERR_CHECK(mpi_errno);
+            } else {
+                /* just choose the first nic */
+                MPIDI_OFI_global.nic_info[0].close = 1;
+            }
+        }
+#else
+            /* just choose the first nic */
+            MPIDI_OFI_global.nic_info[0].close = 1;
+        }
 #endif
-    else {
-        mpi_errno = setup_single_nic();
-        MPIR_ERR_CHECK(mpi_errno);
     }
+
+    int num_close_nics = 0;
+    for (int i = 0; i < MPIDI_OFI_global.num_nics_available; i++) {
+        if (MPIDI_OFI_global.nic_info[i].close) {
+            num_close_nics++;
+        }
+    }
+    /* If there were zero NICs on my socket, then just consider every NIC close
+     * and share them among all ranks with a similar view */
+    if (num_close_nics == 0) {
+        for (int i = 0; i < MPIDI_OFI_global.num_nics_available; i++) {
+            MPIDI_OFI_global.nic_info[i].close = 1;
+        }
+        num_close_nics = MPIDI_OFI_global.num_nics_available;
+    }
+
+    MPIDI_OFI_global.num_close_nics = num_close_nics;
+
     MPIR_Assert(MPIDI_OFI_global.num_nics_available > 0);
+    MPIR_Assert(MPIDI_OFI_global.num_close_nics > 0);
+
+    char nics_str[32];
+    MPIR_Info *info_ptr = NULL;
+    MPIR_Info_get_ptr(MPI_INFO_ENV, info_ptr);
+
+    snprintf(nics_str, 32, "%d", MPIDI_OFI_global.num_nics_available);
+    MPIR_Info_set_impl(info_ptr, "num_nics_available", nics_str);
+    snprintf(nics_str, 32, "%d", MPIDI_OFI_global.num_close_nics);
+    MPIR_Info_set_impl(info_ptr, "num_close_nics", nics_str);
 
   fn_exit:
     return mpi_errno;
@@ -213,242 +278,112 @@ int MPIDI_OFI_init_multi_nic(struct fi_info *prov)
     goto fn_exit;
 }
 
-static int setup_single_nic(void)
+static int order_multi_nic_by_pref(int pref)
 {
-    MPIDI_OFI_global.num_nics_available = 1;
-    MPIDI_OFI_global.nic_info[0].nic = MPIDI_OFI_global.prov_use[0];
-    MPIDI_OFI_global.nic_info[0].id = 0;
-    MPIDI_OFI_global.nic_info[0].close = 1;
-    MPIDI_OFI_global.nic_info[0].prefer = 0;
-    MPIDI_OFI_global.nic_info[0].count = MPIR_Process.local_size;
-    MPIDI_OFI_global.nic_info[0].num_close_ranks = MPIR_Process.local_size;
+    MPIDI_OFI_nic_info_t *nics = MPIDI_OFI_global.nic_info;
 
-    char nics_str[32];
-    MPIR_Info *info_ptr = NULL;
-    MPIR_Info_get_ptr(MPI_INFO_ENV, info_ptr);
-    snprintf(nics_str, 32, "%d", 1);
-    MPIR_Info_set_impl(info_ptr, "num_nics_available", nics_str);
-    snprintf(nics_str, 32, "%d", 1);
-    MPIR_Info_set_impl(info_ptr, "num_close_nics", nics_str);
+    /* 1. move all close nics to the front of the list. */
+    qsort(nics, MPIDI_OFI_global.num_nics_available, sizeof(nics[0]), compare_nics);
+
+    /* 2. rotate the close nics by pref. */
+    if (pref > 0) {
+        MPIDI_OFI_nic_info_t *tmp_nics = MPL_malloc(pref * sizeof(nics[0]), MPL_MEM_OTHER);
+        MPIR_Assert(tmp_nics);
+        for (int i = 0; i < pref; i++) {
+            tmp_nics[i] = nics[i];
+        }
+        for (int i = 0; i < MPIDI_OFI_global.num_close_nics - pref; i++) {
+            nics[i] = nics[i + pref];
+        }
+        for (int i = 0; i < pref; i++) {
+            nics[MPIDI_OFI_global.num_close_nics - pref + i] = tmp_nics[i];
+        }
+        MPL_free(tmp_nics);
+    }
+
+    /* 3. order the prov_use array as well */
+    for (int i = 0; i < MPIDI_OFI_global.num_nics_available; ++i) {
+        MPIDI_OFI_global.prov_use[i] = nics[i].nic;
+    }
 
     return MPI_SUCCESS;
 }
 
-#ifdef HAVE_LIBFABRIC_NIC
-/* Comparison function for NICs in SPR SNC4 mode. This function is used in qsort(). */
-static int compare_nics_snc4(const void *nic1, const void *nic2)
+int MPIDI_OFI_order_multi_nic_local(void)
 {
-    const MPIDI_OFI_nic_info_t *i1 = (const MPIDI_OFI_nic_info_t *) nic1;
-    const MPIDI_OFI_nic_info_t *i2 = (const MPIDI_OFI_nic_info_t *) nic2;
+    /* TODO: pass comm and use comm->local_rank */
+    int pref = MPIR_Process.local_rank % MPIDI_OFI_global.num_close_nics;
 
-    if (i1->close && !i2->close)
-        return -1;
-    else if (i2->close && !i1->close)
-        return 1;
-    return compare_nic_names(&(i1->nic), &(i2->nic));
+    return order_multi_nic_by_pref(pref);
 }
 
-/* TODO: Now that multiple NICs are detected, sort them based on preferred-ness,
- * closeness and count of other processes using the NIC. */
-static int setup_multi_nic(int nic_count)
+int MPIDI_OFI_order_multi_nic_global(void)
 {
-    int mpi_errno = MPI_SUCCESS;
-    MPIR_hwtopo_gid_t parents[MPIDI_OFI_MAX_NICS] = { 0 };
-    int num_parents = 0;
-    int local_rank = MPIR_Process.local_rank;
-    MPIDI_OFI_nic_info_t *nics = MPIDI_OFI_global.nic_info;
-    MPIR_CHKLMEM_DECL();
+    /* TODO: pass comm, use comm->local_rank, and globally determine pref */
+    int pref = MPIR_Process.local_rank % MPIDI_OFI_global.num_close_nics;
 
-    int num_nics = 1;
-    if (MPIR_CVAR_CH4_OFI_MAX_NICS == -1) {
-        /* use all nics */
-        num_nics = nic_count;
-    } else if (MPIR_CVAR_CH4_OFI_MAX_NICS > 1) {
-        /* use multiple nics */
-        num_nics = MPL_MIN(MPIR_CVAR_CH4_OFI_MAX_NICS, nic_count);
-    } else {
-        /* default single nic (will selelct closest nic if nic_count > 1) */
-        num_nics = 1;
-    }
+    return order_multi_nic_by_pref(pref);
+}
 
-    bool pref_nic_set = false;
-    if (MPIR_CVAR_CH4_OFI_PREF_NIC > -1 && MPIR_CVAR_CH4_OFI_PREF_NIC < nic_count) {
-        pref_nic_set = true;
-    }
 
-    /* Initially sort the NICs by name. This way all intranode ranks have a consistent view. */
-    qsort(MPIDI_OFI_global.prov_use, nic_count, sizeof(struct fi_info *), compare_nic_names);
-
+#ifdef HAVE_LIBFABRIC_NIC
+static bool get_is_snc4_with_cxi_nics(void)
+{
     int num_numa_nodes = MPIR_hwtopo_get_num_numa_nodes();
-    bool is_snc4_with_cxi_nics = false;
 
     if ((num_numa_nodes == 8 || num_numa_nodes == 16))
-        if (nic_count > 1)
+        if (MPIDI_OFI_global.num_nics_available > 1)
             if (strstr(MPIDI_OFI_global.prov_use[0]->domain_attr->name, "cxi"))
-                is_snc4_with_cxi_nics = true;
-
-    int num_close_nics = 0;
-    /* check all nics have valid pci info */
-    bool all_valid = true;
-    for (int i = 0; i < nic_count; ++i) {
-        if (!is_nic_pci_valid(MPIDI_OFI_global.prov_use[i])) {
-            all_valid = false;
-            break;
-        }
-    }
-
-    if (is_snc4_with_cxi_nics && !pref_nic_set && all_valid) {
-        /* Special case of nic assignment for SPR in SNC4 mode */
-        for (int i = 0; i < nic_count; ++i) {
-            nics[i].nic = MPIDI_OFI_global.prov_use[i];
-            nics[i].id = i;
-            /* Set the preference of all NICs to least preferable (lower is more preferable) */
-            nics[i].prefer = nic_count + 1;
-            nics[i].count = 0;
-            nics[i].num_close_ranks = 0;
-
-            nics[i].parent = get_nic_parent(nics[i].nic);
-
-            int found = 0;
-            for (int j = 0; j < num_parents; ++j) {
-                if (parents[j] == nics[i].parent) {
-                    found = 1;
-                    break;
-                }
-            }
-            if (!found) {
-                parents[num_parents] = nics[i].parent;
-                num_parents++;
-            }
-        }
-        /* Use num_parents to determine nic closeness */
-        for (int i = 0; i < nic_count; ++i) {
-            nics[i].close = is_nic_close_snc4(&nics[i], num_parents);
-            if (nics[i].close)
-                num_close_nics++;
-        }
-
-    } else {
-        /* General case of nic assignment */
-
-        /* Now go through every NIC and set initial information
-         * from current process's perspective */
-        for (int i = 0; i < nic_count; ++i) {
-            nics[i].nic = MPIDI_OFI_global.prov_use[i];
-            nics[i].id = i;
-            /* Determine NIC's "closeness" to current process */
-            if (all_valid) {
-                nics[i].close = is_nic_close(nics[i].nic);
-                /* Determine NIC's first normal parent topology
-                 * item (e.g., typically the socket parent) */
-                nics[i].parent = get_nic_parent(nics[i].nic);
-            } else {
-                /* treat all nics as equally close */
-                nics[i].close = 0;
-                nics[i].parent = 0;
-            }
-            /* Set the preference of all NICs to least preferable (lower is more preferable) */
-            nics[i].prefer = nic_count + 1;
-            nics[i].count = 0;
-            nics[i].num_close_ranks = 0;
-            /* Expand list of close NIC-parent topology items or increment */
-            if (nics[i].close) {
-                num_close_nics++;
-
-                int found = 0;
-                for (int j = 0; j < num_parents; ++j) {
-                    if (parents[j] == nics[i].parent) {
-                        found = 1;
-                        break;
-                    }
-                }
-                if (!found) {
-                    parents[num_parents] = nics[i].parent;
-                    num_parents++;
-                }
-            }
-        }
-    }
-
-    /* If there were zero NICs on my socket, then just consider every NIC close
-     * and share them among all ranks with a similar view */
-    if (num_close_nics == 0) {
-        for (int i = 0; i < nic_count; ++i)
-            nics[i].close = 1;
-        num_close_nics = nic_count;
-    }
-
-    if (pref_nic_set) {
-        /* When using this CVAR, the rank can only use 1 NIC. We do not reset num_close_nics again
-         * in case a NIC is down and it needs to use another NIC. */
-        MPIDI_OFI_nic_info_t *tmp_nic;
-        MPIR_CHKLMEM_MALLOC(tmp_nic, sizeof(MPIDI_OFI_nic_info_t));
-        int idx_to = 0;
-        int idx_from = MPIR_CVAR_CH4_OFI_PREF_NIC;
-        memcpy(tmp_nic, &nics[idx_from], sizeof(MPIDI_OFI_nic_info_t));
-        memcpy(&nics[idx_from], &nics[idx_to], sizeof(MPIDI_OFI_nic_info_t));
-        memcpy(&nics[idx_to], tmp_nic, sizeof(MPIDI_OFI_nic_info_t));
-    } else {
-        /* Sort the NICs array based on closeness first. This way all the close
-         * NICs are at the beginning of the array */
-        if (is_snc4_with_cxi_nics) {
-            /* Use a separate sorting function for snc4 nics in order to just compare
-             * closeness followed by nic name */
-            qsort(nics, nic_count, sizeof(nics[0]), compare_nics_snc4);
-        } else {
-            qsort(nics, nic_count, sizeof(nics[0]), compare_nics);
-        }
-
-        /* Because we cannot communicate with the other local processes to avoid collisions with the
-         * same NICs, just shift NICs that have multiple close NICs around according to their local
-         * rank. This will likely give the same result as long as processes have been bound properly. */
-        int old_idx = (num_close_nics == 0) ? 0 : local_rank % num_close_nics;
-
-        if (old_idx != 0) {
-            MPIDI_OFI_nic_info_t *old_nics;
-            MPIR_CHKLMEM_MALLOC(old_nics, sizeof(MPIDI_OFI_nic_info_t) * nic_count);
-            memcpy(old_nics, nics, sizeof(MPIDI_OFI_nic_info_t) * nic_count);
-
-            /* Rotate the preferred NIC for each process starting at old_idx. */
-            for (int new_idx = 0; new_idx < num_close_nics; new_idx++) {
-                if (new_idx != old_idx)
-                    memcpy(&nics[new_idx], &old_nics[old_idx], sizeof(MPIDI_OFI_nic_info_t));
-
-                if (++old_idx >= num_close_nics)
-                    old_idx = 0;
-            }
-        }
-    }
-
-    /* Reorder the prov_use array based on nic_info array */
-    for (int i = 0; i < nic_count; ++i) {
-        MPIDI_OFI_global.prov_use[i] = nics[i].nic;
-    }
-
-    /* Set globals */
-    for (int i = num_nics; i < nic_count; i++) {
-        fi_freeinfo(MPIDI_OFI_global.prov_use[i]);
-    }
-    MPIDI_OFI_global.num_nics_available = MPL_MIN(nic_count, num_nics);
-
-    /* Set some info keys on MPI_INFO_ENV to reflect the number of available (close) NICs */
-    char nics_str[32];
-    MPIR_Info *info_ptr = NULL;
-    MPIR_Info_get_ptr(MPI_INFO_ENV, info_ptr);
-    snprintf(nics_str, 32, "%d", MPIDI_OFI_global.num_nics_available);
-    MPIR_Info_set_impl(info_ptr, "num_nics_available", nics_str);
-    snprintf(nics_str, 32, "%d", num_close_nics);
-    MPIR_Info_set_impl(info_ptr, "num_close_nics", nics_str);
-
-  fn_exit:
-    MPIR_CHKLMEM_FREEALL();
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
+                return true;
+    return false;
 }
+
+static void set_nic_close_snc4_with_cxi_nics(MPIDI_OFI_nic_info_t * nics, int nic_count)
+{
+    MPIR_hwtopo_gid_t parents[MPIDI_OFI_MAX_NICS] = { 0 };
+    int num_parents = 0;
+
+    /* Special case of nic assignment for SPR in SNC4 mode */
+    for (int i = 0; i < nic_count; ++i) {
+        nics[i].parent = get_nic_parent(nics[i].nic);
+
+        int found = 0;
+        for (int j = 0; j < num_parents; ++j) {
+            if (parents[j] == nics[i].parent) {
+                found = 1;
+                break;
+            }
+        }
+        if (!found) {
+            parents[num_parents] = nics[i].parent;
+            num_parents++;
+        }
+    }
+    /* Use num_parents to determine nic closeness */
+    for (int i = 0; i < nic_count; ++i) {
+        nics[i].close = is_nic_close_snc4(&nics[i], num_parents);
+    }
+}
+
+static int set_nic_info(void)
+{
+    MPIDI_OFI_nic_info_t *nics = MPIDI_OFI_global.nic_info;
+
+    bool is_snc4_with_cxi_nics = get_is_snc4_with_cxi_nics();
+    if (is_snc4_with_cxi_nics) {
+        set_nic_close_snc4_with_cxi_nics(nics, MPIDI_OFI_global.num_nics_available);
+    } else {
+        for (int i = 0; i < MPIDI_OFI_global.num_nics_available; ++i) {
+            nics[i].close = is_nic_close(nics[i].nic);
+        }
+    }
+
+    return MPI_SUCCESS;
+}
+
 #endif
 
-bool MPIDI_OFI_nic_is_up(struct fi_info *prov)
+bool MPIDI_OFI_nic_is_up(struct fi_info * prov)
 {
 #ifdef HAVE_LIBFABRIC_NIC
     /* Make sure the NIC returned by OFI is not down. Some providers don't include NIC

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -435,9 +435,6 @@ typedef struct {
     struct fi_info *nic;
     int id;                     /* Unique NIC ID, consistent across intranode ranks */
     int close;                  /* Boolean whether nic is close in terms of affinity */
-    int prefer;                 /* Preference to order (lower is more preferred) */
-    int count;                  /* Count of ranks which have this NIC as their preferred NIC */
-    int num_close_ranks;        /* number of ranks which are close to this NIC */
     MPIR_hwtopo_gid_t parent;   /* Parent topology item of NIC which has affinity mask.
                                  * This is typically the socket above the NIC */
 } MPIDI_OFI_nic_info_t;
@@ -457,6 +454,7 @@ typedef struct {
     /* OFI objects */
     int avtid;
     int num_nics_available;
+    int num_close_nics;
     struct fi_info *prov_use[MPIDI_OFI_MAX_NICS];
     MPIDI_OFI_nic_info_t nic_info[MPIDI_OFI_MAX_NICS];
     struct fid_fabric *fabric;


### PR DESCRIPTION
## Pull Request Description
In theory we don't need initialize fabric until we need setup for
communication. Delay it allows us to use collectives over node_comm to
collectively decide on **multi-nic** ordering.

Refactor MPIDI_OFI_init_local to separate out MPIDI_OFI_init_fabric.
Move the latter to be called at the first communicator creation time.
Add a placeholder where we can call collectives on local node_comm so we
can determine multi-nic assignement collectively in the world model.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
