### PR TITLE
config: fix issues in weak symbol support

### DIFF
--- a/confdb/aclocal_cc.m4
+++ b/confdb/aclocal_cc.m4
@@ -229,6 +229,7 @@ int Weak_Fn_B(int); int Fn_B(int);
 #pragma weak Weak_Fn_B = Fn_B
 int Fn_A(int a) { return a; }
 int Fn_B(int a) { return a; }
+int check(int a) { return Weak_Fn_A(a); }
         ])],[
         AC_LANG_SOURCE([
 int Weak_Fn_A(int);
@@ -244,7 +245,7 @@ int main(int argc, char **argv) { return Weak_Fn_A(0) + Weak_Fn_B(0);}
             int Foo(int a) { return a; }
         ]],[[
             return PFoo(1);
-        ]])],pac_cv_prog_c_weak_symbols="pragma _HP_SECONDARY_DEF")
+        ]])],pac_cv_prog_c_weak_symbols="pragma _HP")
     fi
     dnl -------------------------------------
     if test -z "$pac_cv_prog_c_weak_symbols" ; then
@@ -254,22 +255,7 @@ int main(int argc, char **argv) { return Weak_Fn_A(0) + Weak_Fn_B(0);}
             int Foo(int a) { return a; }
         ]],[[
             return PFoo(1);
-        ]])],pac_cv_prog_c_weak_symbols="pragma _CRI duplicate x as y")
-    fi
-    dnl -------------------------------------
-    if test -z "$pac_cv_prog_c_weak_symbols" ; then 
-        PAC_COMPLINK_IFELSE(
-            [AC_LANG_SOURCE([[
-                int Foo(int a);
-                int PFoo(int) __attribute__ ((weak,alias("Foo")));
-                int Foo(int a) { return a; }
-            ]])],
-            [AC_LANG_PROGRAM([[
-                int PFoo(int);
-            ]],[[
-                return PFoo(1);
-            ]])],
-            pac_cv_prog_c_weak_symbols="attribute alias")
+        ]])],pac_cv_prog_c_weak_symbols="pragma _CRI")
     fi
     dnl -------------------------------------
     if test -z "$pac_cv_prog_c_weak_symbols" ; then 
@@ -1281,7 +1267,7 @@ dnl is not declared in a header, this will fail.  Use a non-static global so
 dnl the compiler does not warn about an unused variable.
 dnl
 dnl Simply calling the function is not enough because C89 compilers allow
-dnl calls to implicitly-defined functions.  Re-declaring a library function
+dnl calls to implicitly-defined functions.  Redeclaring a library function
 dnl with an incompatible prototype is also not sufficient because some
 dnl compilers (notably clang-3.2) only produce a warning in this case.
 dnl


### PR DESCRIPTION

## Pull Request Description
There was an issue with icx support of weak symbols using #pragma weak. While the compile works, it will not properly honor the visibility attribute on the weak symbols. It does support weak symbols via attributes thoush. Potentially this is due to #pragma weak is separate from attributes in icx.

Coincidentally, icx will raise error if the weak function is used within the compilation unit. Assumably, it treats the pragma weak declaration as an unresolved duplicate at compile time so it won't compile the function call within the unit.

Anyway, that's how our previous releas worked with icx, by accidentally prefer weak attribute against pragma weak.

This commit restors the previous behavior as a work around for icx's bad support of #pragma weak.

Credit to @colleeneb for bisecting releases and identifying key differences.

Fixes #7913
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
