### PR TITLE
github: Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,0 +1,319 @@
+name: ci-workflow
+
+on:  # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      runs-on:
+        description: "OS & Architecture"
+        default: 'Linux-x86_64'
+        required: false
+        type: string
+      device:
+        description: "MPICH Device"
+        default: 'ch4:ofi'
+        required: false
+        type: string
+      pm:
+        description: "MPICH Process Manager"
+        default: 'hydra:gforker'
+        required: false
+        type: string
+      mpi4py-git:
+        description: 'mpi4py git'
+        default:  mpi4py/mpi4py
+        required: false
+        type: string
+      mpi4py-ref:
+        description: 'mpi4py ref'
+        default:  ''
+        required: false
+        type: string
+  workflow_dispatch:
+    inputs:
+      runs-on:
+        description: "OS & Architecture"
+        default: 'Linux-x86_64'
+        required: false
+        type: choice
+        options:
+          - Linux-aarch64
+          - Linux-x86_64
+          - macOS-arm64
+          - macOS-x86_64
+      device:
+        description: "MPICH Device"
+        default: 'ch4:ofi'
+        required: false
+        type: choice
+        options:
+          - ch4:ucx,ofi
+          - ch4:ofi,ucx
+          - ch4:ucx
+          - ch4:ofi
+          - ch3:nemesis
+          - ch3:sock
+      pm:
+        description: "MPICH Process Manager"
+        default: 'hydra:gforker'
+        required: false
+        type: choice
+        options:
+          - hydra:gforker
+          - hydra
+          - gforker
+      mpi4py-git:
+        description: 'mpi4py git'
+        default:  mpi4py/mpi4py
+        required: false
+        type: string
+      mpi4py-ref:
+        description: 'mpi4py ref'
+        default: ''
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+
+  build:
+    # https://github.com/actions/runner-images#available-images
+    runs-on: &github-runner-label |-
+      ${{ case(
+        inputs.runs-on == 'Linux-aarch64', 'ubuntu-24.04-arm',
+        inputs.runs-on == 'Linux-x86_64',  'ubuntu-24.04',
+        inputs.runs-on == 'macOS-arm64',   'macos-26',
+        inputs.runs-on == 'macOS-x86_64',  'macos-26-intel',
+        inputs.runs-on || 'ubuntu-latest'
+      ) }}
+    outputs:
+      build-tag: ${{ steps.setup.outputs.build-tag }}
+    timeout-minutes: 60
+
+    steps:
+
+    - id: setup
+      name: Setup
+      run: |
+        # setup
+        # build tag to name artifacts
+        system=${{ runner.os }}-$(uname -m)
+        device=$(echo ${{ inputs.device }} | tr ':,' '_')
+        pm=$(echo ${{ inputs.pm }} | tr ':,' '_')
+        echo build-tag="$device-$pm-$system" >> "$GITHUB_OUTPUT"
+        # number of active cores
+        case $(uname) in
+        Linux)  nproc=$(nproc) ;;
+        Darwin) nproc=$(sysctl -n hw.activecpu) ;;
+        esac
+        echo nproc=${nproc:-1} >> "$GITHUB_OUTPUT"
+
+    - if: ${{ runner.os == 'Linux' }}
+      name: Setup Linux
+      run: |
+        # setup Linux
+        true
+
+    - if: ${{ runner.os == 'macOS' }}
+      name: Setup macOS
+      run: |
+        # setup macOS
+        brew untap aws/tap &>/dev/null || true
+        # set MACOSX_DEPLOYMENT_TARGET
+        echo MACOSX_DEPLOYMENT_TARGET=11.0 >> "$GITHUB_ENV"
+        # install autotools
+        brew list autoconf &>/dev/null || brew install autoconf
+        brew list automake &>/dev/null || brew install automake
+        brew list libtool  &>/dev/null || brew install libtool
+        # create gfortran symlink
+        cd $(brew --prefix)/bin
+        gfortran=$(ls gfortran-* | sort | head -n 1)
+        sudo ln -s $gfortran gfortran
+        # show commands
+        command -v autoconf
+        command -v automake
+        command -v glibtool
+        command -v glibtoolize
+        command -v gfortran
+
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+
+    - name: Bootstrap
+      run:  ./autogen.sh
+
+    - name: Configure
+      run:  ./configure
+              --prefix=/opt/mpich
+              --with-pm=${{ inputs.pm }}
+              --with-device=${{ inputs.device }}
+              --disable-dependency-tracking
+              --disable-maintainer-mode
+              --disable-doc
+              --enable-g=all
+              --enable-fast=none
+              --enable-mpi-abi
+              --with-mpl=embedded
+              --with-ucx=embedded
+              --with-json=embedded
+              --with-hwloc=embedded
+              --with-yaksa=embedded
+              --with-libfabric=embedded
+              $(test ${{ inputs.pm }} == gforker &&
+                echo --with-namepublisher=file)
+              || (cat config.log; exit 1)
+
+    - name: Build
+      run:  make -j ${{ steps.setup.outputs.nproc }}
+
+    - name: Install
+      run:  sudo make install
+
+    - name: Archive artifact
+      run:  tar -cvpf mpich.tar /opt/mpich
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: mpich-${{ steps.setup.outputs.build-tag }}
+        path: mpich.tar
+        retention-days: 2
+
+    - name: Update PATH
+      run:  echo /opt/mpich/bin >> "$GITHUB_PATH"
+
+    - name: Show MPICH version
+      run:  mpichversion
+
+    - name: Show MPI control vars
+      run:  mpivars
+
+    - name: Show MPICC
+      run:  mpicc -show
+
+    - name: Show MPICXX
+      run:  mpicxx -show
+
+    - name: Show MPIFORT
+      run:  mpifort -show
+
+    - name: Hello, World!
+      run: |
+        cat > helloworld.c << EOF
+        #include <mpi.h>
+        #include <stdio.h>
+
+        int main(int argc, char *argv[])
+        {
+          int size, rank, len;
+          char name[MPI_MAX_PROCESSOR_NAME];
+          MPI_Init(&argc, &argv);
+          MPI_Comm_size(MPI_COMM_WORLD, &size);
+          MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+          MPI_Get_processor_name(name, &len);
+          if (rank != 0) {
+            MPI_Recv(NULL, 0 , MPI_BYTE, rank-1, 0, MPI_COMM_WORLD,
+                     MPI_STATUS_IGNORE);
+          }
+          printf("Hello, World! I am process %d of %d on %s.\n",
+                  rank, size, name);
+          if (rank != size - 1) {
+            MPI_Send(NULL, 0 , MPI_BYTE, rank+1, 0, MPI_COMM_WORLD);
+          }
+          MPI_Finalize();
+          return 0;
+        }
+        EOF
+
+        set +x
+
+        mpicc helloworld.c -o helloworld
+        mpiexec -n 5 ./helloworld
+
+        mpicc_abi helloworld.c -o helloworld_abi
+        mpiexec -n 5 ./helloworld_abi
+
+  test:
+    runs-on: *github-runner-label
+    needs: build
+    timeout-minutes: 60
+
+    steps:
+
+    - name: Checkout mpi4py
+      uses: actions/checkout@v6
+      with:
+        repository: ${{ inputs.mpi4py-git || 'mpi4py/mpi4py' }}
+        ref: ${{ inputs.mpi4py-ref }}
+
+    - name: Download artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: mpich-${{ needs.build.outputs.build-tag }}
+
+    - name: Extract artifact
+      run:  sudo tar -xvpf mpich.tar -C /
+
+    - name: Update PATH
+      run:  echo /opt/mpich/bin >> "$GITHUB_PATH"
+
+    - name: Setup Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: 3
+
+    - name: Install mpi4py
+      run:  python -m pip install .
+      env:
+        CFLAGS: "-O0"
+
+    - name: Install mpi4py test dependencies
+      run:  python -m pip install --group test
+
+    - name: Configure hostname
+      run:  echo 127.0.0.1 `hostname` | sudo tee -a /etc/hosts > /dev/null
+
+    - name: Test mpi4py (singleton)
+      run:  python test/main.py -v
+    - name: Test mpi4py (np=1)
+      run:  mpiexec -n 1 python test/main.py -v
+    - name: Test mpi4py (np=2)
+      run:  mpiexec -n 2 python test/main.py -v -f
+      timeout-minutes: 10
+
+    - if: ${{ !(runner.os == 'macOS' && runner.arch == 'x64') }}
+      name: Test mpi4py (np=3)
+      run:  mpiexec -n 3 python test/main.py -v -f
+      timeout-minutes: 15
+      env:
+        MPIR_CVAR_POLLS_BEFORE_YIELD: 1
+        MPIR_CVAR_CH4_PROGRESS_THROTTLE: true
+        MPIR_CVAR_CH4_PROGRESS_THROTTLE_NO_PROGRESS_COUNT: 1
+
+    - if: ${{ !(runner.os == 'macOS' && runner.arch == 'x64') }}
+      name: Test mpi4py (np=4)
+      run:  mpiexec -n 4 python test/main.py -v -f
+      timeout-minutes: 15
+      env:
+        MPIR_CVAR_POLLS_BEFORE_YIELD: 1
+        MPIR_CVAR_CH4_PROGRESS_THROTTLE: true
+        MPIR_CVAR_CH4_PROGRESS_THROTTLE_NO_PROGRESS_COUNT: 1
+
+    - if: ${{ !(runner.os == 'macOS' && runner.arch == 'x64') }}
+      name: Test mpi4py (np=5)
+      run:  mpiexec -n 5 python test/main.py -v -f
+      timeout-minutes: 15
+      env:
+        MPIR_CVAR_POLLS_BEFORE_YIELD: 1
+        MPIR_CVAR_CH4_PROGRESS_THROTTLE: true
+        MPIR_CVAR_CH4_PROGRESS_THROTTLE_NO_PROGRESS_COUNT: 1
+
+    - name: Test mpi4py.run
+      run:  python demo/test-run/test_run.py -v
+    - name: Test init-fini
+      run:  bash demo/init-fini/run.sh
+    - name: Test check-mpiexec
+      run:  bash demo/check-mpiexec/run.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ci
+name: mpi4py
 
 on:  # yamllint disable-line rule:truthy
   push:
@@ -6,21 +6,13 @@ on:  # yamllint disable-line rule:truthy
       - "main"
       - "[0-9]+.[0-9]+.x"
   pull_request:
+    types:
+      - labeled
+      - synchronize
     branches:
       - "main"
       - "[0-9]+.[0-9]+.x"
   workflow_dispatch:
-    inputs:
-      Linux:
-        description: 'Linux'
-        required: true
-        type: boolean
-        default: true
-      macOS:
-        description: 'macOS'
-        required: true
-        type: boolean
-        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,21 +22,28 @@ permissions:
   contents: read
 
 jobs:
+  cond-mpi4py:
+    runs-on: ubuntu-slim
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'test-mpi4py') }}
+    steps:
+      - run: true
 
-  Linux:
-    if: |-
-      ${{ case(
-        github.event_name == 'workflow_call' ||
-        github.event_name == 'workflow_dispatch',
-        inputs.Linux,
-        true
-      ) }}
+  result-mpi4py:
+    runs-on: ubuntu-slim
+    needs: test-mpi4py
+    steps:
+      - run: test "${{ needs.test-mpi4py.result }}" = "success"
+
+  test-mpi4py:
+    needs: cond-mpi4py
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - aarch64
-          - x86_64
+        os-arch:
+          - Linux-aarch64
+          - Linux-x86_64
+          - macOS-arm64
+          - macOS-x86_64
         device:
           - ch4:ucx
           - ch4:ofi
@@ -53,35 +52,13 @@ jobs:
         pm:
           - hydra
           - gforker
+        exclude:
+          - os-arch: macOS-arm64
+            device: ch4:ucx
+          - os-arch: macOS-x86_64
+            device: ch4:ucx
     uses: ./.github/workflows/ci-workflow.yml
     with:
-      runs-on: Linux-${{ matrix.arch }}
-      device:  ${{ matrix.device }}
-      pm:      ${{ matrix.pm     }}
-
-  macOS:
-    if: |-
-      ${{ case(
-        github.event_name == 'workflow_call' ||
-        github.event_name == 'workflow_dispatch',
-        inputs.macOS,
-        true
-      ) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        arch:
-          - arm64
-          - x86_64
-        device:
-          - ch4:ofi
-          - ch3:nemesis
-          - ch3:sock
-        pm:
-          - hydra
-          - gforker
-    uses: ./.github/workflows/ci-workflow.yml
-    with:
-      runs-on: macOS-${{ matrix.arch }}
+      runs-on: ${{ matrix.os-arch }}
       device:  ${{ matrix.device }}
       pm:      ${{ matrix.pm     }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,17 +7,81 @@ on:  # yamllint disable-line rule:truthy
       - "[0-9]+.[0-9]+.x"
   pull_request:
     branches:
-      - "main"  # TODO: review
+      - "main"
       - "[0-9]+.[0-9]+.x"
+  workflow_dispatch:
+    inputs:
+      Linux:
+        description: 'Linux'
+        required: true
+        type: boolean
+        default: true
+      macOS:
+        description: 'macOS'
+        required: true
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
 
   Linux:
-    runs-on: ubuntu-latest
-    steps:
-    - run: echo ${{ runner.os }}
+    if: |-
+      ${{ case(
+        github.event_name == 'workflow_call' ||
+        github.event_name == 'workflow_dispatch',
+        inputs.Linux,
+        true
+      ) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - aarch64
+          - x86_64
+        device:
+          - ch4:ucx
+          - ch4:ofi
+          - ch3:nemesis
+          - ch3:sock
+        pm:
+          - hydra
+          - gforker
+    uses: ./.github/workflows/ci-workflow.yml
+    with:
+      runs-on: Linux-${{ matrix.arch }}
+      device:  ${{ matrix.device }}
+      pm:      ${{ matrix.pm     }}
 
   macOS:
-    runs-on: macos-latest
-    steps:
-    - run: echo ${{ runner.os }}
+    if: |-
+      ${{ case(
+        github.event_name == 'workflow_call' ||
+        github.event_name == 'workflow_dispatch',
+        inputs.macOS,
+        true
+      ) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - arm64
+          - x86_64
+        device:
+          - ch4:ofi
+          - ch3:nemesis
+          - ch3:sock
+        pm:
+          - hydra
+          - gforker
+    uses: ./.github/workflows/ci-workflow.yml
+    with:
+      runs-on: macOS-${{ matrix.arch }}
+      device:  ${{ matrix.device }}
+      pm:      ${{ matrix.pm     }}


### PR DESCRIPTION
## Pull Request Description
  - Add a reusable workflow (ci-workflow.yml) that builds MPICH from source and runs the mpi4py test suite, supporting multiple OS/arch (Linux x86_64/aarch64, macOS arm64/x86_64), devices (ch4:ofi, ch4:ucx, ch3:nemesis, ch3:sock), and process managers (hydra, gforker)
  - Rework ci.yml to use a build matrix across all OS/device/PM combinations, calling the reusable workflow, with macOS+UCX excluded
  - Use the `test-mpi4py` PR label (or workflow_dispatch) to trigger the full matrix testing on every push

###  Details

  The reusable workflow (`ci-workflow.yml`) has two jobs:
  - **build**: Configures and builds MPICH with embedded dependencies (libfabric, UCX, yaksa, hwloc, etc.), installs to /opt/mpich, uploads as an artifact, and runs a basic Hello World smoke test (including MPI ABI)
  - **test**: Downloads the MPICH artifact, installs mpi4py, and runs the mpi4py test suite at `np=1` through `np=5` (with throttling CVARs for np>=3 to manage resource usage on CI runners)

  The top-level ci.yml (renamed to "mpi4py") uses a strategy matrix and adds concurrency control to cancel in-progress runs on the same ref.

###
* 28 matrix combinations.

  - 4 OS/arch × 4 devices × 2 PMs = 32
  - minus 4 excluded (macOS-arm64 + ch4:ucx × 2 PMs, macOS-x86_64 + ch4:ucx × 2 PMs)

  Each calls the reusable workflow which has 2 jobs (build + test), so **56** jobs total (plus 2 housekeeping jobs: cond-mpi4py and result-mpi4py).

Fixed #7865 

## Some results (room to improve)
### GitHub Actions Run #29768680640 - Job Statistics

**Repository:** pmodels/mpich
**Date:** 2026-07-20
**Total wall-clock time:** ~1h 17m (<--- this is too long)
**Result:** All 56 jobs (28 build + 28 test) completed successfully

### Build Jobs

| Job | Duration |
|-----|----------|
| Linux (aarch64, ch3:nemesis, gforker) / build | 5m 10s |
| Linux (aarch64, ch3:sock, gforker) / build | 5m 18s |
| Linux (aarch64, ch3:nemesis, hydra) / build | 5m 20s |
| Linux (aarch64, ch3:sock, hydra) / build | 5m 26s |
| Linux (x86_64, ch3:nemesis, gforker) / build | 5m 32s |
| Linux (x86_64, ch3:sock, gforker) / build | 6m 37s |
| Linux (x86_64, ch3:sock, hydra) / build | 6m 59s |
| Linux (x86_64, ch3:nemesis, hydra) / build | 7m 04s |
| macOS (arm64, ch3:sock, hydra) / build | 7m 19s |
| Linux (aarch64, ch4:ucx, gforker) / build | 7m 42s |
| Linux (aarch64, ch4:ucx, hydra) / build | 7m 44s |
| Linux (aarch64, ch4:ofi, gforker) / build | 8m 57s |
| macOS (arm64, ch3:nemesis, gforker) / build | 9m 04s |
| Linux (aarch64, ch4:ofi, hydra) / build | 9m 31s |
| macOS (arm64, ch3:sock, gforker) / build | 9m 57s |
| Linux (x86_64, ch4:ucx, hydra) / build | 10m 19s |
| Linux (x86_64, ch4:ucx, gforker) / build | 10m 24s |
| macOS (x86_64, ch3:nemesis, hydra) / build | 12m 12s |
| macOS (arm64, ch3:nemesis, hydra) / build | 12m 15s |
| macOS (x86_64, ch3:nemesis, gforker) / build | 12m 17s |
| macOS (arm64, ch4:ofi, gforker) / build | 12m 39s |
| Linux (x86_64, ch4:ofi, hydra) / build | 13m 14s |
| macOS (x86_64, ch3:sock, gforker) / build | 13m 17s |
| macOS (x86_64, ch3:sock, hydra) / build | 13m 18s |
| Linux (x86_64, ch4:ofi, gforker) / build | 13m 25s |
| macOS (arm64, ch4:ofi, hydra) / build | 13m 57s |
| macOS (x86_64, ch4:ofi, gforker) / build | 20m 13s |
| macOS (x86_64, ch4:ofi, hydra) / build | 25m 36s |

### Test Jobs

| Job | Duration |
|-----|----------|
| macOS (x86_64, ch3:nemesis, gforker) / test | 7m 34s |
| macOS (x86_64, ch3:sock, hydra) / test | 8m 05s |
| macOS (x86_64, ch3:sock, gforker) / test | 8m 38s |
| macOS (x86_64, ch3:nemesis, hydra) / test | 9m 31s |
| macOS (x86_64, ch4:ofi, hydra) / test | 9m 39s |
| Linux (aarch64, ch3:nemesis, hydra) / test | 10m 50s |
| macOS (x86_64, ch4:ofi, gforker) / test | 11m 23s |
| Linux (aarch64, ch4:ucx, hydra) / test | 11m 43s |
| Linux (aarch64, ch4:ofi, hydra) / test | 12m 41s |
| Linux (x86_64, ch3:nemesis, gforker) / test | 13m 05s |
| Linux (aarch64, ch4:ucx, gforker) / test | 13m 28s |
| Linux (aarch64, ch3:nemesis, gforker) / test | 13m 39s |
| Linux (x86_64, ch4:ucx, hydra) / test | 14m 29s |
| Linux (x86_64, ch4:ofi, hydra) / test | 14m 27s |
| macOS (arm64, ch3:nemesis, gforker) / test | 14m 59s |
| Linux (aarch64, ch3:sock, hydra) / test | 15m 01s |
| macOS (arm64, ch3:sock, hydra) / test | 15m 31s |
| Linux (x86_64, ch3:nemesis, hydra) / test | 15m 35s |
| Linux (aarch64, ch4:ofi, gforker) / test | 15m 42s |
| macOS (arm64, ch3:nemesis, hydra) / test | 15m 54s |
| Linux (aarch64, ch3:sock, gforker) / test | 16m 29s |
| macOS (arm64, ch3:sock, gforker) / test | 16m 44s |
| Linux (x86_64, ch3:sock, hydra) / test | 18m 18s |
| Linux (x86_64, ch3:sock, gforker) / test | 18m 18s |
| Linux (x86_64, ch4:ofi, gforker) / test | 18m 24s |
| Linux (x86_64, ch4:ucx, gforker) / test | 18m 26s |
| macOS (arm64, ch4:ofi, gforker) / test | 21m 29s |
| macOS (arm64, ch4:ofi, hydra) / test | 22m 18s |


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
