### PR TITLE
ch4/ofi: fix distribution of NICs in NUMA systems

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -681,8 +681,6 @@ int MPIDI_OFI_init_local(int *tag_bits)
     goto fn_exit;
 }
 
-static bool fabric_initialized = false;
-
 /* we delay init fabric until the first comm creation (in MPIDI_OFI_mpi_comm_commit_pre_hook) */
 int MPIDI_OFI_init_fabric(MPIR_Comm * comm)
 {
@@ -697,7 +695,7 @@ int MPIDI_OFI_init_fabric(MPIR_Comm * comm)
         /* TODO: run collective and decide all_need_init (as well as num_nics, close_nic_map) */
     }
 
-    if (!fabric_initialized) {
+    if (!MPIDI_OFI_global.fabric_initialized) {
         if (all_need_init) {
             /* order nics based on allgathered global info */
             mpi_errno = MPIDI_OFI_order_multi_nic_global();
@@ -709,7 +707,7 @@ int MPIDI_OFI_init_fabric(MPIR_Comm * comm)
         }
     }
 
-    if (!fabric_initialized) {
+    if (!MPIDI_OFI_global.fabric_initialized) {
         if (MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS) {
 #ifdef MPIDI_OFI_VNI_USE_DOMAIN
             /* Note: currently we request a single tx and rx ctx under MPIDI_OFI_VNI_USE_DOMAIN */
@@ -776,7 +774,7 @@ int MPIDI_OFI_init_fabric(MPIR_Comm * comm)
         MPIDI_OFI_init_per_vci(0);
     }
 
-    fabric_initialized = true;
+    MPIDI_OFI_global.fabric_initialized = true;
 
   fn_exit:
     return mpi_errno;
@@ -884,7 +882,7 @@ int MPIDI_OFI_mpi_finalize_hook(void)
 
     MPIR_FUNC_ENTER;
 
-    if (fabric_initialized) {
+    if (MPIDI_OFI_global.fabric_initialized) {
         /* Progress until we drain all inflight RMA send long buffers */
         /* NOTE: am currently only use vci 0. Need update once that changes */
         for (int vci = 0; vci < MPIDI_OFI_global.num_vcis; vci++) {
@@ -965,7 +963,7 @@ int MPIDI_OFI_mpi_finalize_hook(void)
             }
         }
 
-        fabric_initialized = false;
+        MPIDI_OFI_global.fabric_initialized = false;
     }
 
     for (i = 0; i < MPIDI_OFI_global.num_nics; i++) {

--- a/src/mpid/ch4/netmod/ofi/ofi_init.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.c
@@ -686,25 +686,35 @@ int MPIDI_OFI_init_fabric(MPIR_Comm * comm)
 {
     int mpi_errno = MPI_SUCCESS;
 
-    bool is_comm_world = (comm == MPIR_Process.comm_world);
+    bool is_comm_world = (comm && comm == MPIR_Process.comm_world);
 
-    /* collectively order nics if we are in the world model */
-    bool all_need_init = false;
+    MPIR_Comm *node_comm = NULL;
     if (is_comm_world) {
-        /* NOTE: we can't skip the collective based on `fabric_initialized` */
-        /* TODO: run collective and decide all_need_init (as well as num_nics, close_nic_map) */
+        node_comm = MPIR_Comm_get_node_comm(comm);
     }
 
-    if (!MPIDI_OFI_global.fabric_initialized) {
-        if (all_need_init) {
-            /* order nics based on allgathered global info */
-            mpi_errno = MPIDI_OFI_order_multi_nic_global();
-            MPIR_ERR_CHECK(mpi_errno);
-        } else {
-            /* order nics based on local rank */
-            mpi_errno = MPIDI_OFI_order_multi_nic_local();
-            MPIR_ERR_CHECK(mpi_errno);
-        }
+    /* We currently conflate is_comm_world with any sense that NIC selection should be
+     * performed cooperatively. If Sessions are not used, this should perform proper NIC
+     * selection across local ranks. If Sessions are used, we fall back to local
+     * selection without cooperation
+     *
+     * TODO: Support cooperative NIC selection when using Sessions. Consider:
+     *  - allreduce fabric_initialized within node_comm; if all ranks need to
+     *  initialize, perform cooperative NIC assignment within node_comm. When creating
+     *  multiple communicators, NIC assignment could be suboptimal
+     *  - shared memory/atomics-based NIC claim table. Optimal NIC assignment,
+     *  non-deterministic.
+     *  - hybrid of the two; claim table used across node_comm initialization to avoid
+     *  suboptimal NIC assignment
+     */
+    if (is_comm_world && node_comm && node_comm->local_size > 1) {
+        /* order nics based on allgathered global info */
+        mpi_errno = MPIDI_OFI_order_multi_nic_global(node_comm);
+        MPIR_ERR_CHECK(mpi_errno);
+    } else {
+        /* order nics based on local rank */
+        mpi_errno = MPIDI_OFI_order_multi_nic_local();
+        MPIR_ERR_CHECK(mpi_errno);
     }
 
     if (!MPIDI_OFI_global.fabric_initialized) {

--- a/src/mpid/ch4/netmod/ofi/ofi_init.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_init.h
@@ -42,7 +42,7 @@ bool MPIDI_OFI_nic_is_up(struct fi_info *prov);
 
 int MPIDI_OFI_fill_prov_use(struct fi_info *prov);
 int MPIDI_OFI_order_multi_nic_local(void);
-int MPIDI_OFI_order_multi_nic_global(void);
+int MPIDI_OFI_order_multi_nic_global(MPIR_Comm * node_comm);
 
 int MPIDI_OFI_comm_addr_exchange(MPIR_Comm * comm);
 

--- a/src/mpid/ch4/netmod/ofi/ofi_nic.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_nic.c
@@ -24,12 +24,29 @@ cvars:
 */
 
 /* ---------------------------------- */
+/* NIC affinity mask type and macros  */
+/* ---------------------------------- */
+
+#define MPIDI_OFI_NIC_MASK_WORD_SIZE 64
+#define MPIDI_OFI_NIC_MASK_WORDS (MPIDI_OFI_MAX_NICS / MPIDI_OFI_NIC_MASK_WORD_SIZE)
+MPL_static_assert(MPIDI_OFI_MAX_NICS % MPIDI_OFI_NIC_MASK_WORD_SIZE == 0,
+                  "MPIDI_OFI_MAX_NICS must be a multiple of MPIDI_OFI_NIC_MASK_WORD_SIZE");
+
+typedef struct {
+    uint64_t bits[MPIDI_OFI_NIC_MASK_WORDS];
+} MPIDI_OFI_nic_mask_t;
+
+#define MPIDI_OFI_NIC_MASK_SET(mask, nic) \
+    ((mask).bits[(nic) / 64] |= (uint64_t) 1 << ((nic) % 64))
+
+/* ---------------------------------- */
 /* Forward declarations for static    */
 /* functions called from public APIs  */
 /* ---------------------------------- */
 
 static bool match_prov_addr(struct fi_info *prov, const char *hostname);
 static int compare_nic_names(const void *info1, const void *info2);
+static int compare_nic_closeness(const void *nic1, const void *nic2);
 static int order_multi_nic_by_pref(int pref);
 #ifdef HAVE_LIBFABRIC_NIC
 static bool is_nic_pci_valid(struct fi_info *info);
@@ -224,11 +241,97 @@ int MPIDI_OFI_order_multi_nic_local(void)
     return order_multi_nic_by_pref(pref);
 }
 
-int MPIDI_OFI_order_multi_nic_global(void)
+/* Exchange NIC affinity masks across node-local ranks and compute a preferred
+ * NIC index that distributes load across sharing sets. Returns the preferred
+ * NIC index into close NICs, or -1 on failure (caller should fall back to local
+ * assignment). */
+static int compute_nic_pref_global(MPIR_Comm * node_comm)
 {
-    /* TODO: pass comm, use comm->local_rank, and globally determine pref */
-    int pref = MPIR_Process.local_rank % MPIDI_OFI_global.num_close_nics;
+    int mpi_errno = MPI_SUCCESS;
+    int local_rank = node_comm->rank;
+    int local_size = node_comm->local_size;
+    int num_nics = MPIDI_OFI_global.num_nics_available;
+    int num_close = MPIDI_OFI_global.num_close_nics;
+    int pref = -1;
+    MPIDI_OFI_nic_mask_t *all_masks = NULL;
 
+    /* Build local close_mask */
+    MPIDI_OFI_nic_mask_t my_mask;
+    memset(&my_mask, 0, sizeof(my_mask));
+    for (int i = 0; i < num_nics; i++) {
+        if (MPIDI_OFI_global.nic_info[i].close) {
+            MPIDI_OFI_NIC_MASK_SET(my_mask, i);
+        }
+    }
+
+    /* Allgather masks over node_comm */
+    all_masks = MPL_malloc(local_size * sizeof(MPIDI_OFI_nic_mask_t), MPL_MEM_OTHER);
+    MPIR_ERR_CHKANDJUMP(!all_masks, mpi_errno, MPI_ERR_OTHER, "**nomem");
+
+    memcpy(&all_masks[local_rank], &my_mask, sizeof(my_mask));
+    mpi_errno = MPIR_Allgather_fallback(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL,
+                                        all_masks, sizeof(MPIDI_OFI_nic_mask_t),
+                                        MPIR_BYTE_INTERNAL, node_comm, MPIR_COLL_ATTR_SYNC);
+    MPIR_ERR_CHECK(mpi_errno);
+
+    if (MPIDI_OFI_global.fabric_initialized) {
+        goto fn_exit;
+    }
+
+    /* detect overlapping but unequal masks. this would imply a very strange
+     * architecture and equitable distribution of NICs in that case would be
+     * complicated. Warn and fallback to naive rotation. */
+    for (int i = 0; i < local_size; i++) {
+        for (int j = i + 1; j < local_size; j++) {
+            if (memcmp(&all_masks[i], &all_masks[j], sizeof(my_mask)) == 0)
+                continue;
+            for (int w = 0; w < MPIDI_OFI_NIC_MASK_WORDS; w++) {
+                if (all_masks[i].bits[w] & all_masks[j].bits[w]) {
+                    MPL_DBG_MSG(MPIDI_CH4_DBG_GENERAL, VERBOSE,
+                                "NIC affinity masks overlap but are not equal; "
+                                "falling back to local_rank assignment");
+                    pref = -1;
+                    goto fn_exit;
+                }
+            }
+        }
+    }
+
+    /* Compute my index within my sharing set (ranks with identical mask) */
+    int my_index_in_set = 0;
+    for (int i = 0; i < local_rank; i++) {
+        if (memcmp(&all_masks[i], &my_mask, sizeof(my_mask)) == 0) {
+            my_index_in_set++;
+        }
+    }
+
+    /* Sort NICs so that close NICs come first */
+    qsort(MPIDI_OFI_global.nic_info, num_nics,
+          sizeof(MPIDI_OFI_global.nic_info[0]), compare_nic_closeness);
+
+    /* Round-robin close NICs across ranks in the same sharing set */
+    pref = my_index_in_set % num_close;
+
+  fn_exit:
+    MPL_free(all_masks);
+    return pref;
+  fn_fail:
+    pref = -1;
+    goto fn_exit;
+}
+
+int MPIDI_OFI_order_multi_nic_global(MPIR_Comm * node_comm)
+{
+    int pref = compute_nic_pref_global(node_comm);
+
+    if (MPIDI_OFI_global.fabric_initialized) {
+        return MPI_SUCCESS;
+    }
+
+    if (pref < 0) {
+        /* Fallback: no global info available or unsupported topology */
+        pref = node_comm->rank % MPIDI_OFI_global.num_close_nics;
+    }
     return order_multi_nic_by_pref(pref);
 }
 
@@ -284,7 +387,7 @@ static int compare_nic_names(const void *info1, const void *info2)
 }
 
 /* Comparison function for NICs. This function is used in qsort(). */
-static int compare_nics(const void *nic1, const void *nic2)
+static int compare_nic_closeness(const void *nic1, const void *nic2)
 {
     const MPIDI_OFI_nic_info_t *i1 = (const MPIDI_OFI_nic_info_t *) nic1;
     const MPIDI_OFI_nic_info_t *i2 = (const MPIDI_OFI_nic_info_t *) nic2;
@@ -300,7 +403,7 @@ static int order_multi_nic_by_pref(int pref)
     MPIDI_OFI_nic_info_t *nics = MPIDI_OFI_global.nic_info;
 
     /* 1. move all close nics to the front of the list. */
-    qsort(nics, MPIDI_OFI_global.num_nics_available, sizeof(nics[0]), compare_nics);
+    qsort(nics, MPIDI_OFI_global.num_nics_available, sizeof(nics[0]), compare_nic_closeness);
 
     /* 2. rotate the close nics by pref. */
     if (pref > 0) {

--- a/src/mpid/ch4/netmod/ofi/ofi_types.h
+++ b/src/mpid/ch4/netmod/ofi/ofi_types.h
@@ -498,6 +498,8 @@ typedef struct {
      * ch4 av tables are initialize to 0s. Thus we need know which "0" is valid. */
     MPIR_Lpid lpid0;
 
+    bool fabric_initialized;
+
     /* Capability settings */
 #ifdef MPIDI_OFI_ENABLE_RUNTIME_CHECKS
     MPIDI_OFI_capabilities_t settings;


### PR DESCRIPTION
On systems with non-uniform attachment of NICs to CPU cores, we are considering closeness in NIC assignment, but assigning them by round-robin based on local rank. In a two-NUMA node system (using -map-by numa) this results in only half of the NICs being used (the even-indexed ones on NUMA node 0 and odd-indexed on NUMA node 1).

This fixes this by explicitly sharing the close NICs across all local ranks, and selecting NICs based on index within each "sharing set" of local ranks.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
