### PR TITLE
ch4/ofi: fix missing sigreq creations and completions

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -89,7 +89,6 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, MPI_Aint origin_count,
     origin_iov = MPL_malloc(sizeof(struct iovec) * origin_len, MPL_MEM_RMA);
 
     if (sigreq) {
-        MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, vci);
         flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
     } else {
         flags = FI_DELIVERY_COMPLETE;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -243,6 +243,9 @@ static int issue_packed_put(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
         req->next = MPIDI_OFI_WIN(win).syncQ;
         MPIDI_OFI_WIN(win).syncQ = req;
         MPL_free(req->noncontig.put.target.iov);
+        /* complete sigreq */
+        MPIDI_OFI_sigreq_complete(req->sigreq);
+
     }
 
   fn_exit:
@@ -329,6 +332,9 @@ static int issue_packed_get(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
         req->next = MPIDI_OFI_WIN(win).syncQ;
         MPIDI_OFI_WIN(win).syncQ = req;
         MPL_free(req->noncontig.get.target.iov);
+
+        /* complete sigreq */
+        MPIDI_OFI_sigreq_complete(req->sigreq);
     }
 
   fn_exit:

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.c
@@ -96,7 +96,7 @@ int MPIDI_OFI_nopack_putget(const void *origin_addr, MPI_Aint origin_count,
     }
 
     void *desc = NULL;
-    int nic_target = MPIDI_OFI_get_pref_nic(win->comm_ptr, target_rank);;
+    int nic_target = MPIDI_OFI_get_pref_nic(win->comm_ptr, target_rank);
 
     MPIDI_OFI_gpu_rma_register(origin_addr, origin_bytes, NULL, win, nic_target, &desc);
 
@@ -221,6 +221,7 @@ static int issue_packed_put(MPIR_Win * win, MPIDI_OFI_win_request_t * req)
         riov.addr = (uintptr_t) req->noncontig.put.target.iov[target_cur].iov_base;
         riov.len = msg_len;
         riov.key = req->noncontig.put.target.key;
+
         MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
         MPIDI_OFI_CALL_RETRY(fi_writemsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write);
         req->noncontig.put.origin.pack_offset += msg_len;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -305,6 +305,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
             MPIDI_OFI_nopack_putget(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_count, target_datatype, target_mr, win, addr,
                                     MPIDI_OFI_PUT, sigreq);
+        MPIDI_OFI_sigreq_complete(sigreq);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         goto fn_exit;
     }
@@ -315,6 +316,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         mpi_errno =
             MPIDI_OFI_pack_put(origin_addr, origin_count, origin_datatype, target_rank,
                                target_count, target_datatype, target_mr, win, addr, sigreq);
+        /* complete sigreq after issuing the last chunk in issue_packed_put */
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         goto fn_exit;
     }
@@ -491,6 +493,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
             MPIDI_OFI_nopack_putget(origin_addr, origin_count, origin_datatype, target_rank,
                                     target_count, target_datatype, target_mr, win, addr,
                                     MPIDI_OFI_GET, sigreq);
+        MPIDI_OFI_sigreq_complete(sigreq);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         goto fn_exit;
     }
@@ -501,6 +504,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         mpi_errno =
             MPIDI_OFI_pack_get(origin_addr, origin_count, origin_datatype, target_rank,
                                target_count, target_datatype, target_mr, win, addr, sigreq);
+        /* complete sigreq after issuing the last chunk in issue_packed_get */
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         goto fn_exit;
     }

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -26,6 +26,13 @@ cvars:
 === END_MPI_T_CVAR_INFO_BLOCK ===
 */
 
+enum putget_option {
+    PUTGET_AM,
+    PUTGET_CONTIG,
+    PUTGET_NOPACK,
+    PUTGET_PACKED,
+};
+
 #define MPIDI_OFI_QUERY_ATOMIC_COUNT         0
 #define MPIDI_OFI_QUERY_FETCH_ATOMIC_COUNT   1
 #define MPIDI_OFI_QUERY_COMPARE_ATOMIC_COUNT 2
@@ -255,13 +262,32 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         goto null_op_exit;
     }
 
+    enum putget_option opt = PUTGET_AM;
+    if (origin_contig && target_contig) {
+        opt = PUTGET_CONTIG;
+    } else {
+        MPI_Aint origin_density, target_density;
+        MPIR_Datatype_get_density(origin_datatype, origin_density);
+        MPIR_Datatype_get_density(target_datatype, target_density);
+
+        if (origin_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
+            target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
+            opt = PUTGET_NOPACK;
+        } else if (origin_density < MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
+                   target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
+            opt = PUTGET_PACKED;
+        } else {
+            goto am_fallback;
+        }
+    }
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     if (sigreq) {
         MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, vci);
     }
 
     /* large contiguous messages */
-    if (origin_contig && target_contig) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
+    if (opt == PUTGET_CONTIG) {
         if (sigreq) {
             flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
         } else {
@@ -287,46 +313,27 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         riov.key = target_mr.mr_key;
         MPIDI_OFI_INIT_CHUNK_CONTEXT(win, sigreq);
         MPIDI_OFI_CALL_RETRY(fi_writemsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write);
-        /* Complete signal request to inform completion to user. */
+
         MPIDI_OFI_sigreq_complete(sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
-        goto fn_exit;
-    }
-
-    /* noncontiguous messages */
-    MPI_Aint origin_density, target_density;
-    MPIR_Datatype_get_density(origin_datatype, origin_density);
-    MPIR_Datatype_get_density(target_datatype, target_density);
-
-    if (origin_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
-        target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
-        mpi_errno =
-            MPIDI_OFI_nopack_putget(origin_addr, origin_count, origin_datatype, target_rank,
-                                    target_count, target_datatype, target_mr, win, addr,
-                                    MPIDI_OFI_PUT, sigreq);
+    } else if (opt == PUTGET_NOPACK) {
+        mpi_errno = MPIDI_OFI_nopack_putget(origin_addr, origin_count, origin_datatype, target_rank,
+                                            target_count, target_datatype, target_mr, win, addr,
+                                            MPIDI_OFI_PUT, sigreq);
         MPIDI_OFI_sigreq_complete(sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
-        goto fn_exit;
-    }
-
-    if (origin_density < MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
-        target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
-        mpi_errno =
-            MPIDI_OFI_pack_put(origin_addr, origin_count, origin_datatype, target_rank,
-                               target_count, target_datatype, target_mr, win, addr, sigreq);
+    } else if (opt == PUTGET_PACKED) {
+        mpi_errno = MPIDI_OFI_pack_put(origin_addr, origin_count, origin_datatype, target_rank,
+                                       target_count, target_datatype, target_mr, win, addr, sigreq);
         /* complete sigreq after issuing the last chunk in issue_packed_put */
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
-        goto fn_exit;
+    } else {
+        MPIR_Assert(0);
     }
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
 
-    /* native path not taken, free early-created sigreq before am_fallback */
-    if (sigreq) {
-        MPIR_Request_free(*sigreq);
-        *sigreq = NULL;
-    }
-
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
   am_fallback:
     if (sigreq)
         mpi_errno =
@@ -337,10 +344,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
             MPIDIG_mpi_put(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
                            target_count, target_datatype, win);
 
-  fn_exit:
-    MPIR_FUNC_EXIT;
-    return mpi_errno;
-  fn_fail:
     goto fn_exit;
   null_op_exit:
     mpi_errno = MPI_SUCCESS;
@@ -441,13 +444,31 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
     if (unlikely(!target_mr_found))
         goto am_fallback;
 
+    enum putget_option opt = PUTGET_AM;
+    if (origin_contig && target_contig) {
+        opt = PUTGET_CONTIG;
+    } else {
+        MPI_Aint origin_density, target_density;
+        MPIR_Datatype_get_density(origin_datatype, origin_density);
+        MPIR_Datatype_get_density(target_datatype, target_density);
+
+        if (origin_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
+            target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
+            opt = PUTGET_NOPACK;
+        } else if (origin_density < MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
+                   target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
+            opt = PUTGET_PACKED;
+        } else {
+            goto am_fallback;
+        }
+    }
+
+    MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
     if (sigreq) {
         MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, vci);
     }
 
-    /* contiguous messages */
-    if (origin_contig && target_contig) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
+    if (opt == PUTGET_CONTIG) {
         if (sigreq) {
             flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
         } else {
@@ -477,44 +498,25 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         MPIDI_OFI_CALL_RETRY(fi_readmsg(MPIDI_OFI_WIN(win).ep, &msg, flags), vci, rdma_write);
         /* Complete signal request to inform completion to user. */
         MPIDI_OFI_sigreq_complete(sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
-        goto fn_exit;
-    }
-
-    /* noncontiguous messages */
-    MPI_Aint origin_density, target_density;
-    MPIR_Datatype_get_density(origin_datatype, origin_density);
-    MPIR_Datatype_get_density(target_datatype, target_density);
-
-    if (origin_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
-        target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
-        mpi_errno =
-            MPIDI_OFI_nopack_putget(origin_addr, origin_count, origin_datatype, target_rank,
-                                    target_count, target_datatype, target_mr, win, addr,
-                                    MPIDI_OFI_GET, sigreq);
+    } else if (opt == PUTGET_NOPACK) {
+        mpi_errno = MPIDI_OFI_nopack_putget(origin_addr, origin_count, origin_datatype, target_rank,
+                                            target_count, target_datatype, target_mr, win, addr,
+                                            MPIDI_OFI_GET, sigreq);
         MPIDI_OFI_sigreq_complete(sigreq);
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
-        goto fn_exit;
-    }
-
-    if (origin_density < MPIR_CVAR_CH4_IOV_DENSITY_MIN &&
-        target_density >= MPIR_CVAR_CH4_IOV_DENSITY_MIN) {
-        MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
-        mpi_errno =
-            MPIDI_OFI_pack_get(origin_addr, origin_count, origin_datatype, target_rank,
-                               target_count, target_datatype, target_mr, win, addr, sigreq);
+    } else if (opt == PUTGET_PACKED) {
+        mpi_errno = MPIDI_OFI_pack_get(origin_addr, origin_count, origin_datatype, target_rank,
+                                       target_count, target_datatype, target_mr, win, addr, sigreq);
         /* complete sigreq after issuing the last chunk in issue_packed_get */
-        MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
-        goto fn_exit;
+    } else {
+        MPIR_Assert(0);
     }
+    MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
 
-    /* native path not taken, free early-created sigreq before am_fallback */
-    if (sigreq) {
-        MPIR_Request_free(*sigreq);
-        *sigreq = NULL;
-    }
-
+  fn_exit:
+    MPIR_FUNC_EXIT;
+    return mpi_errno;
+  fn_fail:
+    goto fn_exit;
   am_fallback:
     if (sigreq)
         mpi_errno =
@@ -524,11 +526,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
         mpi_errno =
             MPIDIG_mpi_get(origin_addr, origin_count, origin_datatype, target_rank, target_disp,
                            target_count, target_datatype, win);
-
-  fn_exit:
-    MPIR_FUNC_EXIT;
-    return mpi_errno;
-  fn_fail:
     goto fn_exit;
   null_op_exit:
     mpi_errno = MPI_SUCCESS;

--- a/src/mpid/ch4/netmod/ofi/ofi_rma.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_rma.h
@@ -241,7 +241,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
     /* small contiguous messages */
     /* skip fi_inject path for GPU messages because this path can be
      * very slow */
-    if (origin_contig && target_contig &&
+    if (!sigreq && origin_contig && target_contig &&
         (origin_bytes <= MPIDI_OFI_global.max_buffered_write && !MPL_gpu_attr_is_dev(&attr))) {
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         MPIDI_OFI_win_cntr_incr(win);
@@ -255,11 +255,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
         goto null_op_exit;
     }
 
+    if (sigreq) {
+        MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, vci);
+    }
+
     /* large contiguous messages */
     if (origin_contig && target_contig) {
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         if (sigreq) {
-            MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, vci);
             flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
         } else {
             flags = FI_DELIVERY_COMPLETE;
@@ -314,6 +317,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_put(const void *origin_addr,
                                target_count, target_datatype, target_mr, win, addr, sigreq);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         goto fn_exit;
+    }
+
+    /* native path not taken, free early-created sigreq before am_fallback */
+    if (sigreq) {
+        MPIR_Request_free(*sigreq);
+        *sigreq = NULL;
     }
 
   am_fallback:
@@ -430,11 +439,14 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
     if (unlikely(!target_mr_found))
         goto am_fallback;
 
+    if (sigreq) {
+        MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, vci);
+    }
+
     /* contiguous messages */
     if (origin_contig && target_contig) {
         MPID_THREAD_CS_ENTER(VCI, MPIDI_VCI_LOCK(vci));
         if (sigreq) {
-            MPIDI_OFI_REQUEST_CREATE(*sigreq, MPIR_REQUEST_KIND__RMA, vci);
             flags = FI_COMPLETION | FI_DELIVERY_COMPLETE;
         } else {
             flags = 0;
@@ -491,6 +503,12 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_do_get(void *origin_addr,
                                target_count, target_datatype, target_mr, win, addr, sigreq);
         MPID_THREAD_CS_EXIT(VCI, MPIDI_VCI_LOCK(vci));
         goto fn_exit;
+    }
+
+    /* native path not taken, free early-created sigreq before am_fallback */
+    if (sigreq) {
+        MPIR_Request_free(*sigreq);
+        *sigreq = NULL;
     }
 
   am_fallback:

--- a/src/mpid/ch4/netmod/ofi/ofi_win.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_win.h
@@ -71,9 +71,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_win_do_progress(MPIR_Win * win, int vci)
     r = MPIDI_OFI_WIN(win).syncQ;
     while (r) {
         MPIDI_OFI_win_request_t *next = r->next;
-        MPIR_Request **sigreq = r->sigreq;
         MPIDI_OFI_win_request_complete(r);
-        MPIDI_OFI_sigreq_complete(sigreq);
         r = next;
     }
     MPIDI_OFI_WIN(win).syncQ = NULL;

--- a/test/mpi/rma/Makefile.am
+++ b/test/mpi/rma/Makefile.am
@@ -134,6 +134,7 @@ noinst_PROGRAMS =          \
     flush                  \
     win_shared_put_flush_get          \
     reqops                 \
+    rputget                \
     req_example            \
     req_example_shm        \
     pscw_ordering          \

--- a/test/mpi/rma/rputget.c
+++ b/test/mpi/rma/rputget.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include "mpitest.h"
+
+/* This test is adapted from the reproducer by Jeff Hammond via Github issue #7890 */
+
+/* Target expose a contiguous buffer of 2N size. Origin rput or rget using a datatype
+ * of 2 noncontig block each of size N. Depends on the size of N, this triggers either
+ * the nopack iov path or packed chunk read/write paths.
+ */
+
+#define T int
+#define DT MPI_INT
+
+enum op {
+    PUT,
+    GET,
+    RPUT,
+    RGET,
+};
+
+int test_rputget(enum op op_type, int N, int rank)
+{
+    int errs = 0;
+
+    T *buf;
+    MPI_Win win;
+
+    MPI_Aint buf_size = (MPI_Aint) ((rank == 0) ? N * 2 * sizeof(T) : 0);
+    MPI_Win_allocate(buf_size, sizeof(T), MPI_INFO_NULL, MPI_COMM_WORLD, &buf, &win);
+
+    MPI_Win_lock_all(0, win);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (rank == 1) {
+        /* origin */
+        T *origin = malloc((N * 2 + 1) * sizeof(T));
+        for (int i = 0; i < N; ++i) {
+            origin[i] = i;
+            origin[N + 1 + i] = N + i;
+        }
+
+        const int origin_disps[2] = { 0, N + 1 };
+        const int target_disps[2] = { 0, N };
+        MPI_Datatype origin_type;
+        MPI_Datatype target_type;
+        MPI_Type_create_indexed_block(2, N, origin_disps, DT, &origin_type);
+        MPI_Type_create_indexed_block(2, N, target_disps, DT, &target_type);
+        MPI_Type_commit(&origin_type);
+        MPI_Type_commit(&target_type);
+
+        MPI_Request request;
+        switch (op_type) {
+            case PUT:
+                MPI_Put(origin, 1, origin_type, 0, 0, 1, target_type, win);
+                break;
+            case GET:
+                MPI_Get(origin, 1, origin_type, 0, 0, 1, target_type, win);
+                break;
+            case RPUT:
+                MPI_Rput(origin, 1, origin_type, 0, 0, 1, target_type, win, &request);
+                MPI_Wait(&request, MPI_STATUS_IGNORE);
+                break;
+            case RGET:
+                MPI_Rget(origin, 1, origin_type, 0, 0, 1, target_type, win, &request);
+                MPI_Wait(&request, MPI_STATUS_IGNORE);
+                break;
+        }
+        MPI_Win_flush(0, win);
+
+        /* TODO: verify results */
+
+        free(origin);
+        MPI_Type_free(&target_type);
+        MPI_Type_free(&origin_type);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Win_unlock_all(win);
+    MPI_Win_free(&win);
+
+    return errs;
+}
+
+int main(int argc, char *argv[])
+{
+    int errs = 0;
+
+    int rank, nproc;
+    MTest_Init(&argc, &argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &nproc);
+
+    if (nproc != 2) {
+        if (rank == 0)
+            printf("Error: must be run with two processes\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+
+    int counts[] = { 20, 2500 };
+    enum op ops[] = { PUT, GET, RPUT, RGET };
+    for (int i = 0; i < 2; i++) {
+        for (int j = 0; j < 4; j++) {
+            errs += test_rputget(ops[j], counts[i], rank);
+        }
+    }
+
+    MTest_Finalize(errs);
+
+    return MTestReturnValue(errs);
+}

--- a/test/mpi/rma/testlist.in
+++ b/test/mpi/rma/testlist.in
@@ -118,6 +118,7 @@ get_accumulate_short 4
 get_accumulate_short_derived 4
 flush 4
 reqops 4
+rputget 2
 req_example 4
 req_example_shm 4
 rput_local_comp 2


### PR DESCRIPTION
## Pull Request Description
OFI netmod put or get goes to different paths depend on whether the datatypes are contiguous, dense, or sparse. While the regular put/get are well tested, the less used Rput/Rget hides bugs. In the `nopack_putget` path it's missing `sigreq` completion resulting hangs. In the `packed` path it's missing `sigreq` creation resulting in segfaults. This PR fixes both. 

Thank @jeffhammond for reporting the issue and providing a reproducer.

Fixes #7890

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
