### PR TITLE
errutil: fix buffer overflow in MPIR_Err_print_stack_string

### DIFF
--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -1075,12 +1075,75 @@ int MPIR_Err_create_code_valist(int lastcode, int fatal, const char fcname[],
     return err_code;
 }
 
-/* FIXME: Shouldn't str be const char * ? - no, but you don't know that without
-   some documentation */
+/* Append src and tail to str, writing at most maxlen bytes (including null terminator).
+ * tail may be NULL.  Returns the number of characters appended. */
+static int str_append(char *str, int maxlen, const char *src, const char *tail)
+{
+    if (maxlen <= 0)
+        return 0;
+    int len;
+    if (tail) {
+        len = snprintf(str, maxlen, "%s%s", src, tail);
+    } else {
+        len = snprintf(str, maxlen, "%s", src);
+    }
+    if (len >= maxlen)
+        len = maxlen - 1;
+    return len;
+}
+
+/* Append src to str with line wrapping.  Lines are broken at (width - lead)
+ * characters and continuation lines are indented with lead spaces.
+ * Returns the total number of characters appended. */
+static int str_append_wrap(char *str, int maxlen, const char *src, int width, int lead)
+{
+    int total = 0;
+    int chop_len = width - 1 - lead;
+    int remaining = (int) strlen(src);
+
+    if (maxlen <= 0)
+        return 0;
+
+    if (remaining == 0) {
+        if (maxlen >= 2) {
+            str[total++] = '\n';
+        }
+        str[total] = '\0';
+        return total;
+    }
+
+    while (remaining > 0 && total < maxlen - 1) {
+        if (remaining > chop_len && total + chop_len + 1 <= maxlen) {
+            /* output a chopped line */
+            memcpy(str + total, src, chop_len);
+            str[total + chop_len] = '\n';
+            total += chop_len + 1;
+            src += chop_len;
+            remaining -= chop_len;
+            /* indent continuation line */
+            for (int i = 0; i < lead && total < maxlen - 1; i++) {
+                str[total++] = ' ';
+            }
+        } else {
+            /* last segment — fits on one line */
+            int avail = maxlen - total - 1;     /* reserve 1 for null terminator */
+            int n = (remaining < avail) ? remaining : avail;
+            memcpy(str + total, src, n);
+            total += n;
+            if (total < maxlen - 1) {
+                str[total++] = '\n';
+            }
+            break;
+        }
+    }
+    str[total] = '\0';
+
+    return total;
+}
+
 static void MPIR_Err_print_stack_string(int errcode, char *str, int maxlen)
 {
-    char *str_orig = str;
-    int len;
+    int len = 0;
 
     error_ring_mutex_lock();
     {
@@ -1105,8 +1168,8 @@ static void MPIR_Err_print_stack_string(int errcode, char *str, int maxlen)
             }
 
             if (ErrorRing[ring_idx].id == ring_id) {
-                len = (int) strlen(ErrorRing[ring_idx].location);
-                max_location_len = MPL_MAX(max_location_len, len);
+                int n = (int) strlen(ErrorRing[ring_idx].location);
+                max_location_len = MPL_MAX(max_location_len, n);
                 tmp_errcode = ErrorRing[ring_idx].prev_error;
             } else {
                 break;
@@ -1114,13 +1177,8 @@ static void MPIR_Err_print_stack_string(int errcode, char *str, int maxlen)
         }
         max_location_len += 2;  /* add space for the ": " */
         /* print the error stack */
-        while (errcode != MPI_SUCCESS && maxlen > 1) {
-            int ring_idx;
-            int ring_id;
-            int generic_idx;
-            int i;
-            char *cur_pos;
-
+        while (errcode != MPI_SUCCESS && len < maxlen - 1) {
+            int ring_idx, ring_id, generic_idx;
             if (convertErrcodeToIndexes(errcode, &ring_idx, &ring_id, &generic_idx) != 0) {
                 /* --BEGIN ERROR HANDLING-- */
                 MPL_error_printf("Invalid error code (%d) (error ring index %d invalid)\n",
@@ -1133,66 +1191,24 @@ static void MPIR_Err_print_stack_string(int errcode, char *str, int maxlen)
             }
 
             if (ErrorRing[ring_idx].id == ring_id) {
-                int nchrs;
-                len = snprintf(str, maxlen, "%s", ErrorRing[ring_idx].location);
-                if (len >= maxlen)
-                    len = maxlen - 1;
-                maxlen -= len;
-                str += len;
-                nchrs = max_location_len - (int) strlen(ErrorRing[ring_idx].location) - 2;
-                while (nchrs > 0 && maxlen > 1) {
-                    *str++ = '.';
+                /* Build padded location: "PMPI_Send..: " */
+                int loc_len = (int) strlen(ErrorRing[ring_idx].location);
+                len += str_append(str + len, maxlen - len, ErrorRing[ring_idx].location, NULL);
+                int nchrs = max_location_len - loc_len - 2;
+                while (nchrs > 0 && len < maxlen - 1) {
+                    str[len++] = '.';
                     nchrs--;
-                    maxlen--;
                 }
-                if (maxlen > 1) {
-                    *str++ = ':';
-                    maxlen--;
-                }
-                if (maxlen > 1) {
-                    *str++ = ' ';
-                    maxlen--;
+                if (len + 2 < maxlen) {
+                    str[len++] = ':';
+                    str[len++] = ' ';
                 }
 
                 if (MPIR_CVAR_CHOP_ERROR_STACK > 0) {
-                    cur_pos = ErrorRing[ring_idx].msg;
-                    len = (int) strlen(cur_pos);
-                    if (len == 0 && maxlen > 1) {
-                        *str++ = '\n';
-                        maxlen--;
-                    }
-                    while (len && maxlen > 1) {
-                        int chop_len = MPIR_CVAR_CHOP_ERROR_STACK - 1 - max_location_len;
-                        if (len >= MPIR_CVAR_CHOP_ERROR_STACK - max_location_len) {
-                            if (chop_len + 1 > maxlen)
-                                break;
-                            snprintf(str, chop_len + 1, "%s", cur_pos);
-                            str[chop_len] = '\n';
-                            cur_pos += chop_len;
-                            str += chop_len + 1;
-                            maxlen -= chop_len + 1;
-                            if (maxlen < max_location_len + 1)
-                                break;
-                            for (i = 0; i < max_location_len && maxlen > 1; i++) {
-                                *str++ = ' ';
-                                maxlen--;
-                            }
-                            len = (int) strlen(cur_pos);
-                        } else {
-                            len = snprintf(str, maxlen, "%s\n", cur_pos);
-                            if (len >= maxlen)
-                                len = maxlen - 1;
-                            maxlen -= len;
-                            str += len;
-                            len = 0;
-                        }
-                    }
+                    len += str_append_wrap(str + len, maxlen - len, ErrorRing[ring_idx].msg,
+                                           MPIR_CVAR_CHOP_ERROR_STACK, max_location_len);
                 } else {
-                    len = snprintf(str, maxlen, "%s\n", ErrorRing[ring_idx].msg);
-                    if (len >= maxlen)
-                        len = maxlen - 1;
-                    maxlen -= len;
-                    str += len;
+                    len += str_append(str + len, maxlen - len, ErrorRing[ring_idx].msg, "\n");
                 }
                 errcode = ErrorRing[ring_idx].prev_error;
             } else {
@@ -1202,7 +1218,7 @@ static void MPIR_Err_print_stack_string(int errcode, char *str, int maxlen)
     }
     error_ring_mutex_unlock();
 
-    if (errcode == MPI_SUCCESS || maxlen <= 1) {
+    if (errcode == MPI_SUCCESS || len >= maxlen - 1) {
         goto fn_exit;
     }
 
@@ -1221,11 +1237,8 @@ static void MPIR_Err_print_stack_string(int errcode, char *str, int maxlen)
             if (!p) {
                 p = "<NULL>";
             }
-            len = snprintf(str, maxlen, "(unknown)(): %s\n", p);
-            if (len >= maxlen)
-                len = maxlen - 1;
-            maxlen -= len;
-            str += len;
+            len += str_append(str + len, maxlen - len, "(unknown)(): ", NULL);
+            len += str_append(str + len, maxlen - len, p, "\n");
             goto fn_exit;
         }
     }
@@ -1236,26 +1249,23 @@ static void MPIR_Err_print_stack_string(int errcode, char *str, int maxlen)
         error_class = ERROR_GET_CLASS(errcode);
 
         if (error_class <= MPICH_ERR_LAST_MPIX) {
-            len =
-                snprintf(str, maxlen, "(unknown)(): %s\n", get_class_msg(ERROR_GET_CLASS(errcode)));
-            if (len >= maxlen)
-                len = maxlen - 1;
-            maxlen -= len;
-            str += len;
+            len += str_append(str + len, maxlen - len, "(unknown)(): ", NULL);
+            len += str_append(str + len, maxlen - len,
+                              get_class_msg(ERROR_GET_CLASS(errcode)), "\n");
         } else {
             /* FIXME: Not internationalized */
-            len = snprintf(str, maxlen, "Error code contains an invalid class (%d)\n", error_class);
-            if (len >= maxlen)
-                len = maxlen - 1;
-            maxlen -= len;
-            str += len;
+            int n = snprintf(str + len, maxlen - len,
+                             "Error code contains an invalid class (%d)\n", error_class);
+            if (n >= maxlen - len)
+                n = maxlen - len - 1;
+            len += n;
         }
     }
 
   fn_exit:
-    if (str_orig != str) {
-        str--;
-        *str = '\0';
+    if (len > 0) {
+        len--;
+        str[len] = '\0';
     }
     return;
 }

--- a/src/mpi/errhan/errutil.c
+++ b/src/mpi/errhan/errutil.c
@@ -1114,7 +1114,7 @@ static void MPIR_Err_print_stack_string(int errcode, char *str, int maxlen)
         }
         max_location_len += 2;  /* add space for the ": " */
         /* print the error stack */
-        while (errcode != MPI_SUCCESS) {
+        while (errcode != MPI_SUCCESS && maxlen > 1) {
             int ring_idx;
             int ring_id;
             int generic_idx;
@@ -1134,21 +1134,22 @@ static void MPIR_Err_print_stack_string(int errcode, char *str, int maxlen)
 
             if (ErrorRing[ring_idx].id == ring_id) {
                 int nchrs;
-                snprintf(str, maxlen, "%s", ErrorRing[ring_idx].location);
-                len = (int) strlen(str);
+                len = snprintf(str, maxlen, "%s", ErrorRing[ring_idx].location);
+                if (len >= maxlen)
+                    len = maxlen - 1;
                 maxlen -= len;
                 str += len;
                 nchrs = max_location_len - (int) strlen(ErrorRing[ring_idx].location) - 2;
-                while (nchrs > 0 && maxlen > 0) {
+                while (nchrs > 0 && maxlen > 1) {
                     *str++ = '.';
                     nchrs--;
                     maxlen--;
                 }
-                if (maxlen > 0) {
+                if (maxlen > 1) {
                     *str++ = ':';
                     maxlen--;
                 }
-                if (maxlen > 0) {
+                if (maxlen > 1) {
                     *str++ = ' ';
                     maxlen--;
                 }
@@ -1156,40 +1157,40 @@ static void MPIR_Err_print_stack_string(int errcode, char *str, int maxlen)
                 if (MPIR_CVAR_CHOP_ERROR_STACK > 0) {
                     cur_pos = ErrorRing[ring_idx].msg;
                     len = (int) strlen(cur_pos);
-                    if (len == 0 && maxlen > 0) {
+                    if (len == 0 && maxlen > 1) {
                         *str++ = '\n';
                         maxlen--;
                     }
-                    while (len) {
+                    while (len && maxlen > 1) {
+                        int chop_len = MPIR_CVAR_CHOP_ERROR_STACK - 1 - max_location_len;
                         if (len >= MPIR_CVAR_CHOP_ERROR_STACK - max_location_len) {
-                            if (len > maxlen)
+                            if (chop_len + 1 > maxlen)
                                 break;
-                            /* FIXME: Don't use Snprint to append a string ! */
-                            snprintf(str, MPIR_CVAR_CHOP_ERROR_STACK - 1 - max_location_len,
-                                     "%s", cur_pos);
-                            str[MPIR_CVAR_CHOP_ERROR_STACK - 1 - max_location_len] = '\n';
-                            cur_pos += MPIR_CVAR_CHOP_ERROR_STACK - 1 - max_location_len;
-                            str += MPIR_CVAR_CHOP_ERROR_STACK - max_location_len;
-                            maxlen -= MPIR_CVAR_CHOP_ERROR_STACK - max_location_len;
-                            if (maxlen < max_location_len)
+                            snprintf(str, chop_len + 1, "%s", cur_pos);
+                            str[chop_len] = '\n';
+                            cur_pos += chop_len;
+                            str += chop_len + 1;
+                            maxlen -= chop_len + 1;
+                            if (maxlen < max_location_len + 1)
                                 break;
-                            for (i = 0; i < max_location_len; i++) {
-                                snprintf(str, maxlen, " ");
+                            for (i = 0; i < max_location_len && maxlen > 1; i++) {
+                                *str++ = ' ';
                                 maxlen--;
-                                str++;
                             }
                             len = (int) strlen(cur_pos);
                         } else {
-                            snprintf(str, maxlen, "%s\n", cur_pos);
-                            len = (int) strlen(str);
+                            len = snprintf(str, maxlen, "%s\n", cur_pos);
+                            if (len >= maxlen)
+                                len = maxlen - 1;
                             maxlen -= len;
                             str += len;
                             len = 0;
                         }
                     }
                 } else {
-                    snprintf(str, maxlen, "%s\n", ErrorRing[ring_idx].msg);
-                    len = (int) strlen(str);
+                    len = snprintf(str, maxlen, "%s\n", ErrorRing[ring_idx].msg);
+                    if (len >= maxlen)
+                        len = maxlen - 1;
                     maxlen -= len;
                     str += len;
                 }
@@ -1201,7 +1202,7 @@ static void MPIR_Err_print_stack_string(int errcode, char *str, int maxlen)
     }
     error_ring_mutex_unlock();
 
-    if (errcode == MPI_SUCCESS) {
+    if (errcode == MPI_SUCCESS || maxlen <= 1) {
         goto fn_exit;
     }
 
@@ -1220,8 +1221,9 @@ static void MPIR_Err_print_stack_string(int errcode, char *str, int maxlen)
             if (!p) {
                 p = "<NULL>";
             }
-            snprintf(str, maxlen, "(unknown)(): %s\n", p);
-            len = (int) strlen(str);
+            len = snprintf(str, maxlen, "(unknown)(): %s\n", p);
+            if (len >= maxlen)
+                len = maxlen - 1;
             maxlen -= len;
             str += len;
             goto fn_exit;
@@ -1234,14 +1236,17 @@ static void MPIR_Err_print_stack_string(int errcode, char *str, int maxlen)
         error_class = ERROR_GET_CLASS(errcode);
 
         if (error_class <= MPICH_ERR_LAST_MPIX) {
-            snprintf(str, maxlen, "(unknown)(): %s\n", get_class_msg(ERROR_GET_CLASS(errcode)));
-            len = (int) strlen(str);
+            len =
+                snprintf(str, maxlen, "(unknown)(): %s\n", get_class_msg(ERROR_GET_CLASS(errcode)));
+            if (len >= maxlen)
+                len = maxlen - 1;
             maxlen -= len;
             str += len;
         } else {
             /* FIXME: Not internationalized */
-            snprintf(str, maxlen, "Error code contains an invalid class (%d)\n", error_class);
-            len = (int) strlen(str);
+            len = snprintf(str, maxlen, "Error code contains an invalid class (%d)\n", error_class);
+            if (len >= maxlen)
+                len = maxlen - 1;
             maxlen -= len;
             str += len;
         }


### PR DESCRIPTION
## Pull Request Description

Fix a bug in `MPIR_Err_print_stack_string` that overflows memory.

Use `snprintf` return value instead of `strlen` to track bytes written, clamp `len` when output is truncated, and check `maxlen > 1` (reserving space for null terminator) before writing to the buffer. Also bound the `CHOP_ERROR_STACK` path by `maxlen`.

----
Claude explains:

 The core bug was that `MPIR_Err_print_stack_string` could write past the end of the output buffer through two mechanisms:

  1. `strlen` on unwritten memory

  The old pattern was:
  ```
  snprintf(str, maxlen, "%s", ...);
  len = (int) strlen(str);
  maxlen -= len;
  str += len;
```
  When `maxlen` reached 0, `snprintf(str, 0, ...)` wrote nothing — but `strlen(str)` read whatever stale data was already in the buffer. This produced an arbitrary `len`, which made `maxlen` go negative.

  2. Negative `maxlen` → massive size_t

  On the next iteration, a negative `maxlen` (e.g. -42) was passed to `snprintf` as the `size_t` parameter, wrapping around to ~4 billion. This allowed `snprintf` to write far past the buffer boundary.

  3. CHOP path ignored `maxlen` entirely

  The chopped-output code path used `MPIR_CVAR_CHOP_ERROR_STACK - 1 - max_location_len` as the `snprintf` size limit, completely independent of how much buffer space remained.

  The fix:
  - Use `snprintf`'s return value (bytes it would have written) instead of `strlen` to track output length
  - Clamp `len` to `maxlen - 1` when truncation occurs
  - Guard loops and writes with `maxlen > 1` (reserving 1 byte for the null terminator)
  - Bound the CHOP path by `maxlen`


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
