### PR TITLE
ch4/ofi: fix overwrite of num_nics

### DIFF
--- a/src/mpid/ch4/netmod/ofi/ofi_vci.c
+++ b/src/mpid/ch4/netmod/ofi/ofi_vci.c
@@ -27,7 +27,6 @@
 
 int MPIDI_OFI_vci_init(void)
 {
-    MPIDI_OFI_global.num_nics = 1;
     MPIDI_OFI_global.num_vcis = 1;
     return MPI_SUCCESS;
 }
@@ -96,7 +95,6 @@ static int init_vcis(int num_vcis, int *num_vcis_actual)
     MPIR_Assert(num_vcis == 1 || MPIDI_OFI_ENABLE_SCALABLE_ENDPOINTS);
 #endif
 
-    MPIDI_OFI_global.num_nics = MPIDI_OFI_global.num_nics_available;
     MPIDI_OFI_global.num_vcis = num_vcis;
 
     /* may update MPIDI_OFI_global.num_vcis */


### PR DESCRIPTION
In init_vcis(), we are overwriting num_nics with num_nics_available, which overrides the desired number of active NICs (i.e., MPIR_CVAR_CH4_OFI_MAX_NICS) per rank with whatever the total detected NIC count was. This was a latent bug that got introduced in d6a1df7a5e, when num_nics_available assumed the value of MPIR_CVAR_CH4_OFI_MAX_NICS. In ad9a27357d, this was changed to num_nics_available holding the total number of detected NICs.

As a result we end up initializing a VCI context for all NICs regardless of MPIR_CVAR_CH4_OFI_MAX_NICS. We fix this by removing the assignment of num_nics to num_nics_available, since it's already properly initialized.

## Pull Request Description


## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
