### PR TITLE
pmi/spawn: use environment to pass parent port in pmix

### DIFF
--- a/src/include/mpir_pmi.h
+++ b/src/include/mpir_pmi.h
@@ -35,12 +35,6 @@ typedef enum {
     MPIR_PMI_DOMAIN_NODE_ROOTS = 2
 } MPIR_PMI_DOMAIN;
 
-/* key/val pair struct to abstract PMI key/val pair */
-typedef struct MPIR_PMI_KEYVAL {
-    const char *key;
-    char *val;
-} MPIR_PMI_KEYVAL_t;
-
 #define MPIR_PMI_GROUP_WORLD      ((int *)0)
 #define MPIR_PMI_GROUP_SELF      ((int *)1)
 
@@ -69,8 +63,8 @@ int MPIR_pmi_barrier_group(int *group, int count, const char *stringtag);
 int MPIR_pmi_kvs_put(const char *key, const char *val);
 /* * get. src in [0..size-1] or -1 for anysrc. val_size <= MPIR_pmi_max_val_size(). */
 int MPIR_pmi_kvs_get(int src, const char *key, char *val, int val_size);
-/* get from parent process */
-int MPIR_pmi_kvs_parent_get(const char *key, char *val, int val_size);
+/* get port of parent process */
+int MPIR_pmi_get_parent_port(char *parent_port, int port_size);
 
 /* * bcast from rank 0 to ALL or NODE_ROOTS processes. Both are collective over ALL */
 int MPIR_pmi_bcast(void *buf, int size, MPIR_PMI_DOMAIN domain);
@@ -114,8 +108,7 @@ int MPIR_pmi_get_universe_size(int *universe_size);
 struct MPIR_Info;               /* forward declare (mpir_info.h) */
 int MPIR_pmi_spawn_multiple(int count, char *commands[], char **argvs[],
                             const int maxprocs[], struct MPIR_Info *info_ptrs[],
-                            int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals,
-                            int *pmi_errcodes);
+                            char *port_name, int *pmi_errcodes);
 int MPIR_pmi_has_local_cliques(void);
 int MPIR_pmi_build_nodemap(int *nodemap, int sz);
 int MPIR_pmi_build_nodemap_fallback(int sz, int myrank, int *out_nodemap);

--- a/src/mpid/ch3/src/ch3u_comm_spawn_multiple.c
+++ b/src/mpid/ch3/src/ch3u_comm_spawn_multiple.c
@@ -10,10 +10,6 @@
 
 #ifndef MPIDI_CH3_HAS_NO_DYNAMIC_PROCESS
 
-/* Define the name of the kvs key used to provide the port name to the
-   children */
-#define PARENT_PORT_KVSKEY "PARENT_ROOT_PORT_NAME"
-
 /*
  * MPIDI_CH3_Comm_spawn_multiple()
  */
@@ -53,11 +49,7 @@ int MPIDI_Comm_spawn_multiple(int count, char **commands,
 	/* --END ERROR HANDLING-- */
 
 	/* Spawn the processes */
-        MPIR_PMI_KEYVAL_t preput;
-        preput.key = PARENT_PORT_KVSKEY;
-        preput.val = port_name;
-
-        mpi_errno = MPIR_pmi_spawn_multiple(count, commands, argvs, maxprocs, info_ptrs, 1, &preput, pmi_errcodes);
+        mpi_errno = MPIR_pmi_spawn_multiple(count, commands, argvs, maxprocs, info_ptrs, port_name, pmi_errcodes);
         MPIR_ERR_CHECK(mpi_errno);
 
 	if (errcodes != MPI_ERRCODES_IGNORE) {
@@ -138,7 +130,7 @@ int MPIDI_CH3_GetParentPort(char ** parent_port)
     char val[MPIDI_MAX_KVS_VALUE_LEN];
 
     if (parent_port_name == NULL) {
-        mpi_errno = MPIR_pmi_kvs_parent_get(PARENT_PORT_KVSKEY, val, sizeof(val));
+        mpi_errno = MPIR_pmi_get_parent_port(val, sizeof(val));
         MPIR_ERR_CHECK(mpi_errno);
 
 	parent_port_name = MPL_strdup(val);

--- a/src/mpid/ch4/include/mpidpre.h
+++ b/src/mpid/ch4/include/mpidpre.h
@@ -95,7 +95,6 @@ typedef enum {
 #define MPIDIG_REQ_RTS            (0x1 << 7)
 #define MPIDIG_REQ_IN_PROGRESS    (0x1 << 8)
 
-#define MPIDI_PARENT_PORT_KVSKEY "PARENT_ROOT_PORT_NAME"
 #define MPIDI_MAX_KVS_VALUE_LEN  4096
 
 typedef struct MPIDIG_rreq_t {

--- a/src/mpid/ch4/src/ch4_init.c
+++ b/src/mpid/ch4/src/ch4_init.c
@@ -648,8 +648,7 @@ int MPID_InitCompleted(void)
     if (MPIR_Process.has_parent) {
         MPIR_Assert(MPID_MAX_PORT_NAME >= MPI_MAX_PORT_NAME);
         char parent_port[MPID_MAX_PORT_NAME];
-        mpi_errno =
-            MPIR_pmi_kvs_parent_get(MPIDI_PARENT_PORT_KVSKEY, parent_port, MPID_MAX_PORT_NAME);
+        mpi_errno = MPIR_pmi_get_parent_port(parent_port, MPID_MAX_PORT_NAME);
         MPIR_ERR_CHECK(mpi_errno);
         mpi_errno = MPID_Comm_connect(parent_port, NULL, 0, MPIR_Process.comm_world,
                                       &MPIR_Process.comm_parent);

--- a/src/mpid/ch4/src/ch4_spawn.c
+++ b/src/mpid/ch4/src/ch4_spawn.c
@@ -53,13 +53,9 @@ int MPID_Comm_spawn_multiple(int count, char *commands[], char **argvs[], const 
 
         mpi_errno = MPID_Open_port(NULL, port_name, MPID_MAX_PORT_NAME);
         if (mpi_errno == MPI_SUCCESS) {
-            struct MPIR_PMI_KEYVAL preput_keyval_vector;
-            preput_keyval_vector.key = MPIDI_PARENT_PORT_KVSKEY;
-            preput_keyval_vector.val = port_name;
-
             MPID_THREAD_CS_ENTER(VCI, MPIR_THREAD_VCI_PMI_MUTEX);
             mpi_errno = MPIR_pmi_spawn_multiple(count, commands, argvs, maxprocs, info_ptrs,
-                                                1, &preput_keyval_vector, pmi_errcodes);
+                                                port_name, pmi_errcodes);
             MPID_THREAD_CS_EXIT(VCI, MPIR_THREAD_VCI_PMI_MUTEX);
         }
     }

--- a/src/pmi/errnames.txt
+++ b/src/pmi/errnames.txt
@@ -128,6 +128,8 @@
 **pmix_register_event_handler %s:PMIX_Register_event_handler returned %s
 **pmix_deregister_event_handler:PMIX_Deregister_event_handler failed
 **pmix_deregister_event_handler %s:PMIX_Deregister_event_handler returned %s
+**pmix_argv_append: PMIX_ARGV_APPEND failed
+**pmix_argv_append %s: PMIX_ARGV_APPEND failed with error %s
 #
 # PMI finalize exit handler registration
 #

--- a/src/util/mpir_pmi.c
+++ b/src/util/mpir_pmi.c
@@ -382,7 +382,7 @@ int MPIR_pmi_kvs_get(int src, const char *key, char *val, int val_size)
     return mpi_errno;
 }
 
-int MPIR_pmi_kvs_parent_get(const char *key, char *val, int val_size)
+int MPIR_pmi_get_parent_port(char *parent_port, int port_size)
 {
     int mpi_errno = MPI_SUCCESS;
 
@@ -391,9 +391,9 @@ int MPIR_pmi_kvs_parent_get(const char *key, char *val, int val_size)
         return MPI_ERR_INTERN;
     }
 
-    SWITCH_PMI(mpi_errno = pmi1_get_parent(key, val, val_size),
-               mpi_errno = pmi2_get_parent(key, val, val_size),
-               mpi_errno = pmix_get_parent(key, val, val_size));
+    SWITCH_PMI(mpi_errno = pmi1_get_parent(parent_port, port_size),
+               mpi_errno = pmi2_get_parent(parent_port, port_size),
+               mpi_errno = pmix_get_parent(parent_port, port_size));
     return mpi_errno;
 }
 
@@ -892,8 +892,7 @@ int MPIR_pmi_get_universe_size(int *universe_size)
 /* NOTE: MPIR_pmi_spawn_multiple is to be called by a single root spawning process */
 int MPIR_pmi_spawn_multiple(int count, char *commands[], char **argvs[],
                             const int maxprocs[], MPIR_Info * info_ptrs[],
-                            int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals,
-                            int *pmi_errcodes)
+                            char *port_name, int *pmi_errcodes)
 {
     int mpi_errno = MPI_SUCCESS;
 #ifdef NO_PMI_SPAWN_MULTIPLE
@@ -901,15 +900,15 @@ int MPIR_pmi_spawn_multiple(int count, char *commands[], char **argvs[],
     MPIR_ERR_SETANDJUMP1(mpi_errno, MPI_ERR_OTHER,
                          "**pmi_spawn_multiple", "**pmi_spawn_multiple %d", 0);
 #elif defined(USE_PMI2_SLURM)
-    mpi_errno = pmi2_spawn_slurm(count, commands, argvs, maxprocs, info_ptrs,
-                                 num_preput_keyval, preput_keyvals, pmi_errcodes);
+    mpi_errno = pmi2_spawn_slurm(count, commands, argvs, maxprocs, info_ptrs, port_name,
+                                 pmi_errcodes);
 #else
-    SWITCH_PMI(mpi_errno = pmi1_spawn(count, commands, argvs, maxprocs, info_ptrs,
-                                      num_preput_keyval, preput_keyvals, pmi_errcodes),
-               mpi_errno = pmi2_spawn(count, commands, argvs, maxprocs, info_ptrs,
-                                      num_preput_keyval, preput_keyvals, pmi_errcodes),
-               mpi_errno = pmix_spawn(count, commands, argvs, maxprocs, info_ptrs,
-                                      num_preput_keyval, preput_keyvals, pmi_errcodes));
+    SWITCH_PMI(mpi_errno = pmi1_spawn(count, commands, argvs, maxprocs, info_ptrs, port_name,
+                                      pmi_errcodes),
+               mpi_errno = pmi2_spawn(count, commands, argvs, maxprocs, info_ptrs, port_name,
+                                      pmi_errcodes),
+               mpi_errno = pmix_spawn(count, commands, argvs, maxprocs, info_ptrs, port_name,
+                                      pmi_errcodes));
 #endif
     return mpi_errno;
 }

--- a/src/util/mpir_pmi1.inc
+++ b/src/util/mpir_pmi1.inc
@@ -5,6 +5,9 @@
 
 #ifdef ENABLE_PMI1
 
+/* Key for parent port name on spawn */
+#define PMI1_KVS_PARENT_PORT_NAME "PARENT_ROOT_PORT_NAME"
+
 static int pmi1_init(int *has_parent, int *rank, int *size, int *appnum)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -91,9 +94,9 @@ static int pmi1_get(int src, const char *key, char *val, int val_size)
     goto fn_exit;
 }
 
-static int pmi1_get_parent(const char *key, char *val, int val_size)
+static int pmi1_get_parent(char *parent_port, int port_size)
 {
-    return pmi1_get(-1, key, val, val_size);
+    return pmi1_get(-1, PMI1_KVS_PARENT_PORT_NAME, parent_port, port_size);
 }
 
 static bool pmi1_get_jobattr(const char *key, char *valbuf)
@@ -190,31 +193,28 @@ static int pmi1_get_universe_size(int *universe_size)
 }
 
 static int pmi1_spawn(int count, char *commands[], char **argvs[], const int maxprocs[],
-                      MPIR_Info * info_ptrs[], int num_preput_keyval,
-                      struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+                      MPIR_Info * info_ptrs[], char *port_name, int *pmi_errcodes)
 {
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
-    INFO_TYPE *preput_vector = NULL;
+    INFO_TYPE preput;
+    int have_preput = 0;
 
     int *info_keyval_sizes = NULL;
     INFO_TYPE **info_keyval_vectors = NULL;
     mpi_errno = get_info_kv_vectors(count, info_ptrs, &info_keyval_vectors, &info_keyval_sizes);
     MPIR_ERR_CHECK(mpi_errno);
 
-    if (num_preput_keyval > 0) {
-        preput_vector = MPL_malloc(num_preput_keyval * sizeof(INFO_TYPE), MPL_MEM_BUFFER);
-        MPIR_ERR_CHKANDJUMP(!preput_vector, mpi_errno, MPI_ERR_OTHER, "**nomem");
-        for (int i = 0; i < num_preput_keyval; i++) {
-            INFO_TYPE_KEY(preput_vector[i]) = preput_keyvals[i].key;
-            INFO_TYPE_VAL(preput_vector[i]) = preput_keyvals[i].val;
-        }
+    if (port_name != NULL) {
+        INFO_TYPE_KEY(preput) = PMI1_KVS_PARENT_PORT_NAME;
+        INFO_TYPE_VAL(preput) = port_name;
+        have_preput = 1;
     }
 
     pmi_errno = PMI_Spawn_multiple(count, (const char **) commands, (const char ***) argvs,
-                                   maxprocs,
-                                   info_keyval_sizes, (const PMI_keyval_t **) info_keyval_vectors,
-                                   num_preput_keyval, (const PMI_keyval_t *) preput_vector,
+                                   maxprocs, info_keyval_sizes,
+                                   (const PMI_keyval_t **) info_keyval_vectors,
+                                   have_preput, (const PMI_keyval_t *) &preput,
                                    pmi_errcodes);
 
     MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI_SUCCESS, mpi_errno, MPI_ERR_OTHER,
@@ -222,9 +222,6 @@ static int pmi1_spawn(int count, char *commands[], char **argvs[], const int max
 
   fn_exit:
     free_pmi_keyvals(info_keyval_vectors, count, info_keyval_sizes);
-    if (num_preput_keyval > 0) {
-        MPL_free(preput_vector);
-    }
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -318,7 +315,7 @@ static int pmi1_get(int src, const char *key, char *val, int val_size)
     return MPI_ERR_INTERN;
 }
 
-static int pmi1_get_parent(const char *key, char *val, int val_size)
+static int pmi1_get_parent(char *parent_port, int port_size)
 {
     return MPI_ERR_INTERN;
 }
@@ -365,8 +362,7 @@ static int pmi1_get_universe_size(int *universe_size)
 }
 
 static int pmi1_spawn(int count, char *commands[], char **argvs[], const int maxprocs[],
-                      MPIR_Info * info_ptrs[], int num_preput_keyval,
-                      struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+                      MPIR_Info * info_ptrs[], char *port_name, int *pmi_errcodes)
 {
     return MPI_ERR_INTERN;
 }

--- a/src/util/mpir_pmi2.inc
+++ b/src/util/mpir_pmi2.inc
@@ -9,6 +9,9 @@
 typedef INFO_TYPE PMI2_keyval_t;
 #endif
 
+/* Key for parent port name on spawn */
+#define PMI2_KVS_PARENT_PORT_NAME "PARENT_ROOT_PORT_NAME"
+
 static int pmi2_init(int *has_parent, int *rank, int *size, int *appnum)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -74,9 +77,9 @@ static int pmi2_get(int src, const char *key, char *val, int val_size)
     goto fn_exit;
 }
 
-static int pmi2_get_parent(const char *key, char *val, int val_size)
+static int pmi2_get_parent(char *parent_port, int port_size)
 {
-    return pmi2_get(PMI2_ID_NULL, key, val, val_size);
+    return pmi2_get(PMI2_ID_NULL, PMI2_KVS_PARENT_PORT_NAME, parent_port, port_size);
 }
 
 static bool pmi2_get_jobattr(const char *key, char *valbuf)
@@ -202,25 +205,22 @@ static int pmi2_get_universe_size(int *universe_size)
 }
 
 static int pmi2_spawn(int count, char *commands[], char **argvs[], const int maxprocs[],
-                      MPIR_Info * info_ptrs[], int num_preput_keyval,
-                      struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+                      MPIR_Info * info_ptrs[], char *port_name, int *pmi_errcodes)
 {
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
-    INFO_TYPE *preput_vector = NULL;
+    INFO_TYPE preput;
+    int have_preput = 0;
 
     int *info_keyval_sizes = NULL;
     INFO_TYPE **info_keyval_vectors = NULL;
     mpi_errno = get_info_kv_vectors(count, info_ptrs, &info_keyval_vectors, &info_keyval_sizes);
     MPIR_ERR_CHECK(mpi_errno);
 
-    if (num_preput_keyval > 0) {
-        preput_vector = MPL_malloc(num_preput_keyval * sizeof(INFO_TYPE), MPL_MEM_BUFFER);
-        MPIR_ERR_CHKANDJUMP(!preput_vector, mpi_errno, MPI_ERR_OTHER, "**nomem");
-        for (int i = 0; i < num_preput_keyval; i++) {
-            INFO_TYPE_KEY(preput_vector[i]) = preput_keyvals[i].key;
-            INFO_TYPE_VAL(preput_vector[i]) = preput_keyvals[i].val;
-        }
+    if (port_name != NULL) {
+        INFO_TYPE_KEY(preput) = PMI2_KVS_PARENT_PORT_NAME;
+        INFO_TYPE_VAL(preput) = port_name;
+        have_preput = 1;
     }
 
     int *argcs = MPL_malloc(count * sizeof(int), MPL_MEM_DYNAMIC);
@@ -239,7 +239,7 @@ static int pmi2_spawn(int count, char *commands[], char **argvs[], const int max
     pmi_errno = PMI2_Job_Spawn(count, (const char **) commands,
                                argcs, (const char ***) argvs, maxprocs,
                                info_keyval_sizes, (const PMI2_keyval_t **) info_keyval_vectors,
-                               num_preput_keyval, (const PMI2_keyval_t *) preput_vector,
+                               have_preput, (const PMI2_keyval_t *) &preput,
                                NULL, 0, pmi_errcodes);
     MPL_free(argcs);
     MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
@@ -247,9 +247,6 @@ static int pmi2_spawn(int count, char *commands[], char **argvs[], const int max
 
   fn_exit:
     free_pmi_keyvals(info_keyval_vectors, count, info_keyval_sizes);
-    if (num_preput_keyval > 0) {
-        MPL_free(preput_vector);
-    }
     return mpi_errno;
   fn_fail:
     goto fn_exit;
@@ -331,7 +328,7 @@ static int pmi2_get(int src, const char *key, char *val, int val_size)
     return MPI_ERR_INTERN;
 }
 
-static int pmi2_get_parent(const char *key, char *val, int val_size)
+static int pmi2_get_parent(char *parent_port, int port_size)
 {
     return MPI_ERR_INTERN;
 }
@@ -378,8 +375,7 @@ static int pmi2_get_universe_size(int *universe_size)
 }
 
 static int pmi2_spawn(int count, char *commands[], char **argvs[], const int maxprocs[],
-                      MPIR_Info * info_ptrs[], int num_preput_keyval,
-                      struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+                      MPIR_Info * info_ptrs[], char *port_name, int *pmi_errcodes)
 {
     return MPI_ERR_INTERN;
 }
@@ -404,8 +400,7 @@ static int pmi2_unpublish(const char name[])
 #ifdef USE_PMI2_SLURM
 static int pmi2_spawn_slurm(int count, char *commands[], char **argvs[],
                             const int maxprocs[], MPIR_Info * info_ptrs[],
-                            int num_preput_keyval, struct MPIR_PMI_KEYVAL *preput_keyvals,
-                            int *pmi_errcodes)
+                            char *port_name, int *pmi_errcodes)
 {
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
@@ -417,17 +412,18 @@ static int pmi2_spawn_slurm(int count, char *commands[], char **argvs[],
 
     const INFO_TYPE **preput_vector = NULL;
     INFO_TYPE *preput_vector_array = NULL;
+    int have_preput;
 
-    if (num_preput_keyval > 0) {
-        preput_vector = MPL_malloc(num_preput_keyval * sizeof(INFO_TYPE *), MPL_MEM_BUFFER);
+    if (port_name != NULL) {
+        preput_vector = MPL_malloc(sizeof(INFO_TYPE *), MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP(!preput_vector, mpi_errno, MPI_ERR_OTHER, "**nomem");
-        preput_vector_array = MPL_malloc(num_preput_keyval * sizeof(INFO_TYPE), MPL_MEM_BUFFER);
+        preput_vector_array = MPL_malloc(sizeof(INFO_TYPE), MPL_MEM_BUFFER);
         MPIR_ERR_CHKANDJUMP(!preput_vector_array, mpi_errno, MPI_ERR_OTHER, "**nomem");
-        for (int i = 0; i < num_preput_keyval; i++) {
-            INFO_TYPE_KEY(preput_vector_array[i]) = (char *) preput_keyvals[i].key;
-            INFO_TYPE_VAL(preput_vector_array[i]) = preput_keyvals[i].val;
-            preput_vector[i] = &preput_vector_array[i];
-        }
+
+        INFO_TYPE_KEY(preput_vector_array[0]) = PMI2_KVS_PARENT_PORT_NAME;
+        INFO_TYPE_VAL(preput_vector_array[0]) = port_name;
+        preput_vector[0] = &preput_vector_array[0];
+        have_preput = 1;
     }
 
     int *argcs = MPL_malloc(count * sizeof(int), MPL_MEM_DYNAMIC);
@@ -446,7 +442,7 @@ static int pmi2_spawn_slurm(int count, char *commands[], char **argvs[],
     pmi_errno = PMI2_Job_Spawn(count, (const char **) commands,
                                argcs, (const char ***) argvs, maxprocs,
                                info_keyval_sizes, (const struct MPID_Info **) info_keyval_vectors,
-                               num_preput_keyval, (const struct MPID_Info **) preput_vector,
+                               have_preput, (const struct MPID_Info **) preput_vector,
                                NULL, 0, pmi_errcodes);
     MPL_free(argcs);
     MPIR_ERR_CHKANDJUMP1(pmi_errno != PMI2_SUCCESS, mpi_errno, MPI_ERR_OTHER,
@@ -454,7 +450,7 @@ static int pmi2_spawn_slurm(int count, char *commands[], char **argvs[],
 
   fn_exit:
     free_pmi_keyvals(info_keyval_vectors, count, info_keyval_sizes);
-    if (num_preput_keyval > 0) {
+    if (have_preput) {
         MPL_free(preput_vector_array);
         MPL_free(preput_vector);
     }

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -48,7 +48,6 @@ static int pmix_build_app_cmd(MPIR_Info * info_ptr, char *command, char **app_cm
 static int pmix_prep_spawn(int count, char *commands[], char **argvs[], const int maxprocs[],
                            MPIR_Info * info_ptrs[], pmix_app_t * apps, pmix_info_t ** job_info,
                            size_t * njob_info);
-static int pmix_fence_nspace_proc(const char *nspace, const char *parent_nspace, int parent_rank);
 
 /* For PMIx Psets */
 static int pmix_pset_define_hdlr = -1;
@@ -230,24 +229,13 @@ static int pmix_get(int src, const char *key, char *val, int val_size)
 
 static int pmix_get_parent(const char *key, char *val, int val_size)
 {
-    int mpi_errno = MPI_SUCCESS;
-    int pmi_errno = PMIX_SUCCESS;
-    pmix_value_t *pvalue;
-    pmi_errno = PMIx_Get(&pmix_parent, prefix_key(key), NULL, 0, &pvalue);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER, "**pmix_get",
-                         "**pmix_get %s", PMIx_Error_string(pmi_errno));
-    MPL_strncpy(val, pvalue->data.string, val_size);
-    PMIX_VALUE_RELEASE(pvalue);
+    /* with PMIx the preput values are stored in the environment - not in the KVS */
+    const char *envval;
+    if (MPL_env2str(key, &envval)) {
+        MPL_strncpy(val, envval, val_size);
+    }
 
-    /* Fence with all other spawned procs in namespace and parent proc to
-     * sync with MPIR_pmi_spawn_multiple in parent process */
-    mpi_errno = pmix_fence_nspace_proc(pmix_proc.nspace, pmix_parent.nspace, pmix_parent.rank);
-    MPIR_ERR_CHECK(mpi_errno);
-
-  fn_exit:
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
+    return MPI_SUCCESS;
 }
 
 static bool pmix_get_jobattr(const char *key, char *valbuf)
@@ -529,11 +517,22 @@ static int pmix_spawn(int count, char *commands[], char **argvs[], const int max
                                 apps, &job_info, &njob_info);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* PMIx_Put to the KVS what is required by the spawned processes */
+    /* Add preput key/values to apps' environment */
     if (num_preput_keyval > 0) {
         for (int j = 0; j < num_preput_keyval; j++) {
-            mpi_errno = MPIR_pmi_kvs_put(preput_keyvals[j].key, preput_keyvals[j].val);
-            MPIR_ERR_CHECK(mpi_errno);
+            char *envval = NULL;
+            /* +1 for '=' and +1 for null terminator */
+            size_t len = strlen(preput_keyvals[j].key) + 1 + strlen(preput_keyvals[j].val) + 1;
+            envval = MPL_malloc(len, MPL_MEM_OTHER);
+            snprintf(envval, len, "%s=%s\n", preput_keyvals[j].key, preput_keyvals[j].val);
+
+            for (int i = 0; i < count; i++) {
+                PMIX_ARGV_APPEND(pmi_errno, apps[i].env, envval);
+                MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                                     "**pmix_argv_append", "**pmix_argv_append %s",
+                                     PMIx_Error_string(pmi_errno));
+            }
+            MPL_free(envval);
         }
     }
 
@@ -555,10 +554,6 @@ static int pmix_spawn(int count, char *commands[], char **argvs[], const int max
     MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_SPAWN,
                          "**pmix_spawn", "**pmix_spawn %s", PMIx_Error_string(pmi_errno));
 
-    /* Fence with spawned procs in new nspace (counter part in MPIR_pmi_kvs_parent_get)
-     * Preput data in KVS must be read by child procs before is overwritten in next Spawn */
-    mpi_errno = pmix_fence_nspace_proc(new_nspace, pmix_proc.nspace, pmix_proc.rank);
-    MPIR_ERR_CHECK(mpi_errno);
   fn_exit:
     /* Free job info */
     PMIX_INFO_FREE(job_info, njob_info);
@@ -951,57 +946,6 @@ int pmix_prep_spawn(int count, char *commands[], char **argvs[], const int maxpr
   fn_exit:
     if (path) {
         MPL_free(path);
-    }
-    return mpi_errno;
-  fn_fail:
-    goto fn_exit;
-}
-
-static
-int pmix_fence_nspace_proc(const char *nspace, const char *parent_nspace, int parent_rank)
-{
-    int mpi_errno = MPI_SUCCESS;
-    int pmi_errno = PMIX_SUCCESS;
-    int fence_collect_data = 1;
-    size_t nprocs = 0;
-    pmix_proc_t *procs = NULL;
-    pmix_info_t *fence_info = NULL;
-    pmix_value_t *pvalue = NULL;
-    pmix_proc_t nspace_proc;
-
-    if (nspace == NULL) {
-        mpi_errno = MPI_ERR_OTHER;
-        goto fn_fail;
-    }
-
-    /* Determine size of nspace */
-    PMIX_LOAD_PROCID(&nspace_proc, nspace, PMIX_RANK_WILDCARD);
-    pmi_errno = PMIx_Get(&nspace_proc, PMIX_JOB_SIZE, NULL, 0, &pvalue);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_get", "**pmix_get %d", pmi_errno);
-    nprocs = pvalue->data.uint32;
-    PMIX_VALUE_RELEASE(pvalue);
-
-    /* Create procs array for fence of procs in nspace and parent */
-    PMIX_PROC_CREATE(procs, nprocs + 1);        /* +1 for parent */
-    for (size_t i = 0; i < nprocs; i++) {
-        PMIX_LOAD_PROCID(&(procs[i]), nspace, i);
-    }
-    PMIX_PROC_LOAD(&(procs[nprocs]), parent_nspace, parent_rank);
-
-    /* Fence */
-    PMIX_INFO_CREATE(fence_info, 1);
-    PMIx_Info_load(fence_info, PMIX_COLLECT_DATA, &fence_collect_data, PMIX_BOOL);
-    pmi_errno = PMIx_Fence(procs, nprocs + 1, fence_info, 1);
-    MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                         "**pmix_fence", "**pmix_fence %d", pmi_errno);
-
-  fn_exit:
-    if (fence_info) {
-        PMIX_INFO_FREE(fence_info, 1);
-    }
-    if (procs) {
-        PMIX_PROC_FREE(procs, nprocs + 1);
     }
     return mpi_errno;
   fn_fail:

--- a/src/util/mpir_pmix.inc
+++ b/src/util/mpir_pmix.inc
@@ -15,6 +15,9 @@
 #define PMIX_ERR_NOT_IMPLEMENTED -48
 #endif
 
+/* Env var name for parent port name on spawn */
+#define ENV_VAR_PARENT_PORT_NAME "PARENT_ROOT_PORT_NAME"
+
 /* These are const after init. FIXME: We need a way to guard changes outside init. */
 static pmix_proc_t pmix_proc;
 static pmix_proc_t pmix_wcproc;
@@ -227,12 +230,12 @@ static int pmix_get(int src, const char *key, char *val, int val_size)
     goto fn_exit;
 }
 
-static int pmix_get_parent(const char *key, char *val, int val_size)
+static int pmix_get_parent(char *parent_port, int port_size)
 {
     /* with PMIx the preput values are stored in the environment - not in the KVS */
     const char *envval;
-    if (MPL_env2str(key, &envval)) {
-        MPL_strncpy(val, envval, val_size);
+    if (MPL_env2str(ENV_VAR_PARENT_PORT_NAME, &envval)) {
+        MPL_strncpy(parent_port, envval, port_size);
     }
 
     return MPI_SUCCESS;
@@ -499,8 +502,7 @@ static int pmix_get_universe_size(int *universe_size)
 }
 
 static int pmix_spawn(int count, char *commands[], char **argvs[], const int maxprocs[],
-                      MPIR_Info * info_ptrs[], int num_preput_keyval,
-                      struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+                      MPIR_Info * info_ptrs[], char *port_name, int *pmi_errcodes)
 {
     int mpi_errno = MPI_SUCCESS;
     int pmi_errno;
@@ -517,23 +519,21 @@ static int pmix_spawn(int count, char *commands[], char **argvs[], const int max
                                 apps, &job_info, &njob_info);
     MPIR_ERR_CHECK(mpi_errno);
 
-    /* Add preput key/values to apps' environment */
-    if (num_preput_keyval > 0) {
-        for (int j = 0; j < num_preput_keyval; j++) {
-            char *envval = NULL;
-            /* +1 for '=' and +1 for null terminator */
-            size_t len = strlen(preput_keyvals[j].key) + 1 + strlen(preput_keyvals[j].val) + 1;
-            envval = MPL_malloc(len, MPL_MEM_OTHER);
-            snprintf(envval, len, "%s=%s\n", preput_keyvals[j].key, preput_keyvals[j].val);
+    /* Add port_name to apps' environment so that spawned processes can find it */
+    if (port_name != NULL) {
+        char *envval = NULL;
+        /* +1 for '=' and +1 for null terminator */
+        size_t len = strlen(ENV_VAR_PARENT_PORT_NAME) + 1 + strlen(port_name) + 1;
+        envval = MPL_malloc(len, MPL_MEM_OTHER);
+        snprintf(envval, len, "%s=%s\n", ENV_VAR_PARENT_PORT_NAME, port_name);
 
-            for (int i = 0; i < count; i++) {
-                PMIX_ARGV_APPEND(pmi_errno, apps[i].env, envval);
-                MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
-                                     "**pmix_argv_append", "**pmix_argv_append %s",
-                                     PMIx_Error_string(pmi_errno));
-            }
-            MPL_free(envval);
+        for (int i = 0; i < count; i++) {
+            PMIX_ARGV_APPEND(pmi_errno, apps[i].env, envval);
+            MPIR_ERR_CHKANDJUMP1(pmi_errno != PMIX_SUCCESS, mpi_errno, MPI_ERR_OTHER,
+                                 "**pmix_argv_append", "**pmix_argv_append %s",
+                                 PMIx_Error_string(pmi_errno));
         }
+        MPL_free(envval);
     }
 
     pmi_errno = PMIx_Spawn(job_info, njob_info, apps, count, new_nspace);
@@ -1157,7 +1157,7 @@ static int pmix_get(int src, const char *key, char *val, int val_size)
     return MPI_ERR_INTERN;
 }
 
-static int pmix_get_parent(const char *key, char *val, int val_size)
+static int pmix_get_parent(char *parent_port, int port_size)
 {
     return MPI_ERR_INTERN;
 }
@@ -1219,8 +1219,7 @@ static int pmix_get_universe_size(int *universe_size)
 }
 
 static int pmix_spawn(int count, char *commands[], char **argvs[], const int maxprocs[],
-                      MPIR_Info * info_ptrs[], int num_preput_keyval,
-                      struct MPIR_PMI_KEYVAL *preput_keyvals, int *pmi_errcodes)
+                      MPIR_Info * info_ptrs[], char *port_name, int *pmi_errcodes)
 {
     return MPI_ERR_INTERN;
 }


### PR DESCRIPTION
## Pull Request Description
This PR is motivated by an issue observed with spawning + PMIx (`concurrent_spawns` test): Since overwriting values for the same key in the KVS may sometimes work out but is not generally supported by PMIx, switching from KVS to env var to exchange the parent port information looks like a good idea. Otherwise child processes may obtain wrong outdated parent port information via KVS (from a previous spawn of the parent process) which leads to connection issues. The applied changes also simplify the PMIx spawn code.

Having done this change, we noticed that the `MPIR_pmi_spawn_mulitple` interface could use some clean up with respect to the preput values. These are a mechanism of PMI-1 and PMI-2 spawn interfaces to place some values in the KVS of the child processes. Hence this PR removes the preput values from `MPIR_pmi_spawn_mulitple` and replaces them with the plain parent port name. The use of preput values is moved into the respective PMI-1 and PMI-2 spawn interface wrappers - and removed completely for PMIx.

Feedback is very welcome! :)


## Author Checklist
* [X] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [X] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [X] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
