### PR TITLE
ch4/ipc: fix deadlock issue with parallel GPU buffer copies

### DIFF
--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -638,7 +638,13 @@ static int gpu_ipc_async_start(MPIR_Request * req, MPIR_gpu_req * req_p,
         p->yreq.type = MPIR_NULL_REQUEST;
     }
 
+    /* Release VCI lock before adding to async list to avoid lock ordering
+     * inversion with async_things_mutex (see deadlock: VCI_LOCK -> async_things_mutex
+     * here vs async_things_mutex -> VCI_LOCK in gpu_ipc_async_poll). */
+    int vci = MPIDIG_REQUEST(req, req->local_vci);
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
     mpi_errno = MPIR_Async_things_add(gpu_ipc_async_poll, p, NULL);
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
 
     return mpi_errno;
 }


### PR DESCRIPTION
When running multi-threaded it is possible to end up with an ABBA deadlock with the async_things_mutex and MPIDI_VCI_LOCK. This happens when one thread is actively polling and another tries to add a new async operation. If the poll function acquires the MPIDI_VCI_LOCK, there is a deadlock.

This resolves a specific observed deadlock in CUDA buffer sends over shared memory by releasing the VCI lock before adding the async operation.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
