### PR TITLE
configure: fix loss of USER flags

### DIFF
--- a/confdb/aclocal_util.m4
+++ b/confdb/aclocal_util.m4
@@ -45,9 +45,17 @@ AC_DEFUN([PAC_POP_ALL_FLAGS],[
 	PAC_POP_FLAG(LIBS)
 ])
 
-dnl PAC_PREFIX_FLAG - Initialize a prefixed flag variable
+dnl PAC_PREFIX_FLAG - Initialize a prefixed flag variable by copying FLAG
 dnl Usage: PAC_PREFIX_FLAG(PREFIX, FLAG)
 AC_DEFUN([PAC_PREFIX_FLAG],[
+	$1_$2=$$2
+	export $1_$2
+	AC_SUBST($1_$2)
+])
+
+dnl PAC_INIT_FLAG - Initialize a prefixed flag variable as empty
+dnl Usage: PAC_INIT_FLAG(PREFIX, FLAG)
+AC_DEFUN([PAC_INIT_FLAG],[
 	$1_$2=""
 	export $1_$2
 	AC_SUBST($1_$2)
@@ -64,6 +72,19 @@ AC_DEFUN([PAC_PREFIX_ALL_FLAGS],[
 	PAC_PREFIX_FLAG($1, LDFLAGS)
 	PAC_PREFIX_FLAG($1, LIBS)
 	PAC_PREFIX_FLAG($1, EXTRA_LIBS)
+])
+
+dnl PAC_INIT_ALL_FLAG - Initialize all flags with a prefix
+dnl Usage: PAC_INIT_ALL_FLAGS(PREFIX)
+AC_DEFUN([PAC_INIT_ALL_FLAGS],[
+	PAC_INIT_FLAG($1, CFLAGS)
+	PAC_INIT_FLAG($1, CPPFLAGS)
+	PAC_INIT_FLAG($1, CXXFLAGS)
+	PAC_INIT_FLAG($1, FFLAGS)
+	PAC_INIT_FLAG($1, FCFLAGS)
+	PAC_INIT_FLAG($1, LDFLAGS)
+	PAC_INIT_FLAG($1, LIBS)
+	PAC_INIT_FLAG($1, EXTRA_LIBS)
 ])
 
 dnl PAC_RESET_ALL_FLAGS - Reset precious flags to those set by the user

--- a/configure.ac
+++ b/configure.ac
@@ -257,7 +257,8 @@ export FROM_MPICH
 # so executables built within MPICH use them.  If inter-library
 # dependencies are not supported on the platform, these libraries are
 # added to the MPICH wrappers (mpicc and friends) as well.
-PAC_PREFIX_ALL_FLAGS(WRAPPER)
+# Initialize all WRAPPER flags to empty string.
+PAC_INIT_ALL_FLAGS(WRAPPER)
 
 # confdb routines are used in multiple components. Let the macros know
 # whether WRAPPER FLAGS are used.


### PR DESCRIPTION
## Pull Request Description
There are two cases of using PAC_PREFIX_ALL_FLAGS, once with WRAPPER prefix, and one with USER prefix. The wrapper flags need be initialized to empty strings, while the USER flags should copy the current flags. Previous commit in PR7921 with blind change for both cases caused loss of USER flags, which are used in building submodule packages.

We need separate macros since the behavior are different.


Fixes #7959

## Author Checklist
* [x] **Provide Description** 
      Particularly focus on _why_, not _what_. Reference background, issues, test failures, xfail entries, etc.
* [x] **Commits Follow Good Practice**
      Commits are self-contained and do not do two things at once. 
      Commit message is of the form: `module: short description` 
      Commit message explains what's in the commit.
* [x] **Passes All Tests**
      Whitespace checker. Warnings test. Additional tests via comments.
* [x] **Contribution Agreement**
      For non-Argonne authors, check [contribution agreement](http://www.mpich.org/documentation/contributor-docs/). 
      If necessary, request an explicit comment from your companies PR approval manager.
