### PR TITLE
binding/c: check MPI_IN_PLACE in neighbor collectives

### DIFF
--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -2589,10 +2589,16 @@ def dump_validation(func, t):
         elif kind == "USERBUFFER-reduce":
             G.err_codes['MPI_ERR_OP'] = 1
             dump_validate_userbuffer_reduce(func, p[0], p[1], p[2], p[3], p[4])
-        elif kind == "USERBUFFER-neighbor":
-            dump_validate_userbuffer_simple(func, p[0], p[1], p[2])
         elif kind.startswith("USERBUFFER-neighbor"):
-            dump_validate_userbuffer_neighbor_vw(func, kind, p[0], p[1], p[3], p[2])
+            SEND = "SEND"
+            if RE.search(r'recv', p[0]):
+                SEND = "RECV"
+            # note: for simplicity, we ignore the count argument and always check against MPI_IN_PLACE
+            G.out.append("MPIR_ERRTEST_%sBUF_INPLACE(%s, %s, mpi_errno);" % (SEND, p[0], 1))
+            if kind == "USERBUFFER-neighbor":
+                dump_validate_userbuffer_simple(func, p[0], p[1], p[2])
+            else:
+                dump_validate_userbuffer_neighbor_vw(func, kind, p[0], p[1], p[3], p[2])
         elif RE.search(r'-[vw]$', kind):
             dump_validate_userbuffer_coll(func, kind, p[0], p[1], p[3], p[2])
         else:

--- a/maint/local_python/binding_c.py
+++ b/maint/local_python/binding_c.py
@@ -2590,10 +2590,16 @@ def dump_validation(func, t):
         elif kind == "USERBUFFER-reduce":
             G.err_codes['MPI_ERR_OP'] = 1
             dump_validate_userbuffer_reduce(func, p[0], p[1], p[2], p[3], p[4])
-        elif kind == "USERBUFFER-neighbor":
-            dump_validate_userbuffer_simple(func, p[0], p[1], p[2])
         elif kind.startswith("USERBUFFER-neighbor"):
-            dump_validate_userbuffer_neighbor_vw(func, kind, p[0], p[1], p[3], p[2])
+            SEND = "SEND"
+            if RE.search(r'recv', p[0]):
+                SEND = "RECV"
+            # note: for simplicity, we ignore the count argument and always check against MPI_IN_PLACE
+            G.out.append("MPIR_ERRTEST_%sBUF_INPLACE(%s, %s, mpi_errno);" % (SEND, p[0], 1))
+            if kind == "USERBUFFER-neighbor":
+                dump_validate_userbuffer_simple(func, p[0], p[1], p[2])
+            else:
+                dump_validate_userbuffer_neighbor_vw(func, kind, p[0], p[1], p[3], p[2])
         elif RE.search(r'-[vw]$', kind):
             dump_validate_userbuffer_coll(func, kind, p[0], p[1], p[3], p[2])
         else:


### PR DESCRIPTION
## Pull Request Description
MPI_IN_PLACE is not allowed in MPI_Neighbor_xxx functions.

Fixes #7899


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
