### PR TITLE
ch4/ucx: query max_am_header during init

### DIFF
--- a/src/mpid/ch4/netmod/ucx/ucx_init.c
+++ b/src/mpid/ch4/netmod/ucx/ucx_init.c
@@ -98,6 +98,17 @@ int MPIDI_UCX_init_worker(int vci)
                                            MPIDI_UCX_AM_HANDLER_ID,
                                            &MPIDI_UCX_am_handler, NULL, UCP_AM_FLAG_WHOLE_MSG);
     MPIDI_UCX_CHK_STATUS(ucx_status);
+
+    if (vci == 0) {
+        ucp_worker_attr_t attr;
+        memset(&attr, 0, sizeof(attr));
+        attr.field_mask = UCP_WORKER_ATTR_FIELD_MAX_AM_HEADER;
+
+        ucx_status = ucp_worker_query(MPIDI_UCX_global.ctx[vci].worker, &attr);
+        MPIDI_UCX_CHK_STATUS(ucx_status);
+
+        MPIDI_UCX_global.max_am_header = attr.max_am_header;
+    }
 #ifdef HAVE_UCP_AM_NBX
     ucp_am_handler_param_t param = {
         .field_mask = UCP_AM_HANDLER_PARAM_FIELD_ID | UCP_AM_HANDLER_PARAM_FIELD_CB,
@@ -272,6 +283,7 @@ int MPIDI_UCX_init_local(int *tag_bits)
         dump_ucx_info();
         printf("MPIDI_UCX_CONTEXT_ID_BITS: %d\n", MPIDI_UCX_CONTEXT_ID_BITS);
         printf("MPIDI_UCX_RANK_BITS: %d\n", MPIDI_UCX_RANK_BITS);
+        printf("MPIDI_UCX_MAX_AM_EAGER_SZ: %d\n", MPIDI_UCX_global.max_am_header);
         printf("tag_bits: %d\n", *tag_bits);
         printf("===============================\n");
     }

--- a/src/mpid/ch4/netmod/ucx/ucx_types.h
+++ b/src/mpid/ch4/netmod/ucx/ucx_types.h
@@ -18,7 +18,7 @@
 #define UCP_PEER_NAME_MAX         HOST_NAME_MAX
 
 /* Active Message Stuff */
-#define MPIDI_UCX_MAX_AM_EAGER_SZ      (8000)   /* internal max RTS 8256 */
+#define MPIDI_UCX_MAX_AM_EAGER_SZ      MPIDI_UCX_global.max_am_header
 #define MPIDI_UCX_AM_HANDLER_ID        (0)
 #define MPIDI_UCX_AM_NBX_HANDLER_ID    (1)
 
@@ -33,6 +33,7 @@ typedef struct {
     ucp_context_h context;
     MPIDI_UCX_context_t ctx[MPIDI_CH4_MAX_VCIS];
     int num_vcis;
+    int max_am_header;
 } MPIDI_UCX_global_t;
 
 #define MPIDI_UCX_AV(av)     ((av)->netmod.ucx)


### PR DESCRIPTION
## Pull Request Description
Change MPIDI_UCX_MAX_AM_EAGER_SZ from hardcoded value of 8000 to queried value from ucp_worker_query.

Fixes #7886


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
