### PR TITLE
mpl/gpu: fix conversions/comparisons between runtime/driver API enums

### DIFF
--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -138,13 +138,15 @@ int MPL_gpu_ipc_handle_create(const void *ptr, MPL_gpu_device_attr * ptr_attr,
                               MPL_gpu_ipc_mem_handle_t * ipc_handle)
 {
     int mpl_err = MPL_SUCCESS;
-    cudaError_t ret;
 
+    cudaError_t ret;
     ret = cudaIpcGetMemHandle(&ipc_handle->handle, (void *) ptr);
     CUDA_ERR_CHECK(ret);
 
-    ret = cuPointerGetAttribute(&ipc_handle->id, CU_POINTER_ATTRIBUTE_BUFFER_ID, (CUdeviceptr) ptr);
-    CUDA_ERR_CHECK(ret);
+    CUresult curet;
+    curet =
+        cuPointerGetAttribute(&ipc_handle->id, CU_POINTER_ATTRIBUTE_BUFFER_ID, (CUdeviceptr) ptr);
+    CU_ERR_CHECK(curet);
 
   fn_exit:
     return mpl_err;

--- a/src/mpl/src/gpu/mpl_gpu_cuda.c
+++ b/src/mpl/src/gpu/mpl_gpu_cuda.c
@@ -199,7 +199,7 @@ MPL_gpu_buffer_id_t MPL_gpu_get_buffer_id(void *ptr)
     MPL_gpu_buffer_id_t buffer_id;
 
     ret = cuPointerGetAttribute(&buffer_id, CU_POINTER_ATTRIBUTE_BUFFER_ID, (CUdeviceptr) ptr);
-    assert(ret == cudaSuccess);
+    assert(ret == CUDA_SUCCESS);
 
     return buffer_id;
 }
@@ -210,7 +210,7 @@ bool MPL_gpu_ipc_handle_is_valid(MPL_gpu_ipc_mem_handle_t * handle, void *ptr)
     MPL_gpu_buffer_id_t buffer_id;
 
     ret = cuPointerGetAttribute(&buffer_id, CU_POINTER_ATTRIBUTE_BUFFER_ID, (CUdeviceptr) ptr);
-    assert(ret == cudaSuccess);
+    assert(ret == CUDA_SUCCESS);
 
     return buffer_id == handle->id;
 }

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -9,7 +9,6 @@
 #include <assert.h>
 #ifdef MPL_HAVE_HIP
 #define HIP_ERR_CHECK(ret) if (unlikely((ret) != hipSuccess)) goto fn_fail
-#define HI_ERR_CHECK(ret) if (unlikely((ret) != HIP_SUCCESS)) goto fn_fail
 
 static int gpu_initialized = 0;
 static int device_count = -1;
@@ -442,10 +441,10 @@ int MPL_gpu_get_root_device(int dev_id)
 int MPL_gpu_get_buffer_bounds(const void *ptr, void **pbase, uintptr_t * len)
 {
     int mpl_err = MPL_SUCCESS;
-    hipError_t hiret;
+    hipError_t ret;
 
-    hiret = hipMemGetAddressRange((hipDeviceptr_t *) pbase, (size_t *) len, (hipDeviceptr_t) ptr);
-    HI_ERR_CHECK(hiret);
+    ret = hipMemGetAddressRange((hipDeviceptr_t *) pbase, (size_t *) len, (hipDeviceptr_t) ptr);
+    HIP_ERR_CHECK(ret);
 
   fn_exit:
     return mpl_err;

--- a/src/mpl/src/gpu/mpl_gpu_hip.c
+++ b/src/mpl/src/gpu/mpl_gpu_hip.c
@@ -354,7 +354,6 @@ int MPL_gpu_init(int debug_summary)
         char *free_ptr = devices;
         memcpy(devices, visible_devices, len + 1);
         for (int i = 0; i < device_count; i++) {
-            int global_dev_id;
             char *tmp = strtok(devices, ",");
             assert(tmp);
             local_to_global_map[i] = atoi(tmp);


### PR DESCRIPTION
## Pull Request Description
Fixes conversions and comparisons between different CUDA runtime and driver API enum types:
```
  CC       src/gpu/mpl_gpu_cuda.lo
../../../mpich/src/mpl/src/gpu/mpl_gpu_cuda.c: In function 'MPL_gpu_ipc_handle_create':
../../../mpich/src/mpl/src/gpu/mpl_gpu_cuda.c:146:9: warning: implicit conversion from 'CUresult' {aka 'enum cudaError_enum'} to 'cudaError_t' {aka 'enum cudaError'} [-Wenum-conversion]
  146 |     ret = cuPointerGetAttribute(&ipc_handle->id, CU_POINTER_ATTRIBUTE_BUFFER_ID, (CUdeviceptr) ptr);
      |         ^
In file included from ../../../mpich/src/mpl/src/gpu/mpl_gpu_cuda.c:9:
../../../mpich/src/mpl/src/gpu/mpl_gpu_cuda.c: In function 'MPL_gpu_get_buffer_id':
../../../mpich/src/mpl/src/gpu/mpl_gpu_cuda.c:200:16: warning: comparison between 'CUresult' {aka 'enum cudaError_enum'} and 'enum cudaError' [-Wenum-compare]
  200 |     assert(ret == cudaSuccess);
      |                ^~
../../../mpich/src/mpl/src/gpu/mpl_gpu_cuda.c: In function 'MPL_gpu_ipc_handle_is_valid':
../../../mpich/src/mpl/src/gpu/mpl_gpu_cuda.c:211:16: warning: comparison between 'CUresult' {aka 'enum cudaError_enum'} and 'enum cudaError' [-Wenum-compare]
  211 |     assert(ret == cudaSuccess);
      |                ^~
```
Also removes `HI_ERR_CHECK()`, currently only used to check the return value of `hipMemGetAddressRange()`, which is of type `hipError_t`, so should compare with `hipSuccess` instead:
```
In file included from ../../../mpich/src/mpl/include/mpl.h:9:
../../../mpich/src/mpl/src/gpu/mpl_gpu_hip.c: In function 'MPL_gpu_get_buffer_bounds':
../../../mpich/src/mpl/src/gpu/mpl_gpu_hip.c:12:46: warning: comparison between 'hipError_t' and 'enum <anonymous>' [-Wenum-compare]
   12 | #define HI_ERR_CHECK(ret) if (unlikely((ret) != HIP_SUCCESS)) goto fn_fail
      |                                              ^~
../../../mpich/src/mpl/include/mpl_base.h:81:42: note: in definition of macro 'unlikely'
   81 | #define unlikely(x_) __builtin_expect(!!(x_),0)
      |                                          ^~
../../../mpich/src/mpl/src/gpu/mpl_gpu_hip.c:448:5: note: in expansion of macro 'HI_ERR_CHECK'
  448 |     HI_ERR_CHECK(hiret);
      |     ^~~~~~~~~~~~
```
Plus an unused variable:
```
../../../mpich/src/mpl/src/gpu/mpl_gpu_hip.c: In function 'MPL_gpu_init':
../../../mpich/src/mpl/src/gpu/mpl_gpu_hip.c:358:17: warning: unused variable 'global_dev_id' [-Wunused-variable]
  358 |             int global_dev_id;
      |                 ^~~~~~~~~~~~~
```