### PR TITLE
ch4/ofi: make seg_sz a multiple of datatype size

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -184,6 +184,11 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_init_sreq(const void *am_hdr, size_t a
     MPIR_FUNC_ENTER;
 
     MPIR_Assert(am_hdr_sz < (1ULL << MPIDI_OFI_AM_HDR_SZ_BITS));
+#ifdef NEEDS_STRICT_ALIGNMENT
+    if (am_hdr_sz % MAX_ALIGNMENT) {
+        am_hdr_sz += (MAX_ALIGNMENT - am_hdr_sz % MAX_ALIGNMENT);
+    }
+#endif
 
     if (MPIDI_OFI_AMREQUEST(sreq, sreq_hdr) == NULL) {
         int vci = MPIDI_Request_get_vci(sreq);
@@ -393,19 +398,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_pipeline(int rank, MPIR_Comm * c
     MPI_Aint seg_sz = MPIDI_OFI_DEFAULT_SHORT_SEND_SIZE - sizeof(MPIDI_OFI_am_header_t) - am_hdr_sz;
     seg_sz = MPL_MIN(seg_sz, MPIDIG_am_send_async_get_data_sz_left(sreq));
     MPIR_Assert(seg_sz < (1ULL << MPIDI_OFI_AM_PAYLOAD_SZ_BITS));
-
-    /* make seg_sz a multiple of the datatype extent. */
-    MPI_Aint elem_sz = 0;
-    if (HANDLE_IS_BUILTIN(datatype)) {
-        elem_sz = MPIR_Datatype_get_basic_size(datatype);
-    } else {
-        MPIR_Datatype *dtp;
-        MPIR_Datatype_get_ptr(datatype, dtp);
-        elem_sz = dtp->builtin_element_size;
-    }
-    if (elem_sz) {
-        seg_sz -= (seg_sz % elem_sz);
-    }
 
     msg_hdr = (MPIDI_OFI_am_header_t *) send_req->msg_hdr;
     msg_hdr->handler_id = handler_id;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -184,29 +184,27 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_init_sreq(const void *am_hdr, size_t a
     MPIR_FUNC_ENTER;
 
     MPIR_Assert(am_hdr_sz < (1ULL << MPIDI_OFI_AM_HDR_SZ_BITS));
-#ifdef NEEDS_STRICT_ALIGNMENT
-    if (am_hdr_sz % MAX_ALIGNMENT) {
-        am_hdr_sz += (MAX_ALIGNMENT - am_hdr_sz % MAX_ALIGNMENT);
-    }
-#endif
+    MPIR_Assert(MPIDI_OFI_AMREQUEST(sreq, sreq_hdr) == NULL);
 
-    if (MPIDI_OFI_AMREQUEST(sreq, sreq_hdr) == NULL) {
-        int vci = MPIDI_Request_get_vci(sreq);
-        MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vci[vci].am_hdr_buf_pool,
-                                           (void **) &sreq_hdr);
-        MPIR_Assert(sreq_hdr);
-        MPIDI_OFI_AMREQUEST(sreq, sreq_hdr) = sreq_hdr;
+    int vci = MPIDI_Request_get_vci(sreq);
+    MPIDU_genq_private_pool_alloc_cell(MPIDI_OFI_global.per_vci[vci].am_hdr_buf_pool,
+                                       (void **) &sreq_hdr);
+    MPIR_Assert(sreq_hdr);
+    MPIDI_OFI_AMREQUEST(sreq, sreq_hdr) = sreq_hdr;
 
-        sreq_hdr->am_hdr = (void *) &sreq_hdr->am_hdr_buf[0];
-        sreq_hdr->am_hdr_sz = am_hdr_sz;
-        sreq_hdr->pack_buffer = NULL;
-    } else {
-        sreq_hdr = MPIDI_OFI_AMREQUEST(sreq, sreq_hdr);
-    }
+    sreq_hdr->am_hdr = (void *) &sreq_hdr->am_hdr_buf[0];
+    sreq_hdr->am_hdr_sz = am_hdr_sz;
+    sreq_hdr->pack_buffer = NULL;
 
     if (am_hdr) {
         MPIR_Memcpy(sreq_hdr->am_hdr, am_hdr, am_hdr_sz);
     }
+#ifdef NEEDS_STRICT_ALIGNMENT
+    /* adjust am_hdr_sz so the payload will always start aligned */
+    if (am_hdr_sz % MAX_ALIGNMENT) {
+        sreq_hdr->am_hdr_sz += (MAX_ALIGNMENT - am_hdr_sz % MAX_ALIGNMENT);
+    }
+#endif
 
     MPIR_FUNC_EXIT;
     return mpi_errno;

--- a/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_am_impl.h
@@ -394,6 +394,19 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_OFI_am_isend_pipeline(int rank, MPIR_Comm * c
     seg_sz = MPL_MIN(seg_sz, MPIDIG_am_send_async_get_data_sz_left(sreq));
     MPIR_Assert(seg_sz < (1ULL << MPIDI_OFI_AM_PAYLOAD_SZ_BITS));
 
+    /* make seg_sz a multiple of the datatype extent. */
+    MPI_Aint elem_sz = 0;
+    if (HANDLE_IS_BUILTIN(datatype)) {
+        elem_sz = MPIR_Datatype_get_basic_size(datatype);
+    } else {
+        MPIR_Datatype *dtp;
+        MPIR_Datatype_get_ptr(datatype, dtp);
+        elem_sz = dtp->builtin_element_size;
+    }
+    if (elem_sz) {
+        seg_sz -= (seg_sz % elem_sz);
+    }
+
     msg_hdr = (MPIDI_OFI_am_header_t *) send_req->msg_hdr;
     msg_hdr->handler_id = handler_id;
     msg_hdr->am_hdr_sz = am_hdr_sz;


### PR DESCRIPTION
## Pull Request Description

This PR changes `seg_sz` to a multiple of the element size in `MPIDI_OFI_am_isend_pipeline`.

This is done because the `packed_size` is being made a multiple of the element size
 in [MPIR_Typerep_pack](https://github.com/pmodels/mpich/blob/835c5bac042717eda96a31014e0cd81d0046719a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c#L177), but `seg_sz` has no such restriction, so in some cases they do not 
match. 

This is a potential fix for Issue #7881 . 

With `MPIR_CVAR_CH4_OFI_ENABLE_RMA=0` the reproducer in that issue hits 
`Assertion failed in file [...]/ofi/ofi_am_impl.h at line 413: packed_size == seg_sz`, 
which led to this PR. 

Possibly there are other ways to get this work, but changing `seg_sz` to a multiple of 
the element size seemed the cleanest to me. The code patch here is copied from 
[similar code in MPIR_Typerep_pack](https://github.com/pmodels/mpich/blob/835c5bac042717eda96a31014e0cd81d0046719a/src/mpi/datatype/typerep/src/typerep_yaksa_pack.c#L151-L163) to match it exactly.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
