### PR TITLE
ch4/shm/posix: avoiding device id lookup for ZE registered host memory

### DIFF
--- a/src/mpid/ch4/shm/posix/posix_rma.h
+++ b/src/mpid/ch4/shm/posix/posix_rma.h
@@ -139,7 +139,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
 
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
     MPIR_GPU_query_pointer_attr(origin_addr, &origin_attr);
-    if (MPL_gpu_attr_is_dev(&origin_attr))
+    if (MPL_gpu_attr_is_strict_dev(&origin_attr))
         origin_dev_id = MPL_gpu_local_to_global_dev_id(MPL_gpu_get_dev_id_from_attr(&origin_attr));
 #endif
 
@@ -148,7 +148,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
         disp_unit = win->disp_unit;
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
         MPIR_GPU_query_pointer_attr(base, &target_attr);
-        if (MPL_gpu_attr_is_dev(&target_attr))
+        if (MPL_gpu_attr_is_strict_dev(&target_attr))
             target_dev_id =
                 MPL_gpu_local_to_global_dev_id(MPL_gpu_get_dev_id_from_attr(&target_attr));
 #endif
@@ -168,8 +168,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_put(const void *origin_addr,
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
     if (MPIR_CVAR_CH4_IPC_GPU_RMA_ENGINE_TYPE != MPIR_CVAR_CH4_IPC_GPU_RMA_ENGINE_TYPE_yaksa) {
         MPL_gpu_engine_type_t engine_type =
-            MPIDI_RMA_choose_engine(MPL_gpu_attr_is_dev(&origin_attr), origin_dev_id,
-                                    MPL_gpu_attr_is_dev(&target_attr), target_dev_id);
+            MPIDI_RMA_choose_engine(MPL_gpu_attr_is_strict_dev(&origin_attr), origin_dev_id,
+                                    MPL_gpu_attr_is_strict_dev(&target_attr), target_dev_id);
         /* try to use cached local mmap for fast_memcpy */
         MPI_Aint copy_sz = MPL_MIN(origin_data_sz, target_data_sz);
         void *put_origin = (void *) origin_addr;
@@ -241,7 +241,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
 
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
     MPIR_GPU_query_pointer_attr(origin_addr, &origin_attr);
-    if (MPL_gpu_attr_is_dev(&origin_attr))
+    if (MPL_gpu_attr_is_strict_dev(&origin_attr))
         origin_dev_id = MPL_gpu_local_to_global_dev_id(MPL_gpu_get_dev_id_from_attr(&origin_attr));
 #endif
 
@@ -250,7 +250,7 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
         disp_unit = win->disp_unit;
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
         MPIR_GPU_query_pointer_attr(base, &target_attr);
-        if (MPL_gpu_attr_is_dev(&target_attr))
+        if (MPL_gpu_attr_is_strict_dev(&target_attr))
             target_dev_id =
                 MPL_gpu_local_to_global_dev_id(MPL_gpu_get_dev_id_from_attr(&target_attr));
 #endif
@@ -270,8 +270,8 @@ MPL_STATIC_INLINE_PREFIX int MPIDI_POSIX_do_get(void *origin_addr,
 #ifdef MPIDI_CH4_SHM_ENABLE_GPU
     if (MPIR_CVAR_CH4_IPC_GPU_RMA_ENGINE_TYPE != MPIR_CVAR_CH4_IPC_GPU_RMA_ENGINE_TYPE_yaksa) {
         MPL_gpu_engine_type_t engine_type =
-            MPIDI_RMA_choose_engine(MPL_gpu_attr_is_dev(&origin_attr), origin_dev_id,
-                                    MPL_gpu_attr_is_dev(&target_attr), target_dev_id);
+            MPIDI_RMA_choose_engine(MPL_gpu_attr_is_strict_dev(&origin_attr), origin_dev_id,
+                                    MPL_gpu_attr_is_strict_dev(&target_attr), target_dev_id);
         /* try to use cached local mmap for fast_memcpy */
         MPI_Aint copy_sz = MPL_MIN(origin_data_sz, target_data_sz);
         void *get_origin = origin_addr;

--- a/src/mpl/src/gpu/mpl_gpu_ze.c
+++ b/src/mpl/src/gpu/mpl_gpu_ze.c
@@ -1293,7 +1293,12 @@ int MPL_gpu_global_to_local_dev_id(int global_dev_id)
 
 int MPL_gpu_local_to_global_dev_id(int local_dev_id)
 {
-    assert(local_dev_id < local_ze_device_count);
+    /* Host-owned allocations (e.g. ZE registered host memory) have no
+     * associated device. */
+    if (local_dev_id == -1) {
+        return -1;
+    }
+    assert(local_dev_id >= 0 && (uint32_t) local_dev_id < local_ze_device_count);
     return local_to_global_map[local_dev_id];
 }
 


### PR DESCRIPTION
## Pull Request Description

This is a change to fix https://github.com/pmodels/mpich/issues/7927 . The assertion `Assertion local_dev_id < local_ze_device_count` was failing because the local dev id was -1 (since Level Zero registered host memory, unlike Level Zero device memory, does not have a specific device associated with it(zeMemGetAllocProperties returns a NULL device handle for it)), but local_ze_device_count is an unsigned int32, so in the comparison the -1 was converted to unsigned, and this was larger than the device count. When the asserts are off, it would return `local_to_global_map[-1]`, which is out of bounds.

To fix this, this PR:

1) Adds a check in `MPL_gpu_local_to_global_dev_id` for if the local_dev_id is -1 and returns -1 in that case, avoiding the signed-to-unsigned conversion in the assert and the out-of-bounds `local_to_global_map[-1]` call when the assert is off.

2) Changes `MPL_gpu_attr_is_dev` to `MPL_gpu_attr_is_strict_dev` in `src/mpid/ch4/shm/posix/posix_rma.h` for whenever it tries to look up a device_id, since ZE host registered memory does not have a specific device id. (`MPL_gpu_attr_is_strict_dev` is only true for ZE device memory, and false for ZE host memory). This isn't necessary after the change in 1) but it seems clearer to me since if it's host registered memory we know there's no device id.

3) Changes `MPL_gpu_attr_is_dev` to `MPL_gpu_attr_is_strict_dev` in `src/mpid/ch4/shm/posix/posix_rma.h` as arguments to `MPIDI_RMA_choose_engine`. This is to avoid hitting another assert at https://github.com/pmodels/mpich/blob/6a79bf6575c3b5b41cabbd3d59340634d6f9412d/src/mpl/src/gpu/mpl_gpu_ze.c#L1594 if `MPIDI_RMA_choose_engine` is called with `MPL_gpu_attr_is_dev` and then calls `MPL_gpu_query_is_same_dev`. If instead `MPL_gpu_attr_is_strict_dev` is used, for Level Zero registered host memory, it will be considered "host memory" and it takes the host memory engine path (https://github.com/pmodels/mpich/blob/6a79bf6575c3b5b41cabbd3d59340634d6f9412d/src/mpid/ch4/shm/posix/posix_rma.h#L91). 

I'm happy to make any adjustments in the PR! And thanks to Claude for help understanding the code.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
