### PR TITLE
ch4/ofi: increase max nics

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_pre.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_pre.h
@@ -409,7 +409,7 @@ typedef struct {
 } MPIDI_OFI_win_t;
 
 /* Maximum number of network interfaces CH4 can support. */
-#define MPIDI_OFI_MAX_NICS 8
+#define MPIDI_OFI_MAX_NICS 128
 
 /* Imagine a dimension of [local_vci][local_nic][rank][vci][nic] -
  * all local endpoints will share the same remote address due to the same insertion order


### PR DESCRIPTION
Some systems have tens of NICs now. Increase the hard maximum on the detectable NICs from 8 to 128.

## Pull Request Description
This only changes the `#define`, but on most systems actual NIC selection will likely be poor. A follow-up PR will bring better NIC selection functionality.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
