### PR TITLE
test/mpi: add implicit none to Fortran tests

### DIFF
--- a/test/mpi/errors/f08/io/uerrhandf08.f90
+++ b/test/mpi/errors/f08/io/uerrhandf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer (kind=MPI_ADDRESS_KIND) asize
 
       integer (kind=MPI_OFFSET_KIND) offset
@@ -117,6 +118,7 @@
       end
 !
       subroutine comm_errh_fn( comm, ec )
+      implicit none
       integer comm, ec
       common /ec/ iseen
       integer iseen(3)
@@ -127,6 +129,7 @@
       end
 !
       subroutine win_errh_fn( win, ec )
+      implicit none
       integer win, ec
       common /ec/ iseen
       integer iseen(3)
@@ -136,6 +139,7 @@
 !
       end
       subroutine file_errh_fn( fh, ec )
+      implicit none
       integer fh, ec
       common /ec/ iseen
       integer iseen(3)

--- a/test/mpi/errors/f77/io/uerrhandf.f
+++ b/test/mpi/errors/f77/io/uerrhandf.f
@@ -99,6 +99,7 @@ C NOTE: ierr may be MPI_SUCCESS but handler should be invoked
       end
 C
       subroutine comm_errh_fn( comm, ec )
+      implicit none
       integer comm, ec
       common /ec/ iseen
       integer iseen(3)
@@ -109,6 +110,7 @@ C
       end
 C
       subroutine win_errh_fn( win, ec )
+      implicit none
       integer win, ec
       common /ec/ iseen
       integer iseen(3)
@@ -118,6 +120,7 @@ C
 C
       end
       subroutine file_errh_fn( fh, ec )
+      implicit none
       integer fh, ec
       common /ec/ iseen
       integer iseen(3)

--- a/test/mpi/f08/attr/attrlangf08.f90
+++ b/test/mpi/f08/attr/attrlangf08.f90
@@ -90,6 +90,7 @@
 ! interfaces to the C routines
       module keyvals
         use mpi_f08
+        implicit none
         logical fverbose, useintSize
         integer ptrSize, intSize, aintSize
         integer fcomm1_key, fcomm1_extra
@@ -101,38 +102,47 @@
              & fwin2_extra
         interface
            pure function bigint()
+           implicit none
              integer bigint
            end function bigint
            pure function bigaint()
              use mpi_f08, only : MPI_ADDRESS_KIND
+             implicit none
              integer (kind=MPI_ADDRESS_KIND) bigaint
            end function bigaint
            ! Could use bind(c) once we require that level of Fortran support.
            subroutine csetmpi( fcomm, fkey, val, errs )
              use mpi_f08
+             implicit none
              TYPE(MPI_Comm), INTENT(IN) :: fcomm
              integer, INTENT(IN) :: fkey, val
              integer errs
            end subroutine csetmpi
            subroutine csetmpi2( fcomm, fkey, val, errs )
              use mpi_f08
+             implicit none
              TYPE(MPI_Comm), INTENT(IN) :: fcomm
              integer, INTENT(IN) :: fkey
              integer  errs
              integer (KIND=MPI_ADDRESS_KIND) val
            end subroutine csetmpi2
            subroutine cattrinit( fv )
+           implicit none
              integer fv
            end subroutine cattrinit
            subroutine cgetsizes( ps, is, as )
+           implicit none
              integer, INTENT(OUT) :: ps, is, as
            end subroutine cgetsizes
            subroutine ccreatekeys( k1, k2, k3, k4 )
+           implicit none
              integer, INTENT(OUT) :: k1, k2, k3, k4
            end subroutine ccreatekeys
            subroutine cfreekeys()
+           implicit none
            end subroutine cfreekeys
            subroutine ctoctest( errs )
+           implicit none
              integer errs
            end subroutine ctoctest
         end interface
@@ -254,6 +264,7 @@
 ! -------------------------------------------------------------------
       integer function FMPI1checkCommAttr( comm, key, expected, msg )
       use mpi_f08
+      implicit none
       integer key, expected
       TYPE(MPI_Comm) comm
       character*(*) msg
@@ -282,6 +293,7 @@
            & outval, flag, ierr )
       use mpi_f08
       use keyvals, only : fverbose
+      implicit none
       integer key, extrastate, inval, outval, ierr
       TYPE(MPI_Comm) oldcomm
       logical flag
@@ -299,6 +311,7 @@
      &     ierr )
       use mpi_f08
       use keyvals, only : fverbose
+      implicit none
       integer key, extrastate, inval, ierr
       TYPE(MPI_Comm) oldcomm
       logical flag
@@ -903,6 +916,7 @@
 ! -------------------------------------------------------------------
 ! Return an integer value that fills all of the bytes
       pure integer function bigint()
+      implicit none
         integer i, v, digits
         digits = range(i)
         v = 0

--- a/test/mpi/f08/attr/baseattr2f08.f90
+++ b/test/mpi/f08/attr/baseattr2f08.f90
@@ -7,6 +7,7 @@
 
         program main
         use mpi_f08
+        implicit none
         integer ierr, errs
         logical flag
         integer value, commsize, commrank

--- a/test/mpi/f08/attr/baseattr3f08.f90
+++ b/test/mpi/f08/attr/baseattr3f08.f90
@@ -8,6 +8,7 @@
 ! an INTEGER.
         program main
         use mpi_f08
+        implicit none
         integer ierr, errs
         logical flag
         integer commsize, commrank

--- a/test/mpi/f08/attr/baseattrf08.f90
+++ b/test/mpi/f08/attr/baseattrf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer value, commsize
       logical flag
       integer ierr, errs

--- a/test/mpi/f08/attr/commattr2f08.f90
+++ b/test/mpi/f08/attr/commattr2f08.f90
@@ -10,6 +10,7 @@
 !
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
 

--- a/test/mpi/f08/attr/commattr3f08.f90
+++ b/test/mpi/f08/attr/commattr3f08.f90
@@ -11,6 +11,7 @@
 !
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
 

--- a/test/mpi/f08/attr/commattrf08.f90
+++ b/test/mpi/f08/attr/commattrf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
 
@@ -119,6 +120,7 @@
       subroutine mycopyfn( oldcomm, keyval, extrastate, valin, valout, &
       &                     flag, ierr )
       use mpi_f08
+      implicit none
       type(MPI_Comm) oldcomm
       integer keyval, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
@@ -141,6 +143,7 @@
 !
       subroutine mydelfn( comm, keyval, val, extrastate, ierr )
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer keyval, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val

--- a/test/mpi/f08/attr/fandcattrf08.f90
+++ b/test/mpi/f08/attr/fandcattrf08.f90
@@ -11,6 +11,7 @@
 !
       program main
       use mpi_f08
+      implicit none
       integer (kind=MPI_ADDRESS_KIND) val
       integer ierr, errs, fcomm2_keyval, ftype2_keyval
       integer ccomm2_keyval, ctype2_keyval, cwin2_keyval
@@ -55,6 +56,7 @@
       subroutine mycopyfn( oldcomm, keyval, extrastate, valin, valout, &
       &                     flag, ierr )
       use mpi_f08
+      implicit none
       integer keyval, ierr
       TYPE(MPI_Comm) oldcomm
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
@@ -77,6 +79,7 @@
 !
       subroutine mydelfn( comm, keyval, val, extrastate, ierr )
       use mpi_f08
+      implicit none
       integer keyval, ierr
       TYPE(MPI_Comm) comm
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
@@ -95,6 +98,7 @@
       subroutine mytcopyfn( oldtype, keyval, extrastate, valin, valout, &
       &                     flag, ierr )
       use mpi_f08
+      implicit none
       integer keyval, ierr
       TYPE(MPI_Datatype) oldtype
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
@@ -117,6 +121,7 @@
 !
       subroutine mytdelfn( dtype, keyval, val, extrastate, ierr )
       use mpi_f08
+      implicit none
       integer keyval, ierr
       TYPE(MPI_Datatype) dtype
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val

--- a/test/mpi/f08/attr/typeattr2f08.f90
+++ b/test/mpi/f08/attr/typeattr2f08.f90
@@ -10,6 +10,7 @@
 !
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
 

--- a/test/mpi/f08/attr/typeattr3f08.f90
+++ b/test/mpi/f08/attr/typeattr3f08.f90
@@ -11,6 +11,7 @@
 !
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
 

--- a/test/mpi/f08/attr/typeattrf08.f90
+++ b/test/mpi/f08/attr/typeattrf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
 
@@ -120,6 +121,7 @@
       subroutine mycopyfn( oldtype, keyval, extrastate, valin, valout, &
       &                     flag, ierr )
       use mpi_f08
+      implicit none
       integer keyval, ierr
       TYPE(MPI_Datatype) oldtype
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
@@ -142,6 +144,7 @@
 !
       subroutine mydelfn( type, keyval, val, extrastate, ierr )
       use mpi_f08
+      implicit none
       integer keyval, ierr
       TYPE(MPI_Datatype) type
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val

--- a/test/mpi/f08/coll/allredint8f08.f90
+++ b/test/mpi/f08/coll/allredint8f08.f90
@@ -5,6 +5,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer*8 inbuf, outbuf
       integer errs, ierr
 

--- a/test/mpi/f08/coll/allredopttf08.f90
+++ b/test/mpi/f08/coll/allredopttf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer*8 inbuf, outbuf
       double complex zinbuf, zoutbuf
       integer wsize

--- a/test/mpi/f08/coll/alltoallvf08.f90
+++ b/test/mpi/f08/coll/alltoallvf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer ierr, errs
       integer i, ans, size, rank, color
       TYPE(MPI_Comm) comm, newcomm

--- a/test/mpi/f08/coll/alltoallwf08.f90
+++ b/test/mpi/f08/coll/alltoallwf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer ierr, errs
       integer i, intsize, ans, size, rank, color
       TYPE(MPI_Comm) comm, newcomm

--- a/test/mpi/f08/coll/exscanf08.f90
+++ b/test/mpi/f08/coll/exscanf08.f90
@@ -7,6 +7,7 @@
 
       subroutine uop( cin, cout, count, datatype )
       use mpi_f08
+      implicit none
       integer cin(*), cout(*)
       integer count
       TYPE(MPI_Datatype) datatype
@@ -24,6 +25,7 @@
 !
       program main
       use mpi_f08
+      implicit none
       integer inbuf(2), outbuf(2)
       integer ans, rank, size
       TYPE(MPI_Comm) comm

--- a/test/mpi/f08/coll/inplacef08.f90
+++ b/test/mpi/f08/coll/inplacef08.f90
@@ -9,6 +9,7 @@
 !
        program main
        use mpi_f08
+       implicit none
        integer ierr, errs
        integer root
        TYPE(MPI_Comm) comm

--- a/test/mpi/f08/coll/nonblocking_inpf08.f90
+++ b/test/mpi/f08/coll/nonblocking_inpf08.f90
@@ -9,6 +9,7 @@
 !
        program main
        use mpi_f08
+       implicit none
        integer SIZEOFINT
        integer MAX_SIZE
        parameter (MAX_SIZE=1024)

--- a/test/mpi/f08/coll/nonblockingf08.f90
+++ b/test/mpi/f08/coll/nonblockingf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer NUM_INTS
       parameter (NUM_INTS=2)
       integer maxSize

--- a/test/mpi/f08/coll/red_scat_blockf08.f90
+++ b/test/mpi/f08/coll/red_scat_blockf08.f90
@@ -10,6 +10,7 @@
 !
        program main
        use mpi_f08
+       implicit none
        integer MAX_SIZE
        parameter (MAX_SIZE=1024)
        integer sbuf(MAX_SIZE), rbuf(MAX_SIZE)

--- a/test/mpi/f08/coll/redscatf08.f90
+++ b/test/mpi/f08/coll/redscatf08.f90
@@ -7,6 +7,7 @@
 
       subroutine uop( cin, cout, count, datatype )
       use mpi_f08
+      implicit none
       integer cin(*), cout(*)
       integer count
       TYPE(MPI_Datatype) datatype
@@ -32,6 +33,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr, toterr
       integer maxsize
       parameter (maxsize=1024)

--- a/test/mpi/f08/coll/reducelocalf08.f90
+++ b/test/mpi/f08/coll/reducelocalf08.f90
@@ -9,6 +9,7 @@
 !
       subroutine user_op( invec, outvec, count, datatype )
       use mpi_f08
+      implicit none
       integer invec(*), outvec(*)
       integer count
       TYPE(MPI_Datatype) datatype
@@ -27,6 +28,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer max_buf_size
       parameter (max_buf_size=65000)
       integer vin(max_buf_size), vout(max_buf_size)

--- a/test/mpi/f08/coll/split_typef08.f90
+++ b/test/mpi/f08/coll/split_typef08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer ierr, errs
       integer i, ans, size, rank, color
       TYPE(MPI_Comm) comm, newcomm

--- a/test/mpi/f08/coll/uallreducef08.f90
+++ b/test/mpi/f08/coll/uallreducef08.f90
@@ -9,6 +9,7 @@
 !
       subroutine uop( cin, cout, count, datatype )
       use mpi_f08
+      implicit none
       integer cin(*), cout(*)
       integer count
       TYPE(MPI_Datatype) datatype
@@ -26,6 +27,7 @@
 
       program main
       use mpi_f08
+      implicit none
       external uop
       integer ierr, errs
       integer count, vin(65000), vout(65000), i, size

--- a/test/mpi/f08/coll/vw_inplacef08.f90
+++ b/test/mpi/f08/coll/vw_inplacef08.f90
@@ -9,6 +9,7 @@
 !
        program main
        use mpi_f08
+       implicit none
        integer SIZEOFINT
        integer MAX_SIZE
        parameter (MAX_SIZE=1024)

--- a/test/mpi/f08/comm/commerrf08.f90
+++ b/test/mpi/f08/comm/commerrf08.f90
@@ -7,6 +7,7 @@
 
        program main
        use mpi_f08
+       implicit none
        integer errs, ierr, code(2), newerrclass, eclass
        character*(MPI_MAX_ERROR_STRING) errstring
        integer rlen
@@ -107,6 +108,7 @@
 !
        subroutine myerrhanfunc( comm, errcode )
        use mpi_f08
+       implicit none
        integer errcode
        TYPE(MPI_Comm) comm
        integer rlen, ierr

--- a/test/mpi/f08/comm/commnamef08.f90
+++ b/test/mpi/f08/comm/commnamef08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr
       integer i, rlen, ln
       TYPE(MPI_Comm) comm(4)

--- a/test/mpi/f08/datatype/allctypesf08.f90
+++ b/test/mpi/f08/datatype/allctypesf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer atype, ierr
 !
       call mtest_init(ierr)
@@ -92,6 +93,7 @@
 ! Check name of datatype
       subroutine CheckDtype( intype, name, ierr )
       use mpi_f08
+      implicit none
       integer ierr
       TYPE(MPI_Datatype) intype
       character *(*) name
@@ -117,6 +119,7 @@
 ! Check name of datatype (allows alias)
       subroutine CheckDtype2( intype, name, name2, ierr )
       use mpi_f08
+      implicit none
       integer ierr
       TYPE(MPI_Datatype) intype
       character *(*) name, name2

--- a/test/mpi/f08/datatype/createf08.f90
+++ b/test/mpi/f08/datatype/createf08.f90
@@ -5,6 +5,7 @@
 
         program main
         use mpi_f08
+        implicit none
         integer ierr
         integer errs
         integer nints, nadds, ndtypes, combiner

--- a/test/mpi/f08/datatype/gaddressf08.f90
+++ b/test/mpi/f08/datatype/gaddressf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer max_asizev
       parameter (max_asizev=2)
       integer (kind=MPI_ADDRESS_KIND) aint, aintv(max_asizev)

--- a/test/mpi/f08/datatype/hindex1f08.f90
+++ b/test/mpi/f08/datatype/hindex1f08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr, intsize
       integer i, counts(10)
       integer(kind=MPI_ADDRESS_KIND) displs(10)

--- a/test/mpi/f08/datatype/hindexed_blockf08.f90
+++ b/test/mpi/f08/datatype/hindexed_blockf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr, i, intsize
       TYPE(MPI_Datatype) type1, type2, type3, type4, type5
       integer max_asizev

--- a/test/mpi/f08/datatype/kinds.f90
+++ b/test/mpi/f08/datatype/kinds.f90
@@ -8,6 +8,7 @@
 !
   program main
   use mpi_f08
+  implicit none
   integer (kind=MPI_ADDRESS_KIND) aint, taint
   integer (kind=MPI_OFFSET_KIND) oint, toint
   integer (kind=MPI_INTEGER_KIND) iint, tiint

--- a/test/mpi/f08/datatype/packef08.f90
+++ b/test/mpi/f08/datatype/packef08.f90
@@ -7,6 +7,7 @@
 
        program main
        use mpi_f08
+       implicit none
        integer ierr, errs
        integer inbuf(10), ioutbuf(10), inbuf2(10), ioutbuf2(10)
        integer i, insize, rsize, csize, insize2

--- a/test/mpi/f08/datatype/sizeof.f90
+++ b/test/mpi/f08/datatype/sizeof.f90
@@ -9,6 +9,7 @@
 !
       program main
       use mpi_f08
+      implicit none
       integer ierr, errs
       integer rank, size, mpisize
       logical verbose

--- a/test/mpi/f08/datatype/typecntsf08.f90
+++ b/test/mpi/f08/datatype/typecntsf08.f90
@@ -7,6 +7,7 @@
 
        program main
        use mpi_f08
+       implicit none
        integer errs, ierr
        TYPE(MPI_Datatype) ntype1, ntype2
 !
@@ -34,6 +35,7 @@
 !
        subroutine explore( dtype, mycomb, errs )
        use mpi_f08
+       implicit none
        integer mycomb, errs
        TYPE(MPI_Datatype) dtype
        integer ierr

--- a/test/mpi/f08/datatype/typem2f08.f90
+++ b/test/mpi/f08/datatype/typem2f08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr, i, intsize
       TYPE(MPI_Datatype) type1, type2, type3, type4, type5
       integer max_asizev

--- a/test/mpi/f08/datatype/typename3f08.f90
+++ b/test/mpi/f08/datatype/typename3f08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       character*(MPI_MAX_OBJECT_NAME) name
       integer namelen
       integer ierr, errs

--- a/test/mpi/f08/datatype/typenamef08.f90
+++ b/test/mpi/f08/datatype/typenamef08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       character*(MPI_MAX_OBJECT_NAME) name
       integer namelen
       integer ierr, errs

--- a/test/mpi/f08/datatype/typesnamef08.f90
+++ b/test/mpi/f08/datatype/typesnamef08.f90
@@ -7,6 +7,7 @@
 
        program main
        use mpi_f08
+       implicit none
        character*(MPI_MAX_OBJECT_NAME) cname
        integer rlen, ln
        integer errs, ierr

--- a/test/mpi/f08/datatype/typesubf08.f90
+++ b/test/mpi/f08/datatype/typesubf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr
       integer maxn, maxm
       parameter (maxn=10,maxm=15)

--- a/test/mpi/f08/ext/allocmemf90.f90
+++ b/test/mpi/f08/ext/allocmemf90.f90
@@ -6,6 +6,7 @@
         program main
         use mpi_f08
         use, intrinsic :: iso_c_binding
+        implicit none
         real, pointer :: a(:,:)
         integer (kind=MPI_ADDRESS_KIND) asize
         type(c_ptr) cptr

--- a/test/mpi/f08/ext/c2f2cf90.f90
+++ b/test/mpi/f08/ext/c2f2cf90.f90
@@ -5,6 +5,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer errs, toterrs, ierr
       integer wrank, wsize
       type(MPI_Group) wgroup

--- a/test/mpi/f08/ext/ctypesinf90.f90
+++ b/test/mpi/f08/ext/ctypesinf90.f90
@@ -5,6 +5,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer ierr
       integer errs, wrank
       integer f2ctype

--- a/test/mpi/f08/info/infogetstrf90.f90
+++ b/test/mpi/f08/info/infogetstrf90.f90
@@ -5,6 +5,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer ierr, errs
       type(MPI_Info) inf
       integer nkeys, i, j, bufl, vall

--- a/test/mpi/f08/info/infotest2f90.f90
+++ b/test/mpi/f08/info/infotest2f90.f90
@@ -5,6 +5,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer ierr, errs
       type(MPI_Info) i1, i2
       integer nkeys, i, j, sumindex, vlen, ln, valuelen

--- a/test/mpi/f08/info/infotestf90.f90
+++ b/test/mpi/f08/info/infotestf90.f90
@@ -6,6 +6,7 @@
 ! Simple info test
        program main
        use mpi_f08
+       implicit none
        type(MPI_Info) i1, i2
        integer i, errs, ierr
        integer valuelen

--- a/test/mpi/f08/init/baseenvf90.f90
+++ b/test/mpi/f08/init/baseenvf90.f90
@@ -5,6 +5,7 @@
 
        program main
        use mpi_f08
+       implicit none
        integer ierr, provided, errs, rank, size
        integer iv, isubv, qprovided
        logical flag

--- a/test/mpi/f08/io/atomicityf90.f90
+++ b/test/mpi/f08/io/atomicityf90.f90
@@ -5,6 +5,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer (kind=MPI_OFFSET_KIND) disp
 
 ! tests whether atomicity semantics are satisfied for overlapping accesses

--- a/test/mpi/f08/io/c2f2ciof90.f90
+++ b/test/mpi/f08/io/c2f2ciof90.f90
@@ -6,6 +6,7 @@
 ! Test just the MPI-IO FILE object
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr
       integer wrank
       type(MPI_Group) wgroup

--- a/test/mpi/f08/io/fileerrf90.f90
+++ b/test/mpi/f08/io/fileerrf90.f90
@@ -5,6 +5,7 @@
 
        program main
        use mpi_f08
+       implicit none
        integer errs, ierr, code(2), newerrclass, eclass
        character*(MPI_MAX_ERROR_STRING) errstring
        integer rlen
@@ -136,6 +137,7 @@
 !
        subroutine myerrhanfunc( file, errcode )
        use mpi_f08
+       implicit none
        type(MPI_File) file
        integer errcode
        integer rlen, ierr

--- a/test/mpi/f08/io/fileinfof90.f90
+++ b/test/mpi/f08/io/fileinfof90.f90
@@ -5,6 +5,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer ierr, errs
       type(MPI_File) fh
       type(MPI_Info) info1, info2

--- a/test/mpi/f08/io/ioharness.tlt
+++ b/test/mpi/f08/io/ioharness.tlt
@@ -1,6 +1,7 @@
 <f90header/>
         program main
         use mpi_f08
+        implicit none
         integer maxfparm
         parameter (maxfparm=5)
         integer max_buffer

--- a/test/mpi/f08/io/miscfilef90.f90
+++ b/test/mpi/f08/io/miscfilef90.f90
@@ -7,6 +7,7 @@
       use mpi_f08
 ! iooffset.h provides a variable "offset" that is of type MPI_Offset
 ! (in Fortran 90, kind=MPI_OFFSET_KIND)
+      implicit none
       integer (kind=MPI_OFFSET_KIND) offset
 
 ! iodisp.h declares disp as an MPI_Offset integer

--- a/test/mpi/f08/io/setviewcurf90.f90
+++ b/test/mpi/f08/io/setviewcurf90.f90
@@ -5,6 +5,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer (kind=MPI_OFFSET_KIND) offset
 
       integer errs, ierr, size, rank

--- a/test/mpi/f08/io/shpositionf90.f90
+++ b/test/mpi/f08/io/shpositionf90.f90
@@ -5,6 +5,7 @@
 
         program main
         use mpi_f08
+        implicit none
         type(MPI_Comm) comm
         type(MPI_File) fh
         integer r, s, i

--- a/test/mpi/f08/misc/sizeof2.f90
+++ b/test/mpi/f08/misc/sizeof2.f90
@@ -5,6 +5,7 @@
 
         program main
           use mpi_f08
+          implicit none
           integer ierr, errs
           integer size1, size2
           real    a

--- a/test/mpi/f08/misc/statusconvf08.f90
+++ b/test/mpi/f08/misc/statusconvf08.f90
@@ -5,6 +5,7 @@
 
 program main
     use mpi_f08
+    implicit none
     integer ierr, errs
     INTEGER :: f_status(MPI_STATUS_SIZE)
     type(mpi_status) :: f08_status

--- a/test/mpi/f08/profile/profile1f90.f90
+++ b/test/mpi/f08/profile/profile1f90.f90
@@ -5,6 +5,7 @@
 
        program main
        use mpi_f08
+       implicit none
        integer ierr
        integer smsg(3), rmsg(3), toterrs, wsize, wrank
        common /myinfo/ calls, amount, rcalls, ramount
@@ -56,6 +57,7 @@
 !
        subroutine mpi_send_f08ts( smsg, count, dtype, dest, tag, comm, ierr )
        use :: mpi_f08, my_noname => mpi_send_f08ts
+       implicit none
        type(*), dimension(..), intent(in) :: smsg
        integer, intent(in) :: count, dest, tag
        type(MPI_Datatype), intent(in) :: dtype
@@ -76,6 +78,7 @@
 !
       subroutine mpi_recv_f08ts( rmsg, count, dtype, src, tag, comm, status, ierr )
        use :: mpi_f08, my_noname => mpi_recv_f08ts
+       implicit none
        type(*), dimension(..) :: rmsg
        integer, intent(in) :: count, src, tag
        type(MPI_Datatype), intent(in) :: dtype
@@ -95,6 +98,7 @@
        end
 !
        subroutine init_counts()
+       implicit none
        common /myinfo/ calls, amount, rcalls, ramount
        integer calls, amount, rcalls, ramount
        calls = 0
@@ -104,6 +108,7 @@
        end
 !
        subroutine mpi_pcontrol( ierr )
+       implicit none
        integer ierr
        return
        end

--- a/test/mpi/f08/pt2pt/dummyf08.f90
+++ b/test/mpi/f08/pt2pt/dummyf08.f90
@@ -16,6 +16,7 @@
 ! F90 tests from the F77 tests looks for mpif.h
       subroutine dummyupdate( extrastate )
       use mpi_f08
+      implicit none
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
 
       end

--- a/test/mpi/f08/pt2pt/greqf08.f90
+++ b/test/mpi/f08/pt2pt/greqf08.f90
@@ -7,6 +7,7 @@
 
       subroutine query_fn( extrastate, status, ierr )
       use mpi_f08
+      implicit none
       TYPE(MPI_Status) status
       integer ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
@@ -24,6 +25,7 @@
 !
       subroutine free_fn( extrastate, ierr )
       use mpi_f08
+      implicit none
       integer value, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
 
@@ -42,6 +44,7 @@
 !
       subroutine cancel_fn( extrastate, complete, ierr )
       use mpi_f08
+      implicit none
       integer ierr
       logical complete
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
@@ -63,6 +66,7 @@
 !
        program main
        use mpi_f08
+       implicit none
        integer errs, ierr
        logical flag
        TYPE(MPI_Status) status

--- a/test/mpi/f08/pt2pt/irsendf08.f90
+++ b/test/mpi/f08/pt2pt/irsendf08.f90
@@ -9,6 +9,7 @@
 
       program isend
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer ierr, errs
       logical mtestGetIntraComm
@@ -31,6 +32,7 @@
 !
       subroutine test_pair_irsend( comm, errs )
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer errs
       integer rank, size, ierr, next, prev, tag, count, index, completed, i

--- a/test/mpi/f08/pt2pt/isendf08.f90
+++ b/test/mpi/f08/pt2pt/isendf08.f90
@@ -9,6 +9,7 @@
 
       program isend
       use mpi_f08
+      implicit none
       integer ierr, errs
       type(MPI_Comm) comm
       logical mtestGetIntraComm
@@ -31,6 +32,7 @@
 !
       subroutine test_pair_isend( comm, errs )
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer errs
 

--- a/test/mpi/f08/pt2pt/issendf08.f90
+++ b/test/mpi/f08/pt2pt/issendf08.f90
@@ -10,6 +10,7 @@
 
       program issend
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer ierr, errs
       logical mtestGetIntraComm
@@ -32,6 +33,7 @@
 !
       subroutine test_pair_issend( comm, errs )
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer errs
       integer rank, size, ierr, next, prev, tag, count, index

--- a/test/mpi/f08/pt2pt/mprobef08.f90
+++ b/test/mpi/f08/pt2pt/mprobef08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer ierr, rank, size, count
       integer sendbuf(8), recvbuf(8)
       TYPE(MPI_Status) s1, s2

--- a/test/mpi/f08/pt2pt/prsendf08.f90
+++ b/test/mpi/f08/pt2pt/prsendf08.f90
@@ -9,6 +9,7 @@
 
       program prsend
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer ierr, errs
       logical mtestGetIntraComm
@@ -31,6 +32,7 @@
 !
       subroutine test_pair_prsend( comm, errs )
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer errs
       integer rank, size, ierr, next, prev, tag, count, index, i

--- a/test/mpi/f08/pt2pt/psendf08.f90
+++ b/test/mpi/f08/pt2pt/psendf08.f90
@@ -9,6 +9,7 @@
 
       program psend
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer ierr, errs
       logical mtestGetIntraComm
@@ -27,6 +28,7 @@
 !
       subroutine test_pair_psend( comm, errs )
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer errs
 

--- a/test/mpi/f08/pt2pt/pssendf08.f90
+++ b/test/mpi/f08/pt2pt/pssendf08.f90
@@ -9,6 +9,7 @@
 
       program pssend
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer ierr, errs
       logical mtestGetIntraComm
@@ -31,6 +32,7 @@
 !
       subroutine test_pair_pssend( comm, errs )
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer errs
       integer rank, size, ierr, next, prev, tag, count, index, i

--- a/test/mpi/f08/pt2pt/pt2pt_largef08.f90
+++ b/test/mpi/f08/pt2pt/pt2pt_largef08.f90
@@ -5,6 +5,7 @@
 
 program pt2pt_large
     use mpi_f08
+    implicit none
     integer:: ierr, errs
     integer, parameter:: BUFSIZE = 1024
     Type(MPI_Comm):: comm
@@ -35,6 +36,7 @@ program pt2pt_large
 
     contains
     subroutine init_sendbuf(buf)
+    implicit none
         integer, dimension(:), intent(inout) :: buf
         integer:: i
 
@@ -44,6 +46,7 @@ program pt2pt_large
     end subroutine
 
     subroutine init_recvbuf(buf)
+    implicit none
         integer, dimension(:), intent(inout) :: buf
         integer:: i
 
@@ -53,6 +56,7 @@ program pt2pt_large
     end subroutine
 
     subroutine check_recvbuf(buf, errs)
+    implicit none
         integer, dimension(:), intent(in) :: buf
         integer, intent(inout):: errs
         integer:: i

--- a/test/mpi/f08/pt2pt/rsendf08.f90
+++ b/test/mpi/f08/pt2pt/rsendf08.f90
@@ -10,6 +10,7 @@
 
       program rsend
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer ierr, errs
       logical mtestGetIntraComm
@@ -32,6 +33,7 @@
 !
       subroutine test_pair_rsend( comm, errs )
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer errs
       integer rank, size, ierr, next, prev, tag, count, i

--- a/test/mpi/f08/pt2pt/sendf08.f90
+++ b/test/mpi/f08/pt2pt/sendf08.f90
@@ -10,6 +10,7 @@
 
       program send
       use mpi_f08
+      implicit none
       integer ierr, errs
       type(MPI_Comm) comm
       logical mtestGetIntraComm
@@ -32,6 +33,7 @@
 !
       subroutine test_pair_send( comm, errs )
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer errs
 

--- a/test/mpi/f08/pt2pt/sendrecvf08.f90
+++ b/test/mpi/f08/pt2pt/sendrecvf08.f90
@@ -10,6 +10,7 @@
 
       program sendrecv
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer ierr, errs
       logical mtestGetIntraComm
@@ -32,6 +33,7 @@
 !
       subroutine test_pair_sendrecv( comm, errs )
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer errs
       integer rank, size, ierr, next, prev, tag, count

--- a/test/mpi/f08/pt2pt/sendrecvreplf08.f90
+++ b/test/mpi/f08/pt2pt/sendrecvreplf08.f90
@@ -10,6 +10,7 @@
 
       program sendrecvrepl
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer ierr, errs
       logical mtestGetIntraComm
@@ -32,6 +33,7 @@
 !
       subroutine test_pair_sendrecvrepl( comm, errs )
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer errs
       integer rank, size, ierr, next, prev, tag, count, i

--- a/test/mpi/f08/pt2pt/ssendf08.f90
+++ b/test/mpi/f08/pt2pt/ssendf08.f90
@@ -10,6 +10,7 @@
 
       program ssend
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer ierr, errs
       logical mtestGetIntraComm
@@ -32,6 +33,7 @@
 !
       subroutine test_pair_ssend( comm, errs )
       use mpi_f08
+      implicit none
       type(MPI_Comm) comm
       integer errs
       integer rank, size, ierr, next, prev, tag, count, i

--- a/test/mpi/f08/pt2pt/statusesf08.f90
+++ b/test/mpi/f08/pt2pt/statusesf08.f90
@@ -8,6 +8,7 @@
       program main
 !     Test support for MPI_STATUS_IGNORE and MPI_STATUSES_IGNORE
       use mpi_f08
+      implicit none
       integer nreqs
       parameter (nreqs = 100)
       TYPE(MPI_Request) reqs(nreqs)

--- a/test/mpi/f08/pt2pt/utilsf08.f90
+++ b/test/mpi/f08/pt2pt/utilsf08.f90
@@ -14,6 +14,7 @@
       subroutine msg_check( recv_buf, source, tag, count, status, n, &
       &                      name, errs )
       use mpi_f08
+      implicit none
       integer n, errs
       real    recv_buf(n)
       integer source, tag, count, rank
@@ -59,6 +60,7 @@
 !------------------------------------------------------------------------------
       subroutine rq_check( requests, n, msg )
       use mpi_f08
+      implicit none
       integer n
       type(MPI_Request) requests(n)
       character*(*) msg
@@ -77,6 +79,7 @@
 !
 !------------------------------------------------------------------------------
       subroutine init_test_data(buf,n)
+      implicit none
       integer n
       real buf(n)
       integer i
@@ -92,6 +95,7 @@
 !
 !------------------------------------------------------------------------------
       subroutine clear_test_data(buf, n)
+      implicit none
       integer n
       real buf(n)
       integer i
@@ -108,6 +112,7 @@
 !
 !------------------------------------------------------------------------------
       subroutine verify_test_data( buf, count, n, name, errs )
+      implicit none
       integer n, errs
       real buf(n)
       character *(*) name
@@ -138,6 +143,7 @@
 !    compiler.
 !
       subroutine dummyRef( a, n, ie )
+      implicit none
       integer n, ie
       real    a(n)
 ! This condition will never be true, but the compile won't know that

--- a/test/mpi/f08/rma/aintf08.f90
+++ b/test/mpi/f08/rma/aintf08.f90
@@ -9,6 +9,7 @@
 
 program main
     use mpi_f08
+    implicit none
     integer :: rank, nproc
     integer :: ierr, errs
     integer :: array(0:1023)

--- a/test/mpi/f08/rma/baseattrwinf08.f90
+++ b/test/mpi/f08/rma/baseattrwinf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
 
       logical flag

--- a/test/mpi/f08/rma/c2f2cwinf08.f90
+++ b/test/mpi/f08/rma/c2f2cwinf08.f90
@@ -9,6 +9,7 @@
 !
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr
       integer wrank, wsize
       integer wgroup, info, req

--- a/test/mpi/f08/rma/winaccf08.f90
+++ b/test/mpi/f08/rma/winaccf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer ierr, errs
       integer intsize
       TYPE(MPI_Win) win

--- a/test/mpi/f08/rma/winattr2f08.f90
+++ b/test/mpi/f08/rma/winattr2f08.f90
@@ -10,6 +10,7 @@
 !
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
 

--- a/test/mpi/f08/rma/winattrf08.f90
+++ b/test/mpi/f08/rma/winattrf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
 
@@ -150,6 +151,7 @@
       subroutine mycopyfn( oldwin, keyval, extrastate, valin, valout, &
       &                     flag, ierr )
       use mpi_f08
+      implicit none
       type(MPI_Win) oldwin
       integer keyval, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
@@ -169,6 +171,7 @@
 !
       subroutine mydelfn( win, keyval, val, extrastate, ierr )
       use mpi_f08
+      implicit none
       type(MPI_Win) win
       integer  keyval, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val

--- a/test/mpi/f08/rma/winerrf08.f90
+++ b/test/mpi/f08/rma/winerrf08.f90
@@ -7,6 +7,7 @@
 
        program main
        use mpi_f08
+       implicit none
        integer errs, ierr, code(2), newerrclass, eclass
        character*(MPI_MAX_ERROR_STRING) errstring
        integer rlen, intsize
@@ -117,6 +118,7 @@
 !
        subroutine myerrhanfunc( win, errcode )
        use mpi_f08
+       implicit none
        type(MPI_Win) win
        integer errcode
        integer rlen, ierr

--- a/test/mpi/f08/rma/winfencef08.f90
+++ b/test/mpi/f08/rma/winfencef08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer ierr, errs
       integer intsize
       TYPE(MPI_Win) win

--- a/test/mpi/f08/rma/wingetf08.f90
+++ b/test/mpi/f08/rma/wingetf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer ierr, errs
       integer intsize
       TYPE(MPI_Win) win

--- a/test/mpi/f08/rma/wingroupf08.f90
+++ b/test/mpi/f08/rma/wingroupf08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer ierr, errs
       integer buf(10)
       integer result, intsize

--- a/test/mpi/f08/rma/winnamef08.f90
+++ b/test/mpi/f08/rma/winnamef08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr
       integer rlen, ln
       TYPE(MPI_Win) win

--- a/test/mpi/f08/rma/winscale1f08.f90
+++ b/test/mpi/f08/rma/winscale1f08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer ierr, errs
       integer intsize
       TYPE(MPI_Win) win

--- a/test/mpi/f08/rma/winscale2f08.f90
+++ b/test/mpi/f08/rma/winscale2f08.f90
@@ -7,6 +7,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer ierr, errs
       integer intsize
       TYPE(MPI_Win) win

--- a/test/mpi/f08/spawn/connaccf90.f90
+++ b/test/mpi/f08/spawn/connaccf90.f90
@@ -5,6 +5,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer size, rank, ierr, errs, eclass
       integer color
       type(MPI_Comm) comm, intercomm

--- a/test/mpi/f08/spawn/namepubf90.f90
+++ b/test/mpi/f08/spawn/namepubf90.f90
@@ -5,6 +5,7 @@
 
       program main
       use mpi_f08
+      implicit none
       integer errs
       character*(MPI_MAX_PORT_NAME) port_name
       character*(MPI_MAX_PORT_NAME) port_name_out

--- a/test/mpi/f08/spawn/spawnargvf03.f90
+++ b/test/mpi/f08/spawn/spawnargvf03.f90
@@ -7,8 +7,8 @@
 !  Fortran 2003
 !
         program main
-!     declared on the old sparc compilers
         use mpi_f08
+        implicit none
         integer errs, err
         integer rank, size, rsize, i
         integer np

--- a/test/mpi/f08/spawn/spawnargvf90.f90
+++ b/test/mpi/f08/spawn/spawnargvf90.f90
@@ -17,6 +17,7 @@
         character*(10) inargv(6), outargv(6)
         character*(80)   argv(64)
         integer argc
+        integer iargc
         data inargv /"a", "b=c", "d e", "-pf", " Ss", " " /
         data outargv /"a", "b=c", "d e", "-pf", " Ss", " " /
         integer ierr

--- a/test/mpi/f08/spawn/spawnargvf90.f90
+++ b/test/mpi/f08/spawn/spawnargvf90.f90
@@ -6,8 +6,8 @@
 ! This is a special test that requires an getarg/iargc routine
 !
         program main
-!     declared on the old sparc compilers
         use mpi_f08
+        implicit none
         integer errs, err
         integer rank, size, rsize, i
         integer np

--- a/test/mpi/f08/spawn/spawnf90.f90
+++ b/test/mpi/f08/spawn/spawnf90.f90
@@ -5,6 +5,7 @@
 
         program main
         use mpi_f08
+        implicit none
         integer errs, err
         integer rank, size, rsize, i
         integer np

--- a/test/mpi/f08/spawn/spawnmult2f90.f90
+++ b/test/mpi/f08/spawn/spawnmult2f90.f90
@@ -9,6 +9,7 @@
 !
        program main
        use mpi_f08
+       implicit none
        integer (kind=MPI_ADDRESS_KIND) aint
 
        integer errs, err

--- a/test/mpi/f08/spawn/spawnmultf03.f90
+++ b/test/mpi/f08/spawn/spawnmultf03.f90
@@ -7,8 +7,8 @@
 ! command-line options.
 !
        program main
-!     declared on the old sparc compilers
        use mpi_f08
+       implicit none
        integer errs, err
        integer rank, size, rsize, wsize, i
        integer np(2)

--- a/test/mpi/f08/spawn/spawnmultf90.f90
+++ b/test/mpi/f08/spawn/spawnmultf90.f90
@@ -8,8 +8,8 @@
 ! command-line options.
 !
        program main
-!     declared on the old sparc compilers
        use mpi_f08
+       implicit none
        integer errs, err
        integer rank, size, rsize, wsize, i
        integer np(2)

--- a/test/mpi/f08/spawn/spawnmultf90.f90
+++ b/test/mpi/f08/spawn/spawnmultf90.f90
@@ -21,6 +21,7 @@
        character*(30) cmds(2)
        character*(80) argv(64)
        integer argc
+       integer iargc
        integer ierr
        integer can_spawn
 !

--- a/test/mpi/f08/topo/cartcrf90.f90
+++ b/test/mpi/f08/topo/cartcrf90.f90
@@ -8,6 +8,7 @@
 !
       program main
       use mpi_f08
+      implicit none
       integer errs, ierr
       integer ndims, nperiods, i, size
       integer source, dest

--- a/test/mpi/f08/topo/dgraph_unwgtf90.f90
+++ b/test/mpi/f08/topo/dgraph_unwgtf90.f90
@@ -9,7 +9,7 @@
 
       logical function validate_dgraph(dgraph_comm)
       use mpi_f08
-
+      implicit none
       type(MPI_Comm) dgraph_comm
       integer     comm_topo
       integer     src_sz, dest_sz
@@ -90,6 +90,7 @@
       end
 
       integer function ring_rank(world_size, in_rank)
+      implicit none
       integer world_size, in_rank
       if (in_rank .ge. 0 .and. in_rank .lt. world_size) then
           ring_rank = in_rank
@@ -111,7 +112,7 @@
 
       program dgraph_unwgt
       use mpi_f08
-
+      implicit none
       integer    ring_rank
       external   ring_rank
       logical    validate_dgraph

--- a/test/mpi/f08/topo/dgraph_wgtf90.f90
+++ b/test/mpi/f08/topo/dgraph_wgtf90.f90
@@ -9,7 +9,7 @@
 
       logical function validate_dgraph(dgraph_comm)
       use mpi_f08
-
+      implicit none
       type(MPI_Comm)  dgraph_comm
       integer     comm_topo
       integer     src_sz, dest_sz
@@ -103,6 +103,7 @@
       end
 
       integer function ring_rank(world_size, in_rank)
+      implicit none
       integer world_size, in_rank
       if (in_rank .ge. 0 .and. in_rank .lt. world_size) then
           ring_rank = in_rank
@@ -124,7 +125,7 @@
 
       program dgraph_unwgt
       use mpi_f08
-
+      implicit none
       integer    ring_rank
       external   ring_rank
       logical    validate_dgraph

--- a/test/mpi/f77/attr/commattr4f.f
+++ b/test/mpi/f77/attr/commattr4f.f
@@ -4,6 +4,7 @@ C     See COPYRIGHT in top-level directory
 C
 
       program main
+      implicit none
 C
       include 'mpif.h'
 

--- a/test/mpi/f77/comm/commerrf.f
+++ b/test/mpi/f77/comm/commerrf.f
@@ -12,6 +12,7 @@ C
        external myerrhanfunc
 CF90   INTERFACE 
 CF90   SUBROUTINE myerrhanfunc(vv0,vv1)
+CF90   IMPLICIT NONE
 CF90   INTEGER vv0,vv1
 CF90   END SUBROUTINE
 CF90   END INTERFACE

--- a/test/mpi/f77/datatype/allctypesf.f
+++ b/test/mpi/f77/datatype/allctypesf.f
@@ -4,6 +4,7 @@ C     See COPYRIGHT in top-level directory
 C
 
       program main
+      implicit none
       include 'mpif.h'
       integer atype, ierr
 C
@@ -89,6 +90,7 @@ C
 C
 C Check name of datatype
       subroutine CheckDtype( intype, name, ierr )
+      implicit none
       include 'mpif.h'
       integer intype, ierr
       character *(*) name
@@ -113,6 +115,7 @@ C
 C
 C Check name of datatype (allows alias)
       subroutine CheckDtype2( intype, name, name2, ierr )
+      implicit none
       include 'mpif.h'
       integer intype, ierr
       character *(*) name, name2

--- a/test/mpi/f77/ext/ctypesinf.f
+++ b/test/mpi/f77/ext/ctypesinf.f
@@ -4,6 +4,7 @@ C     See COPYRIGHT in top-level directory
 C
 
       program main
+      implicit none
       include 'mpif.h'
       integer ierr
       integer errs, wrank

--- a/test/mpi/f77/io/fileerrf.f
+++ b/test/mpi/f77/io/fileerrf.f
@@ -14,6 +14,7 @@ C
        external myerrhanfunc
 CF90   INTERFACE 
 CF90   SUBROUTINE myerrhanfunc(vv0,vv1)
+CF90   IMPLICIT NONE
 CF90   INTEGER vv0,vv1
 CF90   END SUBROUTINE
 CF90   END INTERFACE

--- a/test/mpi/f77/profile/profile1f.f
+++ b/test/mpi/f77/profile/profile1f.f
@@ -4,6 +4,7 @@ C     See COPYRIGHT in top-level directory
 C
 
        program main
+      implicit none
        include "mpif.h"
        integer ierr
        integer smsg(3), rmsg(3), toterrs, wsize, wrank
@@ -56,6 +57,7 @@ C
        end
 C
        subroutine mpi_send( smsg, count, dtype, dest, tag, comm, ierr )
+      implicit none
        include "mpif.h"
        integer count, dtype, dest, tag, comm, ierr
        integer smsg(count)
@@ -70,6 +72,7 @@ C
 C
       subroutine mpi_recv( rmsg, count, dtype, src, tag, comm, status,
      $     ierr ) 
+      implicit none
        include "mpif.h"
        integer count, dtype, src, tag, comm, status(MPI_STATUS_SIZE),
      $      ierr 
@@ -84,6 +87,7 @@ C
        end
 C
        subroutine init_counts()
+      implicit none
        common /myinfo/ calls, amount, rcalls, ramount
        integer calls, amount, rcalls, ramount
        calls = 0
@@ -93,6 +97,7 @@ C
        end
 C
        subroutine mpi_pcontrol( ierr )
+      implicit none
        integer ierr
        return
        end

--- a/test/mpi/f77/pt2pt/dummyf.f
+++ b/test/mpi/f77/pt2pt/dummyf.f
@@ -12,6 +12,7 @@ C F90 case it is, because in that case, extrastate is defined as an
 C integer (kind=MPI_ADDRESS_KIND), and the script that creates the
 C F90 tests from the F77 tests looks for mpif.h
       subroutine dummyupdate( extrastate )
+      implicit none
       include 'mpif.h'
       include 'attr1aints.h'
       end

--- a/test/mpi/f77/pt2pt/utilsf.f
+++ b/test/mpi/f77/pt2pt/utilsf.f
@@ -55,6 +55,7 @@ C  Check that requests have been set to null
 C
 C------------------------------------------------------------------------------
       subroutine rq_check( requests, n, msg )
+      implicit none
       include 'mpif.h'
       integer n, requests(n)
       character*(*) msg
@@ -73,6 +74,7 @@ C  Initialize test data buffer with integral sequence.
 C
 C------------------------------------------------------------------------------
       subroutine init_test_data(buf,n)
+      implicit none
       integer n
       real buf(n)
       integer i
@@ -88,6 +90,7 @@ C  Clear test data buffer
 C
 C------------------------------------------------------------------------------
       subroutine clear_test_data(buf, n)
+      implicit none
       integer n
       real buf(n)
       integer i
@@ -136,6 +139,7 @@ C    codes).  Without this, for example, tests fail with the Cray ftn
 C    compiler.
 C
       subroutine dummyRef( a, n, ie )
+      implicit none
       integer n, ie
       real    a(n)
 C This condition will never be true, but the compile won't know that

--- a/test/mpi/f77/rma/winerrf.f
+++ b/test/mpi/f77/rma/winerrf.f
@@ -14,6 +14,7 @@ C
        external myerrhanfunc
 CF90   INTERFACE 
 CF90   SUBROUTINE myerrhanfunc(vv0,vv1)
+CF90   IMPLICIT NONE
 CF90   INTEGER vv0,vv1
 CF90   END SUBROUTINE
 CF90   END INTERFACE

--- a/test/mpi/f77/spawn/spawnargvf.f
+++ b/test/mpi/f77/spawn/spawnargvf.f
@@ -6,9 +6,7 @@ C
 C This is a special test that requires an getarg/iargc routine 
 C
         program main
-C     This implicit none is removed here because the iargc was not
-C     declared on the old sparc compilers
-C       implicit none
+      implicit none
         include 'mpif.h'
         integer errs, err
         integer rank, size, rsize, i

--- a/test/mpi/f77/spawn/spawnargvf.f
+++ b/test/mpi/f77/spawn/spawnargvf.f
@@ -17,6 +17,7 @@ C
         character*(10) inargv(6), outargv(6)
         character*(80)   argv(64)
         integer argc
+        integer iargc
         data inargv /"a", "b=c", "d e", "-pf", " Ss", " " /
         data outargv /"a", "b=c", "d e", "-pf", "Ss", " " /
         integer ierr

--- a/test/mpi/f77/spawn/spawnmultf.f
+++ b/test/mpi/f77/spawn/spawnmultf.f
@@ -21,6 +21,7 @@ C
        character*(30) cmds(2)
        character*(80) argv(64)
        integer argc
+       integer iargc
        integer ierr
        integer can_spawn
 C

--- a/test/mpi/f77/spawn/spawnmultf.f
+++ b/test/mpi/f77/spawn/spawnmultf.f
@@ -8,9 +8,7 @@ C This tests spawn_mult by using the same executable but different
 C command-line options.
 C
        program main
-C     This implicit none is removed here because the iargc was not
-C     declared on the old sparc compilers
-C       implicit none
+      implicit none
        include 'mpif.h'
        integer errs, err
        integer rank, size, rsize, wsize, i

--- a/test/mpi/f90/attr/attrlangf90.f90
+++ b/test/mpi/f90/attr/attrlangf90.f90
@@ -89,6 +89,7 @@
 ! interfaces to the C routines
       module keyvals
         use mpi, only: MPI_ADDRESS_KIND
+        implicit none
         logical fverbose, useintSize
         integer ptrSize, intSize, aintSize
         integer fcomm1_key, fcomm1_extra
@@ -100,35 +101,44 @@
              & fwin2_extra
         interface
            pure function bigint()
+           implicit none
              integer bigint
            end function bigint
            pure function bigaint()
              use mpi, only : MPI_ADDRESS_KIND
+             implicit none
              integer (kind=MPI_ADDRESS_KIND) bigaint
            end function bigaint
            ! Could use bind(c) once we require that level of Fortran support.
            subroutine csetmpi( fcomm, fkey, val, errs ) 
+           implicit none
              integer, INTENT(IN) :: fcomm, fkey, val
              integer errs
            end subroutine csetmpi
            subroutine csetmpi2( fcomm, fkey, val, errs ) 
              use mpi, only : MPI_ADDRESS_KIND
+             implicit none
              integer, INTENT(IN) :: fcomm, fkey
              integer  errs
              integer (KIND=MPI_ADDRESS_KIND) val
            end subroutine csetmpi2
            subroutine cattrinit( fv )
+           implicit none
              integer fv
            end subroutine cattrinit
            subroutine cgetsizes( ps, is, as )
+           implicit none
              integer, INTENT(OUT) :: ps, is, as
            end subroutine cgetsizes
            subroutine ccreatekeys( k1, k2, k3, k4 )
+           implicit none
              integer, INTENT(OUT) :: k1, k2, k3, k4
            end subroutine ccreatekeys
            subroutine cfreekeys()
+           implicit none
            end subroutine cfreekeys
            subroutine ctoctest( errs )
+           implicit none
              integer errs
            end subroutine ctoctest
         end interface
@@ -247,6 +257,7 @@
 ! -------------------------------------------------------------------
       integer function FMPI1checkCommAttr( comm, key, expected, msg )
       use mpi
+      implicit none
       integer comm, key, expected
       character*(*) msg
       integer value, ierr
@@ -274,6 +285,7 @@
            & outval, flag, ierr )  
       use mpi
       use keyvals, only : fverbose
+      implicit none
       integer oldcomm, key, extrastate, inval, outval, ierr
       logical flag
 !
@@ -290,6 +302,7 @@
      &     ierr ) 
       use mpi
       use keyvals, only : fverbose
+      implicit none
       integer oldcomm, key, extrastate, inval, ierr
       logical flag
 !
@@ -875,6 +888,7 @@
 ! -------------------------------------------------------------------
 ! Return an integer value that fills all of the bytes
       pure integer function bigint()
+      implicit none
         integer i, v, digits
         digits = range(i)
         v = 0

--- a/test/mpi/f90/attr/baseattr3f90.f90
+++ b/test/mpi/f90/attr/baseattr3f90.f90
@@ -8,6 +8,7 @@
 ! an INTEGER.
         program main
         use mpi
+        implicit none
         integer ierr, errs
         logical flag
         integer commsize, commrank

--- a/test/mpi/f90/attr/fandcattrf90.f90
+++ b/test/mpi/f90/attr/fandcattrf90.f90
@@ -10,6 +10,7 @@
 !
       program main
       use mpi
+      implicit none
       integer (kind=MPI_ADDRESS_KIND) val
       integer ierr, errs, fcomm2_keyval, ftype2_keyval
       integer ccomm2_keyval, ctype2_keyval, cwin2_keyval
@@ -54,6 +55,7 @@
       subroutine mycopyfn( oldcomm, keyval, extrastate, valin, valout, &
       &                     flag, ierr )
       use mpi
+      implicit none
       integer oldcomm, keyval, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
 
@@ -75,6 +77,7 @@
 !
       subroutine mydelfn( comm, keyval, val, extrastate, ierr )
       use mpi
+      implicit none
       integer comm, keyval, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
 
@@ -92,6 +95,7 @@
       subroutine mytcopyfn( oldtype, keyval, extrastate, valin, valout, &
       &                     flag, ierr )
       use mpi
+      implicit none
       integer oldtype, keyval, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
 
@@ -113,6 +117,7 @@
 !
       subroutine mytdelfn( dtype, keyval, val, extrastate, ierr )
       use mpi
+      implicit none
       integer dtype, keyval, ierr
       integer (kind=MPI_ADDRESS_KIND) extrastate, valin, valout, val
 

--- a/test/mpi/f90/datatype/createf90.f90
+++ b/test/mpi/f90/datatype/createf90.f90
@@ -5,6 +5,7 @@
 
         program main
         use mpi
+        implicit none
         integer ierr
         integer errs
         integer nints, nadds, ndtypes, combiner

--- a/test/mpi/f90/datatype/kinds.f90
+++ b/test/mpi/f90/datatype/kinds.f90
@@ -8,6 +8,7 @@
 !
   program main
   use mpi
+  implicit none
   integer (kind=MPI_ADDRESS_KIND) aint, taint
   integer (kind=MPI_OFFSET_KIND) oint, toint
   integer (kind=MPI_INTEGER_KIND) iint, tiint

--- a/test/mpi/f90/datatype/sizeof.f90
+++ b/test/mpi/f90/datatype/sizeof.f90
@@ -9,6 +9,7 @@
 !
       program main
       use mpi
+      implicit none
       integer ierr, errs
       integer rank, size, mpisize
       logical verbose

--- a/test/mpi/f90/io/Makefile.ap
+++ b/test/mpi/f90/io/Makefile.ap
@@ -8,10 +8,11 @@ $(srcdir)/ioharness.defn: $(srcdir)/../../f77/io/ioharness.defn
 	-e 's/include.*iooffset.*/integer (kind=MPI_OFFSET_KIND)offset/g' \
 	$(srcdir)/../../f77/io/ioharness.defn > $(srcdir)/ioharness.defn
 $(srcdir)/ioharness.tlt: $(srcdir)/../../f77/io/ioharness.tlt
-	sed -e 's/include.*mpif.*/use mpi/g' \
+	sed -e '/implicit *none/d' \
+	    -e 's/include.*mpif.*/use mpi\
+        implicit none/g' \
 	    -e 's/fheader/f90header/g' \
 	    -e 's/^C/!/g' \
-	    -e '/implicit *none/d' \
 	$(srcdir)/../../f77/io/ioharness.tlt > $(srcdir)/ioharness.tlt
 c2f902cio.c: $(srcdir)/../../f90/io/c2f902cio.c
 	cp $(srcdir)/../../f90/io/c2f902cio.c c2f902cio.c

--- a/test/mpi/f90/misc/alloc_mem.f90
+++ b/test/mpi/f90/misc/alloc_mem.f90
@@ -6,6 +6,7 @@
 program main
     use mpi
     use, intrinsic :: iso_c_binding
+    implicit none
     integer ierr, errs
     integer(kind=MPI_ADDRESS_KIND) :: sz
     type(c_ptr) :: baseptr

--- a/test/mpi/f90/misc/sizeof2.f90
+++ b/test/mpi/f90/misc/sizeof2.f90
@@ -5,6 +5,7 @@
 
         program main
           use mpi
+          implicit none
           integer ierr, errs
           integer size1, size2
           real    a

--- a/test/mpi/f90/spawn/spawnargvf03.f90
+++ b/test/mpi/f90/spawn/spawnargvf03.f90
@@ -7,8 +7,8 @@
 !  Fortran 2003
 !
         program main
-!     declared on the old sparc compilers
         use mpi
+        implicit none
         integer errs, err
         integer rank, size, rsize, i
         integer np

--- a/test/mpi/f90/spawn/spawnmultf03.f90
+++ b/test/mpi/f90/spawn/spawnmultf03.f90
@@ -7,8 +7,8 @@
 ! command-line options.
 !
        program main
-!     declared on the old sparc compilers
        use mpi
+       implicit none
        integer errs, err
        integer rank, size, rsize, wsize, i
        integer np(2)

--- a/test/mpi/maint/f77tof90
+++ b/test/mpi/maint/f77tof90
@@ -131,19 +131,20 @@ sub ConvertToF90 {
     print OUTF "! This file created from $infile with f77tof90\n";
     my $lastline = "";
     my $firstline = 1;
-    my $scope = ""; # program or subroutine
+    my $scope = ""; # program, subroutine, or function
+    my $pending_implicit_none = "";
     while (<INF>) {
 	if (/\r/) { $newline = "\r\n"; }
 	# Remove any end-of-line characters
 	s/[\r\n]*//g;
-        if (/^\s*(program|subroutine)\s*(\w+)/i) {
+        my $is_fixed_comment = /^[Cc*!]/;
+        if (!$is_fixed_comment &&
+            /^\s*(?:\w+\s+)*(program|subroutine|function|block\s+data)\s*(\w+)/i) {
             $scope = lc($1) . " " . lc($2);
+            $pending_implicit_none = "";
         }
-        # The implicit none must not come before the use mpi statement,
-	# but in F77, it must come before the include mpif.h statement.
-	# Rather than try and fix this, rely on the F77 versions to 
-	# catch undeclared variables
-        if (/IMPLICIT\s+NONE/i) {
+        if (/^\s*IMPLICIT\s+NONE/i) {
+            $pending_implicit_none = $_;
             next;
         }
 	if (/^(\s*)include\s+[\'\"]mpif\.h/) {
@@ -152,6 +153,10 @@ sub ConvertToF90 {
                 $_ = $sp . "use mpi, skip_$1 => $1";
             } else {
                 $_ = $sp . "use mpi";
+            }
+            if ($pending_implicit_none ne "") {
+                $_ .= $newline . $pending_implicit_none;
+                $pending_implicit_none = "";
             }
 	}
 	# Allow the insertion of Fortran 90 only statements, such as
@@ -172,6 +177,10 @@ sub ConvertToF90 {
 	    s/^C/!/;
 	    s/^c/!/;
 	}	
+        if ($pending_implicit_none ne "" && ! /^\s*($|!)/) {
+            $_ = $pending_implicit_none . $newline . $_;
+            $pending_implicit_none = "";
+        }
 	# Update the special includes that are used to provide 
 	# address or offset sized types with ones the use the
 	# Fortran90 KIND style

--- a/test/mpi/util/mtest_f08.f90
+++ b/test/mpi/util/mtest_f08.f90
@@ -6,6 +6,7 @@
         subroutine MTest_Init( ierr )
 
         use mpi_f08
+        implicit none
         integer ierr
         logical flag
         logical dbgflag
@@ -23,6 +24,7 @@
 !
         subroutine MTest_Finalize( errs )
         use mpi_f08
+        implicit none
         integer errs
         integer rank, toterrs, ierr
 
@@ -45,6 +47,7 @@
 ! A simple get intracomm for now
         logical function MTestGetIntracomm( comm, min_size, qsmaller )
         use mpi_f08
+        implicit none
         integer ierr
         integer min_size, size, rank
         TYPE(MPI_Comm) comm
@@ -74,6 +77,7 @@
 !
         subroutine MTestFreeComm( comm )
         use mpi_f08
+        implicit none
         integer ierr
         TYPE(MPI_Comm) comm
         if (comm .ne. MPI_COMM_WORLD .and. &
@@ -85,6 +89,7 @@
 !
         subroutine MTestPrintError( errcode )
         use mpi_f08
+        implicit none
         integer errcode
         integer errclass, slen, ierr
         character*(MPI_MAX_ERROR_STRING) string
@@ -96,6 +101,7 @@
 !
         subroutine MTestPrintErrorMsg( msg, errcode )
         use mpi_f08
+        implicit none
         character*(*) msg
         integer errcode
         integer errclass, slen, ierr
@@ -109,6 +115,7 @@
 
         subroutine MTestSpawnPossible( can_spawn, errs )
         use mpi_f08
+        implicit none
         integer can_spawn
         integer errs
         integer(kind=MPI_ADDRESS_KIND) val

--- a/test/mpi/util/mtest_f90.f90
+++ b/test/mpi/util/mtest_f90.f90
@@ -11,6 +11,7 @@
 !       the module is in a different place, the compiler can complain
 !       about out-of-order statements
         use mpi
+        implicit none
         integer ierr
         logical flag
         logical dbgflag
@@ -28,6 +29,7 @@
 !
         subroutine MTest_Finalize( errs )
         use mpi
+        implicit none
         integer errs
         integer rank, toterrs, ierr
         
@@ -50,6 +52,7 @@
 ! A simple get intracomm for now
         logical function MTestGetIntracomm( comm, min_size, qsmaller )
         use mpi
+        implicit none
         integer ierr
         integer comm, min_size, size, rank
         logical qsmaller
@@ -78,6 +81,7 @@
 !
         subroutine MTestFreeComm( comm )
         use mpi
+        implicit none
         integer comm, ierr
         if (comm .ne. MPI_COMM_WORLD .and. &
       &      comm .ne. MPI_COMM_SELF  .and. &
@@ -88,6 +92,7 @@
 !
         subroutine MTestPrintError( errcode )
         use mpi
+        implicit none
         integer errcode
         integer errclass, slen, ierr
         character*(MPI_MAX_ERROR_STRING) string
@@ -99,6 +104,7 @@
 !
         subroutine MTestPrintErrorMsg( msg, errcode )
         use mpi
+        implicit none
         character*(*) msg
         integer errcode
         integer errclass, slen, ierr
@@ -112,6 +118,7 @@
 
         subroutine MTestSpawnPossible( can_spawn, errs )
         use mpi
+        implicit none
         integer can_spawn
         integer errs
         integer(kind=MPI_ADDRESS_KIND) val


### PR DESCRIPTION
Goal: address issue #6318 by making the Fortran MPI tests require explicit declarations across the f77, f90, f08, errors, and shared utility test sources.

Reasoning: without `implicit none`, missing or misspelled MPI Fortran names can compile as implicit variables, which hides coverage gaps. The F77-to-F90 converter and F90 IO harness generation were updated so generated sources keep the correct declaration order: F77 keeps `implicit none` before mpif.h includes, while generated F90 emits use mpi before implicit none.

Verification: regenerated MPICH with `./autogen.sh`, configured with `CC=gcc CXX=g++ FC=gfortran F77=gfortran ../configure --with-device=ch4:ofi --with-libfabric=embedded --enable-g --enable-f77 --enable-f90 --enable-f08`, built with `make -j50`, and installed locally. Regenerated test metadata with `./autogen.sh -do=test`, configured the MPI test suite against the local install, forced the F90 IO harness generation path, and verified the test suite builds with `make -j50` in build-gcc-ch4-ofi-g/test/mpi-verify-4. Also ran `git diff --check -- test/mpi` and a structural scan that reported files 337 missing 0.

Context: the F90 IO harness output is generated and ignored, so this commit changes the tracked generator rule instead of committing generated files. Local build, install, log, and generated wrapper outputs are intentionally left untracked.

## Pull Request Description

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [ ] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.

Resolves #6318.