### PR TITLE
binding/c: fix generation of MPI_Pcontrol

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -94,6 +94,8 @@ def dump_mpi_c(func, is_large=False):
         skip_wrappers = True
     elif 'replace' in func and 'body' not in func:
         pass
+    elif "impl" in func and func["impl"] == "skip":
+        pass
     else:
         dump_function_internal(func, kind="normal")
     G.out.append("")
@@ -927,7 +929,10 @@ def dump_qmpi_wrappers(func, is_large):
     func_decl = get_declare_function(func, is_large)
     qmpi_decl = get_qmpi_decl_from_func_decl(func_decl)
 
-    static_call = get_static_call_internal(func, is_large)
+    if "impl" in func and func["impl"] == "skip":
+        static_call = "MPI_SUCCESS"
+    else:
+        static_call = get_static_call_internal(func, is_large)
 
     G.out.append("#ifdef ENABLE_QMPI")
     G.out.append("#ifndef MPICH_MPI_FROM_PMPI")
@@ -936,6 +941,7 @@ def dump_qmpi_wrappers(func, is_large):
     if func_name == "MPI_Pcontrol":
         G.out.append("    va_list varargs;")
         G.out.append("    va_start(varargs, level);")
+        G.out.append("    va_end(varargs);")
         G.out.append("")
     G.out.append("    return " + static_call + ";")
     G.out.append("}")
@@ -964,7 +970,13 @@ def dump_qmpi_wrappers(func, is_large):
     G.out.append("")
     dump_line_with_break("    fn_ptr = (Q%s_t *) MPIR_QMPI_first_fn_ptrs[%s_T];" % (func_name, func_name.upper()))
     G.out.append("")
-    dump_line_with_break("    return (*fn_ptr) (context, MPIR_QMPI_first_tool_ids[%s_T]%s);" % (func_name.upper(), parameters));
+
+    if func_name == "MPI_Pcontrol":
+        dump_line_with_break("    int ret = (*fn_ptr) (context, MPIR_QMPI_first_tool_ids[%s_T]%s);" % (func_name.upper(), parameters));
+        G.out.append("    va_end(varargs);")
+        G.out.append("    return ret;")
+    else:
+        dump_line_with_break("    return (*fn_ptr) (context, MPIR_QMPI_first_tool_ids[%s_T]%s);" % (func_name.upper(), parameters));
     G.out.append("}")
     G.out.append("#else /* ENABLE_QMPI */")
 
@@ -973,6 +985,7 @@ def dump_qmpi_wrappers(func, is_large):
     if func_name == "MPI_Pcontrol":
         G.out.append("    va_list varargs;")
         G.out.append("    va_start(varargs, level);")
+        G.out.append("    va_end(varargs);")
         G.out.append("")
     G.out.append("    return " + static_call + ";")
     G.out.append("}")
@@ -1197,7 +1210,10 @@ def dump_abi_wrappers(func, is_large):
         ret = mapping[func['return']]
         ret = re.sub(re_Handle, r'ABI_\1', ret)
 
-    static_call = get_static_call_internal(func, is_large)
+    if 'impl' in func and func['impl'] == "skip":
+        static_call = "MPI_SUCCESS"
+    else:
+        static_call = get_static_call_internal(func, is_large)
 
     s_param = ', '.join(param_list)
     func_decl = "%s %s(%s)" % (ret, func_name, s_param)
@@ -1238,6 +1254,7 @@ def dump_abi_wrappers(func, is_large):
         if func_name == "MPI_Pcontrol":
             G.out.append("va_list varargs;")
             G.out.append("va_start(varargs, level);")
+            G.out.append("va_end(varargs);")
             G.out.append("")
         G.out.append("int ret = " + static_call + ";")
         for l in post_filters:

--- a/src/binding/c/misc_api.txt
+++ b/src/binding/c/misc_api.txt
@@ -49,31 +49,7 @@ MPI_Get_library_version:
 MPI_Pcontrol:
     .desc: Controls profiling
     .skip: initcheck, ThreadSafe, validate-PROFILE_LEVEL, validate-VARARGS
-    .impl: direct
-{
-    int mpi_errno = MPI_SUCCESS;
-    va_list list;
-
-    MPIR_ERRTEST_INITIALIZED_ORDIE();
-
-    MPIR_FUNC_TERSE_ENTER;
-
-    /* ... body of routine ...  */
-
-    /* This is a dummy routine that does nothing.  It is intended for
-     * use by the user (or a tool) with the profiling interface */
-    /* We include a reference to va_start and va_end to (a) quiet some
-     * compilers that warn when they are not present and (b) show how to
-     * access any optional arguments */
-    va_start(list, level);
-    va_end(list);
-
-    /* ... end of body of routine ... */
-    MPIR_FUNC_TERSE_EXIT;
-    return mpi_errno;
-    /* There should never be any fn_fail case; this suppresses warnings from
-     * compilers that object to unused labels */
-}
+    .impl: skip
 
 MPI_Get_version:
     .desc: Return the version number of MPI


### PR DESCRIPTION
## Pull Request Description
`internal_Pcontrol` is a NOOP. Simplify it away by directly return `MPI_SUCCESS` in `QMPI_Pcontrol` and `PMPI_Pcontrol`.

Previously we are missing a `va_end(varargs);`
Fixes #7879



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
