### PR TITLE
mpit: fix early MPI_T_finalize issue

### DIFF
--- a/src/binding/c/mpit_api.txt
+++ b/src/binding/c/mpit_api.txt
@@ -205,7 +205,6 @@ MPI_T_finalize:
     }
 
     if (MPIR_T_init_balance == 0) {
-        MPIR_T_THREAD_CS_FINALIZE();
         MPIR_T_env_finalize();
     }
 }
@@ -230,7 +229,6 @@ MPI_T_init_thread:
 
     ++MPIR_T_init_balance;
     if (MPIR_T_init_balance == 1) {
-        MPIR_T_THREAD_CS_INIT();
         mpi_errno = MPIR_T_env_init();
         if (mpi_errno) {
             goto fn_fail;

--- a/src/mpi/init/mpir_init.c
+++ b/src/mpi/init/mpir_init.c
@@ -181,8 +181,11 @@ int MPII_Init_thread(int *argc, char ***argv, int user_required, int *provided,
     MPID_Thread_init(&err);
     MPIR_Assert(err == 0);
 
-    mpi_errno = MPIR_T_env_init();
-    MPIR_ERR_CHECK(mpi_errno);
+    MPIR_T_init_balance++;
+    if (MPIR_T_init_balance == 1) {
+        mpi_errno = MPIR_T_env_init();
+        MPIR_ERR_CHECK(mpi_errno);
+    }
 
     MPIR_Err_init();
     MPII_pre_init_dbg_logging(argc, argv);
@@ -445,8 +448,10 @@ int MPII_Finalize(MPIR_Session * session_ptr)
 
     /* Users did not call MPI_T_init_thread(), so we free memories allocated to
      * MPIR_T during MPI_Init here. Otherwise, free them in MPI_T_finalize() */
-    if (!MPIR_T_is_initialized())
+    MPIR_T_init_balance--;
+    if (MPIR_T_init_balance == 0) {
         MPIR_T_env_finalize();
+    }
 
     /* If performing coverage analysis, make each process sleep for
      * rank * 100 ms, to give time for the coverage tool to write out

--- a/src/mpi_t/mpit_finalize.c
+++ b/src/mpi_t/mpit_finalize.c
@@ -139,14 +139,13 @@ static void MPIR_T_pvar_env_finalize(void)
     }
 }
 
-extern int MPIR_T_env_initialized;
-
 void MPIR_T_env_finalize(void)
 {
+    MPIR_T_THREAD_CS_FINALIZE();
+
     MPIR_T_enum_env_finalize();
     MPIR_T_cvar_env_finalize();
     MPIR_T_pvar_env_finalize();
     MPIR_T_cat_env_finalize();
     MPIR_T_events_finalize();
-    MPIR_T_env_initialized = FALSE;
 }

--- a/src/mpi_t/mpit_initthread.c
+++ b/src/mpi_t/mpit_initthread.c
@@ -77,8 +77,6 @@ static inline int MPIR_T_cvar_env_init(void)
     return MPIR_T_cvar_init();
 }
 
-int MPIR_T_env_initialized = FALSE;
-
 int MPIR_T_env_init(void)
 {
     int mpi_errno = MPI_SUCCESS;
@@ -91,15 +89,15 @@ int MPIR_T_env_init(void)
     }
 #endif
 
-    if (!MPIR_T_env_initialized) {
-        MPIR_T_env_initialized = TRUE;
-        MPIR_T_enum_env_init();
-        MPIR_T_cat_env_init();
-        mpi_errno = MPIR_T_cvar_env_init();
-        MPIR_T_pvar_env_init();
-        if (MPIR_CVAR_DEBUG_SUMMARY && config_filename) {
-            printf("Global config file: %s\n", config_filename);
-        }
+    MPIR_T_THREAD_CS_INIT();
+
+    MPIR_T_enum_env_init();
+    MPIR_T_cat_env_init();
+    mpi_errno = MPIR_T_cvar_env_init();
+    MPIR_T_pvar_env_init();
+    if (MPIR_CVAR_DEBUG_SUMMARY && config_filename) {
+        printf("Global config file: %s\n", config_filename);
     }
+
     return mpi_errno;
 }

--- a/src/mpid/ch4/shm/posix/release_gather/release_gather.h
+++ b/src/mpid/ch4/shm/posix/release_gather/release_gather.h
@@ -65,7 +65,7 @@ int MPIDI_POSIX_mpi_release_gather_comm_free(MPIR_Comm * comm_ptr);
 MPL_STATIC_INLINE_PREFIX MPIDI_POSIX_release_gather_tree_type_t
 MPIDI_POSIX_mpi_release_gather_get_tree_type(const char *tree_type_name)
 {
-    if (0 == strcmp(tree_type_name, "kary"))
+    if (tree_type_name == NULL || 0 == strcmp(tree_type_name, "kary"))
         return MPIDI_POSIX_RELEASE_GATHER_TREE_TYPE_KARY;
     else if (0 == strcmp(tree_type_name, "knomial_1"))
         return MPIDI_POSIX_RELEASE_GATHER_TREE_TYPE_KNOMIAL_1;


### PR DESCRIPTION
## Pull Request Description
MPI_Init initiazes MPIT yet it does not increament the init counter,
MPIR_T_init_balance. This let MPI_T_finalize finalize the cvars before
MPI_Finalize, resulting in segfault when a fialized CVAR resulted in
NULL tree_type_name in release_gather.h and then leads to a segfault.

While we should fix the lack of NULL check in release_gather.h, the
messy init tracking needs to be cleaned up. There are two designs
options:

1. Both MPI_T_init_thread and MPI_Init and both MPI_T_finalize and
MPI_Finalize initializes and finalizes the MPI_T system equally,
tracked via counter MPIR_T_init_balance.

2. Split MPI_T init into two parts, one part just initiazes CVAR
*globals* by loading environment. The sencond part initializes the
runtime MPI_T system such as cvar and pavar data structures. Both part
needs separate init trackers.

This PR implements this option 1 as it is the simpler path for now.
Option 2 is certainly a cleaner option, left as future TODOs. 

Fixes #7954 
## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [ ] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
