### PR TITLE
ch4/ipc/gpu: set global_dev_id for MPIDI_IPCI_TYPE__DIRECT

### DIFF
--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -525,6 +525,8 @@ int MPIDI_GPU_fill_ipc_handle_cache(MPIDI_IPCI_ipc_attr_t * ipc_attr,
                 uintptr_t offset = (uintptr_t) ipc_attr->u.gpu.vaddr - (uintptr_t) pbase;
                 ipc_attr->ipc_type = MPIDI_IPCI_TYPE__DIRECT;
                 ipc_handle->direct = (void *) ((uintptr_t) maps[i].map.mapped_addr + offset);
+                int local_dev_id = MPL_gpu_get_dev_id_from_attr(&ipc_attr->u.gpu.gpu_attr);
+                ipc_handle->gpu.global_dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
                 goto fn_done;
             }
         }

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_post.c
@@ -524,9 +524,9 @@ int MPIDI_GPU_fill_ipc_handle_cache(MPIDI_IPCI_ipc_attr_t * ipc_attr,
             if (maps[i].remote_lrank == remote_lrank) {
                 uintptr_t offset = (uintptr_t) ipc_attr->u.gpu.vaddr - (uintptr_t) pbase;
                 ipc_attr->ipc_type = MPIDI_IPCI_TYPE__DIRECT;
-                ipc_handle->direct = (void *) ((uintptr_t) maps[i].map.mapped_addr + offset);
+                ipc_handle->direct.addr = (void *) ((uintptr_t) maps[i].map.mapped_addr + offset);
                 int local_dev_id = MPL_gpu_get_dev_id_from_attr(&ipc_attr->u.gpu.gpu_attr);
-                ipc_handle->gpu.global_dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
+                ipc_handle->direct.global_dev_id = MPL_gpu_local_to_global_dev_id(local_dev_id);
                 goto fn_done;
             }
         }
@@ -803,7 +803,7 @@ static int ipc_map_addr(MPIDI_IPC_hdr * ipc_hdr, MPIR_Request * req, MPI_Aint da
 
     memset(&MPIDI_SHM_REQUEST(req, ipc.u.map), 0, sizeof(MPL_gpu_map_t));
     if (ipc_hdr->ipc_type == MPIDI_IPCI_TYPE__DIRECT) {
-        *addr_out = ipc_hdr->ipc_handle.direct;
+        *addr_out = ipc_hdr->ipc_handle.direct.addr;
     } else {
 #ifdef MPL_HAVE_ZE
         bool do_mmap = (data_sz <= MPIR_CVAR_GPU_FAST_COPY_MAX_SIZE);
@@ -874,9 +874,11 @@ int MPIDI_GPU_copy_data_async(MPIDI_IPC_hdr * ipc_hdr, MPIR_Request * req, MPI_A
     mpi_errno = MPIDI_GPU_ipc_local_mmap(local_buf, &attr, src_data_sz, &local_buf);
     MPIR_ERR_CHECK(mpi_errno);
 
+    int remote_global_dev_id = (ipc_hdr->ipc_type == MPIDI_IPCI_TYPE__DIRECT) ?
+        ipc_hdr->ipc_handle.direct.global_dev_id : ipc_hdr->ipc_handle.gpu.global_dev_id;
+
     MPIR_gpu_req yreq;
-    MPL_gpu_engine_type_t engine =
-        MPIDI_IPCI_choose_engine(ipc_hdr->ipc_handle.gpu.global_dev_id, dev_id);
+    MPL_gpu_engine_type_t engine = MPIDI_IPCI_choose_engine(remote_global_dev_id, dev_id);
     mpi_errno = MPIR_Ilocalcopy_gpu(src_buf, src_count, src_dt, 0, NULL,
                                     local_buf, MPIDIG_REQUEST(req, count),
                                     MPIDIG_REQUEST(req, datatype), 0, &attr, engine, true, &yreq);
@@ -935,9 +937,11 @@ int MPIDI_GPU_write_data_async(MPIDI_IPC_hdr * ipc_hdr, MPIR_Request * sreq)
     MPIR_ERR_CHECK(mpi_errno);
 
     /* copy */
+    int remote_global_dev_id = (ipc_hdr->ipc_type == MPIDI_IPCI_TYPE__DIRECT) ?
+        ipc_hdr->ipc_handle.direct.global_dev_id : ipc_hdr->ipc_handle.gpu.global_dev_id;
+
     MPIR_gpu_req yreq;
-    MPL_gpu_engine_type_t engine =
-        MPIDI_IPCI_choose_engine(ipc_hdr->ipc_handle.gpu.global_dev_id, dev_id);
+    MPL_gpu_engine_type_t engine = MPIDI_IPCI_choose_engine(remote_global_dev_id, dev_id);
     mpi_errno = MPIR_Ilocalcopy_gpu(src_buf, src_count, src_datatype, 0, &attr,
                                     dst_buf, dst_count, dst_datatype, 0, NULL, engine, true, &yreq);
     MPIR_ERR_CHECK(mpi_errno);

--- a/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
+++ b/src/mpid/ch4/shm/ipc/gpu/gpu_pre.h
@@ -20,6 +20,12 @@ typedef struct MPIDI_GPU_ipc_handle {
     bool handle_is_cached;
 } MPIDI_GPU_ipc_handle_t;
 
+/* ipc handle for MPIDI_IPCI_TYPE__DIRECT: sender has a cached mapped address */
+typedef struct MPIDI_GPU_ipc_direct {
+    void *addr;
+    int global_dev_id;
+} MPIDI_GPU_ipc_direct_t;
+
 /* local struct used for query and preparing memory handle */
 typedef struct MPIDI_GPU_ipc_attr {
     MPL_pointer_attr_t gpu_attr;

--- a/src/mpid/ch4/shm/ipc/src/ipc_types.h
+++ b/src/mpid/ch4/shm/ipc/src/ipc_types.h
@@ -16,8 +16,7 @@ typedef union MPIDI_IPCI_ipc_handle {
     MPIDI_XPMEM_ipc_handle_t xpmem;
     MPIDI_CMA_ipc_handle_t cma;
     MPIDI_GPU_ipc_handle_t gpu;
-    /* ipc_type is MPIDI_IPCI_TYPE__DIRECT */
-    void *direct;
+    MPIDI_GPU_ipc_direct_t direct;
 } MPIDI_IPCI_ipc_handle_t;
 
 typedef struct MPIDI_IPCI_ipc_attr {


### PR DESCRIPTION
## Pull Request Description

This is to fix https://github.com/pmodels/mpich/issues/7944 . 

It adds in the `gpu.global_dev_id` to `ipc_handle` for when there's a cache hit and it's IPC `MPIDI_IPCI_TYPE__DIRECT`. As mentioned in the issue, the `gpu.global_dev_id` is set for cache misses. If it's not set, it will read whatever was in the memory before -- either an older device id or a random value. This should be set since it's used in `MPIDI_GPU_{copy,write}_data_async` when it calls `MPIDI_IPCI_choose_engine` and passes the global device id.

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
