### PR TITLE
Fortran: fix mapping of Fortran REAL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3486,7 +3486,7 @@ if test "$enable_f77" = "yes" ; then
     len=`expr $pac_cv_f77_sizeof_integer \* 8`
     AC_DEFINE_UNQUOTED([MPIR_INTEGER_INTERNAL],       [MPIR_INT$len], [Internal type for MPI_INTEGER])
     len=`expr $pac_cv_f77_sizeof_real \* 8`
-    AC_DEFINE_UNQUOTED([MPIR_REAL_INTERNAL],          [MPIR_INT$len], [Internal type for MPI_REAL])
+    AC_DEFINE_UNQUOTED([MPIR_REAL_INTERNAL],          [MPIR_FLOAT$len], [Internal type for MPI_REAL])
     len=`expr $pac_cv_f77_sizeof_logical \* 8`
     AC_DEFINE_UNQUOTED([MPIR_LOGICAL_INTERNAL],       [MPIR_FORTRAN_LOGICAL$len], [Internal type for MPI_LOGICAL])
     len=`expr $pac_cv_f77_sizeof_real \* 8`

--- a/test/mpi/f77/coll/Makefile.am
+++ b/test/mpi/f77/coll/Makefile.am
@@ -9,4 +9,4 @@ include $(top_srcdir)/Makefile_f77.mtest
 # avoid having to write many "foo_SOURCES = foo.f" lines
 AM_DEFAULT_SOURCE_EXT = .f
 
-noinst_PROGRAMS = uallreducef exscanf alltoallwf inplacef allredint8f allredopttf reducelocalf alltoallvf redscatf split_typef nonblockingf vw_inplacef red_scat_blockf nonblocking_inpf
+noinst_PROGRAMS = uallreducef exscanf alltoallwf inplacef allredint8f allredopttf reducelocalf alltoallvf redscatf split_typef nonblockingf vw_inplacef red_scat_blockf nonblocking_inpf reducef

--- a/test/mpi/f77/coll/reducef.f
+++ b/test/mpi/f77/coll/reducef.f
@@ -1,0 +1,76 @@
+C
+C Copyright (C) by Argonne National Laboratory
+C     See COPYRIGHT in top-level directory
+C
+
+C
+C Test MPI_REDUCE with various builtin types
+C
+C This test catches potential internal datatype mapping issues.
+C
+
+      program main
+      implicit none
+      include 'mpif.h'
+
+      integer rank, comm, size
+      integer errs, ierr
+      integer val_i, sum_i, ans_i
+      real val_f, sum_f, ans_f
+      double precision val_d, sum_d, ans_d
+
+      errs = 0
+
+      call mtest_init(ierr)
+      comm = MPI_COMM_WORLD
+      call MPI_Comm_rank(comm, rank, ierr)
+      call MPI_Comm_size(comm, size, ierr)
+
+C ---- INTEGER ----
+      val_i = real(rank + 1)
+
+      call MPI_REDUCE(val_i, sum_i, 1, MPI_INTEGER, MPI_SUM, 0, comm,
+     & ierr)
+
+      if (rank .eq. 0) then
+         ans_i = size * (size + 1) / 2
+         if (sum_i .ne. ans_i) then
+            errs = errs + 1
+            print *, 'MPI_Reduce on INTEGER: unexpected value'
+            print *, '    Got ', sum_i, ', Expect ', ans_i
+         endif
+      endif
+
+C ---- REAL ----
+      val_f = real(rank + 1)
+
+      call MPI_REDUCE(val_f, sum_f, 1, MPI_REAL, MPI_SUM,
+     &     0, comm, ierr)
+
+      if (rank .eq. 0) then
+         ans_f = real(size * (size + 1) / 2)
+         if (abs(sum_f - ans_f) .gt. 1.0e-4) then
+            errs = errs + 1
+            print *, 'MPI_Reduce on REAL: unexpected value'
+            print *, '    Got ', sum_f, ', Expect ', ans_f
+         endif
+      endif
+
+C ---- DOUBLE PRECISION ----
+      val_d = dble(rank + 1)
+
+      call MPI_REDUCE(val_d, sum_d, 1, MPI_DOUBLE_PRECISION, MPI_SUM,
+     & 0, comm, ierr)
+
+      if (rank .eq. 0) then
+         ans_d = dble(size * (size + 1) / 2)
+         if (abs(sum_d - ans_d) .gt. 1.0e-4) then
+            errs = errs + 1
+            print *, 'MPI_Reduce on DOUBLE PREC: '
+     &           //'unexpected value'
+            print *, '    Got ', sum_d, ', Expect ', ans_d
+         endif
+      endif
+
+      call mtest_finalize(errs)
+      end

--- a/test/mpi/f77/coll/testlist
+++ b/test/mpi/f77/coll/testlist
@@ -10,3 +10,4 @@ nonblockingf 4
 vw_inplacef 4
 red_scat_blockf 4
 nonblocking_inpf 4
+reducef 4


### PR DESCRIPTION
## Pull Request Description
Fix a typo in configure resulted mapping Fortran `REAL` to internal `MPIR_INT32`.

Add a test cover future mapping issues.

Fixes #7911
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
