### PR TITLE
ch4/ipc: fix host (cma ipc) -> device (gpu/skip ipc) copies for oversized data types

### DIFF
--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -65,23 +65,28 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_get_ipc_attr(const void *buf, MPI_Aint c
     ipc_attr->ipc_type = MPIDI_IPCI_TYPE__NONE;
     MPIDI_IPCI_NO_IPC_EXIT;
 
+    int oversized = false;
     int dt_contig;
     MPIR_Datatype_is_contig(datatype, &dt_contig);
     if (!dt_contig) {
         int flattened_sz;
         void *flattened_dt;
         MPIR_Datatype_get_flattened(datatype, &flattened_dt, &flattened_sz);
-        if (msg_hdr_sz + sizeof(MPIDI_IPC_hdr) + flattened_sz > MPIDI_POSIX_am_hdr_max_sz()) {
-            goto fn_exit;
-        }
+        oversized = msg_hdr_sz + sizeof(MPIDI_IPC_hdr) + flattened_sz > MPIDI_POSIX_am_hdr_max_sz();
     }
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
     mpi_errno = MPIDI_GPU_get_ipc_attr(buf, count, datatype, ipc_attr);
     MPIR_ERR_CHECK(mpi_errno);
     if (ipc_attr->ipc_type != MPIDI_IPCI_TYPE__NONE) {
+        if (oversized) {
+            ipc_attr->ipc_type = MPIDI_IPCI_TYPE__SKIP;
+        }
         goto fn_exit;
     }
 #endif
+    if (oversized) {
+        goto fn_exit;
+    }
 #ifdef MPIDI_CH4_SHM_ENABLE_XPMEM
     mpi_errno = MPIDI_XPMEM_get_ipc_attr(buf, count, datatype, ipc_attr);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_p2p.h
@@ -78,11 +78,6 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_IPCI_get_ipc_attr(const void *buf, MPI_Aint c
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
     mpi_errno = MPIDI_GPU_get_ipc_attr(buf, count, datatype, ipc_attr);
     MPIR_ERR_CHECK(mpi_errno);
-    if (ipc_attr->ipc_type == MPIDI_IPCI_TYPE__SKIP) {
-        /* GPU IPC is not supported but it is still a device memory,
-         * we can't do shared memory IPC either, so skip to fn_exit. */
-        goto fn_exit;
-    }
     if (ipc_attr->ipc_type != MPIDI_IPCI_TYPE__NONE) {
         goto fn_exit;
     }


### PR DESCRIPTION
## Pull Request Description
The aim is to fix the bcast tests when `MPIR_CVAR_CH4_CMA_ENABLE=1`, which is the default on my machine:
```
../../installed/bin/mpirun -n 2 ./coll/bcast -seed=106 -testsize=2 -type=MPI_INT -count=65530 -evenmemtype=device -oddmemtype=host
Error class 15 (Other MPI error, error stack:
internal_Bcast(128)......................: MPI_Bcast(buffer=0x7fa3c4e00000, count=2, dtype=USER<hvector>, 1, MPI_COMM_WORLD) failed
MPID_Bcast(290)..........................: 
MPIDI_Bcast_allcomm_composition_json(236): 
MPIDI_Bcast_intra_composition_alpha(255).: 
MPIC_Recv(210)...........................: 
MPIC_Wait(99)............................: 
MPIR_Wait(745)...........................: 
MPIDI_IPC_rndv_cb(302)...................: 
MPIDI_CMA_copy_data(67).................)
expected 0 at 0x7fa3c523ffe0, but found -1
DTP_obj_buf_check failed.
coll [nesting levels: 3
0: hvector [numblks 1, blklen 1, stride 10484648]
1: resized [lb 2621160, extent 2621160]
2: blkindx [numblks 32765, blklen 1, displs (65528,65526,65524,65522,65520,65518,65516,65514,65512,65510,...,18,16,14,12,10,8,6,4,2,0)]
base: MPI_INT
]
```

I now realise that the tests were crashing on my machine for different reasons they are crashing in the Jenkins...
I suppose the CI machines have CMA disabled?

Also, can I ask how I can control the correct execution of `alltoall, allgather_gpu, allgatherv_gpu` at the bottom of `testlist.gpu` given we are setting `MPIR_CVAR_ALLGATHERV_POSIX_INTRA_ALGORITHM=ipc_read` (only valid on ZE)? How's Jenkins not crashing for those?