### PR TITLE
test/f77: fix bsendf.f

### DIFF
--- a/test/mpi/f77/pt2pt/bsendf.f
+++ b/test/mpi/f77/pt2pt/bsendf.f
@@ -4,20 +4,22 @@ C     See COPYRIGHT in top-level directory
 C
 
 C Basic test for MPI_Bsend
-C     We test a basic buffered send of 10 INTEGERs and assume a buffer
-C     of 400 CHARACTERs are sufficient to account for MPI_BSEND_OVERHEAD
+C     We test a basic buffered send of 10 INTEGERs and size the
+C     attached buffer from MPI_BSEND_OVERHEAD.
 
       program bsend
       implicit none
       include 'mpif.h'
       integer ierr, errs, comm
-      character dummy_buf(400)
+      integer dummy_buf_size
+      parameter (dummy_buf_size=MPI_BSEND_OVERHEAD+400)
+      character dummy_buf(dummy_buf_size)
       INTEGER dummy_size
 C
       errs = 0
       comm = MPI_COMM_WORLD;
       call MTest_Init( ierr )
-      call mpi_buffer_attach(dummy_buf, 400, ierr )
+      call mpi_buffer_attach(dummy_buf, dummy_buf_size, ierr )
       call test_bsend( comm, errs )
       call mpi_buffer_detach(dummy_buf, dummy_size, ierr )
       call MTest_Finalize( errs )


### PR DESCRIPTION
## Pull Request Description
Instead of assuming the hardcoded 400 buffer size is sufficient to account for MPI_BSEND_OVERHEAD, actually account for it.

Fixes #7846



## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
